### PR TITLE
Support build on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ backtrace = "0.3"
 
 [build-dependencies]
 cc = "1"
-cmake = "0.1.29"
-pkg-config = "0.3.9"
+cmake = "0.1.32"
+pkg-config = "0.3.12"
 bindgen = { version = "0.37", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ autobenches = false
 
 [features]
 repl = ["rustyline"]
-decode_test = ["bindgen"]
 comparative_bench = []
+decode_test = ["bindgen"]
 
 [dependencies]
 bitstream-io = "0.6"
@@ -22,8 +22,9 @@ enum-iterator-derive = "0.1.1"
 backtrace = "0.3"
 
 [build-dependencies]
-cc = "1"
 cmake = { git = "https://github.com/alexcrichton/cmake-rs", rev = "4998d28" }
+
+[target.'cfg(unix)'.build-dependencies]
 pkg-config = "0.3.12"
 bindgen = { version = "0.37", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ enum-iterator-derive = "0.1.1"
 backtrace = "0.3"
 
 [build-dependencies]
-cmake = { git = "https://github.com/alexcrichton/cmake-rs", rev = "4998d28" }
+cmake = "0.1.32"
 
 [target.'cfg(unix)'.build-dependencies]
 pkg-config = "0.3.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ backtrace = "0.3"
 
 [build-dependencies]
 cc = "1"
-cmake = "0.1.32"
+cmake = { git = "https://github.com/alexcrichton/cmake-rs", rev = "4998d28" }
 pkg-config = "0.3.12"
 bindgen = { version = "0.37", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ git submodule update --init
 
 This is also required every time you switch branches or pull a submodule change.
 
-In order to build and link to the codec, you need Perl, Yasm, CMake, and pkg-config. To install this on Ubuntu or Linux Mint, run:
+In order to build and link to the codec on UNIX, you need Perl, Yasm, CMake, and pkg-config. To install this on Ubuntu or Linux Mint, run:
 
 ```
 sudo apt install perl yasm cmake pkg-config
 ```
+
+On Windows, pkg-config is not required. A Perl distribution such as Strawberry Perl, CMake, and a Yasm binary in your system PATH are required.
 
 # Compressing video
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ git submodule update --init
 
 This is also required every time you switch branches or pull a submodule change.
 
-In order to build the codec, you need perl, yasm and cmake. To install this on Ubuntu or Linux Mint, run:
+In order to build and link to the codec, you need Perl, Yasm, CMake, and pkg-config. To install this on Ubuntu or Linux Mint, run:
 
 ```
-sudo apt install perl yasm cmake
+sudo apt install perl yasm cmake pkg-config
 ```
 
 # Compressing video

--- a/build.rs
+++ b/build.rs
@@ -8,9 +8,8 @@ extern crate pkg_config;
 extern crate bindgen;
 
 use std::env;
-use std::path::Path;
-#[cfg(unix)]
 use std::fs;
+use std::path::Path;
 
 fn main() {
     if cfg!(windows) && cfg!(feature = "decode_test") {

--- a/build.rs
+++ b/build.rs
@@ -51,14 +51,14 @@ fn main() {
     
     #[cfg(unix)] {
         env::set_var("PKG_CONFIG_PATH", dst.join("lib/pkgconfig"));
-        let libs = pkg_config::Config::new().statik(true).probe("aom").unwrap();
+        let _libs = pkg_config::Config::new().statik(true).probe("aom").unwrap();
 
         #[cfg(feature = "decode_test")] {
             use std::io::Write;
 
             let out_dir = env::var("OUT_DIR").unwrap();
 
-            let headers = libs.include_paths.clone();
+            let headers = _libs.include_paths.clone();
 
             let mut builder = bindgen::builder()
                 .blacklist_type("max_align_t")
@@ -81,11 +81,10 @@ fn main() {
 
             let mut file = fs::File::create(dest_path).unwrap();
 
-            file.write(s.as_bytes());
+            let _ = file.write(s.as_bytes());
         }
     }
 
-    use std::fs;
     fn rerun_dir<P: AsRef<Path>>(dir: P) {
         for entry in fs::read_dir(dir).unwrap() {
             let entry = entry.unwrap();

--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,22 @@
 // build.rs
 
 extern crate cmake;
-extern crate cc;
+#[cfg(unix)]
 extern crate pkg_config;
+#[cfg(unix)]
 #[cfg(feature = "decode_test")]
 extern crate bindgen;
 
 use std::env;
 use std::path::Path;
-
+#[cfg(unix)]
 use std::fs;
 
-fn main() {    
+fn main() {
+    if cfg!(windows) && cfg!(feature = "decode_test") {
+        panic!("Unsupported feature on this platform!");
+    }
+
     let cargo_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let build_path = Path::new(&cargo_dir).join("aom_build/aom");
     let debug = if let Some(v) = env::var("PROFILE").ok() {
@@ -34,7 +39,7 @@ fn main() {
     // Dirty hack to force a rebuild whenever the defaults are changed upstream
     let _ = fs::remove_file(dst.join("build/CMakeCache.txt"));
 
-    if cfg!(windows) {
+    #[cfg(windows)] {
         let bin_dir = if debug {
             "Debug"
         } else {
@@ -42,56 +47,56 @@ fn main() {
         };
         println!("cargo:rustc-link-search=native={}", dst.join("build").join(bin_dir).to_str().unwrap());
         println!("cargo:rustc-link-lib=static=aom");
-    } else {
+    }
+    
+    #[cfg(unix)] {
         env::set_var("PKG_CONFIG_PATH", dst.join("lib/pkgconfig"));
-        pkg_config::Config::new().statik(true).probe("aom").unwrap();
-    }
+        let libs = pkg_config::Config::new().statik(true).probe("aom").unwrap();
 
-    #[cfg(feature = "decode_test")] {
-        use std::io::Write;
+        #[cfg(feature = "decode_test")] {
+            use std::io::Write;
 
-        let out_dir = env::var("OUT_DIR").unwrap();
+            let out_dir = env::var("OUT_DIR").unwrap();
 
-        let headers = _libs.include_paths.clone();
+            let headers = libs.include_paths.clone();
 
-        let mut builder = bindgen::builder()
-            .blacklist_type("max_align_t")
-            .rustfmt_bindings(false)
-            .header("data/aom.h");
+            let mut builder = bindgen::builder()
+                .blacklist_type("max_align_t")
+                .rustfmt_bindings(false)
+                .header("data/aom.h");
 
-        for header in headers {
-            builder = builder.clang_arg("-I").clang_arg(header.to_str().unwrap());
+            for header in headers {
+                builder = builder.clang_arg("-I").clang_arg(header.to_str().unwrap());
+            }
+
+            // Manually fix the comment so rustdoc won't try to pick them
+            let s = builder
+                .generate()
+                .unwrap()
+                .to_string()
+                .replace("/**", "/*")
+                .replace("/*!", "/*");
+
+            let dest_path = Path::new(&out_dir).join("aom.rs");
+
+            let mut file = fs::File::create(dest_path).unwrap();
+
+            file.write(s.as_bytes());
         }
-
-        // Manually fix the comment so rustdoc won't try to pick them
-        let s = builder
-            .generate()
-            .unwrap()
-            .to_string()
-            .replace("/**", "/*")
-            .replace("/*!", "/*");
-
-        let dest_path = Path::new(&out_dir).join("aom.rs");
-
-        let mut file = fs::File::create(dest_path).unwrap();
-
-        let _ = file.write(s.as_bytes());
     }
 
-    {
-        use std::fs;
-        fn rerun_dir<P: AsRef<Path>>(dir: P) {
-            for entry in fs::read_dir(dir).unwrap() {
-                let entry = entry.unwrap();
-                let path = entry.path();
-                println!("cargo:rerun-if-changed={}", path.to_string_lossy());
+    use std::fs;
+    fn rerun_dir<P: AsRef<Path>>(dir: P) {
+        for entry in fs::read_dir(dir).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            println!("cargo:rerun-if-changed={}", path.to_string_lossy());
 
-                if path.is_dir() {
-                    rerun_dir(path);
-                }
+            if path.is_dir() {
+                rerun_dir(path);
             }
         }
-
-        rerun_dir("aom_build");
     }
+
+    rerun_dir("aom_build");
 }


### PR DESCRIPTION
This allows `libaom` to compile and link to `rav1e` on Windows, tested with MSVC. Note that this will not compile until https://github.com/alexcrichton/cmake-rs/pull/49 is pulled and `cmake-rs` receives a version update.

Closes #412.