### PR TITLE
Try not to save BlockContext

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -528,8 +528,7 @@ impl BlockContext {
 #[derive(Clone)]
 pub struct ContextWriterCheckpoint {
     pub w: ec::WriterCheckpoint,
-    pub fc: CDFContext,
-    pub bc: BlockContext
+    pub fc: CDFContext
 }
 
 pub struct ContextWriter {
@@ -690,14 +689,12 @@ impl ContextWriter {
     pub fn checkpoint(&mut self) -> ContextWriterCheckpoint {
         ContextWriterCheckpoint {
             w: self.w.checkpoint(),
-            fc: self.fc.clone(),
-            bc: self.bc.clone()
+            fc: self.fc.clone()
         }
     }
 
     pub fn rollback(&mut self, checkpoint: ContextWriterCheckpoint) {
         self.w.rollback(&checkpoint.w);
-        self.fc = checkpoint.fc.clone();
-        self.bc = checkpoint.bc.clone();
+        self.fc = checkpoint.fc.clone()
     }
 }


### PR DESCRIPTION
Current checkpoint/rollback saves and restores three pieces of info:
1) States of arithmetic encoder
2) CDFs
3) All of the block contexts in a frame! (Wow.. We didn't mean this...)

So, let's try whether our RDO mode decision (esp. with future
extensions) can survide w/o saving 3).