### PR TITLE
Add missing Paeth predictor test

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,16 +9,23 @@ use rand::{ChaChaRng, Rng};
 use rav1e::predict::*;
 
 extern {
-    fn highbd_dc_predictor(dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
-                                           bh: libc::c_int, above: *const u16,
-                           left: *const u16, bd: libc::c_int);
-    fn highbd_h_predictor(dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
-                           bh: libc::c_int, above: *const u16,
-                           left: *const u16, bd: libc::c_int);
-    fn highbd_v_predictor(dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+    fn highbd_dc_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
         bh: libc::c_int, above: *const u16,
         left: *const u16, bd: libc::c_int);
-    fn highbd_paeth_predictor(dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+
+    fn highbd_h_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+        bh: libc::c_int, above: *const u16,
+        left: *const u16, bd: libc::c_int);
+
+    fn highbd_v_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+        bh: libc::c_int, above: *const u16,
+        left: *const u16, bd: libc::c_int);
+
+    fn highbd_paeth_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
         bh: libc::c_int, above: *const u16,
         left: *const u16, bd: libc::c_int);
 }
@@ -55,97 +62,97 @@ fn pred_paeth_4x4(output: &mut [u16], stride: usize, above: &[u16], left: &[u16]
 const MAX_ITER: usize = 50000;
 
 fn setup_pred(ra: &mut ChaChaRng) -> (Vec<u16>, Vec<u16>, Vec<u16>) {
-    let o1 = vec![0u16; 32 * 32];
+    let output = vec![0u16; 32 * 32];
     let above: Vec<u16> = (0..32).map(|_| ra.gen()).collect();
     let left: Vec<u16> = (0..32).map(|_| ra.gen()).collect();
 
-    (above, left, o1)
+    (above, left, output)
 }
 
 fn intra_dc_pred_native(b: &mut Bencher) {
     let mut ra = ChaChaRng::new_unseeded();
-    let (above, left, mut o2) = setup_pred(&mut ra);
+    let (above, left, mut output) = setup_pred(&mut ra);
 
     b.iter(|| {
         for _ in 0..MAX_ITER {
-            Block4x4::pred_dc(&mut o2, 32, &above[..4], &left[..4]);
+            Block4x4::pred_dc(&mut output, 32, &above[..4], &left[..4]);
         }
     })
 }
 
 fn intra_dc_pred_aom(b: &mut Bencher) {
     let mut ra = ChaChaRng::new_unseeded();
-    let (above, left, mut o2) = setup_pred(&mut ra);
+    let (above, left, mut output) = setup_pred(&mut ra);
 
     b.iter(|| {
         for _ in 0..MAX_ITER {
-            pred_dc_4x4(&mut o2, 32, &above[..4], &left[..4]);
+            pred_dc_4x4(&mut output, 32, &above[..4], &left[..4]);
         }
     })
 }
 
 fn intra_h_pred_native(b: &mut Bencher) {
     let mut ra = ChaChaRng::new_unseeded();
-    let (_above, left, mut o2) = setup_pred(&mut ra);
+    let (_above, left, mut output) = setup_pred(&mut ra);
 
     b.iter(|| {
         for _ in 0..MAX_ITER {
-            Block4x4::pred_h(&mut o2, 32, &left[..4]);
+            Block4x4::pred_h(&mut output, 32, &left[..4]);
         }
     })
 }
 
 fn intra_h_pred_aom(b: &mut Bencher) {
     let mut ra = ChaChaRng::new_unseeded();
-    let (above, left, mut o2) = setup_pred(&mut ra);
+    let (above, left, mut output) = setup_pred(&mut ra);
 
     b.iter(|| {
         for _ in 0..MAX_ITER {
-            pred_h_4x4(&mut o2, 32, &above[..4], &left[..4]);
+            pred_h_4x4(&mut output, 32, &above[..4], &left[..4]);
         }
     })
 }
 
 fn intra_v_pred_native(b: &mut Bencher) {
     let mut ra = ChaChaRng::new_unseeded();
-    let (above, _left, mut o2) = setup_pred(&mut ra);
+    let (above, _left, mut output) = setup_pred(&mut ra);
 
     b.iter(|| {
         for _ in 0..MAX_ITER {
-            Block4x4::pred_v(&mut o2, 32, &above[..4]);
+            Block4x4::pred_v(&mut output, 32, &above[..4]);
         }
     })
 }
 
 fn intra_v_pred_aom(b: &mut Bencher) {
     let mut ra = ChaChaRng::new_unseeded();
-    let (above, left, mut o2) = setup_pred(&mut ra);
+    let (above, left, mut output) = setup_pred(&mut ra);
 
     b.iter(|| {
         for _ in 0..MAX_ITER {
-            pred_v_4x4(&mut o2, 32, &above[..4], &left[..4]);
+            pred_v_4x4(&mut output, 32, &above[..4], &left[..4]);
         }
     })
 }
 
 fn intra_paeth_pred_native(b: &mut Bencher) {
     let mut ra = ChaChaRng::new_unseeded();
-    let (above, left, mut o2) = setup_pred(&mut ra);
+    let (above, left, mut output) = setup_pred(&mut ra);
 
     b.iter(|| {
         for _ in 0..MAX_ITER {
-            Block4x4::pred_paeth(&mut o2, 32, &above[..4], &left[..4]);
+            Block4x4::pred_paeth(&mut output, 32, &above[..4], &left[..4]);
         }
     })
 }
 
 fn intra_paeth_pred_aom(b: &mut Bencher) {
     let mut ra = ChaChaRng::new_unseeded();
-    let (above, left, mut o2) = setup_pred(&mut ra);
+    let (above, left, mut output) = setup_pred(&mut ra);
 
     b.iter(|| {
         for _ in 0..MAX_ITER {
-            pred_paeth_4x4(&mut o2, 32, &above[..4], &left[..4]);
+            pred_paeth_4x4(&mut output, 32, &above[..4], &left[..4]);
         }
     })
 }

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -6,27 +6,36 @@ pub static RAV1E_INTRA_MODES: &'static [PredictionMode] = &[PredictionMode::DC_P
 
 extern {
     #[cfg(test)]
-    fn highbd_dc_predictor(dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
-                                           bh: libc::c_int, above: *const u16,
-                           left: *const u16, bd: libc::c_int);
-    fn highbd_dc_left_predictor(dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
-                           bh: libc::c_int, above: *const u16,
-                           left: *const u16, bd: libc::c_int);
-    fn highbd_dc_top_predictor(dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
-                           bh: libc::c_int, above: *const u16,
-                           left: *const u16, bd: libc::c_int);
-    #[cfg(test)]
-    fn highbd_h_predictor(dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
-                           bh: libc::c_int, above: *const u16,
-                           left: *const u16, bd: libc::c_int);
+    fn highbd_dc_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+        bh: libc::c_int, above: *const u16,
+        left: *const u16, bd: libc::c_int);
 
-    #[cfg(test)]
-    fn highbd_v_predictor(dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+    fn highbd_dc_left_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+        bh: libc::c_int, above: *const u16,
+        left: *const u16, bd: libc::c_int);
+
+    fn highbd_dc_top_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
         bh: libc::c_int, above: *const u16,
         left: *const u16, bd: libc::c_int);
 
     #[cfg(test)]
-    fn highbd_paeth_predictor(dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+    fn highbd_h_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+        bh: libc::c_int, above: *const u16,
+        left: *const u16, bd: libc::c_int);
+
+    #[cfg(test)]
+    fn highbd_v_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+        bh: libc::c_int, above: *const u16,
+        left: *const u16, bd: libc::c_int);
+
+    #[cfg(test)]
+    fn highbd_paeth_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
         bh: libc::c_int, above: *const u16,
         left: *const u16, bd: libc::c_int);
 }
@@ -290,6 +299,14 @@ pub mod test {
           for v in l[..4].iter() {
             assert_eq!(*v, max12bit);
           }
+        }
+
+        Block4x4::pred_paeth(&mut o, 32, &above[..4], &left[..4]);
+
+        for l in o.chunks(32).take(4) {
+            for v in l[..4].iter() {
+                assert_eq!(*v, max12bit);
+            }
         }
     }
 }


### PR DESCRIPTION
This tests the Paeth predictor as part of the `pred_max()` function.

Some indentation and naming consistency fixes in `predict.rs` and `bench.rs` were added as well. These can be moved to a different PR if preferred.