### PR TITLE
Cdef counter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1524,7 +1524,7 @@ fn encode_block(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
 
     let tx_type = if tx_set > TxSet::TX_SET_DCTONLY && fi.config.speed <= 3 {
         // FIXME: there is one redundant transform type decision per encoded block
-        rdo_tx_type_decision(fi, fs, cw, w, luma_mode, bsize, bo, tx_size, tx_set)
+        rdo_tx_type_decision(fi, fs, cw, luma_mode, bsize, bo, tx_size, tx_set)
     } else {
         TxType::DCT_DCT
     };
@@ -1717,7 +1717,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
         if bsize >= BlockSize::BLOCK_8X8 {
             cw.write_partition(w, bo, partition, bsize);
         }
-        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, w, bsize, bo, cdef_index).part_modes[0].clone();
+        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, bsize, bo, cdef_index).part_modes[0].clone();
         let (mode_luma, mode_chroma) = (mode_decision.pred_mode_luma, mode_decision.pred_mode_chroma);
         let skip = mode_decision.skip;
         rd_cost = mode_decision.rd_cost;
@@ -1802,7 +1802,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
         partition = PartitionType::PARTITION_SPLIT;
     } else if bsize > fi.min_partition_size {
         // Blocks of sizes within the supported range are subjected to a partitioning decision
-        rdo_output = rdo_partition_decision(seq, fi, fs, cw, w, bsize, bo, &rdo_output, cdef_index);
+        rdo_output = rdo_partition_decision(seq, fi, fs, cw, bsize, bo, &rdo_output, cdef_index);
         partition = rdo_output.part_type;
     } else {
         // Blocks of sizes below the supported range are encoded directly
@@ -1827,7 +1827,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
                     rdo_output.part_modes[0].clone()
                 } else {
                     // Make a prediction mode decision for blocks encoded with no rdo_partition_decision call (e.g. edges)
-                    rdo_mode_decision(seq, fi, fs, cw, w, bsize, bo, cdef_index).part_modes[0].clone()
+                    rdo_mode_decision(seq, fi, fs, cw, bsize, bo, cdef_index).part_modes[0].clone()
                 };
 
             let (mode_luma, mode_chroma) = (part_decision.pred_mode_luma, part_decision.pred_mode_chroma);

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -14,6 +14,7 @@
 use context::*;
 use ec::OD_BITRES;
 use ec::Writer;
+use ec::WriterCounter;
 use encode_block;
 use partition::*;
 use plane::*;
@@ -160,15 +161,13 @@ fn compute_rd_cost(
 
 // RDO-based mode decision
 pub fn rdo_mode_decision(
-  seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
-  cw: &mut ContextWriter, wr: &mut Writer,
+  seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
   bsize: BlockSize, bo: &BlockOffset, cdef_index: u8
 ) -> RDOOutput {
   let mut best_mode_luma = PredictionMode::DC_PRED;
   let mut best_mode_chroma = PredictionMode::DC_PRED;
   let mut best_skip = false;
   let mut best_rd = std::f64::MAX;
-  let tell = wr.tell_frac();
 
   // Get block luma and chroma dimensions
   let w = bsize.width();
@@ -189,7 +188,6 @@ pub fn rdo_mode_decision(
   let skip = false;
 
   let cw_checkpoint = cw.checkpoint();
-  let w_checkpoint = wr.checkpoint();
 
   // Exclude complex prediction modes at higher speed levels
   let mode_set = if fi.config.speed <= 3 {
@@ -206,6 +204,9 @@ pub fn rdo_mode_decision(
     if is_chroma_block && fi.config.speed <= 3 && luma_mode.is_intra() {
       // Find the best chroma prediction mode for the current luma prediction mode
       for &chroma_mode in RAV1E_INTRA_MODES {
+        let mut wr: &mut Writer = &mut WriterCounter::new();
+        let tell = wr.tell_frac();
+        
         encode_block(seq, fi, fs, cw, wr, luma_mode, chroma_mode, bsize, bo, skip, cdef_index);
 
         let cost = wr.tell_frac() - tell;
@@ -228,9 +229,10 @@ pub fn rdo_mode_decision(
         }
 
         cw.rollback(&cw_checkpoint);
-        wr.rollback(&w_checkpoint);
       }
     } else {
+      let mut wr: &mut Writer = &mut WriterCounter::new();
+      let tell = wr.tell_frac();
       encode_block(seq, fi, fs, cw, wr, luma_mode, luma_mode, bsize, bo, skip, cdef_index);
 
       let cost = wr.tell_frac() - tell;
@@ -253,7 +255,6 @@ pub fn rdo_mode_decision(
       }
 
       cw.rollback(&cw_checkpoint);
-      wr.rollback(&w_checkpoint);
     }
   }
 
@@ -274,14 +275,12 @@ pub fn rdo_mode_decision(
 
 // RDO-based intra frame transform type decision
 pub fn rdo_tx_type_decision(
-  fi: &FrameInvariants, fs: &mut FrameState,
-  cw: &mut ContextWriter, wr: &mut Writer,
+  fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
   mode: PredictionMode, bsize: BlockSize, bo: &BlockOffset, tx_size: TxSize,
   tx_set: TxSet
 ) -> TxType {
   let mut best_type = TxType::DCT_DCT;
   let mut best_rd = std::f64::MAX;
-  let tell = wr.tell_frac();
 
   // Get block luma and chroma dimensions
   let w = bsize.width();
@@ -300,7 +299,6 @@ pub fn rdo_tx_type_decision(
   let is_inter = mode >= PredictionMode::NEARESTMV;
 
   let cw_checkpoint = cw.checkpoint();
-  let w_checkpoint = wr.checkpoint();
 
   for &tx_type in RAV1E_TX_TYPES {
     // Skip unsupported transform types
@@ -308,6 +306,8 @@ pub fn rdo_tx_type_decision(
       continue;
     }
 
+    let mut wr: &mut Writer = &mut WriterCounter::new();
+    let tell = wr.tell_frac();
     if is_inter {
       write_tx_tree(
         fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false,
@@ -336,7 +336,6 @@ pub fn rdo_tx_type_decision(
     }
 
     cw.rollback(&cw_checkpoint);
-    wr.rollback(&w_checkpoint);
   }
 
   assert!(best_rd >= 0_f64);
@@ -346,8 +345,7 @@ pub fn rdo_tx_type_decision(
 
 // RDO-based single level partitioning decision
 pub fn rdo_partition_decision(
-  seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
-  cw: &mut ContextWriter, wr: &mut Writer,
+  seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
   bsize: BlockSize, bo: &BlockOffset, cached_block: &RDOOutput, cdef_index: u8
 ) -> RDOOutput {
   let max_rd = std::f64::MAX;
@@ -357,7 +355,6 @@ pub fn rdo_partition_decision(
   let mut best_pred_modes = cached_block.part_modes.clone();
 
   let cw_checkpoint = cw.checkpoint();
-  let w_checkpoint = wr.checkpoint();
 
   for &partition in RAV1E_PARTITION_TYPES {
     // Do not re-encode results we already have
@@ -377,7 +374,7 @@ pub fn rdo_partition_decision(
         let mode_decision = cached_block
           .part_modes
           .get(0)
-          .unwrap_or(&rdo_mode_decision(seq, fi, fs, cw, wr, bsize, bo, cdef_index).part_modes[0])
+          .unwrap_or(&rdo_mode_decision(seq, fi, fs, cw, bsize, bo, cdef_index).part_modes[0])
           .clone();
         child_modes.push(mode_decision);
       }
@@ -392,26 +389,26 @@ pub fn rdo_partition_decision(
         let hbs = bs >> 1; // Half the block size in blocks
 
         let offset = BlockOffset { x: bo.x, y: bo.y };
-        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, wr, subsize, &offset, cdef_index)
+        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, subsize, &offset, cdef_index)
           .part_modes[0]
           .clone();
         child_modes.push(mode_decision);
 
         let offset = BlockOffset { x: bo.x + hbs as usize, y: bo.y };
-        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, wr, subsize, &offset, cdef_index)
+        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, subsize, &offset, cdef_index)
           .part_modes[0]
           .clone();
         child_modes.push(mode_decision);
 
         let offset = BlockOffset { x: bo.x, y: bo.y + hbs as usize };
-        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, wr, subsize, &offset, cdef_index)
+        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, subsize, &offset, cdef_index)
           .part_modes[0]
           .clone();
         child_modes.push(mode_decision);
 
         let offset =
           BlockOffset { x: bo.x + hbs as usize, y: bo.y + hbs as usize };
-        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, wr, subsize, &offset, cdef_index)
+        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, subsize, &offset, cdef_index)
           .part_modes[0]
           .clone();
         child_modes.push(mode_decision);
@@ -430,7 +427,6 @@ pub fn rdo_partition_decision(
     }
 
     cw.rollback(&cw_checkpoint);
-    wr.rollback(&w_checkpoint);
   }
 
   assert!(best_rd >= 0_f64);


### PR DESCRIPTION
Add a new Writer type 'WriterCounter' that stores nothing, it merely tracks bits for cost analysis

Convert RDO to use local throwaway WriterCounters instead of checkpointing/rolling back a master Writer