### PR TITLE
Remove lookup tables

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -332,7 +332,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
                             let po = tx_bo.plane_offset(&fs.input.planes[p].cfg);
                             encode_tx_block(&mut fi, &mut fs, &mut cw, p, &bo, mode,
                                             tx_size, tx_type,
-                                            tx_size.to_block_size(),
+                                            tx_size.block_size(),
                                             &po, false);
                     }
                 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -332,7 +332,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
                             let po = tx_bo.plane_offset(&fs.input.planes[p].cfg);
                             encode_tx_block(&mut fi, &mut fs, &mut cw, p, &bo, mode,
                                             tx_size, tx_type,
-                                            txsize_to_bsize[tx_size as usize],
+                                            tx_size.to_block_size(),
                                             &po, false);
                     }
                 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -46,11 +46,6 @@ const MAX_ANGLE_DELTA: usize = 3;
 const DIRECTIONAL_MODES: usize = 8;
 const KF_MODE_CONTEXTS: usize= 5;
 
-pub static b_width_log2_lookup: [u8; BlockSize::BLOCK_SIZES_ALL] =
-    [0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 0, 2, 1, 3, 2, 4];
-pub static b_height_log2_lookup: [u8; BlockSize::BLOCK_SIZES_ALL] =
-    [0, 1, 0, 1, 2, 1, 2, 3, 2, 3, 4, 3, 4, 2, 0, 3, 1, 4, 2];
-
 const EXT_TX_SIZES: usize = 4;
 const EXT_TX_SET_TYPES: usize = 9;
 const EXT_TX_SETS_INTRA: usize = 3;
@@ -1360,11 +1355,11 @@ impl BlockContext {
         // TODO: this should be way simpler without sub8x8
         let above_ctx = self.above_partition_context[bo.x];
         let left_ctx = self.left_partition_context[bo.y_in_sb()];
-        let bsl = b_width_log2_lookup[bsize as usize] - b_width_log2_lookup[BlockSize::BLOCK_8X8 as usize];
+        let bsl = bsize.width_log2() - BLOCK_8X8.width_log2();
         let above = (above_ctx >> bsl) & 1;
         let left = (left_ctx >> bsl) & 1;
 
-        assert!(b_width_log2_lookup[bsize as usize] == b_height_log2_lookup[bsize as usize]);
+        assert!(bsize.is_sqr());
 
         (left * 2 + above) as usize + bsl as usize * PARTITION_PLOFFSET
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -47,9 +47,9 @@ const MAX_ANGLE_DELTA: usize = 3;
 const DIRECTIONAL_MODES: usize = 8;
 const KF_MODE_CONTEXTS: usize= 5;
 
-pub static b_width_log2_lookup: [u8; BLOCK_SIZES_ALL] =
+pub static b_width_log2_lookup: [u8; BlockSize::BLOCK_SIZES_ALL] =
     [0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 0, 2, 1, 3, 2, 4];
-pub static b_height_log2_lookup: [u8; BLOCK_SIZES_ALL] =
+pub static b_height_log2_lookup: [u8; BlockSize::BLOCK_SIZES_ALL] =
     [0, 1, 0, 1, 2, 1, 2, 3, 2, 3, 4, 3, 4, 2, 0, 3, 1, 4, 2];
 
 const EXT_TX_SIZES: usize = 4;
@@ -235,7 +235,7 @@ static txsize_log2_minus4: [usize; TxSize::TX_SIZES_ALL] = [
     5
 ];
 
-static ss_size_lookup: [[[BlockSize; 2]; 2]; BLOCK_SIZES_ALL] = [
+static ss_size_lookup: [[[BlockSize; 2]; 2]; BlockSize::BLOCK_SIZES_ALL] = [
   //  ss_x == 0    ss_x == 0        ss_x == 1      ss_x == 1
   //  ss_y == 0    ss_y == 1        ss_y == 0      ss_y == 1
   [  [ BLOCK_4X4, BLOCK_4X4 ], [BLOCK_4X4, BLOCK_4X4 ] ],
@@ -267,7 +267,7 @@ pub fn get_plane_block_size(bsize: BlockSize, subsampling_x: usize, subsampling_
 // Generates 4 bit field in which each bit set to 1 represents
 // a blocksize partition  1111 means we split 64x64, 32x32, 16x16
 // and 8x8.  1000 means we just split the 64x64 to 32x32
-static partition_context_lookup: [[u8; 2]; BLOCK_SIZES_ALL] = [
+static partition_context_lookup: [[u8; 2]; BlockSize::BLOCK_SIZES_ALL] = [
   [ 15, 15 ],  // 4X4   - [0b1111, 0b1111]
   [ 15, 14 ],  // 4X8   - [0b1111, 0b1110]
   [ 14, 15 ],  // 8X4   - [0b1110, 0b1111]
@@ -290,7 +290,7 @@ static partition_context_lookup: [[u8; 2]; BLOCK_SIZES_ALL] = [
   [ 0, 12 ],   // 64X16- [0b0000, 0b1100]
 ];
 
-static size_group_lookup: [u8; BLOCK_SIZES_ALL] = [
+static size_group_lookup: [u8; BlockSize::BLOCK_SIZES_ALL] = [
   0, 0,
   0, 1,
   1, 1,
@@ -303,10 +303,10 @@ static size_group_lookup: [u8; BLOCK_SIZES_ALL] = [
   2,
 ];
 
-static num_pels_log2_lookup: [u8; BLOCK_SIZES_ALL] = [
+static num_pels_log2_lookup: [u8; BlockSize::BLOCK_SIZES_ALL] = [
   4, 5, 5, 6, 7, 7, 8, 9, 9, 10, 11, 11, 12, 6, 6, 8, 8, 10, 10];
 
-pub static subsize_lookup: [[BlockSize; BLOCK_SIZES_ALL]; PARTITION_TYPES] =
+pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; PARTITION_TYPES] =
 [
   [ // PARTITION_NONE
     //                            4X4

--- a/src/context.rs
+++ b/src/context.rs
@@ -1440,7 +1440,7 @@ impl BlockContext {
 
         // Decide txb_ctx.txb_skip_ctx
         if plane == 0 {
-            if plane_bsize == tx_size.to_block_size() {
+            if plane_bsize == tx_size.block_size() {
               txb_ctx.txb_skip_ctx = 0;
             } else {
                 // This is the algorithm to generate table skip_contexts[min][max].
@@ -1489,7 +1489,7 @@ impl BlockContext {
             }
             let ctx_base = (top != 0) as usize + (left != 0) as usize;
             let ctx_offset = if num_pels_log2_lookup[plane_bsize as usize] >
-                                 num_pels_log2_lookup[tx_size.to_block_size() as usize]
+                                 num_pels_log2_lookup[tx_size.block_size() as usize]
                                 { 10 }
                              else { 7 };
             txb_ctx.txb_skip_ctx = ctx_base + ctx_offset;

--- a/src/context.rs
+++ b/src/context.rs
@@ -51,18 +51,6 @@ pub static b_width_log2_lookup: [u8; BLOCK_SIZES_ALL] =
     [0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 0, 2, 1, 3, 2, 4];
 pub static b_height_log2_lookup: [u8; BLOCK_SIZES_ALL] =
     [0, 1, 0, 1, 2, 1, 2, 3, 2, 3, 4, 3, 4, 2, 0, 3, 1, 4, 2];
-// Transform block width in pixels
-pub static tx_size_wide: [usize; TxSize::TX_SIZES_ALL] =
-    [ 4, 8, 16, 32, 64, 4, 8, 8, 16, 16, 32, 32, 64, 4, 16, 8, 32, 16, 64 ];
-// Transform block height in pixels
-pub static tx_size_high: [usize; TxSize::TX_SIZES_ALL] =
-    [ 4, 8, 16, 32, 64, 8, 4, 16, 8, 32, 16, 64, 32, 16, 4, 32, 8, 64, 16 ];
-// Transform block width in unit
-pub static tx_size_wide_unit: [usize; TxSize::TX_SIZES_ALL] =
-    [1, 2, 4, 8, 16, 1, 2, 2, 4, 4, 8, 8, 16, 1, 4, 2, 8, 4, 16];
-// Transform block height in unit
-pub static tx_size_high_unit: [usize; TxSize::TX_SIZES_ALL] =
-    [1, 2, 4, 8, 16, 2, 1, 4, 2, 8, 4, 16, 8, 4, 1, 8, 2, 16, 4];
 
 const EXT_TX_SIZES: usize = 4;
 const EXT_TX_SET_TYPES: usize = 9;
@@ -1526,8 +1514,8 @@ impl BlockContext {
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2];
         let mut dc_sign: i16 = 0;
-        let txb_w_unit = tx_size_wide_unit[tx_size as usize];
-        let txb_h_unit = tx_size_high_unit[tx_size as usize];
+        let txb_w_unit = tx_size.width_mi();
+        let txb_h_unit = tx_size.height_mi();
 
         // Decide txb_ctx.dc_sign_ctx
         for k in 0..txb_w_unit {
@@ -1872,8 +1860,8 @@ impl ContextWriter {
         match tx_class {
           TX_CLASS_2D => {
             // This is the algorithm to generate av1_nz_map_ctx_offset[][]
-            //   const int width = tx_size_wide[tx_size];
-            //   const int height = tx_size_high[tx_size];
+            //   const int width = tx_size.width();
+            //   const int height = tx_size.height();
             //   if (width < height) {
             //     if (row < 2) return 11 + ctx;
             //   } else if (width > height) {
@@ -1919,7 +1907,7 @@ impl ContextWriter {
                                  coeff_contexts: &mut [i8]) {
         // TODO: If TX_64X64 is enabled, use av1_get_adjusted_tx_size()
         let bwl = tx_size.width_log2();
-        let height = tx_size_high[tx_size as usize];
+        let height = tx_size.height();
         for i in 0..eob {
             let pos = scan[i as usize];
             coeff_contexts[pos as usize] =

--- a/src/context.rs
+++ b/src/context.rs
@@ -1878,10 +1878,10 @@ impl ContextWriter {
         let scan_order = &av1_inter_scan_orders[tx_size as usize][tx_type as usize];
         let scan = scan_order.scan;
         let mut coeffs_storage = [0 as i32; 32*32];
-        let coeffs = &mut coeffs_storage[..tx_size.width()*tx_size.height()];
+        let coeffs = &mut coeffs_storage[..tx_size.area()];
         let mut cul_level = 0 as u32;
 
-        for i in 0..tx_size.width()*tx_size.height() {
+        for i in 0..tx_size.area() {
             coeffs[i] = coeffs_in[scan[i] as usize];
             cul_level += coeffs[i].abs() as u32;
         }
@@ -1926,7 +1926,7 @@ impl ContextWriter {
         // Encode EOB
         let mut eob_extra = 0 as u32;
         let eob_pt = self.get_eob_pos_token(eob, &mut eob_extra);
-        let eob_multi_size: usize = tx_size.log2() - 4;
+        let eob_multi_size: usize = tx_size.area_log2() - 4;
         let eob_multi_ctx: usize = if tx_class == TX_CLASS_2D { 0 } else { 1 };
 
         match eob_multi_size {

--- a/src/context.rs
+++ b/src/context.rs
@@ -141,28 +141,6 @@ static av1_coefband_trans_8x8plus: [u8; 32*32] = [
   5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
   5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
 
-static txsize_log2_minus4: [usize; TxSize::TX_SIZES_ALL] = [
-    0,  // TX_4X4
-    2,  // TX_8X8
-    4,  // TX_16X16
-    6,  // TX_32X32
-    6,  // TX_64X64
-    1,  // TX_4X8
-    1,  // TX_8X4
-    3,  // TX_8X16
-    3,  // TX_16X8
-    5,  // TX_16X32
-    5,  // TX_32X16
-    6,  // TX_32X64
-    6,  // TX_64X32
-    2,  // TX_4X16
-    2,
-    4,
-    4,
-    5,
-    5
-];
-
 static ss_size_lookup: [[[BlockSize; 2]; 2]; BlockSize::BLOCK_SIZES_ALL] = [
   //  ss_x == 0    ss_x == 0        ss_x == 1      ss_x == 1
   //  ss_y == 0    ss_y == 1        ss_y == 0      ss_y == 1
@@ -1948,7 +1926,7 @@ impl ContextWriter {
         // Encode EOB
         let mut eob_extra = 0 as u32;
         let eob_pt = self.get_eob_pos_token(eob, &mut eob_extra);
-        let eob_multi_size: usize = txsize_log2_minus4[tx_size as usize];
+        let eob_multi_size: usize = tx_size.log2() - 4;
         let eob_multi_ctx: usize = if tx_class == TX_CLASS_2D { 0 } else { 1 };
 
         match eob_multi_size {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,7 +545,7 @@ pub fn encode_tx_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Conte
     let mut coeffs_storage: [i32; 64*64] = unsafe { uninitialized() };
     let mut rcoeffs: [i32; 64*64] = unsafe { uninitialized() };
 
-    let coeffs = &mut coeffs_storage[..tx_size.width()*tx_size.height()];
+    let coeffs = &mut coeffs_storage[..tx_size.area()];
 
     diff(&mut residual,
          &fs.input.planes[p].slice(po),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -626,8 +626,8 @@ fn encode_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWrite
 pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
                        luma_mode: PredictionMode, chroma_mode: PredictionMode, bo: &BlockOffset,
                        bsize: BlockSize, tx_size: TxSize, tx_type: TxType, skip: bool) {
-    let bw = mi_size_wide[bsize as usize] as usize / tx_size.width_mi();
-    let bh = mi_size_high[bsize as usize] as usize / tx_size.height_mi();
+    let bw = bsize.width_mi() / tx_size.width_mi();
+    let bh = bsize.height_mi() / tx_size.height_mi();
 
     let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
 
@@ -703,7 +703,7 @@ bsize: BlockSize, bo: &BlockOffset) -> f64 {
         return rd_cost;
     }
 
-    let bs = mi_size_wide[bsize as usize];
+    let bs = bsize.width_mi();
 
     // Always split if the current partition is too large
     let must_split = bo.x + bs as usize > fi.w_in_b ||
@@ -797,7 +797,7 @@ fn encode_partition_topdown(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut 
         return;
     }
 
-    let bs = mi_size_wide[bsize as usize];
+    let bs = bsize.width_mi();
 
     // Always split if the current partition is too large
     let must_split = bo.x + bs as usize > fi.w_in_b ||
@@ -823,7 +823,7 @@ fn encode_partition_topdown(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut 
         partition = PartitionType::PARTITION_NONE;
     }
 
-    assert!(mi_size_wide[bsize as usize] == mi_size_high[bsize as usize]);
+    assert!(bsize.width_mi() == bsize.height_mi());
     assert!(PartitionType::PARTITION_NONE <= partition &&
             partition < PartitionType::PARTITION_INVALID);
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -149,7 +149,11 @@ impl TxSize {
         self.width() >> MI_SIZE_LOG2
     }
 
-    pub fn log2(self) -> usize {
+    pub fn area(self) -> usize {
+        1 << self.area_log2()
+    }
+
+    pub fn area_log2(self) -> usize {
         self.width_log2() + self.height_log2()
     }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -50,11 +50,10 @@ impl BlockSize {
 
     pub const BLOCK_SIZES_ALL: usize = 19;
 
-    // Width/height lookup tables in units of various block sizes
-    const BLOCK_SIZE_WIDE_LOG2: [usize; BlockSize::BLOCK_SIZES_ALL] =
+    const BLOCK_SIZE_WIDTH_LOG2: [usize; BlockSize::BLOCK_SIZES_ALL] =
         [2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 2, 4, 3, 5, 4, 6];
 
-    const BLOCK_SIZE_HIGH_LOG2: [usize; BlockSize::BLOCK_SIZES_ALL] =
+    const BLOCK_SIZE_HEIGHT_LOG2: [usize; BlockSize::BLOCK_SIZES_ALL] =
         [2, 3, 2, 3, 4, 3, 4, 5, 4, 5, 6, 5, 6, 4, 2, 5, 3, 6, 4];
 
     pub fn cfl_allowed(self) -> bool {
@@ -63,11 +62,11 @@ impl BlockSize {
     }
 
     pub fn width(self) -> usize {
-        1 << BlockSize::BLOCK_SIZE_WIDE_LOG2[self as usize]
+        1 << BlockSize::BLOCK_SIZE_WIDTH_LOG2[self as usize]
     }
 
     pub fn width_log2(self) -> usize {
-        BlockSize::BLOCK_SIZE_WIDE_LOG2[self as usize]
+        BlockSize::BLOCK_SIZE_WIDTH_LOG2[self as usize]
     }
 
     pub fn width_mi(self) -> usize {
@@ -75,11 +74,11 @@ impl BlockSize {
     }
 
     pub fn height(self) -> usize {
-        1 << BlockSize::BLOCK_SIZE_HIGH_LOG2[self as usize]
+        1 << BlockSize::BLOCK_SIZE_HEIGHT_LOG2[self as usize]
     }
 
     pub fn height_log2(self) -> usize {
-        BlockSize::BLOCK_SIZE_HIGH_LOG2[self as usize]
+        BlockSize::BLOCK_SIZE_HEIGHT_LOG2[self as usize]
     }
 
     pub fn height_mi(self) -> usize {
@@ -122,22 +121,18 @@ impl TxSize {
     /// Number of transform sizes (including non-square sizes)
     pub const TX_SIZES_ALL: usize = 14 + 5;
 
-    const TX_SIZE_WIDE_LOG2: [usize; TxSize::TX_SIZES_ALL] =
-        [2, 3, 4, 5, 6, 2, 3, 3, 4, 4, 5, 5, 6, 2, 4, 3, 5, 4, 6];
-
-    const TX_SIZE_HIGH_LOG2: [usize; TxSize::TX_SIZES_ALL] =
-        [2, 3, 4, 5, 6, 3, 2, 4, 3, 5, 4, 6, 5, 4, 2, 5, 3, 6, 4];
-
     pub fn width(self) -> usize {
         1 << self.width_log2()
     }
 
     pub fn width_log2(self) -> usize {
-        TxSize::TX_SIZE_WIDE_LOG2[self as usize]
+        const TX_SIZE_WIDTH_LOG2: [usize; TxSize::TX_SIZES_ALL] =
+            [2, 3, 4, 5, 6, 2, 3, 3, 4, 4, 5, 5, 6, 2, 4, 3, 5, 4, 6];
+        TX_SIZE_WIDTH_LOG2[self as usize]
     }
     
     pub fn smallest_width_log2() -> usize {
-        TxSize::TX_SIZE_WIDE_LOG2[0]
+        TX_4X4.width_log2()
     }
 
     pub fn height(self) -> usize {
@@ -145,7 +140,9 @@ impl TxSize {
     }
 
     pub fn height_log2(self) -> usize {
-        TxSize::TX_SIZE_HIGH_LOG2[self as usize]
+        const TX_SIZE_HEIGHT_LOG2: [usize; TxSize::TX_SIZES_ALL] =
+            [2, 3, 4, 5, 6, 3, 2, 4, 3, 5, 4, 6, 5, 4, 2, 5, 3, 6, 4];
+        TX_SIZE_HEIGHT_LOG2[self as usize]
     }
 
     pub fn width_mi(self) -> usize {
@@ -160,82 +157,79 @@ impl TxSize {
         self.height() >> MI_SIZE_LOG2
     }
 
-    const TX_SIZE_TO_BLOCK_SIZE: [BlockSize; TxSize::TX_SIZES_ALL] = [
-        BLOCK_4X4,    // TX_4X4
-        BLOCK_8X8,    // TX_8X8
-        BLOCK_16X16,  // TX_16X16
-        BLOCK_32X32,  // TX_32X32
-        BLOCK_64X64,
-        BLOCK_4X8,    // TX_4X8
-        BLOCK_8X4,    // TX_8X4
-        BLOCK_8X16,   // TX_8X16
-        BLOCK_16X8,   // TX_16X8
-        BLOCK_16X32,  // TX_16X32
-        BLOCK_32X16,  // TX_32X16
-        BLOCK_32X64,
-        BLOCK_64X32,
-        BLOCK_4X16,   // TX_4X16
-        BLOCK_16X4,   // TX_16X4
-        BLOCK_8X32,   // TX_8X32
-        BLOCK_32X8,   // TX_32X8
-        BLOCK_16X64,
-        BLOCK_64X16
-    ];
-
-    pub fn to_block_size(self) -> BlockSize {
-        TxSize::TX_SIZE_TO_BLOCK_SIZE[self as usize]
+    pub fn block_size(self) -> BlockSize {
+        const TX_SIZE_TO_BLOCK_SIZE: [BlockSize; TxSize::TX_SIZES_ALL] = [
+            BLOCK_4X4,    // TX_4X4
+            BLOCK_8X8,    // TX_8X8
+            BLOCK_16X16,  // TX_16X16
+            BLOCK_32X32,  // TX_32X32
+            BLOCK_64X64,
+            BLOCK_4X8,    // TX_4X8
+            BLOCK_8X4,    // TX_8X4
+            BLOCK_8X16,   // TX_8X16
+            BLOCK_16X8,   // TX_16X8
+            BLOCK_16X32,  // TX_16X32
+            BLOCK_32X16,  // TX_32X16
+            BLOCK_32X64,
+            BLOCK_64X32,
+            BLOCK_4X16,   // TX_4X16
+            BLOCK_16X4,   // TX_16X4
+            BLOCK_8X32,   // TX_8X32
+            BLOCK_32X8,   // TX_32X8
+            BLOCK_16X64,
+            BLOCK_64X16
+        ];
+        TX_SIZE_TO_BLOCK_SIZE[self as usize]
     }
-
-    const TX_SIZE_SQR: [TxSize; TxSize::TX_SIZES_ALL] = [
-        TX_4X4,
-        TX_8X8,
-        TX_16X16,
-        TX_32X32,
-        TX_64X64,
-        TX_4X4,
-        TX_4X4,
-        TX_8X8,
-        TX_8X8,
-        TX_16X16,
-        TX_16X16,
-        TX_32X32,
-        TX_32X32,
-        TX_4X4,
-        TX_4X4,
-        TX_8X8,
-        TX_8X8,
-        TX_16X16,
-        TX_16X16
-    ];
 
     pub fn sqr(self) -> TxSize {
-        TxSize::TX_SIZE_SQR[self as usize]
+        const TX_SIZE_SQR: [TxSize; TxSize::TX_SIZES_ALL] = [
+            TX_4X4,
+            TX_8X8,
+            TX_16X16,
+            TX_32X32,
+            TX_64X64,
+            TX_4X4,
+            TX_4X4,
+            TX_8X8,
+            TX_8X8,
+            TX_16X16,
+            TX_16X16,
+            TX_32X32,
+            TX_32X32,
+            TX_4X4,
+            TX_4X4,
+            TX_8X8,
+            TX_8X8,
+            TX_16X16,
+            TX_16X16
+        ];
+        TX_SIZE_SQR[self as usize]
     }
 
-    const TX_SIZE_SQR_UP: [TxSize; TxSize::TX_SIZES_ALL] = [
-        TX_4X4,
-        TX_8X8,
-        TX_16X16,
-        TX_32X32,
-        TX_64X64,
-        TX_8X8,
-        TX_8X8,
-        TX_16X16,
-        TX_16X16,
-        TX_32X32,
-        TX_32X32,
-        TX_64X64,
-        TX_64X64,
-        TX_16X16,
-        TX_16X16,
-        TX_32X32,
-        TX_32X32,
-        TX_64X64,
-        TX_64X64
-    ];
-
     pub fn sqr_up(self) -> TxSize {
-        TxSize::TX_SIZE_SQR_UP[self as usize]
+        const TX_SIZE_SQR_UP: [TxSize; TxSize::TX_SIZES_ALL] = [
+            TX_4X4,
+            TX_8X8,
+            TX_16X16,
+            TX_32X32,
+            TX_64X64,
+            TX_8X8,
+            TX_8X8,
+            TX_16X16,
+            TX_16X16,
+            TX_32X32,
+            TX_32X32,
+            TX_64X64,
+            TX_64X64,
+            TX_16X16,
+            TX_16X16,
+            TX_32X32,
+            TX_32X32,
+            TX_64X64,
+            TX_64X64
+        ];
+        TX_SIZE_SQR_UP[self as usize]
     }
 }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -112,7 +112,7 @@ impl TxSize {
         [2, 3, 4, 5, 6, 3, 2, 4, 3, 5, 4, 6, 5, 4, 2, 5, 3, 6, 4];
 
     pub fn width(self) -> usize {
-        1<<TxSize::TX_SIZE_WIDE_LOG2[self as usize]
+        1 << TxSize::TX_SIZE_WIDE_LOG2[self as usize]
     }
 
     pub fn width_log2(self) -> usize {
@@ -124,15 +124,15 @@ impl TxSize {
     }
 
     pub fn height(self) -> usize {
-        1<<TxSize::TX_SIZE_HIGH_LOG2[self as usize]
+        1 << TxSize::TX_SIZE_HIGH_LOG2[self as usize]
     }
 
     pub fn width_mi(self) -> usize {
-        (1<<TxSize::TX_SIZE_WIDE_LOG2[self as usize])>>2
+        self.width() >> MI_SIZE_LOG2
     }
 
     pub fn height_mi(self) -> usize {
-        (1<<TxSize::TX_SIZE_HIGH_LOG2[self as usize])>>2
+        self.height() >> MI_SIZE_LOG2
     }
 }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -129,7 +129,7 @@ impl TxSize {
         [2, 3, 4, 5, 6, 3, 2, 4, 3, 5, 4, 6, 5, 4, 2, 5, 3, 6, 4];
 
     pub fn width(self) -> usize {
-        1 << TxSize::TX_SIZE_WIDE_LOG2[self as usize]
+        1 << self.width_log2()
     }
 
     pub fn width_log2(self) -> usize {
@@ -141,11 +141,19 @@ impl TxSize {
     }
 
     pub fn height(self) -> usize {
-        1 << TxSize::TX_SIZE_HIGH_LOG2[self as usize]
+        1 << self.height_log2()
+    }
+
+    pub fn height_log2(self) -> usize {
+        TxSize::TX_SIZE_HIGH_LOG2[self as usize]
     }
 
     pub fn width_mi(self) -> usize {
         self.width() >> MI_SIZE_LOG2
+    }
+
+    pub fn log2(self) -> usize {
+        self.width_log2() + self.height_log2()
     }
 
     pub fn height_mi(self) -> usize {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -46,9 +46,31 @@ pub enum BlockSize {
 }
 
 impl BlockSize {
+    // Width/height lookup tables in units of various block sizes
+    const BLOCK_SIZE_WIDE: [usize; BLOCK_SIZES_ALL] =
+        [4, 4, 8, 8, 8, 16, 16, 16, 32, 32, 32, 64, 64, 4, 16, 8, 32, 16, 64 ];
+    const BLOCK_SIZE_HIGH: [usize; BLOCK_SIZES_ALL] =
+        [4, 8, 4, 8, 16, 8, 16, 32, 16, 32, 64, 32, 64, 16,4, 32, 8, 64, 16 ];
+
     pub fn cfl_allowed(self) -> bool {
         // TODO: fix me when enabling EXT_PARTITION_TYPES
         self <= BlockSize::BLOCK_32X32
+    }
+
+    pub fn width(self) -> usize {
+        BlockSize::BLOCK_SIZE_WIDE[self as usize]
+    }
+
+    pub fn width_mi(self) -> usize {
+        self.width() >> MI_SIZE_LOG2
+    }
+
+    pub fn height(self) -> usize {
+        BlockSize::BLOCK_SIZE_HIGH[self as usize]
+    }
+
+    pub fn height_mi(self) -> usize {
+        self.height() >> MI_SIZE_LOG2
     }
 }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -51,11 +51,11 @@ impl BlockSize {
     pub const BLOCK_SIZES_ALL: usize = 19;
 
     // Width/height lookup tables in units of various block sizes
-    const BLOCK_SIZE_WIDE: [usize; BlockSize::BLOCK_SIZES_ALL] =
-        [4, 4, 8, 8, 8, 16, 16, 16, 32, 32, 32, 64, 64, 4, 16, 8, 32, 16, 64 ];
+    const BLOCK_SIZE_WIDE_LOG2: [usize; BlockSize::BLOCK_SIZES_ALL] =
+        [2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 2, 4, 3, 5, 4, 6];
 
-    const BLOCK_SIZE_HIGH: [usize; BlockSize::BLOCK_SIZES_ALL] =
-        [4, 8, 4, 8, 16, 8, 16, 32, 16, 32, 64, 32, 64, 16,4, 32, 8, 64, 16 ];
+    const BLOCK_SIZE_HIGH_LOG2: [usize; BlockSize::BLOCK_SIZES_ALL] =
+        [2, 3, 2, 3, 4, 3, 4, 5, 4, 5, 6, 5, 6, 4, 2, 5, 3, 6, 4];
 
     pub fn cfl_allowed(self) -> bool {
         // TODO: fix me when enabling EXT_PARTITION_TYPES
@@ -63,7 +63,7 @@ impl BlockSize {
     }
 
     pub fn width(self) -> usize {
-        BlockSize::BLOCK_SIZE_WIDE[self as usize]
+        1 << BlockSize::BLOCK_SIZE_WIDE_LOG2[self as usize]
     }
 
     pub fn width_mi(self) -> usize {
@@ -71,7 +71,7 @@ impl BlockSize {
     }
 
     pub fn height(self) -> usize {
-        BlockSize::BLOCK_SIZE_HIGH[self as usize]
+        1 << BlockSize::BLOCK_SIZE_HIGH_LOG2[self as usize]
     }
 
     pub fn height_mi(self) -> usize {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -19,8 +19,6 @@ pub enum PartitionType {
     PARTITION_INVALID
 }
 
-pub const BLOCK_SIZES_ALL: usize = 19;
-
 #[derive(Copy,Clone,PartialEq,PartialOrd)]
 pub enum BlockSize {
     BLOCK_4X4,
@@ -46,10 +44,13 @@ pub enum BlockSize {
 }
 
 impl BlockSize {
+
+    pub const BLOCK_SIZES_ALL: usize = 19;
+
     // Width/height lookup tables in units of various block sizes
-    const BLOCK_SIZE_WIDE: [usize; BLOCK_SIZES_ALL] =
+    const BLOCK_SIZE_WIDE: [usize; BlockSize::BLOCK_SIZES_ALL] =
         [4, 4, 8, 8, 8, 16, 16, 16, 32, 32, 32, 64, 64, 4, 16, 8, 32, 16, 64 ];
-    const BLOCK_SIZE_HIGH: [usize; BLOCK_SIZES_ALL] =
+    const BLOCK_SIZE_HIGH: [usize; BlockSize::BLOCK_SIZES_ALL] =
         [4, 8, 4, 8, 16, 8, 16, 32, 16, 32, 64, 32, 64, 16,4, 32, 8, 64, 16 ];
 
     pub fn cfl_allowed(self) -> bool {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -66,6 +66,10 @@ impl BlockSize {
         1 << BlockSize::BLOCK_SIZE_WIDE_LOG2[self as usize]
     }
 
+    pub fn width_log2(self) -> usize {
+        BlockSize::BLOCK_SIZE_WIDE_LOG2[self as usize]
+    }
+
     pub fn width_mi(self) -> usize {
         self.width() >> MI_SIZE_LOG2
     }
@@ -74,8 +78,16 @@ impl BlockSize {
         1 << BlockSize::BLOCK_SIZE_HIGH_LOG2[self as usize]
     }
 
+    pub fn height_log2(self) -> usize {
+        BlockSize::BLOCK_SIZE_HIGH_LOG2[self as usize]
+    }
+
     pub fn height_mi(self) -> usize {
         self.height() >> MI_SIZE_LOG2
+    }
+
+    pub fn is_sqr(self) -> bool {
+        self.width_log2() == self.height_log2()
     }
 }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -10,6 +10,9 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
+use TxSize::*;
+use BlockSize::*;
+
 #[derive(Copy,Clone,PartialEq,PartialOrd)]
 pub enum PartitionType {
     PARTITION_NONE,
@@ -50,6 +53,7 @@ impl BlockSize {
     // Width/height lookup tables in units of various block sizes
     const BLOCK_SIZE_WIDE: [usize; BlockSize::BLOCK_SIZES_ALL] =
         [4, 4, 8, 8, 8, 16, 16, 16, 32, 32, 32, 64, 64, 4, 16, 8, 32, 16, 64 ];
+
     const BLOCK_SIZE_HIGH: [usize; BlockSize::BLOCK_SIZES_ALL] =
         [4, 8, 4, 8, 16, 8, 16, 32, 16, 32, 64, 32, 64, 16,4, 32, 8, 64, 16 ];
 
@@ -134,6 +138,84 @@ impl TxSize {
 
     pub fn height_mi(self) -> usize {
         self.height() >> MI_SIZE_LOG2
+    }
+
+    const TX_SIZE_TO_BLOCK_SIZE: [BlockSize; TxSize::TX_SIZES_ALL] = [
+        BLOCK_4X4,    // TX_4X4
+        BLOCK_8X8,    // TX_8X8
+        BLOCK_16X16,  // TX_16X16
+        BLOCK_32X32,  // TX_32X32
+        BLOCK_64X64,
+        BLOCK_4X8,    // TX_4X8
+        BLOCK_8X4,    // TX_8X4
+        BLOCK_8X16,   // TX_8X16
+        BLOCK_16X8,   // TX_16X8
+        BLOCK_16X32,  // TX_16X32
+        BLOCK_32X16,  // TX_32X16
+        BLOCK_32X64,
+        BLOCK_64X32,
+        BLOCK_4X16,   // TX_4X16
+        BLOCK_16X4,   // TX_16X4
+        BLOCK_8X32,   // TX_8X32
+        BLOCK_32X8,   // TX_32X8
+        BLOCK_16X64,
+        BLOCK_64X16
+    ];
+
+    pub fn to_block_size(self) -> BlockSize {
+        TxSize::TX_SIZE_TO_BLOCK_SIZE[self as usize]
+    }
+
+    const TX_SIZE_SQR: [TxSize; TxSize::TX_SIZES_ALL] = [
+        TX_4X4,
+        TX_8X8,
+        TX_16X16,
+        TX_32X32,
+        TX_64X64,
+        TX_4X4,
+        TX_4X4,
+        TX_8X8,
+        TX_8X8,
+        TX_16X16,
+        TX_16X16,
+        TX_32X32,
+        TX_32X32,
+        TX_4X4,
+        TX_4X4,
+        TX_8X8,
+        TX_8X8,
+        TX_16X16,
+        TX_16X16
+    ];
+
+    pub fn sqr(self) -> TxSize {
+        TxSize::TX_SIZE_SQR[self as usize]
+    }
+
+    const TX_SIZE_SQR_UP: [TxSize; TxSize::TX_SIZES_ALL] = [
+        TX_4X4,
+        TX_8X8,
+        TX_16X16,
+        TX_32X32,
+        TX_64X64,
+        TX_8X8,
+        TX_8X8,
+        TX_16X16,
+        TX_16X16,
+        TX_32X32,
+        TX_32X32,
+        TX_64X64,
+        TX_64X64,
+        TX_16X16,
+        TX_16X16,
+        TX_32X32,
+        TX_32X32,
+        TX_64X64,
+        TX_64X64
+    ];
+
+    pub fn sqr_up(self) -> TxSize {
+        TxSize::TX_SIZE_SQR_UP[self as usize]
     }
 }
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -55,7 +55,7 @@ fn sse_wxh(src1: &PlaneSlice, src2: &PlaneSlice, w: usize, h: usize) -> u64 {
 
 // Compute the rate-distortion cost for an encode
 fn compute_rd_cost(fi: &FrameInvariants, fs: &FrameState,
-                   w_y: u8, h_y: u8, w_uv: u8, h_uv: u8,
+                   w_y: usize, h_y: usize, w_uv: usize, h_uv: usize,
                    partition_start_x: usize, partition_start_y: usize,
                    bo: &BlockOffset, bit_cost: u32) -> f64 {
     let q = dc_q(fi.qindex) as f64;
@@ -71,7 +71,7 @@ fn compute_rd_cost(fi: &FrameInvariants, fs: &FrameState,
     let po = bo.plane_offset(&fs.input.planes[0].cfg);
     let mut distortion = sse_wxh(&fs.input.planes[0].slice(&po),
                                  &fs.rec.planes[0].slice(&po),
-                                 w_y as usize, h_y as usize);
+                                 w_y, h_y);
 
     // Add chroma distortion only when it is available
     if w_uv > 0 && h_uv > 0 {
@@ -84,7 +84,7 @@ fn compute_rd_cost(fi: &FrameInvariants, fs: &FrameState,
 
             distortion += sse_wxh(&fs.input.planes[p].slice(&po),
                                   &fs.rec.planes[p].slice(&po),
-                                  w_uv as usize, h_uv as usize);
+                                  w_uv, h_uv);
         }
     };
 
@@ -106,8 +106,8 @@ pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Con
     let tell = cw.w.tell_frac();
 
     // Get block luma and chroma dimensions
-    let w = block_size_wide[bsize as usize];
-    let h = block_size_high[bsize as usize];
+    let w = bsize.width();
+    let h = bsize.height();
 
     let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
 
@@ -206,8 +206,8 @@ pub fn rdo_tx_type_decision(fi: &FrameInvariants, fs: &mut FrameState,
     let tell = cw.w.tell_frac();
 
     // Get block luma and chroma dimensions
-    let w = block_size_wide[bsize as usize];
-    let h = block_size_high[bsize as usize];
+    let w = bsize.width();
+    let h = bsize.height();
 
     let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
 
@@ -287,7 +287,7 @@ pub fn rdo_partition_decision(fi: &FrameInvariants, fs: &mut FrameState,
                     continue;
                 }
 
-                let bs = mi_size_wide[bsize as usize];
+                let bs = bsize.width_mi();
                 let hbs = bs >> 1; // Half the block size in blocks
 
                 let offset = BlockOffset { x: bo.x, y: bo.y };


### PR DESCRIPTION
This PR refactors the usage of TxSize and BlockSize, removes several lookup tables and exposes most of the previous functionality as member methods on `TxSize` and `BlockSize`.