### PR TITLE
build.rs: watch for changes the full aom/ folder

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -67,7 +67,7 @@ fn main() {
     // Manually fix the comment so rustdoc won't try to pick them
     format_write(builder, "tests/aom.rs");
 
-    println!("cargo:rerun-if-changed=aom_build/aom/build");
+    println!("cargo:rerun-if-changed=aom_build/aom/");
 
     cc::Build::new()
         .file("aom_build/aom/aom_dsp/fwd_txfm.c")


### PR DESCRIPTION
The aom/build folder watched before may not change for all changes.

Closes #233