### PR TITLE
Enable partition : part 1, split down to 8x8 blocks

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -135,7 +135,6 @@ fn write_b_bench(b: &mut Bencher) {
         bc: bc,
     };
 
-    let mode = PredictionMode::DC_PRED;
     let tx_type = TxType::DCT_DCT;
 
     let sbx = 0;
@@ -148,7 +147,9 @@ fn write_b_bench(b: &mut Bencher) {
                 for by in 0..8 {
                     for bx in 0..8 {
                         let bo = sbo.block_offset(bx, by);
-                            write_b(&mut cw, &mut fi, &mut fs, p, &bo, mode, tx_type);
+                            let tx_bo = BlockOffset{x: bo.x + bx, y: bo.y + by};
+                            let po = tx_bo.plane_offset(&fs.input.planes[p].cfg);
+                            encode_tx_block(&mut fi, &mut fs, &mut cw, p, &bo, mode, tx_type, &po);
                     }
                 }
             }

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -13,9 +13,10 @@ fn main() {
         Some(rec_file) => Some(y4m::encode(width, height, framerate).write_header(rec_file).unwrap()),
         None => None
     };
+
     let mut fi = FrameInvariants::new(width, height, files.quantizer);
     let sequence = Sequence::new();
-    write_ivf_header(&mut files.output_file, fi.sb_width*64, fi.sb_height*64, framerate.num, framerate.den);
+    write_ivf_header(&mut files.output_file, fi.padded_w, fi.padded_h, framerate.num, framerate.den);
 
     let mut last_rec: Option<Frame> = None;
     loop {

--- a/src/bin/rav1repl.rs
+++ b/src/bin/rav1repl.rs
@@ -19,7 +19,7 @@ fn main() {
     };
     let mut fi = FrameInvariants::new(width, height, files.quantizer);
     let sequence = Sequence::new();
-    write_ivf_header(&mut files.output_file, fi.sb_width*64, fi.sb_height*64, framerate.num, framerate.den);
+    write_ivf_header(&mut files.output_file, fi.padded_w, fi.padded_h, framerate.num, framerate.den);
 
     let mut rl = Editor::<()>::new();
     let _ = rl.load_history(".rav1e-history");

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -1,18 +1,18 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-#[derive(Copy,Clone,PartialEq)]
+#[derive(Copy,Clone,PartialEq,PartialOrd)]
 pub enum PartitionType {
     PARTITION_NONE,
     PARTITION_HORZ,
     PARTITION_VERT,
     PARTITION_SPLIT,
-    PARTITION_INVALID = 255
+    PARTITION_INVALID
 }
 
 pub const BLOCK_SIZES_ALL: usize = 19;
 
-#[derive(Copy,Clone)]
+#[derive(Copy,Clone,PartialEq,PartialOrd)]
 pub enum BlockSize {
     BLOCK_4X4,
     BLOCK_4X8,
@@ -33,7 +33,7 @@ pub enum BlockSize {
     BLOCK_32X8,
     BLOCK_16X64,
     BLOCK_64X16,
-    BLOCK_INVALID = 255
+    BLOCK_INVALID
 }
 
 pub const TX_SIZES: usize = 4;
@@ -80,7 +80,7 @@ pub enum TxType {
     H_FLIPADST = 15,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
 pub enum PredictionMode {
     DC_PRED,    // Average of above and left pixels
     V_PRED,     // Vertical

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -11,12 +11,20 @@
 #![allow(non_camel_case_types)]
 
 use plane::*;
+use partition::PredictionMode;
+//use std::io::prelude::*;
 
-// Sum of Squared Error for a 64x64 block
-pub fn sse_64x64(src1: &PlaneSlice, src2: &PlaneSlice) -> u64 {
+#[derive(Copy,Clone)]
+pub struct RDOOutput {
+    pub rd_cost: u64,
+    pub pred_mode: PredictionMode,
+}
+
+// Sum of Squared Error for a wxh block
+pub fn sse_wxh(src1: &PlaneSlice, src2: &PlaneSlice, w: usize, h: usize) -> u64 {
     let mut sse: u64 = 0;
-    for j in 0..64 {
-        for i in 0..64 {
+    for j in 0..h {
+        for i in 0..w {
             let dist = (src1.p(i, j) as i16 - src2.p(i, j) as i16) as i64;
             sse += (dist * dist) as u64;
         }


### PR DESCRIPTION
This is part 1 of ongoing work of enabling partition encoding.
Every SuperBlock is partitioned down to 8x8 partitions,
where pre-existing RDO mode decision decides intra modes
(among three, DC_PRED, HORZ_PRED. VERT_PRED) for the 8x8 partition.

If input image size is not multiple of 8 pixels,
the coded image is padded to be multiple of 8 pixels in both width and height.

TEST: subset1 images.

cargo build --bin rav1e --release
rm test.ivf test_rec.y4m test_dec.y4m
./target/release/rav1e /home/yushin/sequences/subset1-y4m/125_-_Québec_-_Pont_de_Québec_de_nuit_-_Septembre_2009.y4m -o test.ivf  -r test_rec.y4m --quantizer 50
./aom_test/aomdec test.ivf -o test_dec.y4m -v
mpv --keep-open test_dec.y4m &
mpv --keep-open test_rec.y4m &

KNOWN ISSUES:
1. If SBs on right and bottom frame borders are encoded by 8x8 partiions
   and other SBs are encoded by 64x64 partition sizes, SBs start to corrupt from
   the last SB row.

TODO:
1. Fix partition down to 4x4 blocks.
2. Fix has_chroma() function.
3  Fix KNOWN ISSUE 1.
4. RDO-based block size decision