### PR TITLE
Restore pkg-config dependency for non-MSVC Windows targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ backtrace = "0.3"
 
 [build-dependencies]
 cmake = "0.1.32"
+pkg-config = "0.3.12"
 
 [target.'cfg(unix)'.build-dependencies]
-pkg-config = "0.3.12"
 bindgen = { version = "0.37", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This aims to enable compilation on non-MSVC Windows targets.
This change is untested, so in order to pull it I would like confirmation that it works on at least one non-MSVC Windows target. If compilation fails, please provide the location of the `aom.pc` file in the build directory.