### PR TITLE
Temporary fix to cdef_dist_8x8 (#432)

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -44,7 +44,7 @@ pub enum PartitionType {
   PARTITION_INVALID
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq)]
 pub enum BlockSize {
   BLOCK_4X4,
   BLOCK_4X8,


### PR DESCRIPTION
If tune=Psychovisual is used, min partition size is enforced to 8x8.

Temporary fix for #432.