### PR TITLE
Support encoding of smooth prediction modes

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -161,13 +161,11 @@ impl PredictionMode {
         let x = dst.x;
         let y = dst.y;
 
-        if (self == &PredictionMode::V_PRED ||
-            self == &PredictionMode::DC_PRED) && y != 0 {
+        if self != &PredictionMode::H_PRED && y != 0 {
             above.copy_from_slice(&dst.go_up(1).as_slice()[..B::W]);
         }
 
-        if (self == &PredictionMode::H_PRED ||
-            self == &PredictionMode::DC_PRED) && x != 0 {
+        if self != &PredictionMode::V_PRED && x != 0 {
             let left_slice = dst.go_left(1);
             for i in 0..B::H {
                 left[i] = left_slice.p(0, i);
@@ -187,6 +185,10 @@ impl PredictionMode {
             },
             PredictionMode::H_PRED => B::pred_h(slice, stride, left),
             PredictionMode::V_PRED => B::pred_v(slice, stride, above),
+            PredictionMode::PAETH_PRED => B::pred_paeth(slice, stride, above, left),
+            PredictionMode::SMOOTH_PRED => B::pred_smooth(slice, stride, above, left, 8),
+            PredictionMode::SMOOTH_H_PRED => B::pred_smooth_h(slice, stride, above, left, 8),
+            PredictionMode::SMOOTH_V_PRED => B::pred_smooth_v(slice, stride, above, left, 8),
             _ => unimplemented!(),
         }
     }

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -6,9 +6,19 @@ use std::mem::*;
 use partition::*;
 use context::MAX_TX_SIZE;
 
-pub static RAV1E_INTRA_MODES: &'static [PredictionMode] =
-    &[PredictionMode::DC_PRED, PredictionMode::H_PRED, PredictionMode::V_PRED];
-pub static RAV1E_PARTITION_TYPES: &'static [PartitionType] = &[PartitionType::PARTITION_NONE, PartitionType::PARTITION_SPLIT];
+pub static RAV1E_INTRA_MODES: &'static [PredictionMode] = &[
+    PredictionMode::DC_PRED,
+    PredictionMode::H_PRED,
+    PredictionMode::V_PRED,
+    PredictionMode::SMOOTH_PRED,
+    PredictionMode::SMOOTH_H_PRED,
+    PredictionMode::SMOOTH_V_PRED
+];
+
+pub static RAV1E_PARTITION_TYPES: &'static [PartitionType] = &[
+    PartitionType::PARTITION_NONE,
+    PartitionType::PARTITION_SPLIT
+];
 
 // Weights are quadratic from '1' to '1 / block_size', scaled by 2^sm_weight_log2_scale.
 const sm_weight_log2_scale: u8 = 8;


### PR DESCRIPTION
At s=0, with exhaustive partitioning:

```
bup@2018-06-14T23:26:50.801Z -> smooth@2018-06-15T19:42:21.397Z

   PSNR |  PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000
-0.1549 | -11.2290 |     N/A |   2.0102 | 1.0432 |  2.2848 |    -6.1379
```