### PR TITLE
Add block skip RDO decision at low speed levels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,10 +559,6 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
         _ => TxSize::TX_32X32
     };
 
-    if skip {
-        cw.bc.reset_skip_context(bo, bsize, xdec, ydec);
-    }
-
     // Luma plane transform type decision
     let tx_set_type = get_ext_tx_set_type(tx_size, is_inter, fi.use_reduced_tx_set);
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -36,7 +36,8 @@ pub struct RDOOutput {
 pub struct RDOPartitionOutput {
     pub rd_cost: f64,
     pub bo: BlockOffset,
-    pub pred_mode: PredictionMode
+    pub pred_mode: PredictionMode,
+    pub skip: bool
 }
 
 // Sum of Squared Error for a wxh block
@@ -98,6 +99,7 @@ fn compute_rd_cost(fi: &FrameInvariants, fs: &FrameState,
 pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
                          bsize: BlockSize, bo: &BlockOffset) -> RDOOutput {
     let mut best_mode = PredictionMode::DC_PRED;
+    let mut best_skip = false;
     let mut best_rd = std::f64::MAX;
     let tell = cw.w.tell_frac();
 
@@ -118,25 +120,33 @@ pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Con
     let partition_start_x = (bo.x & LOCAL_BLOCK_MASK) >> xdec << MI_SIZE_LOG2;
     let partition_start_y = (bo.y & LOCAL_BLOCK_MASK) >> ydec << MI_SIZE_LOG2;
 
-    for &mode in RAV1E_INTRA_MODES {
-        if fi.frame_type == FrameType::KEY && mode >= PredictionMode::NEARESTMV {
-            break;
+    for &skip in [false, true].iter() {
+        // Don't test skipped blocks at higher speed levels
+        if fi.speed > 1 && skip == true {
+            continue;
         }
 
-        let checkpoint = cw.checkpoint();
+        for &mode in RAV1E_INTRA_MODES {
+            if fi.frame_type == FrameType::KEY && mode >= PredictionMode::NEARESTMV {
+                break;
+            }
 
-        encode_block(fi, fs, cw, mode, bsize, bo);
+            let checkpoint = cw.checkpoint();
 
-        let cost = cw.w.tell_frac() - tell;
-        let rd = compute_rd_cost(fi, fs, w, h, w_uv, h_uv,
-                                 partition_start_x, partition_start_y, bo, cost);
+            encode_block(fi, fs, cw, mode, bsize, bo, skip);
 
-        if rd < best_rd {
-            best_rd = rd;
-            best_mode = mode;
+            let cost = cw.w.tell_frac() - tell;
+            let rd = compute_rd_cost(fi, fs, w, h, w_uv, h_uv,
+                                     partition_start_x, partition_start_y, bo, cost);
+
+            if rd < best_rd {
+                best_rd = rd;
+                best_mode = mode;
+                best_skip = skip;
+            }
+
+            cw.rollback(&checkpoint);
         }
-
-        cw.rollback(&checkpoint);
     }
 
     assert!(best_rd >= 0_f64);
@@ -144,7 +154,11 @@ pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Con
     let rdo_output = RDOOutput {
         rd_cost: best_rd,
         part_type: PartitionType::PARTITION_NONE,
-        part_modes: vec![RDOPartitionOutput { bo: bo.clone(), pred_mode: best_mode, rd_cost: best_rd }]
+        part_modes: vec![RDOPartitionOutput {
+            bo: bo.clone(),
+            pred_mode: best_mode,
+            rd_cost: best_rd,
+            skip: best_skip }]
     };
 
     rdo_output

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -126,12 +126,12 @@ pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Con
             continue;
         }
 
+        let checkpoint = cw.checkpoint();
+
         for &mode in RAV1E_INTRA_MODES {
             if fi.frame_type == FrameType::KEY && mode >= PredictionMode::NEARESTMV {
                 break;
             }
-
-            let checkpoint = cw.checkpoint();
 
             encode_block(fi, fs, cw, mode, bsize, bo, skip);
 
@@ -189,13 +189,13 @@ pub fn rdo_tx_type_decision(fi: &FrameInvariants, fs: &mut FrameState,
     let partition_start_x = (bo.x & LOCAL_BLOCK_MASK) >> xdec << MI_SIZE_LOG2;
     let partition_start_y = (bo.y & LOCAL_BLOCK_MASK) >> ydec << MI_SIZE_LOG2;
 
+    let checkpoint = cw.checkpoint();
+
     for &tx_type in RAV1E_TX_TYPES {
         // Skip unsupported transform types
         if av1_ext_tx_used[tx_set_type as usize][tx_type as usize] == 0 {
             continue;
         }
-
-        let checkpoint = cw.checkpoint();
 
         write_tx_blocks(fi, fs, cw, mode, bo, bsize, tx_size, tx_type, false);
 
@@ -226,13 +226,13 @@ pub fn rdo_partition_decision(fi: &FrameInvariants, fs: &mut FrameState,
     let mut best_rd = cached_block.rd_cost;
     let mut best_pred_modes = cached_block.part_modes.clone();
 
+    let checkpoint = cw.checkpoint();
+
     for &partition in RAV1E_PARTITION_TYPES {
         // Do not re-encode results we already have
         if partition == cached_block.part_type && cached_block.rd_cost < max_rd {
             continue;
         }
-
-        let checkpoint = cw.checkpoint();
 
         let mut rd: f64;
         let mut child_modes = std::vec::Vec::new();


### PR DESCRIPTION
Resolves #278.

This is exhaustively tested during mode RDO and applies to speed levels 0 (exhaustive partitioning) and 1 (top-down partitioning).

```
idtx_max16x16@2018-06-23T00:13:43.743Z -> skip_nohv@2018-06-25T19:17:44.838Z

   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-1.2821 |     N/A | 14.4267 |  -1.3549 | -1.7057 | -1.4930 |     2.3784
```

Encoding time (Q80): 37.841 -> 66.445

Relative to #279:
```
tx_h_v@2018-06-25T16:06:25.030Z@2018-06-25T16:07:04.497Z -> skip@2018-06-25T18:54:47.920Z

   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-1.4006 | 16.0167 | 15.1763 |  -1.4152 | -1.7293 | -1.4402 |     2.1841
```