### PR TITLE
Fix set_mode() function

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -493,8 +493,15 @@ impl BlockContext {
         //TODO(anyone): Call reset_left_tx_context() here.
     }
 
-    pub fn set_mode(&mut self, bo: &BlockOffset, mode: PredictionMode) {
-        self.blocks[bo.y][bo.x].mode = mode;
+    pub fn set_mode(&mut self, bo: &BlockOffset, bsize: BlockSize, mode: PredictionMode) {
+        let bw = mi_size_wide[bsize as usize];
+        let bh = mi_size_high[bsize as usize];
+
+        for y in 0..bh {
+            for x in 0..bw {
+              self.blocks[bo.y + y as usize][bo.x + x as usize].mode = mode;
+            };
+        }
     }
 
     pub fn get_mode(&mut self, bo: &BlockOffset) -> PredictionMode {
@@ -518,22 +525,20 @@ impl BlockContext {
     pub fn update_partition_context(&mut self, bo: &BlockOffset,
                                 subsize : BlockSize, bsize: BlockSize) {
 #[allow(dead_code)]
-        // TODO(yushin): If CONFIG_EXT_PARTITION_TYPES is enabled, use bw and bh
-        //let bw = mi_size_wide[bsize as usize];
-        //let bh = mi_size_high[bsize as usize];
-        let bs = mi_size_wide[bsize as usize];
+        let bw = mi_size_wide[bsize as usize];
+        let bh = mi_size_high[bsize as usize];
 
-        let above_ctx = &mut self.above_partition_context[bo.x..bo.x + bs as usize];
-        let left_ctx = &mut self.left_partition_context[bo.y_in_sb()..bo.y_in_sb() + bs as usize];
+        let above_ctx = &mut self.above_partition_context[bo.x..bo.x + bw as usize];
+        let left_ctx = &mut self.left_partition_context[bo.y_in_sb()..bo.y_in_sb() + bh as usize];
 
         // update the partition context at the end notes. set partition bits
         // of block sizes larger than the current one to be one, and partition
         // bits of smaller block sizes to be zero.
-        for i in 0..bs {
+        for i in 0..bw {
             above_ctx[i as usize] = partition_context_lookup[subsize as usize][0];
         }
 
-        for i in 0..bs {
+        for i in 0..bh {
             left_ctx[i as usize] = partition_context_lookup[subsize as usize][1];
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,6 +330,7 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
 
     cw.bc.set_skip(bo, bsize, skip);
     cw.write_skip(bo, skip);
+    cw.bc.set_mode(bo, bsize, mode);
     cw.write_intra_mode_kf(bo, mode);
 
     let xdec = fs.input.planes[1].cfg.xdec;
@@ -355,10 +356,6 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
             for bx in 0..bw {
                 let tx_bo = BlockOffset{x: bo.x + bx, y: bo.y + by};
                 let po = tx_bo.plane_offset(&fs.input.planes[p].cfg);
-                // FIXME(anyone): Another way to do this is
-                // to set mode for each MI block after mode decision is done.
-                // It works now because we set mode for each tx position, where tx_size is 4x4.
-                cw.bc.set_mode(&tx_bo, mode);
                 encode_tx_block(fi, fs, cw, p, &tx_bo, mode, tx_type, &po, skip);
             }
         }
@@ -461,7 +458,7 @@ fn encode_partition(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextW
             let rdo_none = rdo_mode_decision(fi, fs, cw, bsize, bo);
             // FIXME(anyone): Instead of calling set_mode() in encode_block() for each 4x4tx position,
             // it would be better to call set_mode() for each MI block position here.
-            cw.bc.set_mode(bo, rdo_none.pred_mode);
+            cw.bc.set_mode(bo, bsize, rdo_none.pred_mode);
 
             encode_block(fi, fs, cw, rdo_none.pred_mode, bsize, bo);
         },


### PR DESCRIPTION
This patch is for issue: #127.
So that it sets mode for all the MI blocks in block size, not just one MI block.