### PR TITLE
Slice before building the iterators in pred_dc

### DIFF
--- a/src/predict.rs
+++ b/src/predict.rs
@@ -74,7 +74,7 @@ impl Dim for Block4x4 {
 }
 
 pub fn pred_dc_trait<D: Dim>(output: &mut [u16], stride: usize, above: &[u16], left: &[u16]) {
-    let edges = left.iter().chain(above.iter());
+    let edges = left[..D::H].iter().chain(above[..D::W].iter());
     let bw = D::W;
     let bh = D::H;
     let len = (bw + bh) as u32;


### PR DESCRIPTION
rust-1.24
from
test native_trait  ... bench:     988,673 ns/iter (+/- 185,503)
to
test native_trait  ... bench:     806,088 ns/iter (+/- 150,647)

rust-1.25 (nightly)
from
test native_trait  ... bench:     653,069 ns/iter (+/- 104,601)
to
test native_trait  ... bench:     421,896 ns/iter (+/- 78,777)