### PR TITLE
Set codegen-units = 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,11 @@ bencher = "0.1.5"
 [[bench]]
 name = "bench"
 harness = false
+
+[profile.release]
+codegen-units = 1  # if > 1 enables parallel code generation which improves
+                   # compile times, but prevents some optimizations.
+                   # Passes `-C codegen-units`. Ignored when `lto = true`.
+
+[profile.bench]
+codegen-units = 1


### PR DESCRIPTION
So that upgraded rustc 1.25.0 version does not slow down
the release/test/bench binary by setting the default value of
codegen-units = 16.