### PR TITLE
Use the default initializer for ReferenceFramesSet frames

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub struct ReferenceFramesSet {
 impl ReferenceFramesSet {
     pub fn new() -> ReferenceFramesSet {
         ReferenceFramesSet {
-            frames: [None, None, None, None, None, None, None, None]
+            frames: Default::default()
         }
     }
 }


### PR DESCRIPTION
Minor improvement to #384 as suggested by @lu-zero.