### PR TITLE
Cdef recorder

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -59,7 +59,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
   let config =
     EncoderConfig { quantizer: qindex, speed: 10, ..Default::default() };
   let mut fi = FrameInvariants::new(1024, 1024, config);
-  let mut w = ec::Writer::new();
+  let mut w = ec::WriterEncoder::new();
   let fc = CDFContext::new(fi.config.quantizer as u8);
   let bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
   let mut fs = FrameState::new(&fi);

--- a/src/context.rs
+++ b/src/context.rs
@@ -1647,6 +1647,7 @@ pub struct ContextWriterCheckpoint {
   pub bc: BlockContext
 }
 
+#[derive(Clone)]
 pub struct ContextWriter {
   pub bc: BlockContext,
   fc: CDFContext,

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -19,247 +19,214 @@ use std;
 pub const OD_BITRES: u8 = 3;
 const EC_PROB_SHIFT: u32 = 6;
 const EC_MIN_PROB: u32 = 4;
+type ec_window = u32;
 
-#[derive(Clone)]
-pub struct Writer {
-  enc: od_ec_enc,
-  #[cfg(debug)]
-  debug: bool
+/// Public trait interface to a bitstream writer; can be used either
+/// to record tokens for later writing (using a new::WriterRecorder()
+/// as a Writer) or to write atual final bits out using a range
+/// encoder (using a new::WriterEncoder() as a Writer).  A
+/// WriterRecorder's contents can be replayed into a WriterEncoder.
+pub trait Writer {
+  /// Write a symbol s, using the passed in cdf reference; leaves cdf unchanged
+  fn symbol(&mut self, s: u32, cdf: &[u16]);
+  /// Write a symbol s, using the passed in cdf reference; updates the referenced cdf.
+  fn symbol_with_update(&mut self, s: u32, cdf: &mut [u16]);
+  /// Write a bool using passed in probability
+  fn bool(&mut self, val: bool, f: u16);
+  /// Write a single bit with flat proability
+  fn bit(&mut self, bit: u16);
+  /// Write literal bits with flat probability
+  fn literal(&mut self, bits: u8, s: u32);
+  /// Write passed level as a golomb code
+  fn write_golomb(&mut self, level: u16);
+  /// Return current length of range-coded bitsream in integer bits
+  fn tell(&mut self) -> u32;
+  /// Return currrent length of range-coded bitsream in fractional
+  /// bits with OD_BITRES decimal precision
+  fn tell_frac(&mut self) -> u32;
+  /// Save current point in coding/recording to a checkpoint  
+  fn checkpoint(&mut self) -> WriterCheckpoint;
+  /// Restore saved position in coding/recording from a checkpoint  
+  fn rollback(&mut self, &WriterCheckpoint);
 }
 
-pub type od_ec_window = u32;
+/// StorageBackend is an internal trait used to tie a specific Writer
+/// implementation's storage to the generic Writer.  It would be
+/// private, but Rust is deprecating 'private trait in a public
+/// interface' support.
+pub trait StorageBackend {
+  /// Store partially-computed range code into given storage backend
+  fn store(&mut self, l: ec_window, r: u16);
+  /// Return byte-length of encoded stream to date  
+  fn stream_bytes(&mut self) -> usize;
+  /// Backend implenetaiton of checkpoint to pass through Writer interface  
+  fn checkpoint(&mut self) -> WriterCheckpoint;
+  /// Backend implenetaiton of rollback to pass through Writer interface  
+  fn rollback(&mut self, &WriterCheckpoint);
+}
 
 #[derive(Debug, Clone)]
-pub struct od_ec_enc {
-  /// A buffer for output bytes with their associated carry flags.
-  pub precarry: Vec<u16>,
-  /// The low end of the current range.
-  pub low: od_ec_window,
+pub struct WriterBase<S> {
   /// The number of values in the current range.
-  pub rng: u16,
+  rng: u16,
   /// The number of bits of data in the current value.
-  pub cnt: i16,
-  /// Are we recording for replay?
-  pub recordp: bool,
-  /// A buffer for probabilities
-  pub fl: Vec<u16>,
-  /// A buffer for probabilities
-  pub fh: Vec<u16>,
-  /// Buffer for symbols
-  pub nms: Vec<u16>,
+  cnt: i16,
+  /// Debug enable flag
+  debug: bool,
+  /// Use-specific storage
+  s: S
 }
 
-impl od_ec_enc {
-  fn new() -> od_ec_enc {
-    od_ec_enc {
+#[derive(Debug, Clone)]
+pub struct WriterRecorder {
+  /// Storage for tokens
+  storage: Vec<(ec_window, u16)>,
+  /// Bytes that would be shifted out to date
+  bytes: usize  
+}
+
+#[derive(Debug, Clone)]
+pub struct WriterEncoder {
+  /// A buffer for output bytes with their associated carry flags.
+  precarry: Vec<u16>,
+  /// The low end of the current range.
+  low: ec_window,
+}
+
+#[derive(Clone)]
+pub struct WriterCheckpoint {
+  /// Byte length coded/recorded to date  
+  stream_bytes: usize,
+  /// To be defined by backend  
+  backend_var: usize,
+  /// Saved number of values in the current range.
+  rng: u16,
+  /// Saved number of bits of data in the current value.
+  cnt: i16,
+}
+
+/// Constructor for a recording Writer
+impl WriterRecorder {
+  pub fn new () -> WriterBase<WriterRecorder> {
+    WriterBase::new(WriterRecorder {
+      storage: Vec::new(),
+      bytes: 0
+    })
+  }
+}
+
+/// Constructor for a encoding Writer
+impl WriterEncoder {
+  pub fn new () -> WriterBase<WriterEncoder> {
+    WriterBase::new(WriterEncoder {
       precarry: Vec::new(),
-      low: 0,
-      rng: 0x8000,
-      // This is initialized to -9 so that it crosses zero after we've
-      // accumulated one byte + one carry bit
-      cnt: -9,
-      recordp: false,
-      fl: Vec::new(),
-      fh: Vec::new(),
-      nms: Vec::new()
-    }
+      low: 0
+    })
   }
+}
 
-  fn new_recorder() -> od_ec_enc {
-    od_ec_enc {
-      precarry: Vec::new(),
-      low: 0,
-      rng: 0x8000,
-      cnt: -9,
-      recordp: true,
-      fl: Vec::new(),
-      fh: Vec::new(),
-      nms: Vec::new()
-    }
-  }
-
-  /// Encode a single binary value.
-  /// `val`: The value to encode (0 or 1).
-  /// `f`: The probability that the val is one, scaled by 32768.
-  fn od_ec_encode_bool_q15(&mut self, val: bool, f: u16) {
-    debug_assert!(0 < f);
-    debug_assert!(f < 32768);
-    let mut l = self.low;
-    let mut r = self.rng as u32;
-    debug_assert!(32768 <= r);
-
-    let mut v =
-      ((r >> 8) * (f as u32 >> EC_PROB_SHIFT)) >> (7 - EC_PROB_SHIFT);
-    v += EC_MIN_PROB;
-    if val {
-      if self.recordp {
-        self.fl.push(f);
-        self.fh.push(0);
-        self.nms.push(1);
-      }
-      l += r - v;
-      r = v;
-    } else {
-      if self.recordp {
-        self.fl.push(32768);
-        self.fh.push(f);
-        self.nms.push(0);
-      }
-      r -= v;
-    }
-
-    self.od_ec_enc_normalize(l, r as u16);
-  }
-
-  /// Encodes a symbol given a cumulative distribution function (CDF) table in Q15.
-  /// `s`: The index of the symbol to encode.
-  /// `cdf`: The CDF, such that symbol s falls in the range
-  ///        `[s > 0 ? cdf[s - 1] : 0, cdf[s])`.
-  ///       The values must be monotonically non-decreasing, and the last value
-  ///       must be exactly 32768. There should be at most 16 values.
-  fn od_ec_encode_cdf_q15(&mut self, s: usize, cdf: &[u16]) {
-    debug_assert!(cdf[cdf.len() - 1] == 0);
-    let nsyms = cdf.len();
-    self.od_ec_encode_q15(
-      if s > 0 { cdf[s - 1] } else { 32768 },
-      cdf[s],
-      nsyms - s
-    );
-  }
-
-  /// Encodes a symbol given its frequency in Q15.
-  /// `fl`: 32768 minus the cumulative frequency of all symbols that come
-  ///       before the one to be encoded.
-  /// `fh`: 32768 moinus the cumulative frequency of all symbols up to and
-  ///       including the one to be encoded.
-  fn od_ec_encode_q15(&mut self, fl: u16, fh: u16, nms: usize) {
-    let mut l = self.low;
-    let mut r = self.rng as u32;
-    let u: u32;
-    let v: u32;
-    debug_assert!(32768 <= r);
-
-    debug_assert!(fh <= fl);
-    debug_assert!(fl <= 32768);
-
-    if self.recordp {
-      self.fl.push(fl);
-      self.fh.push(fh);
-      self.nms.push(nms as u16);
-    }
-
-    if fl < 32768 {
-      u = (((r >> 8) * (fl as u32 >> EC_PROB_SHIFT)) >> (7 - EC_PROB_SHIFT))
-        + EC_MIN_PROB * nms as u32;
-      v = (((r >> 8) * (fh as u32 >> EC_PROB_SHIFT)) >> (7 - EC_PROB_SHIFT))
-        + EC_MIN_PROB * (nms - 1) as u32;
-      l += r - u;
-      r = u - v;
-    } else {
-      r -= (((r >> 8) * (fh as u32 >> EC_PROB_SHIFT)) >> (7 - EC_PROB_SHIFT))
-        + EC_MIN_PROB * (nms - 1) as u32;
-    }
-
-    self.od_ec_enc_normalize(l, r as u16);
-  }
-
-  fn od_ilog_nz(x: u16) -> u16 {
-    16 - (x.leading_zeros() as u16)
-  }
-
-  /// Takes updated low and range values, renormalizes them so that
-  /// 32768 <= `rng` < 65536 (flushing bytes from low to the pre-carry buffer if
-  /// necessary), and stores them back in the encoder context.
-  /// `low0`: The new value of low.
-  /// `rng`: The new value of the range.
-  fn od_ec_enc_normalize(&mut self, low0: od_ec_window, rng: u16) {
-    let mut low = low0;
+/// The Recorder does not produce a range-coded bitstream, but it
+/// still tracks the range coding progress like in an Encoder, as it
+/// neds to be able to report bit costs for RDO decsions.  It stores a
+/// pair of mostly-computed range coding values per token recorded.
+impl StorageBackend for WriterBase<WriterRecorder> {
+  fn store(&mut self, l: ec_window, r: u16) {
+    let d = 16 - WriterBase::<Self>::ilog_nz(r);
     let mut c = self.cnt;
-    let d = 16 - od_ec_enc::od_ilog_nz(rng);
+    let mut s = c + (d as i16);
+
+    if s >= 0 {
+      c += 16;
+      if s >= 8 {
+        self.s.bytes += 1;
+        c -= 8;
+      }
+      self.s.bytes += 1;
+      s = c + (d as i16) - 24;
+    }
+    self.rng = r << d;
+    self.cnt = s;
+    self.s.storage.push((l,r));
+  }
+  fn stream_bytes(&mut self) -> usize {
+      self.s.bytes
+  }
+  fn checkpoint(&mut self) -> WriterCheckpoint {
+    WriterCheckpoint {
+      stream_bytes: self.s.bytes,
+      backend_var: self.s.storage.len(),
+      rng: self.rng,
+      cnt: self.cnt,
+    }
+  }    
+  fn rollback(&mut self, checkpoint: &WriterCheckpoint) {
+    self.rng = checkpoint.rng;
+    self.cnt = checkpoint.cnt;
+    self.s.bytes = checkpoint.stream_bytes;
+    self.s.storage.truncate(checkpoint.backend_var);
+  }
+}
+
+/// An Encoder produces an actual range-coded bitstream from passed in
+/// tokens.  It does not retain any information about the coded
+/// tokens, only the resulting bitstream, and so it cannot be replayed
+/// (only checkpointed and rolled back).
+impl StorageBackend for WriterBase<WriterEncoder> {
+  fn store(&mut self, l: ec_window, r: u16) {
+    let mut low = l + self.s.low;
+    let mut c = self.cnt;
+    let d = 16 - WriterBase::<Self>::ilog_nz(r);
     let mut s = c + (d as i16);
 
     if s >= 0 {
       c += 16;
       let mut m = (1 << c) - 1;
       if s >= 8 {
-        self.precarry.push((low >> c) as u16);
+        self.s.precarry.push((low >> c) as u16);
         low &= m;
         c -= 8;
         m >>= 8;
       }
-      self.precarry.push((low >> c) as u16);
+      self.s.precarry.push((low >> c) as u16);
       s = c + (d as i16) - 24;
       low &= m;
     }
-    self.low = low << d;
-    self.rng = rng << d;
+    self.s.low = low << d;
+    self.rng = r << d;
     self.cnt = s;
   }
-
-  /// Indicates that there are no more symbols to encode.
-  /// Returns a vector containing the final bitstream.
-  fn od_ec_enc_done(&mut self) -> Vec<u8> {
-    // We output the minimum number of bits that ensures that the symbols encoded
-    // thus far will be decoded correctly regardless of the bits that follow.
-    let l = self.low;
-    let mut c = self.cnt;
-    let mut s = 10;
-    let m = 0x3FFF;
-    let mut e = ((l + m) & !m) | (m + 1);
-
-    s += c;
-
-    if s > 0 {
-      let mut n = (1 << (c + 16)) - 1;
-
-      loop {
-        self.precarry.push((e >> (c + 16)) as u16);
-        e &= n;
-        s -= 8;
-        c -= 8;
-        n >>= 8;
-
-        if s <= 0 {
-          break;
-        }
-      }
+  fn stream_bytes(&mut self) -> usize {
+      self.s.precarry.len()
+  }
+  fn checkpoint(&mut self) -> WriterCheckpoint {
+    WriterCheckpoint {
+        stream_bytes: self.s.precarry.len(),
+        backend_var: self.s.low as usize,
+        rng: self.rng,
+        cnt: self.cnt,
     }
+  }
+  fn rollback(&mut self, checkpoint: &WriterCheckpoint) {
+    self.rng = checkpoint.rng;
+    self.cnt = checkpoint.cnt;
+    self.s.low = checkpoint.backend_var as ec_window;
+    self.s.precarry.truncate(checkpoint.stream_bytes);
+  }
+}
 
-    let mut c = 0;
-    let mut offs = self.precarry.len();
-    let mut out = vec![0 as u8; offs];
-    while offs > 0 {
-      offs -= 1;
-      c += self.precarry[offs];
-      out[offs] = c as u8;
-      c >>= 8;
+/// A few local helper functions needed by the Writer that are not
+/// part of the public interface.
+impl<S> WriterBase<S>{
+  /// Internal constructor called by the subtypes that implement the
+  /// actual encoder and Recorder.
+  fn new(storage: S) -> Self {
+    WriterBase {
+      rng: 0x8000,
+      cnt: -9,
+      debug: false, 
+      s: storage
     }
-
-    out
   }
-
-  /// Returns the number of bits "used" by the encoded symbols so far.
-  /// This same number can be computed in either the encoder or the decoder, and is
-  ///  suitable for making coding decisions.
-  /// Return: The number of bits.
-  ///         This will always be slightly larger than the exact value (e.g., all
-  ///          rounding error is in the positive direction).
-  pub fn od_ec_enc_tell(&mut self) -> u32 {
-    // The 10 here counteracts the offset of -9 baked into cnt, and adds 1 extra
-    // bit, which we reserve for terminating the stream.
-    (((self.precarry.len() * 8) as i32) + (self.cnt as i32) + 10) as u32
-  }
-
-  /// Returns the number of bits "used" by the encoded symbols so far.
-  /// This same number can be computed in either the encoder or the decoder, and is
-  /// suitable for making coding decisions.
-  /// Return: The number of bits scaled by `2**OD_BITRES`.
-  ///         This will always be slightly larger than the exact value (e.g., all
-  ///          rounding error is in the positive direction).
-  pub fn od_ec_enc_tell_frac(&mut self) -> u32 {
-    od_ec_enc::od_ec_tell_frac(self.od_ec_enc_tell(), self.rng as u32)
-  }
-
   /// Given the current total integer number of bits used and the current value of
   /// rng, computes the fraction number of bits used to `OD_BITRES` precision.
   /// This is used by `od_ec_enc_tell_frac()` and `od_ec_dec_tell_frac()`.
@@ -269,7 +236,7 @@ impl od_ec_enc {
   /// Return: The number of bits scaled by `2**OD_BITRES`.
   ///         This will always be slightly larger than the exact value (e.g., all
   ///         rounding error is in the positive direction).
-  fn od_ec_tell_frac(nbits_total: u32, mut rng: u32) -> u32 {
+  fn frac_compute(nbits_total: u32, mut rng: u32) -> u32 {
     // To handle the non-integral number of bits still left in the encoder/decoder
     //  state, we compute the worst-case number of bits of val that must be
     //  encoded to ensure that the value is inside the range for any possible
@@ -294,46 +261,11 @@ impl od_ec_enc {
     }
     nbits - l
   }
-
-  /// Replay our contents into the passed-in od_ec_enc writer
-  pub fn od_ec_enc_replay(&mut self, dest: &mut od_ec_enc) {
-    if self.recordp {
-        for i in 0..self.fl.len() {
-            dest.od_ec_encode_q15(self.fl[i],self.fh[i],self.nms[i] as usize);
-        }
-    }
+  /// Simple calculation of position of leading 1 bit.
+  fn ilog_nz(x: u16) -> u16 {
+    16 - (x.leading_zeros() as u16)
   }
-}
-
-impl Writer {
-  pub fn new() -> Writer {
-    // use std::env;
-    Writer {
-      enc: od_ec_enc::new(),
-      #[cfg(debug)]
-      debug: std::env::var_os("RAV1E_DEBUG").is_some()
-    }
-  }
-  pub fn new_recorder() -> Writer {
-    // use std::env;
-    Writer {
-      enc: od_ec_enc::new_recorder(),
-      #[cfg(debug)]
-      debug: std::env::var_os("RAV1E_DEBUG").is_some()
-    }
-  }
-  pub fn done(&mut self) -> Vec<u8> {
-    self.enc.od_ec_enc_done()
-  }
-  pub fn replay(&mut self, dest: &mut Writer){
-    self.enc.od_ec_enc_replay(&mut dest.enc);
-  }
-  pub fn cdf(&mut self, s: u32, cdf: &[u16]) {
-    self.enc.od_ec_encode_cdf_q15(s as usize, cdf)
-  }
-  pub fn bool(&mut self, val: bool, f: u16) {
-    self.enc.od_ec_encode_bool_q15(val, f)
-  }
+  /// Function to update the CDF for Writer calls that do so.
   fn update_cdf(cdf: &mut [u16], val: u32) {
     let nsymbs = cdf.len() - 1;
     let nsymbs2speed: [usize; 17] =
@@ -378,8 +310,135 @@ impl Writer {
       }
     });
   }
+}
 
-  pub fn symbol(&mut self, s: u32, cdf: &mut [u16]) {
+/// Replay implemenetation specific to the Recorder
+impl WriterBase<WriterRecorder> {
+  /// Replays the partiall-computer range tokens out of the Recorder's
+  /// storage and into the passed in Writer, which may be an Encoder
+  /// or another Recorder.  Clears the Recorder after replay.
+  pub fn replay(&mut self, dest: &mut StorageBackend) {
+    for i in 0..self.s.storage.len() {
+      let (l, r) = self.s.storage[i];
+      dest.store(l, r);
+    }
+    self.s.storage.truncate(0);
+    self.s.bytes = 0;
+  }
+}
+
+/// Done implementation specific to the Encoder
+impl WriterBase<WriterEncoder> {
+  /// Indicates that there are no more symbols to encode.  Flushes
+  /// remaining state into coding and returns a vector containing the
+  /// final bitstream.
+  pub fn done(&mut self) -> Vec<u8> {
+    // We output the minimum number of bits that ensures that the symbols encoded
+    // thus far will be decoded correctly regardless of the bits that follow.
+    let l = self.s.low;
+    let mut c = self.cnt;
+    let mut s = 10;
+    let m = 0x3FFF;
+    let mut e = ((l + m) & !m) | (m + 1);
+
+    s += c;
+
+    if s > 0 {
+      let mut n = (1 << (c + 16)) - 1;
+
+      loop {
+        self.s.precarry.push((e >> (c + 16)) as u16);
+        e &= n;
+        s -= 8;
+        c -= 8;
+        n >>= 8;
+
+        if s <= 0 {
+          break;
+        }
+      }
+    }
+
+    let mut c = 0;
+    let mut offs = self.s.precarry.len();
+    let mut out = vec![0 as u8; offs];
+    while offs > 0 {
+      offs -= 1;
+      c += self.s.precarry[offs];
+      out[offs] = c as u8;
+      c >>= 8;
+    }
+
+    out
+  }
+}
+
+/// Generic/shared implementation for Writers with StorageBackends (ie, Encoders and Recorders)
+impl<S> Writer for WriterBase<S> where WriterBase<S>: StorageBackend {
+  /// Encode a single binary value.
+  /// `val`: The value to encode (0 or 1).
+  /// `f`: The probability that the val is one, scaled by 32768.
+  fn bool(&mut self, val: bool, f: u16) {
+    debug_assert!(0 < f);
+    debug_assert!(f < 32768);
+    self.symbol(if val {1} else {0}, &[f, 0]);
+  }
+  /// Encode a single boolean value.
+  /// `val`: The value to encode (false or true).
+  /// `f`: The probability that the val is true, scaled by 32768.
+  fn bit(&mut self, bit: u16) {
+    self.bool(bit == 1, 16384);
+  }
+  /// Encode a literal bitstring, bit by bit in MSB order, with flat
+  /// probability.
+  /// 'bits': Length of bitstring
+  /// 's': Bit string to encode
+  fn literal(&mut self, bits: u8, s: u32) {
+    for bit in (0..bits).rev() {
+      self.bit((1 & (s >> bit)) as u16);
+    }
+  }
+  /// Encodes a symbol given a cumulative distribution function (CDF) table in Q15.
+  /// `s`: The index of the symbol to encode.
+  /// `cdf`: The CDF, such that symbol s falls in the range
+  ///        `[s > 0 ? cdf[s - 1] : 0, cdf[s])`.
+  ///       The values must be monotonically non-decreasing, and the last value
+  ///       must be exactly 32768. There should be at most 16 values.
+  fn symbol(&mut self, s: u32, cdf: &[u16]) {
+    debug_assert!(cdf[cdf.len() - 1] == 0);
+    let nms =  cdf.len() - s as usize;
+    let fl = if s > 0 { cdf[s as usize - 1] } else { 32768 };
+    let fh = cdf[s as usize];
+    debug_assert!(fh <= fl);
+    debug_assert!(fl <= 32768);
+
+    let u: u32;
+    let v: u32;
+    let mut l = 0;
+    let mut r = self.rng as u32;
+    debug_assert!(32768 <= r); 
+    if fl < 32768 {
+      u = (((r >> 8) * (fl as u32 >> EC_PROB_SHIFT)) >> (7 - EC_PROB_SHIFT))
+            + EC_MIN_PROB * nms as u32;
+      v = (((r >> 8) * (fh as u32 >> EC_PROB_SHIFT)) >> (7 - EC_PROB_SHIFT))
+            + EC_MIN_PROB * (nms - 1) as u32;
+      l += r - u;
+      r = u - v;
+    } else {
+        r -= (((r >> 8) * (fh as u32 >> EC_PROB_SHIFT)) >> (7 - EC_PROB_SHIFT))
+            + EC_MIN_PROB * (nms - 1) as u32;
+    }
+    self.store(l, r as u16);
+  }
+  /// Encodes a symbol given a cumulative distribution function (CDF)
+  /// table in Q15, then updates the CDF probabilities to relect we've
+  /// written one more symbol 's'.  
+  /// `s`: The index of the symbol to encode.
+  /// `cdf`: The CDF, such that symbol s falls in the range
+  ///        `[s > 0 ? cdf[s - 1] : 0, cdf[s])`.
+  ///       The values must be monotonically non-decreasing, and the last value
+  ///       must be exactly 32768. There should be at most 16 values.
+  fn symbol_with_update(&mut self, s: u32, cdf: &mut [u16]) {
     let nsymbs = cdf.len() - 1;
     #[cfg(debug)]
     {
@@ -387,21 +446,12 @@ impl Writer {
         self.print_backtrace(s);
       }
     }
-    self.cdf(s, &cdf[..nsymbs]);
-    Writer::update_cdf(cdf, s);
+    self.symbol(s, &cdf[..nsymbs]);
+    Self::update_cdf(cdf, s);
   }
-
-  pub fn bit(&mut self, bit: u16) {
-    self.bool(bit == 1, 16384);
-  }
-
-  pub fn literal(&mut self, bits: u8, s: u32) {
-    for bit in (0..bits).rev() {
-      self.bit(1 & (s >> bit), 16384);
-    }
-  }
-
-  pub fn write_golomb(&mut self, level: u16) {
+  /// Encode a golomb to the bitstream.
+  /// 'level': passed in value to encode
+  fn write_golomb(&mut self, level: u16) {
     let x = level + 1;
     let mut i = x;
     let mut length = 0;
@@ -420,36 +470,39 @@ impl Writer {
       self.bit((x >> i) & 0x01);
     }
   }
-
-  #[allow(dead_code)]
-  pub fn tell(&mut self) -> u32 {
-    self.enc.od_ec_enc_tell_frac()
+  /// Returns the number of bits "used" by the encoded symbols so far.
+  /// This same number can be computed in either the encoder or the
+  /// decoder, and is suitable for making coding decisions.  The value
+  /// will be the same whether using an Encoder or Recorder.
+  /// Return: The integer number of bits.
+  ///         This will always be slightly larger than the exact value (e.g., all
+  ///          rounding error is in the positive direction).
+  fn tell(&mut self) -> u32 {
+    // The 10 here counteracts the offset of -9 baked into cnt, and adds 1 extra
+    // bit, which we reserve for terminating the stream.
+    (((self.stream_bytes() * 8) as i32) + (self.cnt as i32) + 10) as u32
   }
-
-  pub fn tell_frac(&mut self) -> u32 {
-    self.enc.od_ec_enc_tell_frac()
+  /// Returns the number of bits "used" by the encoded symbols so far.
+  /// This same number can be computed in either the encoder or the
+  /// decoder, and is suitable for making coding decisions. The value
+  /// will be the same whether using an Encoder or Recorder.
+  /// Return: The number of bits scaled by `2**OD_BITRES`.
+  ///         This will always be slightly larger than the exact value (e.g., all
+  ///          rounding error is in the positive direction).
+  fn tell_frac(&mut self) -> u32 {
+    Self::frac_compute(self.tell(), self.rng as u32)
   }
-
-  pub fn checkpoint(&mut self) -> WriterCheckpoint {
-    WriterCheckpoint {
-      precarry_len: self.enc.precarry.len(),
-      low: self.enc.low,
-      rng: self.enc.rng,
-      cnt: self.enc.cnt,
-      recordp: self.enc.recordp,
-      rec_len: self.enc.fl.len(),
-    }
+  /// Save current point in coding/recording to a checkpoint that can
+  /// be restored later.  A WriterCheckpoint can be generated for an
+  /// Encoder or Recorder, but can only be used to rollback the Writer
+  /// instance from which it was generated.
+  fn checkpoint (&mut self) -> WriterCheckpoint {
+    StorageBackend::checkpoint(self)
   }
-
-  pub fn rollback(&mut self, checkpoint: &WriterCheckpoint) {
-    self.enc.precarry.truncate(checkpoint.precarry_len);
-    self.enc.low = checkpoint.low;
-    self.enc.rng = checkpoint.rng;
-    self.enc.cnt = checkpoint.cnt;
-    self.enc.recordp = checkpoint.recordp;
-    self.enc.fl.truncate(checkpoint.rec_len);
-    self.enc.fh.truncate(checkpoint.rec_len);
-    self.enc.nms.truncate(checkpoint.rec_len);
+  /// Roll back a given Writer to the state saved in the WriterCheckpoint
+  /// 'wc': Saved Writer state/posiiton to restore  
+  fn rollback (&mut self, wc: &WriterCheckpoint) {
+    StorageBackend::rollback(self,wc)
   }
 }
 
@@ -547,27 +600,17 @@ impl<'a> BCodeWriter for BitWriter<'a, BE> {
   }
 }
 
-#[derive(Clone)]
-pub struct WriterCheckpoint {
-  precarry_len: usize,
-  low: od_ec_window,
-  rng: u16,
-  cnt: i16,
-  recordp: bool,
-  rec_len: usize,
-}
-
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct od_ec_dec {
   pub buf: *const ::std::os::raw::c_uchar,
   pub eptr: *const ::std::os::raw::c_uchar,
-  pub end_window: od_ec_window,
+  pub end_window: ec_window,
   pub nend_bits: ::std::os::raw::c_int,
   pub tell_offs: i32,
   pub end: *const ::std::os::raw::c_uchar,
   pub bptr: *const ::std::os::raw::c_uchar,
-  pub dif: od_ec_window,
+  pub dif: ec_window,
   pub rng: u16,
   pub cnt: i16,
   pub error: ::std::os::raw::c_int
@@ -608,7 +651,7 @@ mod test {
       unsafe { od_ec_decode_bool_q15(&mut self.dec, f) != 0 }
     }
 
-    fn cdf(&mut self, icdf: &[u16]) -> i32 {
+    fn symbol(&mut self, icdf: &[u16]) -> i32 {
       let nsyms = icdf.len();
       unsafe {
         od_ec_decode_cdf_q15(&mut self.dec, icdf.as_ptr(), nsyms as i32)
@@ -618,7 +661,7 @@ mod test {
 
   #[test]
   fn booleans() {
-    let mut w = Writer::new();
+    let mut w = WriterEncoder::new();
 
     w.bool(false, 1);
     w.bool(true, 2);
@@ -643,71 +686,71 @@ mod test {
   fn cdf() {
     let cdf = [7296, 3819, 1716, 0];
 
-    let mut w = Writer::new();
+    let mut w = WriterEncoder::new();
 
-    w.cdf(0, &cdf);
-    w.cdf(0, &cdf);
-    w.cdf(0, &cdf);
-    w.cdf(1, &cdf);
-    w.cdf(1, &cdf);
-    w.cdf(1, &cdf);
-    w.cdf(2, &cdf);
-    w.cdf(2, &cdf);
-    w.cdf(2, &cdf);
+    w.symbol(0, &cdf);
+    w.symbol(0, &cdf);
+    w.symbol(0, &cdf);
+    w.symbol(1, &cdf);
+    w.symbol(1, &cdf);
+    w.symbol(1, &cdf);
+    w.symbol(2, &cdf);
+    w.symbol(2, &cdf);
+    w.symbol(2, &cdf);
 
     let b = w.done();
 
     let mut r = Reader::new(&b);
 
-    assert_eq!(r.cdf(&cdf), 0);
-    assert_eq!(r.cdf(&cdf), 0);
-    assert_eq!(r.cdf(&cdf), 0);
-    assert_eq!(r.cdf(&cdf), 1);
-    assert_eq!(r.cdf(&cdf), 1);
-    assert_eq!(r.cdf(&cdf), 1);
-    assert_eq!(r.cdf(&cdf), 2);
-    assert_eq!(r.cdf(&cdf), 2);
-    assert_eq!(r.cdf(&cdf), 2);
+    assert_eq!(r.symbol(&cdf), 0);
+    assert_eq!(r.symbol(&cdf), 0);
+    assert_eq!(r.symbol(&cdf), 0);
+    assert_eq!(r.symbol(&cdf), 1);
+    assert_eq!(r.symbol(&cdf), 1);
+    assert_eq!(r.symbol(&cdf), 1);
+    assert_eq!(r.symbol(&cdf), 2);
+    assert_eq!(r.symbol(&cdf), 2);
+    assert_eq!(r.symbol(&cdf), 2);
   }
 
   #[test]
   fn mixed() {
     let cdf = [7296, 3819, 1716, 0];
 
-    let mut w = Writer::new();
+    let mut w = WriterEncoder::new();
 
-    w.cdf(0, &cdf);
+    w.symbol(0, &cdf);
     w.bool(true, 2);
-    w.cdf(0, &cdf);
+    w.symbol(0, &cdf);
     w.bool(true, 2);
-    w.cdf(0, &cdf);
+    w.symbol(0, &cdf);
     w.bool(true, 2);
-    w.cdf(1, &cdf);
+    w.symbol(1, &cdf);
     w.bool(true, 1);
-    w.cdf(1, &cdf);
+    w.symbol(1, &cdf);
     w.bool(false, 2);
-    w.cdf(1, &cdf);
-    w.cdf(2, &cdf);
-    w.cdf(2, &cdf);
-    w.cdf(2, &cdf);
+    w.symbol(1, &cdf);
+    w.symbol(2, &cdf);
+    w.symbol(2, &cdf);
+    w.symbol(2, &cdf);
 
     let b = w.done();
 
     let mut r = Reader::new(&b);
 
-    assert_eq!(r.cdf(&cdf), 0);
+    assert_eq!(r.symbol(&cdf), 0);
     assert_eq!(r.bool(2), true);
-    assert_eq!(r.cdf(&cdf), 0);
+    assert_eq!(r.symbol(&cdf), 0);
     assert_eq!(r.bool(2), true);
-    assert_eq!(r.cdf(&cdf), 0);
+    assert_eq!(r.symbol(&cdf), 0);
     assert_eq!(r.bool(2), true);
-    assert_eq!(r.cdf(&cdf), 1);
+    assert_eq!(r.symbol(&cdf), 1);
     assert_eq!(r.bool(1), true);
-    assert_eq!(r.cdf(&cdf), 1);
+    assert_eq!(r.symbol(&cdf), 1);
     assert_eq!(r.bool(2), false);
-    assert_eq!(r.cdf(&cdf), 1);
-    assert_eq!(r.cdf(&cdf), 2);
-    assert_eq!(r.cdf(&cdf), 2);
-    assert_eq!(r.cdf(&cdf), 2);
+    assert_eq!(r.symbol(&cdf), 1);
+    assert_eq!(r.symbol(&cdf), 2);
+    assert_eq!(r.symbol(&cdf), 2);
+    assert_eq!(r.symbol(&cdf), 2);
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1869,7 +1869,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
 }
 
 fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameState) -> Vec<u8> {
-    let mut w = ec::Writer::new();
+    let mut w = ec::WriterEncoder::new();
     let fc = CDFContext::new(fi.config.quantizer as u8);
     let bc = BlockContext::new(fi.w_in_b, fi.h_in_b);
     let mut cw = ContextWriter::new(fc,  bc);


### PR DESCRIPTION
Reimplement od_ec_enc and Writer, add record/playback
    
Flatten od_ec_enc and Writer, as one was just a thin wrapper for the other
Reimplement range encoding writer as a Writer trait and encoding backend
Reimplement recording as a second backend to same Writer trait

