### PR TITLE
Propagate skip to the transform type decision function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1498,7 +1498,7 @@ fn encode_block(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState, cw: &
 
     let tx_type = if tx_set > TxSet::TX_SET_DCTONLY && fi.config.speed <= 3 {
         // FIXME: there is one redundant transform type decision per encoded block
-        rdo_tx_type_decision(fi, fs, cw, luma_mode, bsize, bo, tx_size, tx_set)
+        rdo_tx_type_decision(fi, fs, cw, luma_mode, bsize, bo, tx_size, tx_set, skip)
     } else {
         TxType::DCT_DCT
     };

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -284,7 +284,7 @@ pub fn rdo_mode_decision(
 pub fn rdo_tx_type_decision(
   fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
   mode: PredictionMode, bsize: BlockSize, bo: &BlockOffset, tx_size: TxSize,
-  tx_set: TxSet
+  tx_set: TxSet, skip: bool
 ) -> TxType {
   let mut best_type = TxType::DCT_DCT;
   let mut best_rd = std::f64::MAX;
@@ -316,7 +316,7 @@ pub fn rdo_tx_type_decision(
     }
 
     write_tx_blocks(
-      fi, fs, cw, mode, mode, bo, bsize, tx_size, tx_type, false,
+      fi, fs, cw, mode, mode, bo, bsize, tx_size, tx_type, skip,
     );
 
     let cost = cw.w.tell_frac() - tell;


### PR DESCRIPTION
This should make skip decisions more accurate, but skip RDO remains disabled, as it currently reduces coding efficiency. No desynchronization is detected via the decoding tests with this change and skip RDO enabled. Related: #374