### PR TITLE
WIP - Align plane data to 16 bytes.

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -253,7 +253,7 @@ pub fn cdef_frame(fi: &FrameInvariants, rec: &mut Frame, bc: &mut BlockContext) 
                     }
                 } else {
                     let rec_stride = rec.planes[p].cfg.stride;
-                    cdef_row.copy_from_slice(&rec.planes[p].data[(row-2)*rec_stride..(row-1)*rec_stride]);
+                    cdef_row.copy_from_slice(&rec.planes[p].data[(row-2)*rec_stride..(row-1)*rec_stride][..rec_w]);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,32 +224,6 @@ impl FrameState {
     }
 }
 
-trait Fixed {
-    fn floor_log2(&self, n: usize) -> usize;
-    fn ceil_log2(&self, n: usize) -> usize;
-    fn align_power_of_two(&self, n: usize) -> usize;
-    fn align_power_of_two_and_shift(&self, n: usize) -> usize;
-}
-
-impl Fixed for usize {
-    #[inline]
-    fn floor_log2(&self, n: usize) -> usize {
-        self & !((1 << n) - 1)
-    }
-    #[inline]
-    fn ceil_log2(&self, n: usize) -> usize {
-        (self + (1 << n) - 1).floor_log2(n)
-    }
-    #[inline]
-    fn align_power_of_two(&self, n: usize) -> usize {
-        self.ceil_log2(n)
-    }
-    #[inline]
-    fn align_power_of_two_and_shift(&self, n: usize) -> usize {
-        (self + (1 << n) - 1) >> n
-    }
-}
-
 // Frame Invariants are invariant inside a frame
 #[allow(dead_code)]
 #[derive(Debug)]
@@ -2006,7 +1980,7 @@ mod test_encode_decode {
     }
 
     // TODO: support non-multiple-of-16 dimensions
-    static DIMENSION_OFFSETS: &[(usize, usize)] = &[(0, 0), (16, 16)];
+    static DIMENSION_OFFSETS: &[(usize, usize)] = &[(0, 0), (4, 4), (8, 8), (16, 16)];
 
     #[test]
     #[ignore]

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -9,6 +9,8 @@
 
 #![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
 
+use util::*;
+
 /// Plane-specific configuration.
 #[derive(Debug, Clone)]
 pub struct PlaneConfig {
@@ -34,9 +36,10 @@ pub struct Plane {
 
 impl Plane {
   pub fn new(width: usize, height: usize, xdec: usize, ydec: usize) -> Plane {
+    let stride = width.align_power_of_two(4); // Force 16 byte alignment.
     Plane {
-      data: vec![128; width * height],
-      cfg: PlaneConfig { stride: width, width, height, xdec, ydec }
+      data: vec![128; stride * height],
+      cfg: PlaneConfig { stride, width, height, xdec, ydec }
     }
   }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -46,3 +46,29 @@ fn sanity() {
   let a: AlignedArray<_> = AlignedArray([0u8; 3]);
   assert!(a.array.as_ptr() as usize % 16 == 0);
 }
+
+pub trait Fixed {
+    fn floor_log2(&self, n: usize) -> usize;
+    fn ceil_log2(&self, n: usize) -> usize;
+    fn align_power_of_two(&self, n: usize) -> usize;
+    fn align_power_of_two_and_shift(&self, n: usize) -> usize;
+}
+
+impl Fixed for usize {
+    #[inline]
+    fn floor_log2(&self, n: usize) -> usize {
+        self & !((1 << n) - 1)
+    }
+    #[inline]
+    fn ceil_log2(&self, n: usize) -> usize {
+        (self + (1 << n) - 1).floor_log2(n)
+    }
+    #[inline]
+    fn align_power_of_two(&self, n: usize) -> usize {
+        self.ceil_log2(n)
+    }
+    #[inline]
+    fn align_power_of_two_and_shift(&self, n: usize) -> usize {
+        (self + (1 << n) - 1) >> n
+    }
+}


### PR DESCRIPTION
The first step is to aligns plane strides to 16 bytes. This caused a bug in the CDEF code related to slices not matching. I think I fixed that issue, but multiplication overflow errors still remain and I'm not sure how to fix this. 

@xiphmont can you take a look and see if I'm doing something obviously wrong here?

