### PR TITLE
 Enable partition : part 2, split down to 4x4 blocks & Encode exact image frame size

### DIFF
--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -16,7 +16,7 @@ fn main() {
 
     let mut fi = FrameInvariants::new(width, height, files.quantizer);
     let sequence = Sequence::new();
-    write_ivf_header(&mut files.output_file, fi.padded_w, fi.padded_h, framerate.num, framerate.den);
+    write_ivf_header(&mut files.output_file, width, height, framerate.num, framerate.den);
 
     let mut last_rec: Option<Frame> = None;
     loop {


### PR DESCRIPTION
Patch for issues #127 and #37 

Partitioning can split a SuperBlock downto 4x4 block sizes, i.e. the smallest possible size.

Also, now rav1e does not encode padded image frame size such as multiple of 8 pixels but
it can encode original image frame size (even odd size), then libaom decoder,
i.e. aomdec can decode the original image frame size w/o padding!

Also has_chroma() has been verfied working with its target usage, i.e. < BLOCK_8x8.