### PR TITLE
Revert "Only allocate coeff buffers up to 32x32."

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,7 +483,7 @@ pub fn encode_tx_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Conte
          1<<tx_size_wide_log2[tx_size as usize],
          1<<tx_size_high_log2[tx_size as usize]);
 
-    let mut coeffs_storage = [0 as i32; 32*32];
+    let mut coeffs_storage = [0 as i32; 64*64];
     let coeffs = &mut coeffs_storage[..tx_size.width()*tx_size.height()];
     forward_transform(&residual, coeffs, 1<<tx_size_wide_log2[tx_size as usize], tx_size, tx_type);
     quantize_in_place(fi.qindex, coeffs, tx_size);
@@ -492,7 +492,7 @@ pub fn encode_tx_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Conte
                             fi.use_reduced_tx_set);
 
     //reconstruct
-    let mut rcoeffs = [0 as i32; 32*32];
+    let mut rcoeffs = [0 as i32; 64*64];
     dequantize(fi.qindex, &coeffs, &mut rcoeffs, tx_size);
 
     inverse_transform_add(&mut rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type);


### PR DESCRIPTION
This reverts commit 6f61d4c0382fc45cdd034ce66950735095bb2c7f.

For 64x64 TX, forward_transform() still needs 64x64 coefficients buffer
as input and inverse_transform_add() needs 64x64 coefficients buffer as
output. This is because forward_transform() and inverse_transform_add()
do packing and unpacking to/from upper left 32x32 coefficients area
inside themselves.

So, after calling 64x64 fwd tx, the output has first 1/4 area filled in
64x64 buffer. The level map encoder can encode maximum 32x32
coefficients thus it only encodes first 32z32 coefficnets in the buffer
for the 64x64 tx block.

Instead, what we can reduce is the buffer inside level map encoder,
from 64x64 down to 32x32, as I commited in libaom codebase,
https://aomedia.googlesource.com/aom/+/4f347987bb14b6bdc10a121659e5608731e71e02.
That I can commit soon.