### PR TITLE
Use static instead of const for array

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -32,41 +32,41 @@ static mi_size_wide: [u8; BLOCK_SIZES_ALL] = [
   1, 1, 2, 2, 2, 4, 4, 4, 8, 8, 8, 16, 16, 1, 4, 2, 8, 4, 16];
 static mi_size_high: [u8; BLOCK_SIZES_ALL] = [
   1, 2, 1, 2, 4, 2, 4, 8, 4, 8, 16, 8, 16, 4, 1, 8, 2, 16, 4];
-static b_width_log2_lookup: [u8; BLOCK_SIZES_ALL] = [ 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 0, 2, 1, 3, 2, 4];
-static b_height_log2_lookup: [u8; BLOCK_SIZES_ALL] = [ 0, 1, 0, 1, 2, 1, 2, 3, 2, 3, 4, 3, 4, 2, 0, 3, 1, 4, 2];
-const tx_size_wide_log2: [usize; TX_SIZES_ALL] = [2, 3, 4, 5, 2, 3, 3, 4, 4, 5, 2, 4, 3, 5];
-const tx_size_high_log2: [usize; TX_SIZES_ALL] = [2, 3, 4, 5, 3, 2, 4, 3, 5, 4, 4, 2, 5, 3];
+static b_width_log2_lookup: [u8; 20] = [0, 0, 0,  0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 0, 2, 1, 3];
+static b_height_log2_lookup: [u8; 20] = [ 0, 0, 0, 0, 1, 0, 1, 2, 1, 2, 3, 2, 3, 4, 3, 4, 2, 0, 3, 1];
+static tx_size_wide_log2: [usize; 14] = [2, 3, 4, 5, 2, 3, 3, 4, 4, 5, 2, 4, 3, 5];
+static tx_size_high_log2: [usize; 14] = [2, 3, 4, 5, 3, 2, 4, 3, 5, 4, 4, 2, 5, 3];
 
 const EXT_TX_SIZES: usize = 4;
 const EXT_TX_SET_TYPES: usize = 6;
 const EXT_TX_SETS_INTRA: usize = 3;
 const EXT_TX_SETS_INTER: usize = 4;
 // Number of transform types in each set type
-const num_ext_tx_set: [usize; EXT_TX_SET_TYPES] = [1, 2, 5, 7, 12, 16];
+static num_ext_tx_set: [usize; EXT_TX_SET_TYPES] = [1, 2, 5, 7, 12, 16];
 // Maps intra set index to the set type
-const ext_tx_set_type_intra: [TxSetType; EXT_TX_SETS_INTRA] = [
+static ext_tx_set_type_intra: [TxSetType; EXT_TX_SETS_INTRA] = [
     TxSetType::EXT_TX_SET_DCTONLY, TxSetType::EXT_TX_SET_DTT4_IDTX_1DDCT, TxSetType::EXT_TX_SET_DTT4_IDTX
 ];
 // Maps inter set index to the set type
 #[allow(dead_code)]
-const ext_tx_set_type_inter: [TxSetType; EXT_TX_SETS_INTER] = [
+static ext_tx_set_type_inter: [TxSetType; EXT_TX_SETS_INTER] = [
     TxSetType::EXT_TX_SET_DCTONLY, TxSetType::EXT_TX_SET_ALL16, TxSetType::EXT_TX_SET_DTT9_IDTX_1DDCT,
     TxSetType::EXT_TX_SET_DCT_IDTX
 ];
 // Maps set types above to the indices used for intra
-const ext_tx_set_index_intra: [i8; EXT_TX_SET_TYPES] = [0, -1, 2, 1, -1, -1 ];
+static ext_tx_set_index_intra: [i8; EXT_TX_SET_TYPES] = [0, -1, 2, 1, -1, -1 ];
 // Maps set types above to the indices used for inter
-const ext_tx_set_index_inter: [i8; EXT_TX_SET_TYPES] = [0, 3, -1, -1, 2, 1];
-const av1_ext_tx_intra_ind: [[u32; TX_TYPES]; EXT_TX_SETS_INTRA] = [[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,],[1,5,6,4,0,0,0,0,0,0,2,3,0,0,0,0,],[1,3,4,2,0,0,0,0,0,0,0,0,0,0,0,0,],];
+static ext_tx_set_index_inter: [i8; EXT_TX_SET_TYPES] = [0, 3, -1, -1, 2, 1];
+static av1_ext_tx_intra_ind: [[u32; TX_TYPES]; EXT_TX_SETS_INTRA] = [[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,],[1,5,6,4,0,0,0,0,0,0,2,3,0,0,0,0,],[1,3,4,2,0,0,0,0,0,0,0,0,0,0,0,0,],];
 #[allow(dead_code)]
-const av1_ext_tx_inter_ind: [[usize; TX_TYPES]; EXT_TX_SETS_INTER] = [[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,],[1,5,6,4,0,0,0,0,0,0,2,3,0,0,0,0,],[1,3,4,2,0,0,0,0,0,0,0,0,0,0,0,0,],[0,1,2,0,0,0,0,0,0,0,0,0,0,0,0,0,],];
-const ext_tx_cnt_intra: [usize;EXT_TX_SETS_INTRA] = [ 1, 7, 5 ];
+static av1_ext_tx_inter_ind: [[usize; TX_TYPES]; EXT_TX_SETS_INTER] = [[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,],[1,5,6,4,0,0,0,0,0,0,2,3,0,0,0,0,],[1,3,4,2,0,0,0,0,0,0,0,0,0,0,0,0,],[0,1,2,0,0,0,0,0,0,0,0,0,0,0,0,0,],];
+static ext_tx_cnt_intra: [usize;EXT_TX_SETS_INTRA] = [ 1, 7, 5 ];
 
-const av1_coefband_trans_4x4: [u8; 16] = [
+static av1_coefband_trans_4x4: [u8; 16] = [
     0, 1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 5, 5,
 ];
 
-const TXSIZE_SQR_MAP: [TxSize; TX_SIZES_ALL] = [
+static TXSIZE_SQR_MAP: [TxSize; TX_SIZES_ALL] = [
     TX_4X4,
     TX_8X8,
     TX_16X16,
@@ -83,7 +83,7 @@ const TXSIZE_SQR_MAP: [TxSize; TX_SIZES_ALL] = [
     TX_8X8,
 ];
 
-const TXSIZE_SQR_UP_MAP: [TxSize; TX_SIZES_ALL] = [
+static TXSIZE_SQR_UP_MAP: [TxSize; TX_SIZES_ALL] = [
     TX_4X4,
     TX_8X8,
     TX_16X16,


### PR DESCRIPTION
To avoid the multiple copies of array whenever it is referenced,
also more importantly, the generated asm code seems slower
if const is used w/o '&', i.e. referencing.