### PR TITLE
Set proper size for intra reference sample buffers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -65,7 +65,7 @@ DEC_FILE="dec_file.y4m"
 export RUST_BACKTRACE=1
 
 # Build and run encoder
-cargo run --bin rav1e --release -- $SEQ -o $ENC_FILE -s 2
+cargo run --bin rav1e --release -- $SEQ -o $ENC_FILE -s 3
 
 # Decode
 ${AOM_TEST}/aomdec $ENC_FILE -o $DEC_FILE

--- a/src/context.rs
+++ b/src/context.rs
@@ -2157,7 +2157,7 @@ impl ContextWriter {
         }
     }
 
-    pub fn rollback(&mut self, checkpoint: ContextWriterCheckpoint) {
+    pub fn rollback(&mut self, checkpoint: &ContextWriterCheckpoint) {
         self.w.rollback(&checkpoint.w);
         self.fc = checkpoint.fc.clone();
         self.bc.rollback(&checkpoint.bc);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -640,7 +640,7 @@ fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState,
             best_mode = mode;
         }
 
-        cw.rollback(checkpoint.clone());
+        cw.rollback(&checkpoint);
     }
 
     assert!(best_rd >= 0_f64);
@@ -722,7 +722,7 @@ fn rdo_partition_decision(fi: &FrameInvariants, fs: &mut FrameState,
             best_pred_modes = child_modes.clone();
         }
 
-        cw.rollback(checkpoint.clone());
+        cw.rollback(&checkpoint);
     }
 
     assert!(best_rd >= 0_f64);
@@ -780,7 +780,7 @@ bsize: BlockSize, bo: &BlockOffset) -> f64 {
 
     // Code a split partition and compare RD costs
     if is_splittable {
-        cw.rollback(checkpoint.clone());
+        cw.rollback(&checkpoint);
 
         partition = PartitionType::PARTITION_SPLIT;
         subsize = get_subsize(bsize, partition);
@@ -798,7 +798,7 @@ bsize: BlockSize, bo: &BlockOffset) -> f64 {
 
         // Recode the full block if it is more efficient
         if is_codable && nosplit_rd_cost < rd_cost {
-            cw.rollback(checkpoint.clone());
+            cw.rollback(&checkpoint);
 
             partition = PartitionType::PARTITION_NONE;
 
@@ -814,7 +814,7 @@ bsize: BlockSize, bo: &BlockOffset) -> f64 {
     }
 
     subsize = get_subsize(bsize, partition);
-    
+
     if bsize >= BlockSize::BLOCK_8X8 &&
         (bsize == BlockSize::BLOCK_8X8 || partition != PartitionType::PARTITION_SPLIT) {
         cw.bc.update_partition_context(bo, subsize, bsize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -973,7 +973,10 @@ pub fn process_frame(sequence: &Sequence, fi: &FrameInvariants,
     let y4m_bytes = y4m_dec.get_bytes_per_sample();
     let csp = y4m_dec.get_colorspace();
     match csp {
-        y4m::Colorspace::C420 => {},
+        y4m::Colorspace::C420 | 
+        y4m::Colorspace::C420jpeg |
+        y4m::Colorspace::C420paldv | 
+        y4m::Colorspace::C420mpeg2 => {},
         _ => {
             panic!("Colorspace {:?} is not supported yet.", csp);
         },

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -161,13 +161,11 @@ impl PredictionMode {
         let x = dst.x;
         let y = dst.y;
 
-        if (self == &PredictionMode::V_PRED ||
-            self == &PredictionMode::DC_PRED) && y != 0 {
+        if self != &PredictionMode::H_PRED && y != 0 {
             above.copy_from_slice(&dst.go_up(1).as_slice()[..B::W]);
         }
 
-        if (self == &PredictionMode::H_PRED ||
-            self == &PredictionMode::DC_PRED) && x != 0 {
+        if self != &PredictionMode::V_PRED && x != 0 {
             let left_slice = dst.go_left(1);
             for i in 0..B::H {
                 left[i] = left_slice.p(0, i);
@@ -187,6 +185,10 @@ impl PredictionMode {
             },
             PredictionMode::H_PRED => B::pred_h(slice, stride, left),
             PredictionMode::V_PRED => B::pred_v(slice, stride, above),
+            PredictionMode::PAETH_PRED => B::pred_paeth(slice, stride, above, left),
+            PredictionMode::SMOOTH_PRED => B::pred_smooth(slice, stride, above, left, 8),
+            PredictionMode::SMOOTH_H_PRED => B::pred_smooth_h(slice, stride, above, left, 8),
+            PredictionMode::SMOOTH_V_PRED => B::pred_smooth_v(slice, stride, above, left, 8),
             _ => unimplemented!(),
         }
     }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -155,20 +155,23 @@ impl PredictionMode {
 
     #[inline(always)]
     fn predict_inner<'a, B: Intra>(&self, dst: &'a mut PlaneMutSlice<'a>) {
-        let above = &mut [127u16; 64][..B::W];
-        let left = &mut [129u16; 64][..B::H];
+        // above and left arrays include above-left sample
+        // above array includes above-right samples
+        // left array includes below-left samples
+        let above = &mut [127u16; 2*MAX_TX_SIZE+1][..B::W+B::H+1];
+        let left = &mut [129u16; 2*MAX_TX_SIZE+1][..B::H+B::W+1];
         let stride = dst.plane.cfg.stride;
         let x = dst.x;
         let y = dst.y;
 
         if self != &PredictionMode::H_PRED && y != 0 {
-            above.copy_from_slice(&dst.go_up(1).as_slice()[..B::W]);
+            above[1..B::W+1].copy_from_slice(&dst.go_up(1).as_slice()[..B::W]);
         }
 
         if self != &PredictionMode::V_PRED && x != 0 {
             let left_slice = dst.go_left(1);
             for i in 0..B::H {
-                left[i] = left_slice.p(0, i);
+                left[i+1] = left_slice.p(0, i);
             }
         }
 
@@ -178,17 +181,17 @@ impl PredictionMode {
             PredictionMode::DC_PRED => {
                 match (x, y) {
                     (0, 0) => B::pred_dc_128(slice, stride),
-                    (_, 0) => B::pred_dc_left(slice, stride, above, left),
-                    (0, _) => B::pred_dc_top(slice, stride, above, left),
-                    _ => B::pred_dc(slice, stride, above, left),
+                    (_, 0) => B::pred_dc_left(slice, stride, &above[1..B::W+1], &left[1..B::H+1]),
+                    (0, _) => B::pred_dc_top(slice, stride, &above[1..B::W+1], &left[1..B::H+1]),
+                    _ => B::pred_dc(slice, stride, &above[1..B::W+1], &left[1..B::H+1]),
                 }
             },
-            PredictionMode::H_PRED => B::pred_h(slice, stride, left),
-            PredictionMode::V_PRED => B::pred_v(slice, stride, above),
-            PredictionMode::PAETH_PRED => B::pred_paeth(slice, stride, above, left),
-            PredictionMode::SMOOTH_PRED => B::pred_smooth(slice, stride, above, left, 8),
-            PredictionMode::SMOOTH_H_PRED => B::pred_smooth_h(slice, stride, above, left, 8),
-            PredictionMode::SMOOTH_V_PRED => B::pred_smooth_v(slice, stride, above, left, 8),
+            PredictionMode::H_PRED => B::pred_h(slice, stride, &left[1..B::H+1]),
+            PredictionMode::V_PRED => B::pred_v(slice, stride, &above[1..B::W+1]),
+            PredictionMode::PAETH_PRED => B::pred_paeth(slice, stride, &above[1..B::W+1], &left[1..B::H+1]),
+            PredictionMode::SMOOTH_PRED => B::pred_smooth(slice, stride, &above[1..B::W+1], &left[1..B::H+1], 8),
+            PredictionMode::SMOOTH_H_PRED => B::pred_smooth_h(slice, stride, &above[1..B::W+1], &left[1..B::H+1], 8),
+            PredictionMode::SMOOTH_V_PRED => B::pred_smooth_v(slice, stride, &above[1..B::W+1], &left[1..B::H+1], 8),
             _ => unimplemented!(),
         }
     }

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -6,9 +6,19 @@ use std::mem::*;
 use partition::*;
 use context::MAX_TX_SIZE;
 
-pub static RAV1E_INTRA_MODES: &'static [PredictionMode] =
-    &[PredictionMode::DC_PRED, PredictionMode::H_PRED, PredictionMode::V_PRED];
-pub static RAV1E_PARTITION_TYPES: &'static [PartitionType] = &[PartitionType::PARTITION_NONE, PartitionType::PARTITION_SPLIT];
+pub static RAV1E_INTRA_MODES: &'static [PredictionMode] = &[
+    PredictionMode::DC_PRED,
+    PredictionMode::H_PRED,
+    PredictionMode::V_PRED,
+    PredictionMode::SMOOTH_PRED,
+    PredictionMode::SMOOTH_H_PRED,
+    PredictionMode::SMOOTH_V_PRED
+];
+
+pub static RAV1E_PARTITION_TYPES: &'static [PartitionType] = &[
+    PartitionType::PARTITION_NONE,
+    PartitionType::PARTITION_SPLIT
+];
 
 // Weights are quadratic from '1' to '1 / block_size', scaled by 2^sm_weight_log2_scale.
 const sm_weight_log2_scale: u8 = 8;


### PR DESCRIPTION
Increase size for intra reference sample buffers to include
above-left, above-right and below-left samples. Make size a
function of the maximum supported transform size.