### PR TITLE
Enable identity transform for sizes 16x16 and below

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,7 +505,7 @@ pub fn encode_tx_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Conte
     cw.write_coeffs_lv_map(p, bo, &coeffs, tx_size, tx_type, plane_bsize, xdec, ydec,
                             fi.use_reduced_tx_set);
 
-    //reconstruct
+    // Reconstruct
     dequantize(fi.qindex, &coeffs, &mut rcoeffs, tx_size);
 
     inverse_transform_add(&mut rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type);
@@ -558,7 +558,7 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
         cw.bc.reset_skip_context(bo, bsize, xdec, ydec);
     }
 
-    let tx_type = if tx_size > TxSize::TX_32X32 {
+    let tx_type = if tx_size >= TxSize::TX_32X32 {
         TxType::DCT_DCT
     } else {
         // FIXME: there is one redundant transform type decision per encoded block

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,7 +558,7 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
         cw.bc.reset_skip_context(bo, bsize, xdec, ydec);
     }
 
-    let tx_type = if tx_size >= TxSize::TX_32X32 {
+    let tx_type = if tx_size > TxSize::TX_32X32 {
         TxType::DCT_DCT
     } else {
         // FIXME: there is one redundant transform type decision per encoded block

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -156,7 +156,8 @@ pub static RAV1E_INTRA_TX_TYPES: &'static [TxType] = &[
     TxType::DCT_DCT,
     TxType::ADST_DCT,
     TxType::DCT_ADST,
-    TxType::ADST_ADST
+    TxType::ADST_ADST,
+    TxType::IDTX
 ];
 
 use plane::*;

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -14,6 +14,16 @@ extern {
     static ac_qlookup_Q3: [i16; 256];
 }
 
+fn get_tx_scale(tx_size: TxSize) -> u8 {
+    let tx_scale = match tx_size {
+        TxSize::TX_64X64 => 4,
+        TxSize::TX_32X32 => 2,
+        _ => 1
+    };
+
+    tx_scale
+}
+
 pub fn dc_q(qindex: usize) -> i16 {
     unsafe {
         dc_qlookup_Q3[qindex]
@@ -27,15 +37,15 @@ pub fn ac_q(qindex: usize) -> i16 {
 }
 
 pub fn quantize_in_place(qindex: usize, coeffs: &mut [i32], tx_size: TxSize) {
-    let tx_scale = match tx_size {
-        TxSize::TX_32X32 => 2,
-        _ => 1
-    };
+    let tx_scale = get_tx_scale(tx_size) as i32;
+
     let dc_quant = dc_q(qindex) as i32;
     let ac_quant = ac_q(qindex) as i32;
+
     // using 21/64=0.328125 as rounding offset. To be tuned
     let dc_offset = dc_quant * 21 / 64 as i32;
     let ac_offset = ac_quant * 21 / 64 as i32;
+
     coeffs[0] *= tx_scale;
     coeffs[0] += coeffs[0].signum() * dc_offset;
     coeffs[0] /= dc_quant;
@@ -45,15 +55,11 @@ pub fn quantize_in_place(qindex: usize, coeffs: &mut [i32], tx_size: TxSize) {
         *c += c.signum() * ac_offset;
         *c /= ac_quant;
     }
-    // workaround for bug in token coder
-    *coeffs.last_mut().unwrap() = 0;
 }
 
 pub fn dequantize(qindex:usize, coeffs: &[i32], rcoeffs: &mut [i32], tx_size: TxSize) {
-    let tx_scale = match tx_size {
-        TxSize::TX_32X32 => 2,
-        _ => 1
-    };
+    let tx_scale = get_tx_scale(tx_size) as i32;
+
     rcoeffs[0] = (coeffs[0] * dc_q(qindex) as i32) / tx_scale;
     let ac_quant = ac_q(qindex) as i32;
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -176,6 +176,10 @@ pub fn rdo_tx_type_decision(fi: &FrameInvariants, fs: &mut FrameState,
     let partition_start_y = (bo.y & LOCAL_BLOCK_MASK) >> ydec << MI_SIZE_LOG2;
 
     for &tx_type in RAV1E_INTRA_TX_TYPES {
+        if tx_type == TxType::IDTX && tx_size >= TxSize::TX_32X32 {
+            continue;
+        }
+
         let checkpoint = cw.checkpoint();
 
         write_tx_blocks(fi, fs, cw, mode, bo, bsize, tx_size, tx_type, false);


### PR DESCRIPTION
```
txtype@2018-06-21T09:57:19.682Z -> idtx_max16x16@2018-06-23T00:13:43.743Z

   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-0.7795 |  1.3157 |  1.0336 |   0.7239 | -0.1461 |  0.6128 |    -0.0174
```
Encoding time (Q80): 32.739 -> 37.841