### PR TITLE
Clean up and refactor RDO-related areas

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,9 @@ echo $ACTUAL_VERSION > $GITHASH
 # Update aombuild
 git submodule update --init
 
+# Clean project files
+cargo clean
+
 # Get configure command from readme
 CONFIGURE_CMD=$(fgrep cmake README.md)
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -2016,10 +2016,6 @@ impl ContextWriter {
           }
         }
 
-        if plane == 0 && eob == 0 {
-            assert!(tx_type == TxType::DCT_DCT);
-        }
-
         let txs_ctx = self.get_txsize_entropy_ctx(tx_size);
         let txb_ctx = self.bc.get_txb_ctx(plane_bsize, tx_size, plane, bo, xdec, ydec);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -717,7 +717,11 @@ fn encode_partition_topdown(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut 
     }
 
     let bs = mi_size_wide[bsize as usize];
-    let must_split = bo.x + bs as usize > fi.w_in_b || bo.y + bs as usize > fi.h_in_b;
+
+    // Always split if the current partition is too large
+    let must_split = bo.x + bs as usize > fi.w_in_b ||
+        bo.y + bs as usize > fi.h_in_b ||
+        bsize >= BlockSize::BLOCK_64X64;
 
     let mut rdo_output = block_output.clone().unwrap_or(RDOOutput {
         part_type: PartitionType::PARTITION_INVALID,
@@ -727,10 +731,7 @@ fn encode_partition_topdown(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut 
     let partition: PartitionType;
 
     if must_split {
-        // SBs on right or bottom frame borders split down to the maximum possible size
-        partition = PartitionType::PARTITION_SPLIT;
-    } else if bsize >= BlockSize::BLOCK_64X64 {
-        // Blocks of sizes above the supported range are automatically split
+        // Oversized blocks are split automatically
         partition = PartitionType::PARTITION_SPLIT;
     } else if bsize > fi.min_partition_size {
         // Blocks of sizes within the supported range are subjected to a partitioning decision

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -147,6 +147,19 @@ pub enum PredictionMode {
     NEW_NEWMV,
 }
 
+pub static RAV1E_PARTITION_TYPES: &'static [PartitionType] = &[
+    PartitionType::PARTITION_NONE,
+    PartitionType::PARTITION_SPLIT
+];
+
+pub static RAV1E_INTRA_TX_TYPES: &'static [TxType] = &[
+    TxType::DCT_DCT,
+    TxType::ADST_DCT,
+    TxType::DCT_ADST,
+    TxType::ADST_ADST,
+    TxType::IDTX
+];
+
 use plane::*;
 use predict::*;
 use context::*;

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -24,11 +24,6 @@ pub static RAV1E_INTRA_MODES: &'static [PredictionMode] = &[
     PredictionMode::SMOOTH_V_PRED
 ];
 
-pub static RAV1E_PARTITION_TYPES: &'static [PartitionType] = &[
-    PartitionType::PARTITION_NONE,
-    PartitionType::PARTITION_SPLIT
-];
-
 // Weights are quadratic from '1' to '1 / block_size', scaled by 2^sm_weight_log2_scale.
 const sm_weight_log2_scale: u8 = 8;
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -10,12 +10,19 @@
 
 #![allow(non_camel_case_types)]
 
-use context::BlockOffset;
+use BlockSize;
+use FrameInvariants;
+use FrameState;
+use FrameType;
+use encode_block;
+use ec::OD_BITRES;
+use context::*;
+use partition::*;
+use quantize::dc_q;
 use plane::*;
-use partition::PredictionMode;
-use partition::PartitionType;
+use predict::RAV1E_INTRA_MODES;
+use std;
 use std::vec::Vec;
-//use std::io::prelude::*;
 
 #[derive(Clone)]
 pub struct RDOOutput {
@@ -32,7 +39,7 @@ pub struct RDOPartitionOutput {
 }
 
 // Sum of Squared Error for a wxh block
-pub fn sse_wxh(src1: &PlaneSlice, src2: &PlaneSlice, w: usize, h: usize) -> u64 {
+fn sse_wxh(src1: &PlaneSlice, src2: &PlaneSlice, w: usize, h: usize) -> u64 {
     let mut sse: u64 = 0;
     for j in 0..h {
         for i in 0..w {
@@ -41,4 +48,183 @@ pub fn sse_wxh(src1: &PlaneSlice, src2: &PlaneSlice, w: usize, h: usize) -> u64 
         }
     }
     sse
+}
+
+// Compute the rate-distortion cost for an encode
+fn compute_rd_cost(fi: &FrameInvariants, fs: &FrameState,
+                   w_y: u8, h_y: u8, w_uv: u8, h_uv: u8,
+                   partition_start_x: usize, partition_start_y: usize,
+                   bo: &BlockOffset, bit_cost: u32) -> f64 {
+    let q = dc_q(fi.qindex) as f64;
+
+    // Convert q into Q0 precision, given that libaom quantizers are Q3
+    let q0 = q / 8.0_f64;
+
+    // Lambda formula from doc/theoretical_results.lyx in the daala repo
+    // Use Q0 quantizer since lambda will be applied to Q0 pixel domain
+    let lambda = q0 * q0 * std::f64::consts::LN_2 / 6.0;
+
+    // Compute distortion
+    let po = bo.plane_offset(&fs.input.planes[0].cfg);
+    let mut distortion = sse_wxh(&fs.input.planes[0].slice(&po),
+                                 &fs.rec.planes[0].slice(&po),
+                                 w_y as usize, h_y as usize);
+
+    // Add chroma distortion only when it is available
+    if w_uv > 0 && h_uv > 0 {
+        for p in 1..3 {
+            let sb_offset = bo.sb_offset().plane_offset(&fs.input.planes[p].cfg);
+            let po = PlaneOffset {
+                x: sb_offset.x + partition_start_x,
+                y: sb_offset.y + partition_start_y
+            };
+
+            distortion += sse_wxh(&fs.input.planes[p].slice(&po),
+                                  &fs.rec.planes[p].slice(&po),
+                                  w_uv as usize, h_uv as usize);
+        }
+    };
+
+    // Compute rate
+    let rate = (bit_cost as f64) / ((1 << OD_BITRES) as f64);
+
+    let rd_cost = (distortion as f64) + lambda * rate;
+
+    rd_cost
+}
+
+// RDO-based mode decision
+pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
+                         bsize: BlockSize, bo: &BlockOffset) -> RDOOutput {
+    let mut best_mode = PredictionMode::DC_PRED;
+    let mut best_rd = std::f64::MAX;
+    let tell = cw.w.tell_frac();
+
+    // Get block luma and chroma dimensions
+    let w = block_size_wide[bsize as usize];
+    let h = block_size_high[bsize as usize];
+
+    let xdec = fs.input.planes[1].cfg.xdec;
+    let ydec = fs.input.planes[1].cfg.ydec;
+    let mut w_uv = w >> xdec;
+    let mut h_uv = h >> ydec;
+
+    if (w_uv == 0 || h_uv == 0) && has_chroma(bo, bsize, xdec, ydec) {
+        w_uv = 4;
+        h_uv = 4;
+    }
+
+    let partition_start_x = (bo.x & LOCAL_BLOCK_MASK) >> xdec << MI_SIZE_LOG2;
+    let partition_start_y = (bo.y & LOCAL_BLOCK_MASK) >> ydec << MI_SIZE_LOG2;
+
+    for &mode in RAV1E_INTRA_MODES {
+        if fi.frame_type == FrameType::KEY && mode >= PredictionMode::NEARESTMV {
+            break;
+        }
+
+        let checkpoint = cw.checkpoint();
+
+        encode_block(fi, fs, cw, mode, bsize, bo);
+
+        let cost = cw.w.tell_frac() - tell;
+        let rd = compute_rd_cost(fi, fs, w, h, w_uv, h_uv,
+                                 partition_start_x, partition_start_y, bo, cost);
+
+        if rd < best_rd {
+            best_rd = rd;
+            best_mode = mode;
+        }
+
+        cw.rollback(&checkpoint);
+    }
+
+    assert!(best_rd >= 0_f64);
+
+    let rdo_output = RDOOutput {
+        rd_cost: best_rd,
+        part_type: PartitionType::PARTITION_NONE,
+        part_modes: vec![RDOPartitionOutput { bo: bo.clone(), pred_mode: best_mode, rd_cost: best_rd }]
+    };
+
+    rdo_output
+}
+
+// RDO-based single level partitioning decision
+pub fn rdo_partition_decision(fi: &FrameInvariants, fs: &mut FrameState,
+                          cw: &mut ContextWriter, bsize: BlockSize, bo: &BlockOffset,
+                          cached_block: &RDOOutput) -> RDOOutput {
+    let max_rd = std::f64::MAX;
+
+    let mut best_partition = cached_block.part_type;
+    let mut best_rd = cached_block.rd_cost;
+    let mut best_pred_modes = cached_block.part_modes.clone();
+
+    for &partition in RAV1E_PARTITION_TYPES {
+        // Do not re-encode results we already have
+        if partition == cached_block.part_type && cached_block.rd_cost < max_rd {
+            continue;
+        }
+
+        let checkpoint = cw.checkpoint();
+
+        let mut rd: f64;
+        let mut child_modes = std::vec::Vec::new();
+
+        match partition {
+            PartitionType::PARTITION_NONE => {
+                if bsize > BlockSize::BLOCK_32X32 {
+                    continue;
+                }
+
+                let mode_decision = cached_block.part_modes.get(0)
+                    .unwrap_or(&rdo_mode_decision(fi, fs, cw, bsize, bo).part_modes[0]).clone();
+                child_modes.push(mode_decision);
+            },
+            PartitionType::PARTITION_SPLIT => {
+                let subsize = get_subsize(bsize, partition);
+
+                if subsize == BlockSize::BLOCK_INVALID {
+                    continue;
+                }
+
+                let bs = mi_size_wide[bsize as usize];
+                let hbs = bs >> 1; // Half the block size in blocks
+
+                let offset = BlockOffset { x: bo.x, y: bo.y };
+                let mode_decision = rdo_mode_decision(fi, fs, cw, subsize, &offset).part_modes[0].clone();
+                child_modes.push(mode_decision);
+
+                let offset = BlockOffset { x: bo.x + hbs as usize, y: bo.y };
+                let mode_decision = rdo_mode_decision(fi, fs, cw, subsize, &offset).part_modes[0].clone();
+                child_modes.push(mode_decision);
+
+                let offset = BlockOffset { x: bo.x, y: bo.y + hbs as usize };
+                let mode_decision = rdo_mode_decision(fi, fs, cw, subsize, &offset).part_modes[0].clone();
+                child_modes.push(mode_decision);
+
+                let offset = BlockOffset { x: bo.x + hbs as usize, y: bo.y + hbs as usize };
+                let mode_decision = rdo_mode_decision(fi, fs, cw, subsize, &offset).part_modes[0].clone();
+                child_modes.push(mode_decision);
+            },
+            _ => { assert!(false); },
+        }
+
+        rd = child_modes.iter().map(|m| m.rd_cost).sum::<f64>();
+
+        if rd < best_rd {
+            best_rd = rd;
+            best_partition = partition;
+            best_pred_modes = child_modes.clone();
+        }
+
+        cw.rollback(&checkpoint);
+    }
+
+    assert!(best_rd >= 0_f64);
+
+    let rdo_output = RDOOutput { rd_cost: best_rd,
+        part_type: best_partition,
+        part_modes: best_pred_modes };
+
+    rdo_output
 }


### PR DESCRIPTION
* Force a `cargo clean` when the submodule is out of date, as it can be necessary to link correctly  
* Remove assertion to support additional (non-DCT) transform types (as part of #267)  
* Rename some variables, simplify some operations
* Move `RAV1E_PARTITION_TYPES` to `partition.rs` (from `predict.rs`)
* Move RDO decision functions to `rdo.rs`
* Extract rate-distortion cost computation to a new function