### PR TITLE
Encode decode tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 Cargo.lock
 *.y4m
 *.ivf
+src/lib/aom.rs

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ script:
     - |
         cargo build --verbose &&
         cargo test --verbose &&
+        cargo test --verbose --release --features=decode_test -- --ignored &&
         cargo bench --verbose &&
         cargo doc --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ include = ["/src/**", "/aom_build/**", "/Cargo.toml"]
 
 [features]
 repl = ["rustyline"]
+decode_test = ["bindgen"]
 
 [dependencies]
 bitstream-io = "0.6"
@@ -21,8 +22,8 @@ backtrace = "0.3"
 [build-dependencies]
 cc = "1"
 cmake = "0.1.29"
-bindgen = "0.33"
 pkg-config = "0.3.9"
+bindgen = { version = "0.33", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/build.rs
+++ b/build.rs
@@ -38,17 +38,20 @@ fn main() {
 
     let dst = cmake::Config::new(build_path)
         .define("CONFIG_DEBUG", debug)
-        .define("CONFIG_EXPERIMENTAL", "1")
-        .define("CONFIG_UNIT_TESTS", "0")
         .define("CONFIG_EXT_PARTITION_TYPES", "0")
+        .define("CONFIG_INTRA_EDGE2", "0")
         .define("CONFIG_OBU", "1")
         .define("CONFIG_FILTER_INTRA", "1")
+        .define("CONFIG_MONO_VIDEO", "1")
+        .define("CONFIG_Q_ADAPT_PROBS", "1")
+        .define("CONFIG_SCALABILITY", "1")
+        .define("CONFIG_OBU_SIZING", "1")
+        .define("CONFIG_TIMING_INFO_IN_SEQ_HEADERS", "0")
+        .define("CONFIG_FILM_GRAIN", "0")
         .define("CONFIG_LV_MAP", "1")
         .define("CONFIG_ANALYZER", "0")
-        .define("CONFIG_Q_ADAPT_PROBS", "1")
-        .define("CONFIG_INTRA_EDGE", "0")
-        .define("CONFIG_SCALABILITY", "1")
         .define("ENABLE_DOCS", "0")
+        .define("CONFIG_UNIT_TESTS", "0")
         .build();
 
     // Dirty hack to force a rebuild whenever the defaults are changed upstream

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ extern {
     pub fn aom_dsp_rtcd();
 }
 
+#[derive(Debug)]
 pub struct Frame {
     pub planes: [Plane; 3]
 }
@@ -204,6 +205,7 @@ impl Sequence {
     }
 }
 
+#[derive(Debug)]
 pub struct FrameState {
     pub input: Frame,
     pub rec: Frame,
@@ -248,6 +250,7 @@ impl Fixed for usize {
 
 // Frame Invariants are invariant inside a frame
 #[allow(dead_code)]
+#[derive(Debug)]
 pub struct FrameInvariants {
     pub width: usize,
     pub height: usize,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -22,7 +22,7 @@ pub enum PartitionType {
   PARTITION_INVALID
 }
 
-#[derive(Copy, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub enum BlockSize {
   BLOCK_4X4,
   BLOCK_4X8,

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -10,6 +10,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
 
 /// Plane-specific configuration.
+#[derive(Debug)]
 pub struct PlaneConfig {
   pub stride: usize,
   pub xdec: usize,
@@ -17,11 +18,13 @@ pub struct PlaneConfig {
 }
 
 /// Absolute offset in pixels inside a plane
+#[derive(Debug)]
 pub struct PlaneOffset {
   pub x: usize,
   pub y: usize
 }
 
+#[derive(Debug)]
 pub struct Plane {
   pub data: Vec<u16>,
   pub cfg: PlaneConfig

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -60,8 +60,21 @@ extern {
     tx_type: libc::c_int,
     bd: libc::c_int
   );
-
+  fn av1_inv_txfm2d_add_4x4_c(
+    input: *const i32,
+    output: *mut u16,
+    stride: libc::c_int,
+    tx_type: libc::c_int,
+    bd: libc::c_int
+  );
   static av1_inv_txfm2d_add_8x8: extern fn(
+    input: *const i32,
+    output: *mut u16,
+    stride: libc::c_int,
+    tx_type: libc::c_int,
+    bd: libc::c_int
+  ) -> ();
+  fn av1_inv_txfm2d_add_8x8_c(
     input: *const i32,
     output: *mut u16,
     stride: libc::c_int,
@@ -140,14 +153,27 @@ fn fht4x4(input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType) {
 fn iht4x4_add(
   input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType
 ) {
-  unsafe {
-    av1_inv_txfm2d_add_4x4(
-      input.as_ptr(),
-      output.as_mut_ptr(),
-      stride as libc::c_int,
-      tx_type as libc::c_int,
-      8
-    );
+  // SIMD code may assert for transform types beyond TxType::IDTX.
+  if tx_type < TxType::IDTX {
+    unsafe {
+      av1_inv_txfm2d_add_4x4(
+        input.as_ptr(),
+        output.as_mut_ptr(),
+        stride as libc::c_int,
+        tx_type as libc::c_int,
+        8
+      );
+    }
+  } else {
+    unsafe {
+      av1_inv_txfm2d_add_4x4_c(
+        input.as_ptr(),
+        output.as_mut_ptr(),
+        stride as libc::c_int,
+        tx_type as libc::c_int,
+        8
+      );
+    }
   }
 }
 
@@ -165,14 +191,27 @@ fn fht8x8(input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType) {
 fn iht8x8_add(
   input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType
 ) {
-  unsafe {
-    av1_inv_txfm2d_add_8x8(
-      input.as_ptr(),
-      output.as_mut_ptr(),
-      stride as libc::c_int,
-      tx_type as libc::c_int,
-      8
-    );
+  // SIMD code may assert for transform types beyond TxType::IDTX.
+  if tx_type < TxType::IDTX {
+    unsafe {
+      av1_inv_txfm2d_add_8x8(
+        input.as_ptr(),
+        output.as_mut_ptr(),
+        stride as libc::c_int,
+        tx_type as libc::c_int,
+        8
+      );
+    }
+  } else {
+    unsafe {
+      av1_inv_txfm2d_add_8x8_c(
+        input.as_ptr(),
+        output.as_mut_ptr(),
+        stride as libc::c_int,
+        tx_type as libc::c_int,
+        8
+      );
+    }
   }
 }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -111,6 +111,13 @@ extern {
     tx_type: libc::c_int,
     bd: libc::c_int
   );
+  fn av1_inv_txfm2d_add_32x32_c(
+    input: *const i32,
+    output: *mut u16,
+    stride: libc::c_int,
+    tx_type: libc::c_int,
+    bd: libc::c_int
+  );
 }
 
 pub fn forward_transform(
@@ -270,12 +277,23 @@ fn iht32x32_add(
   input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType
 ) {
   unsafe {
-    av1_inv_txfm2d_add_32x32(
-      input.as_ptr(),
-      output.as_mut_ptr(),
-      stride as libc::c_int,
-      tx_type as libc::c_int,
-      8
-    );
+    if tx_type < TxType::IDTX {
+      // SIMDI code may assert for transform types beyond TxType::IDTX.
+      av1_inv_txfm2d_add_32x32(
+        input.as_ptr(),
+        output.as_mut_ptr(),
+        stride as libc::c_int,
+        tx_type as libc::c_int,
+        8
+      );
+    } else {
+      av1_inv_txfm2d_add_32x32_c(
+        input.as_ptr(),
+        output.as_mut_ptr(),
+        stride as libc::c_int,
+        tx_type as libc::c_int,
+        8
+      );
+    }
   }
 }


### PR DESCRIPTION
Here the initial implementation of two encode-decode test.
It cover all the speeds and some quantization.
- [x] Encodes random frame data
- [x] Decodes successfully the produced packet
- [x] Decodes unsuccessfully the produced packets
- [x] Detects packet corruption

In the process of using the test, I found the hard way a couple of issues that got fixed in the first commits.

Fixes #3 