### PR TITLE
Future proof the benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
 build = "build.rs"
 include = ["/src/**", "/aom_build/**", "/Cargo.toml"]
+autobenches = false
 
 [features]
 repl = ["rustyline"]


### PR DESCRIPTION
Cargo would try to compile each file at the root of benches/ as
stand alone benchmark.

Disable the behaviour.