### PR TITLE
Specify quantizer in write_b_bench

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -124,7 +124,7 @@ use rav1e::partition::*;
 use rav1e::ec;
 
 fn write_b_bench(b: &mut Bencher) {
-    let mut fi = FrameInvariants::new(1024, 1024);
+    let mut fi = FrameInvariants::new(1024, 1024, 100);
     let w = ec::Writer::new();
     let fc = CDFContext::new();
     let bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);


### PR DESCRIPTION
Fixes build error for `cargo bench` since:
c6504a9 "Add quantizer parameter."