### PR TITLE
Add smooth predictors and tests

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -28,6 +28,11 @@ extern {
         dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
         bh: libc::c_int, above: *const u16,
         left: *const u16, bd: libc::c_int);
+
+    fn highbd_smooth_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+        bh: libc::c_int, above: *const u16,
+        left: *const u16, bd: libc::c_int);
 }
 
 #[inline(always)]
@@ -56,6 +61,13 @@ fn pred_v_4x4(output: &mut [u16], stride: usize, above: &[u16], left: &[u16]) {
 fn pred_paeth_4x4(output: &mut [u16], stride: usize, above: &[u16], left: &[u16]) {
     unsafe {
         highbd_paeth_predictor(output.as_mut_ptr(), stride as libc::ptrdiff_t, 4, 4, above.as_ptr(), left.as_ptr(), 8);
+    }
+}
+
+#[inline(always)]
+fn pred_smooth_4x4(output: &mut [u16], stride: usize, above: &[u16], left: &[u16]) {
+    unsafe {
+        highbd_smooth_predictor(output.as_mut_ptr(), stride as libc::ptrdiff_t, 4, 4, above.as_ptr(), left.as_ptr(), 8);
     }
 }
 
@@ -157,6 +169,28 @@ fn intra_paeth_pred_aom(b: &mut Bencher) {
     })
 }
 
+fn intra_smooth_pred_native(b: &mut Bencher) {
+    let mut ra = ChaChaRng::new_unseeded();
+    let (above, left, mut output) = setup_pred(&mut ra);
+
+    b.iter(|| {
+        for _ in 0..MAX_ITER {
+            Block4x4::pred_smooth(&mut output, 32, &above[..4], &left[..4], 8);
+        }
+    })
+}
+
+fn intra_smooth_pred_aom(b: &mut Bencher) {
+    let mut ra = ChaChaRng::new_unseeded();
+    let (above, left, mut output) = setup_pred(&mut ra);
+
+    b.iter(|| {
+        for _ in 0..MAX_ITER {
+            pred_smooth_4x4(&mut output, 32, &above[..4], &left[..4]);
+        }
+    })
+}
+
 use rav1e::*;
 use rav1e::context::*;
 use rav1e::partition::*;
@@ -231,5 +265,6 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
 
 benchmark_group!(intra, intra_dc_pred_native, intra_dc_pred_aom,
     intra_h_pred_native, intra_h_pred_aom, intra_v_pred_native,
-    intra_v_pred_aom, intra_paeth_pred_native, intra_paeth_pred_aom);
+    intra_v_pred_aom, intra_paeth_pred_native, intra_paeth_pred_aom,
+    intra_smooth_pred_native, intra_smooth_pred_aom);
 benchmark_main!(intra, write_b);

--- a/src/context.rs
+++ b/src/context.rs
@@ -28,7 +28,7 @@ const MAX_SB_SIZE_LOG2: usize = 6;
 const MAX_SB_SIZE: usize = (1 << MAX_SB_SIZE_LOG2);
 const MAX_SB_SQUARE: usize = (MAX_SB_SIZE * MAX_SB_SIZE);
 
-const MAX_TX_SIZE: usize = 32;
+pub const MAX_TX_SIZE: usize = 32;
 const MAX_TX_SQUARE: usize = MAX_TX_SIZE * MAX_TX_SIZE;
 
 const INTRA_MODES: usize = 13;

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1,10 +1,39 @@
+#![allow(non_upper_case_globals)]
+
 use libc;
 
 use partition::*;
+use context::MAX_TX_SIZE;
 
 pub static RAV1E_INTRA_MODES: &'static [PredictionMode] =
     &[PredictionMode::DC_PRED, PredictionMode::H_PRED, PredictionMode::V_PRED];
 pub static RAV1E_PARTITION_TYPES: &'static [PartitionType] = &[PartitionType::PARTITION_NONE, PartitionType::PARTITION_SPLIT];
+
+// Weights are quadratic from '1' to '1 / block_size', scaled by 2^sm_weight_log2_scale.
+const sm_weight_log2_scale: u8 = 8;
+
+// Smooth predictor weights
+static sm_weight_arrays: [u8; 2 * MAX_TX_SIZE] = [
+    // Unused, because we always offset by bs, which is at least 2.
+    0, 0,
+    // bs = 2
+    255, 128,
+    // bs = 4
+    255, 149, 85, 64,
+    // bs = 8
+    255, 197, 146, 105, 73, 50, 37, 32,
+    // bs = 16
+    255, 225, 196, 170, 145, 123, 102, 84, 68, 54, 43, 33, 26, 20, 17, 16,
+    // bs = 32
+    255, 240, 225, 210, 196, 182, 169, 157, 145, 133, 122, 111, 101, 92, 83, 74,
+    66, 59, 52, 45, 39, 34, 29, 25, 21, 17, 14, 12, 10, 9, 8, 8,
+    // TODO: enable extra weights for TX64X64
+    // bs = 64
+    /*255, 248, 240, 233, 225, 218, 210, 203, 196, 189, 182, 176, 169, 163, 156,
+    150, 144, 138, 133, 127, 121, 116, 111, 106, 101, 96, 91, 86, 82, 77, 73, 69,
+    65, 61, 57, 54, 50, 47, 44, 41, 38, 35, 32, 29, 27, 25, 22, 20, 18, 16, 15,
+    13, 12, 10, 9, 8, 7, 6, 6, 5, 5, 4, 4, 4,*/
+];
 
 extern {
     #[cfg(test)]
@@ -37,6 +66,12 @@ extern {
 
     #[cfg(test)]
     fn highbd_paeth_predictor(
+        dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
+        bh: libc::c_int, above: *const u16,
+        left: *const u16, bd: libc::c_int);
+
+    #[cfg(test)]
+    fn highbd_smooth_predictor(
         dst: *mut u16, stride: libc::ptrdiff_t, bw: libc::c_int,
         bh: libc::c_int, above: *const u16,
         left: *const u16, bd: libc::c_int);
@@ -150,6 +185,53 @@ pub trait Intra: Dim {
             }
         }
     }
+
+    fn pred_smooth(output: &mut [u16], stride: usize, above: &[u16], left: &[u16], bd: u8) {
+        let below_pred = left[Self::H - 1]; // estimated by bottom-left pixel
+        let right_pred = above[Self::W - 1]; // estimated by top-right pixel
+        let sm_weights_w = &sm_weight_arrays[Self::W..];
+        let sm_weights_h = &sm_weight_arrays[Self::H..];
+
+        let log2_scale = 1 + sm_weight_log2_scale;
+        let scale = 1_u16 << sm_weight_log2_scale as u16;
+
+        // Weights sanity checks
+        assert!((sm_weights_w[0] as u16) < scale);
+        assert!((sm_weights_h[0] as u16) < scale);
+        assert!((scale - sm_weights_w[Self::W - 1] as u16) < scale);
+        assert!((scale - sm_weights_h[Self::H - 1] as u16) < scale);
+        assert!(log2_scale < 31); // ensures no overflow when calculating predictor
+
+        for r in 0..Self::H {
+            for c in 0..Self::W {
+                let pixels = [
+                    above[c],
+                    below_pred,
+                    left[r],
+                    right_pred
+                ];
+
+                let weights = [
+                    sm_weights_h[r] as u16,
+                    scale - sm_weights_h[r] as u16,
+                    sm_weights_w[c] as u16,
+                    scale - sm_weights_w[c] as u16
+                ];
+
+                assert!(scale >= (sm_weights_h[r] as u16) && scale >= (sm_weights_w[c] as u16));
+
+                // Sum up weighted pixels
+                let mut this_pred: u32 = weights.iter().zip(pixels.iter())
+                    .map(|(w, p)| (*w as u32) * (*p as u32)).sum();
+                this_pred = (this_pred + (1 << (log2_scale - 1))) >> log2_scale;
+
+                let output_index = r * stride + c;
+
+                // Clamp the output to the correct bit depth
+                output[output_index] = this_pred.max(0).min((1_u32 << bd) - 1) as u16;
+            }
+        }
+    }
 }
 
 impl Intra for Block4x4 {}
@@ -199,6 +281,12 @@ pub mod test {
         }
     }
 
+    pub fn pred_smooth_4x4(output: &mut [u16], stride: usize, above: &[u16], left: &[u16]) {
+        unsafe {
+            highbd_smooth_predictor(output.as_mut_ptr(), stride as libc::ptrdiff_t, 4, 4, above.as_ptr(), left.as_ptr(), 8);
+        }
+    }
+
     fn do_dc_pred(ra: &mut ChaChaRng) -> (Vec<u16>, Vec<u16>) {
         let (above, left, mut o1, mut o2) = setup_pred(ra);
 
@@ -235,6 +323,15 @@ pub mod test {
         (o1, o2)
     }
 
+    fn do_smooth_pred(ra: &mut ChaChaRng) -> (Vec<u16>, Vec<u16>) {
+        let (above, left, mut o1, mut o2) = setup_pred(ra);
+
+        pred_smooth_4x4(&mut o1, 32, &above[..4], &left[..4]);
+        Block4x4::pred_smooth(&mut o2, 32, &above[..4], &left[..4], 8);
+
+        (o1, o2)
+    }
+
     fn assert_same(o2: Vec<u16>) {
         for l in o2.chunks(32).take(4) {
             for v in l[..4].windows(2) {
@@ -257,6 +354,9 @@ pub mod test {
             assert_eq!(o1, o2);
 
             let (o1, o2) = do_paeth_pred(&mut ra);
+            assert_eq!(o1, o2);
+
+            let (o1, o2) = do_smooth_pred(&mut ra);
             assert_eq!(o1, o2);
         }
     }
@@ -304,6 +404,14 @@ pub mod test {
         }
 
         Block4x4::pred_paeth(&mut o, 32, &above[..4], &left[..4]);
+
+        for l in o.chunks(32).take(4) {
+            for v in l[..4].iter() {
+                assert_eq!(*v, max12bit);
+            }
+        }
+
+        Block4x4::pred_smooth(&mut o, 32, &above[..4], &left[..4], 12);
 
         for l in o.chunks(32).take(4) {
             for v in l[..4].iter() {


### PR DESCRIPTION
Smooth predictors require knowledge of bit depth to clamp predictions, so the native function includes the `bd` parameter.