### PR TITLE
 Basic speed level based on minimum partition block size

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -124,7 +124,7 @@ use rav1e::partition::*;
 use rav1e::ec;
 
 fn write_b_bench(b: &mut Bencher) {
-    let mut fi = FrameInvariants::new(1024, 1024, 100);
+    let mut fi = FrameInvariants::new(1024, 1024, 100, 10);
     let w = ec::Writer::new();
     let fc = CDFContext::new();
     let bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -14,7 +14,7 @@ fn main() {
         None => None
     };
 
-    let mut fi = FrameInvariants::new(width, height, files.quantizer);
+    let mut fi = FrameInvariants::new(width, height, files.quantizer, files.speed);
     let sequence = Sequence::new();
     write_ivf_header(&mut files.output_file, width, height, framerate.num, framerate.den);
 

--- a/src/bin/rav1repl.rs
+++ b/src/bin/rav1repl.rs
@@ -17,7 +17,7 @@ fn main() {
         Some(rec_file) => Some(y4m::encode(width, height, framerate).write_header(rec_file).unwrap()),
         None => None
     };
-    let mut fi = FrameInvariants::new(width, height, files.quantizer);
+    let mut fi = FrameInvariants::new(width, height, files.quantizer, files.speed);
     let sequence = Sequence::new();
     write_ivf_header(&mut files.output_file, fi.padded_w, fi.padded_h, framerate.num, framerate.den);
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,7 +19,7 @@ pub const MI_SIZE_LOG2: usize = 2;
 const MI_SIZE: usize = (1 << MI_SIZE_LOG2);
 const MAX_MIB_SIZE_LOG2: usize = (MAX_SB_SIZE_LOG2 - MI_SIZE_LOG2);
 pub const MAX_MIB_SIZE: usize = (1 << MAX_MIB_SIZE_LOG2);
-const MAX_MIB_MASK: usize = (MAX_MIB_SIZE - 1);
+pub const MAX_MIB_MASK: usize = (MAX_MIB_SIZE - 1);
 
 const MAX_SB_SIZE_LOG2: usize = 6;
 const MAX_SB_SIZE: usize = (1 << MAX_SB_SIZE_LOG2);


### PR DESCRIPTION
This patch is for issue: #140.

Speed level decides the minimum partition block size, where recursive quadri-sect splitting stops at.
0(slowest) : BLOCK_4X4
1 : BLOCK_8X8
2 : BLOCK_16X16
3 : BLOCK_32X32
4~10(fastest) : BLOCK_64X64

Encoder option : "--speed=[0..10]" or "-s [0..10]".

Exception: SuperBlock(SB)s on right or bottom frame borders always split down to BLOCK_4X4.

In the future, min partition block size may be controlled by separate encoder option.