### PR TITLE
build.sh: don't error out if distclean target is not available

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ pushd $AOM_TEST
 if [ -f Makefile ]; then
   # Clean if needed
   make clean
-  make distclean
+  make distclean || true
 fi
 echo CONFIGURE COMMAND
 echo $CONFIGURE_CMD


### PR DESCRIPTION
This is an edge case, e.g., when trying to run ./build.sh after an incomplete build.