### PR TITLE
context: fix non-reference pattern used to match a reference

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1587,9 +1587,9 @@ struct FieldMap {
 impl FieldMap {
     /// Print the field the address belong to
     fn lookup(&self, addr: usize) {
-        for (name, start, end) in &self.map {
+        for &(name, start, end) in &self.map {
             // eprintln!("{} {} {} val {}", name, start, end, addr);
-            if addr >= *start && addr < *end {
+            if addr >= start && addr < end {
                 eprintln!(" CDF {}", name);
                 eprintln!("");
                 return;


### PR DESCRIPTION
Fixes:
```
error[E0658]: non-reference pattern used to match a reference (see issue #42640)
    --> src/context.rs:1590:13
     |
1590 |         for (name, start, end) in &self.map {
     |             ^^^^^^^^^^^^^^^^^^ help: consider using a reference: `&(name, start, end)`
```