### PR TITLE
Add rouding to quantization process

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,7 +611,7 @@ fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState,
     let q0 = q / 8.0_f64;	// Convert q into Q0 precision, given thatn libaom quantizers are Q3.
 
     // Lambda formula from doc/theoretical_results.lyx in the daala repo
-    let lambda = q0*q0*2.0_f64.ln()/6.0;	// Use Q0 quantizer since lambda will be applied to Q0 pixel domain
+    let lambda = q0*q0*2.0_f64.log2()/6.0;	// Use Q0 quantizer since lambda will be applied to Q0 pixel domain
 
     let mut best_mode = PredictionMode::DC_PRED;
     let mut best_rd = std::f64::MAX;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,7 +611,7 @@ fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState,
     let q0 = q / 8.0_f64;	// Convert q into Q0 precision, given thatn libaom quantizers are Q3.
 
     // Lambda formula from doc/theoretical_results.lyx in the daala repo
-    let lambda = q0*q0*2.0_f64.log2()/6.0;	// Use Q0 quantizer since lambda will be applied to Q0 pixel domain
+    let lambda = q0*q0*2.0_f64.ln()/6.0;	// Use Q0 quantizer since lambda will be applied to Q0 pixel domain
 
     let mut best_mode = PredictionMode::DC_PRED;
     let mut best_rd = std::f64::MAX;

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -22,12 +22,18 @@ pub fn quantize_in_place(qindex: usize, coeffs: &mut [i32], tx_size: TxSize) {
         TxSize::TX_32X32 => 2,
         _ => 1
     };
-    coeffs[0] *= tx_scale;
-    coeffs[0] /= dc_q(qindex) as i32;
+    let dc_quant = dc_q(qindex) as i32;
     let ac_quant = ac_q(qindex) as i32;
+    // using 21/64=0.328125 as rounding offset. To be tuned
+    let dc_offset = dc_quant * 21 / 64 as i32;
+    let ac_offset = ac_quant * 21 / 64 as i32;
+    coeffs[0] *= tx_scale;
+    coeffs[0] += coeffs[0].signum() * dc_offset;
+    coeffs[0] /= dc_quant;
 
     for c in coeffs[1..].iter_mut() {
         *c *= tx_scale;
+        *c += c.signum() * ac_offset;
         *c /= ac_quant;
     }
     // workaround for bug in token coder


### PR DESCRIPTION
A rounding offset of 21/64 is added to reduce
reconstruction error