### PR TITLE
build: make fgrep invocation more specfic

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,7 +42,7 @@ git submodule update --init
 cargo clean
 
 # Get configure command from readme
-CONFIGURE_CMD=$(fgrep cmake README.md)
+CONFIGURE_CMD=$(fgrep "cmake ../aom" README.md)
 
 # Wipe and create aom_test folder
 rm -fR $AOM_TEST


### PR DESCRIPTION
Fixes ./build.sh since README.md now includes more references to cmake.