### PR TITLE
Fix skip mode

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -149,7 +149,8 @@ fn write_b_bench(b: &mut Bencher) {
                         let bo = sbo.block_offset(bx, by);
                             let tx_bo = BlockOffset{x: bo.x + bx, y: bo.y + by};
                             let po = tx_bo.plane_offset(&fs.input.planes[p].cfg);
-                            encode_tx_block(&mut fi, &mut fs, &mut cw, p, &bo, mode, tx_type, &po);
+                            encode_tx_block(&mut fi, &mut fs, &mut cw, p, &bo, mode, 
+                                            tx_type, &po, false);
                     }
                 }
             }

--- a/src/context.rs
+++ b/src/context.rs
@@ -539,7 +539,22 @@ impl BlockContext {
     }
 
     fn skip_context(&mut self, bo: &BlockOffset) -> usize {
-        (self.above_of(bo).skip as usize) + (self.left_of(bo).skip as usize)
+        let above_skip = if bo.y > 0 { self.above_of(bo).skip as usize }
+                         else { 0 };
+        let left_skip = if bo.x > 0 { self.left_of(bo).skip as usize }
+                         else { 0 };
+        above_skip + left_skip
+    }
+
+    pub fn set_skip(&mut self, bo: &BlockOffset, bsize: BlockSize, skip: bool) {
+        let bw = mi_size_wide[bsize as usize];
+        let bh = mi_size_high[bsize as usize];
+
+        for y in 0..bh {
+            for x in 0..bw {
+                self.blocks[bo.y + y as usize][bo.x + x as usize].skip = skip;
+            };
+        }
     }
 }
 


### PR DESCRIPTION
For #131.

Add set_skip() function which sets skip flags of all MI blocks in
a partition block size.