### PR TITLE
Document dependencies required to build rav1e.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ git submodule update --init
 
 This is also required everytime you switch branch or pull code and the submodule changed.
 
+In order to build the codec, you need two libraries: wxWidgets 3.0 and yasm. To install these on Ubuntu or Linux Mint, run:
+
+```
+sudo apt install libwxgtk3.0-dev libwxgtk3.0-0v5-dbg yasm
+```
 
 # Compressing video
 


### PR DESCRIPTION
I decided to try out rav1e this weekend. There were dependencies that I needed to install but weren't explained in the documentation. It's a good idea to note that we need these libraries and how to install them.