### PR TITLE
Restrict scope of RDO above low speed levels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,7 +588,7 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
     // Luma plane transform type decision
     let tx_set_type = get_ext_tx_set_type(tx_size, is_inter, fi.use_reduced_tx_set);
 
-    let tx_type = if tx_set_type > TxSetType::EXT_TX_SET_DCTONLY {
+    let tx_type = if tx_set_type > TxSetType::EXT_TX_SET_DCTONLY && fi.speed <= 3 {
         // FIXME: there is one redundant transform type decision per encoded block
         rdo_tx_type_decision(fi, fs, cw, luma_mode, bsize, bo, tx_size, tx_set_type)
     } else {

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -25,6 +25,13 @@ pub static RAV1E_INTRA_MODES: &'static [PredictionMode] = &[
     PredictionMode::PAETH_PRED
 ];
 
+// Intra prediction modes tested at high speed levels
+pub static RAV1E_INTRA_MODES_MINIMAL: &'static [PredictionMode] = &[
+    PredictionMode::DC_PRED,
+    PredictionMode::H_PRED,
+    PredictionMode::V_PRED
+];
+
 // Weights are quadratic from '1' to '1 / block_size', scaled by 2^sm_weight_log2_scale.
 const sm_weight_log2_scale: u8 = 8;
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -20,7 +20,7 @@ use context::*;
 use ec::OD_BITRES;
 use partition::*;
 use plane::*;
-use predict::RAV1E_INTRA_MODES;
+use predict::{RAV1E_INTRA_MODES, RAV1E_INTRA_MODES_MINIMAL};
 use quantize::dc_q;
 use std;
 use std::vec::Vec;
@@ -132,7 +132,14 @@ pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Con
 
         let checkpoint = cw.checkpoint();
 
-        for &luma_mode in RAV1E_INTRA_MODES {
+        // Exclude complex prediction modes at higher speed levels
+        let mode_set = if fi.speed <= 3 {
+            RAV1E_INTRA_MODES
+        } else {
+            RAV1E_INTRA_MODES_MINIMAL
+        };
+
+        for &luma_mode in mode_set {
             if fi.frame_type == FrameType::KEY && luma_mode >= PredictionMode::NEARESTMV {
                 break;
             }


### PR DESCRIPTION
Transform types and prediction modes are currently all tested at all speed levels, which slows down every speed level considerably. With this change, speed levels 0-3 will test all prediction modes and transform types exhaustively, while higher levels will default to a smaller set of prediction modes and DCT transforms.