### PR TITLE
In inter frame, only write intra mode if block is intra

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1755,7 +1755,7 @@ impl ContextWriter {
         let ctx = self.bc.skip_context(bo);
         symbol!(self, skip as u32, &mut self.fc.skip_cdfs[ctx], 2);
     }
-    pub fn write_inter_mode(&mut self, bo: &BlockOffset, is_inter: bool) {
+    pub fn write_is_inter(&mut self, bo: &BlockOffset, is_inter: bool) {
         let ctx = self.bc.intra_inter_context(bo);
         symbol!(self, is_inter as u32, &mut self.fc.intra_inter_cdfs[ctx], 2);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,7 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
     cw.write_skip(bo, skip);
 
     if fi.frame_type == FrameType::INTER {
-        cw.write_inter_mode(bo, is_inter);
+        cw.write_is_inter(bo, is_inter);
         if !is_inter {
             cw.write_intra_mode(bsize, mode);
         }
@@ -516,6 +516,10 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
     }
 
     cw.bc.set_mode(bo, bsize, mode);
+
+    if mode.is_directional() && bsize >= BlockSize::BLOCK_8X8 {
+        cw.write_angle_delta(0, mode);
+    }
 
     let xdec = fs.input.planes[1].cfg.xdec;
     let ydec = fs.input.planes[1].cfg.ydec;
@@ -526,9 +530,6 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
         cw.write_intra_uv_mode(uv_mode, mode, bsize);
     }
 
-    if mode.is_directional() && bsize >= BlockSize::BLOCK_8X8 {
-        cw.write_angle_delta(0, mode);
-    }
     if uv_mode.is_directional() && bsize >= BlockSize::BLOCK_8X8 {
         cw.write_angle_delta(0, uv_mode);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,7 +508,9 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
 
     if fi.frame_type == FrameType::INTER {
         cw.write_inter_mode(bo, is_inter);
-        cw.write_intra_mode(bsize, mode);
+        if !is_inter {
+            cw.write_intra_mode(bsize, mode);
+        }
     } else {
         cw.write_intra_mode_kf(bo, mode);
     }


### PR DESCRIPTION
While looking at #189, I found that inter blocks in inter frames are
still writing an intra mode.  This doesn't get tripped yet as we're
only writing intra frames, but it will soon enough.