### PR TITLE
Alignment Cleanup

### DIFF
--- a/src/plane.rs
+++ b/src/plane.rs
@@ -35,12 +35,17 @@ pub struct Plane {
 }
 
 impl Plane {
+  /// Stride alignment in bytes.
+  const STRIDE_ALIGNMENT_LOG2: usize = 4;
+
+  /// Data alignment in bytes.
+  const DATA_ALIGNMENT_LOG2: usize = 4;
+
   pub fn new(width: usize, height: usize, xdec: usize, ydec: usize) -> Plane {
-    let stride = width.align_power_of_two(4); // Force 16 byte alignment.
-    Plane {
-      data: vec![128; stride * height],
-      cfg: PlaneConfig { stride, width, height, xdec, ydec }
-    }
+    let stride = width.align_power_of_two(Plane::STRIDE_ALIGNMENT_LOG2 - 1);
+    let data = vec![128u16; stride * height];
+    assert!(is_aligned(data.as_ptr(), Plane::DATA_ALIGNMENT_LOG2));
+    Plane { data, cfg: PlaneConfig { stride, width, height, xdec, ydec } }
   }
 
   pub fn slice<'a>(&'a self, po: &PlaneOffset) -> PlaneSlice<'a> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -44,7 +44,7 @@ pub fn UninitializedAlignedArray<ARRAY>() -> AlignedArray<ARRAY> {
 #[test]
 fn sanity() {
   let a: AlignedArray<_> = AlignedArray([0u8; 3]);
-  assert!(a.array.as_ptr() as usize % 16 == 0);
+  assert!(is_aligned(a.array.as_ptr(), 4));
 }
 
 pub trait Fixed {
@@ -71,4 +71,9 @@ impl Fixed for usize {
   fn align_power_of_two_and_shift(&self, n: usize) -> usize {
     (self + (1 << n) - 1) >> n
   }
+}
+
+/// Check alignment.
+pub fn is_aligned<T>(ptr: *const T, n: usize) -> bool {
+  return ((ptr as usize) & ((1 << n) - 1)) == 0;
 }


### PR DESCRIPTION
Plane data uses `u16` so the stride just needs to be a multiple of 8 to be 16 byte aligned.