### PR TITLE
Add Paeth to the list of supported prediction modes

### DIFF
--- a/src/predict.rs
+++ b/src/predict.rs
@@ -21,7 +21,8 @@ pub static RAV1E_INTRA_MODES: &'static [PredictionMode] = &[
     PredictionMode::V_PRED,
     PredictionMode::SMOOTH_PRED,
     PredictionMode::SMOOTH_H_PRED,
-    PredictionMode::SMOOTH_V_PRED
+    PredictionMode::SMOOTH_V_PRED,
+    PredictionMode::PAETH_PRED
 ];
 
 // Weights are quadratic from '1' to '1 / block_size', scaled by 2^sm_weight_log2_scale.


### PR DESCRIPTION
Oops.

```
nopaeth@2018-06-21T09:29:47.514Z -> paeth@2018-06-21T09:28:52.893Z

   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-0.0962 | -0.4074 | -0.3002 |   0.0372 | -0.1525 | -0.0627 |    -0.0307
```