### PR TITLE
Use Q0 quantizers to derive lambda for Q0 pixel domain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,9 +351,10 @@ fn encode_tile(fi: &FrameInvariants, fs: &mut FrameState) -> Vec<u8> {
     };
 
     let q = dc_q(fi.qindex) as f64;
+    let q0 = q / 8.0_f64;	// Convert q into Q0 precision, given thatn libaom quantizers are Q3.
 
     // Lambda formula from doc/theoretical_results.lyx in the daala repo
-    let lambda = q*q*2.0_f64.log2()/6.0;
+    let lambda = q0*q0*2.0_f64.log2()/6.0;	// Use Q0 quantizer since lambda will be applied to Q0 pixel domain
 
     for sby in 0..fi.sb_height {
         for p in 0..3 {


### PR DESCRIPTION
The quantizer tables that rav1e currently use are those from libaom,
which are all in Q3 precision (except, qindex=0, lossless mode, which is Q2).
Thus, if we derive lambda which applies to pixel domain in Q0,
we should use quantizers in Q0.