### PR TITLE
Properly handle transform type sets

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -83,7 +83,7 @@ const EXT_TX_SETS_INTRA: usize = 3;
 const EXT_TX_SETS_INTER: usize = 4;
 // Number of transform types in each set type
 static num_ext_tx_set: [usize; EXT_TX_SET_TYPES] = [ 1, 2, 5, 7, 7, 10, 12, 16, 16];
-static av1_ext_tx_used: [[usize; TX_TYPES]; EXT_TX_SET_TYPES] = [
+pub static av1_ext_tx_used: [[usize; TX_TYPES]; EXT_TX_SET_TYPES] = [
     [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
     [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0 ],
     [ 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0 ],
@@ -194,7 +194,7 @@ pub static txsize_to_bsize: [BlockSize; TX_SIZES_ALL] = [
   BLOCK_64X16
 ];
 
-static TXSIZE_SQR_MAP: [TxSize; TX_SIZES_ALL] = [
+pub static TXSIZE_SQR_MAP: [TxSize; TX_SIZES_ALL] = [
     TX_4X4,
     TX_8X8,
     TX_16X16,
@@ -915,7 +915,7 @@ pub fn has_chroma(bo: &BlockOffset, bsize: BlockSize,
 
 }
 
-fn get_ext_tx_set_type(tx_size: TxSize, is_inter: bool, use_reduced_set: bool) -> TxSetType {
+pub fn get_ext_tx_set_type(tx_size: TxSize, is_inter: bool, use_reduced_set: bool) -> TxSetType {
     let tx_size_sqr_up = TXSIZE_SQR_UP_MAP[tx_size as usize];
     let tx_size_sqr = TXSIZE_SQR_MAP[tx_size as usize];
     if tx_size_sqr > TxSize::TX_32X32 {
@@ -949,7 +949,8 @@ fn get_ext_tx_set_type(tx_size: TxSize, is_inter: bool, use_reduced_set: bool) -
 
 fn get_ext_tx_set(tx_size: TxSize, is_inter: bool,
                                  use_reduced_set: bool) -> i8 {
-  let set_type = get_ext_tx_set_type(tx_size, is_inter, use_reduced_set);
+    let set_type = get_ext_tx_set_type(tx_size, is_inter, use_reduced_set);
+
     if is_inter {
         ext_tx_set_index_inter[set_type as usize]
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,8 @@ impl FrameInvariants {
                                  else if speed <= 2 { BlockSize::BLOCK_8X8 }
                                  else if speed <= 3 { BlockSize::BLOCK_16X16 }
                                  else { BlockSize::BLOCK_32X32 };
+        let use_reduced_tx_set = if speed > 1 { true } else { false };
+
         FrameInvariants {
             qindex: qindex,
             speed: speed,
@@ -143,7 +145,7 @@ impl FrameInvariants {
             intra_only: false,
             frame_type: FrameType::KEY,
             show_existing_frame: false,
-            use_reduced_tx_set: true,
+            use_reduced_tx_set: use_reduced_tx_set,
             reference_mode: ReferenceMode::SINGLE,
             use_prev_frame_mvs: false,
             min_partition_size: min_partition_size,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,8 +561,7 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
     }
 
     // Luma plane transform type decision
-    let square_tx_size = TXSIZE_SQR_MAP[tx_size as usize];
-    let tx_set_type = get_ext_tx_set_type(square_tx_size, is_inter, fi.use_reduced_tx_set);
+    let tx_set_type = get_ext_tx_set_type(tx_size, is_inter, fi.use_reduced_tx_set);
 
     let tx_type = if tx_set_type > TxSetType::EXT_TX_SET_DCTONLY {
         // FIXME: there is one redundant transform type decision per encoded block

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,11 +558,15 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
         cw.bc.reset_skip_context(bo, bsize, xdec, ydec);
     }
 
-    let tx_type = if tx_size > TxSize::TX_32X32 {
-        TxType::DCT_DCT
-    } else {
+    // Luma plane transform type decision
+    let square_tx_size = TXSIZE_SQR_MAP[tx_size as usize];
+    let tx_set_type = get_ext_tx_set_type(square_tx_size, is_inter, fi.use_reduced_tx_set);
+
+    let tx_type = if tx_set_type > TxSetType::EXT_TX_SET_DCTONLY {
         // FIXME: there is one redundant transform type decision per encoded block
-        rdo_tx_type_decision(fi, fs, cw, mode, bsize, bo, tx_size)
+        rdo_tx_type_decision(fi, fs, cw, mode, bsize, bo, tx_size, tx_set_type)
+    } else {
+        TxType::DCT_DCT
     };
 
     write_tx_blocks(fi, fs, cw, mode, bo, bsize, tx_size, tx_type, skip);

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -231,7 +231,7 @@ impl PredictionMode {
     }
 }
 
-#[derive(Copy,Clone)]
+#[derive(Copy,Clone,PartialEq,PartialOrd)]
 pub enum TxSetType {
     // DCT only
     EXT_TX_SET_DCTONLY,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -152,12 +152,14 @@ pub static RAV1E_PARTITION_TYPES: &'static [PartitionType] = &[
     PartitionType::PARTITION_SPLIT
 ];
 
-pub static RAV1E_INTRA_TX_TYPES: &'static [TxType] = &[
+pub static RAV1E_TX_TYPES: &'static [TxType] = &[
     TxType::DCT_DCT,
     TxType::ADST_DCT,
     TxType::DCT_ADST,
     TxType::ADST_ADST,
-    TxType::IDTX
+    TxType::IDTX,
+    TxType::V_DCT,
+    TxType::H_DCT
 ];
 
 use plane::*;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -152,8 +152,8 @@ pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Con
 
 // RDO-based intra frame transform type decision
 pub fn rdo_tx_type_decision(fi: &FrameInvariants, fs: &mut FrameState,
-                                   cw: &mut ContextWriter, mode: PredictionMode,
-                                   bsize: BlockSize, bo: &BlockOffset, tx_size: TxSize) -> TxType {
+                            cw: &mut ContextWriter, mode: PredictionMode, bsize: BlockSize,
+                            bo: &BlockOffset, tx_size: TxSize, tx_set_type: TxSetType) -> TxType {
     let mut best_type = TxType::DCT_DCT;
     let mut best_rd = std::f64::MAX;
     let tell = cw.w.tell_frac();
@@ -176,6 +176,12 @@ pub fn rdo_tx_type_decision(fi: &FrameInvariants, fs: &mut FrameState,
     let partition_start_y = (bo.y & LOCAL_BLOCK_MASK) >> ydec << MI_SIZE_LOG2;
 
     for &tx_type in RAV1E_INTRA_TX_TYPES {
+        // Skip unsupported transform types
+        if av1_ext_tx_used[tx_set_type as usize][tx_type as usize] == 0 {
+            continue;
+        }
+
+        // Skip oversized identity transform
         if tx_type == TxType::IDTX && tx_size >= TxSize::TX_32X32 {
             continue;
         }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -175,14 +175,9 @@ pub fn rdo_tx_type_decision(fi: &FrameInvariants, fs: &mut FrameState,
     let partition_start_x = (bo.x & LOCAL_BLOCK_MASK) >> xdec << MI_SIZE_LOG2;
     let partition_start_y = (bo.y & LOCAL_BLOCK_MASK) >> ydec << MI_SIZE_LOG2;
 
-    for &tx_type in RAV1E_INTRA_TX_TYPES {
+    for &tx_type in RAV1E_TX_TYPES {
         // Skip unsupported transform types
         if av1_ext_tx_used[tx_set_type as usize][tx_type as usize] == 0 {
-            continue;
-        }
-
-        // Skip oversized identity transform
-        if tx_type == TxType::IDTX && tx_size >= TxSize::TX_32X32 {
             continue;
         }
 


### PR DESCRIPTION
Further work for #267.

* Skip unsupported/invalid transform types during RDO
  * ADST and DCT/ADST combinations no longer coded at sizes of 32x32
  * Remove the identity transform size check workaround, as it is not valid
* Enable full intra transform type set (`H_DCT` and `V_DCT`) at speed levels 0 (exhaustive partitioning) and 1 (top-down partitioning)

At speed = 0:
```
idtx_max16x16@2018-06-23T00:13:43.743Z -> tx_h_v@2018-06-25T16:06:25.030Z@2018-06-25T16:07:04.497Z

   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000
-0.5303 |  1.1060 |  1.0042 |   0.3591 | 0.3729 |  1.3064 |     0.4017
```

Encoding time (Q80): 37.841 -> 41.557