### PR TITLE
Fix reconstruction on fresh builds.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -48,6 +48,7 @@ fn main() {
         .define("CONFIG_SIMPLIFY_TX_MODE", "0")
         .define("CONFIG_OBU", "0")
         .define("CONFIG_FILTER_INTRA", "0")
+        .define("CONFIG_EXT_SKIP", "0")
         .define("CONFIG_LV_MAP", "0")
         .define("CONFIG_LV_MAP_MULTI", "0")
         .define("CONFIG_ANALYZER", "0")


### PR DESCRIPTION
The internal cmake build used for CDF tables is "sticky" - it doesn't
track new flags getting turned on by default. This means that changes
will only be discovered when doing a fresh build. In this case,
the EXT_SKIP flag was missed.