### PR TITLE
Fix plane_offset() of BlockOffset struct for chroma planes

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -77,6 +77,9 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
       for p in 1..3 {
         for by in 0..8 {
           for bx in 0..8 {
+            // For ex, 8x8 tx should be applied to even numbered (bx,by)
+            if (tx_size.width_mi() >> 1) & bx != 0 ||
+              (tx_size.height_mi() >> 1) & by != 0 { continue; };
             let bo = sbo.block_offset(bx, by);
             let tx_bo = BlockOffset { x: bo.x + bx, y: bo.y + by };
             let po = tx_bo.plane_offset(&fs.input.planes[p].cfg);

--- a/src/context.rs
+++ b/src/context.rs
@@ -1167,11 +1167,13 @@ impl BlockOffset {
   /// Offset of the top-left pixel of this block.
   pub fn plane_offset(&self, plane: &PlaneConfig) -> PlaneOffset {
     let po = self.sb_offset().plane_offset(plane);
+
     let x_offset = self.x & LOCAL_BLOCK_MASK;
     let y_offset = self.y & LOCAL_BLOCK_MASK;
+
     PlaneOffset {
-      x: po.x + (x_offset << BLOCK_TO_PLANE_SHIFT),
-      y: po.y + (y_offset << BLOCK_TO_PLANE_SHIFT)
+        x: po.x + (x_offset >> plane.xdec << BLOCK_TO_PLANE_SHIFT),
+        y: po.y + (y_offset >> plane.ydec << BLOCK_TO_PLANE_SHIFT)
     }
   }
 


### PR DESCRIPTION
It has been wrong when SB is partitioned, thus we were using a block of codes doing that.