### PR TITLE
Enable and test high bit depth input

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "aom"]
 	path = aom_build/aom
 	url = https://gitlab.xiph.org/xiph/aom-rav1e.git
-	branch = rav1e_15b
+	branch = rav1e_16b

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = "2"
 libc = "0.2"
 rand = "0.5"
 rustyline = { version = "1", optional = true }
-y4m = "0.2"
+y4m = "0.3"
 enum-iterator-derive = "0.1.1"
 backtrace = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ On Windows, pkg-config is not required. A Perl distribution such as Strawberry P
 
 # Compressing video
 
-Input videos must be 8-bit 4:2:0, in y4m format.
+Input videos must be 8- or 10-bit 4:2:0, in y4m format.
 
 ```
 cargo run --release --bin rav1e -- input.y4m -o output.ivf

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ rav1e temporarily uses libaom's transforms and CDF initialization tables, but is
 * 4x4 to 32x32 RDO-selected square blocks
 * DC, H, V, Paeth, and smooth prediction modes
 * 4x4 DCT and ADST transforms
+* 8-, 10- and 12-bit depth color
 * Variable speed settings
 * ~10 fps encoding @ 480p
 
@@ -38,7 +39,7 @@ On Windows, pkg-config is not required. A Perl distribution such as Strawberry P
 
 # Compressing video
 
-Input videos must be 8- or 10-bit 4:2:0, in y4m format.
+Input videos must be in y4m format and have 4:2:0 chroma subsampling.
 
 ```
 cargo run --release --bin rav1e -- input.y4m -o output.ivf

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -73,7 +73,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
   b.iter(|| {
     for &mode in RAV1E_INTRA_MODES {
       let sbo = SuperBlockOffset { x: sbx, y: sby };
-      fs.qc.update(fi.config.quantizer, tx_size, mode.is_intra());
+      fs.qc.update(fi.config.quantizer, tx_size, mode.is_intra(), 8);
       for p in 1..3 {
         for by in 0..8 {
           for bx in 0..8 {
@@ -95,7 +95,8 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
               tx_type,
               tx_size.block_size(),
               &po,
-              false
+              false,
+              8
             );
           }
         }

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,12 @@ set -e
 
 if [[ -z "${SEQ}" ]]; then
   SEQ=nyan.y4m
+  SEQ10=nyan10.y4m
+  SEQ12=nyan12.y4m
+  
   wget -nc https://mf4.xiph.org/~ltrudeau/videos/nyan.y4m
+  #wget -nc https://people.xiph.org/~tdaede/nyan10.y4m
+  #wget -nc https://people.xiph.org/~tdaede/nyan12.y4m
 fi
 
 
@@ -87,3 +92,12 @@ ${AOM_TEST}/aomdec $ENC_FILE -o $DEC_FILE
 # Show decoded sequence
 # --pause
 mpv --loop $DEC_FILE
+
+# Repeat for high bit depth clips
+#cargo run --bin rav1e --release -- $SEQ10 -o $ENC_FILE -s 3
+#${AOM_TEST}/aomdec $ENC_FILE -o $DEC_FILE
+#mpv --loop $DEC_FILE
+
+#cargo run --bin rav1e --release -- $SEQ12 -o $ENC_FILE -s 3
+#${AOM_TEST}/aomdec $ENC_FILE -o $DEC_FILE
+#mpv --loop $DEC_FILE

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -21,7 +21,8 @@ fn main() {
   let bit_depth = y4m_dec.get_bit_depth();
   let mut y4m_enc = match io.rec.as_mut() {
     Some(rec) =>
-      Some(y4m::encode(width, height, framerate).write_header(rec).unwrap()),
+      Some(y4m::encode(width, height, framerate)
+		.with_colorspace(y4m_dec.get_colorspace()).write_header(rec).unwrap()),
     None => None
   };
 

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -18,6 +18,7 @@ fn main() {
   let width = y4m_dec.get_width();
   let height = y4m_dec.get_height();
   let framerate = y4m_dec.get_framerate();
+  let bit_depth = y4m_dec.get_bit_depth();
   let mut y4m_enc = match io.rec.as_mut() {
     Some(rec) =>
       Some(y4m::encode(width, height, framerate).write_header(rec).unwrap()),
@@ -25,7 +26,8 @@ fn main() {
   };
 
   let mut fi = FrameInvariants::new(width, height, config);
-  let mut sequence = Sequence::new(width, height);
+  
+  let mut sequence = Sequence::new(width, height, bit_depth);
   write_ivf_header(
     &mut io.output,
     width,

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -191,9 +191,8 @@ fn adjust_strength(strength: i32, var: i32) -> i32 {
 // CDEF parameters are stored for each 64 by 64 block of pixels.
 // The CDEF filter is applied on each 8 by 8 block of pixels.
 // Reference: http://av1-spec.argondesign.com/av1-spec/av1-spec.html#cdef-process
-pub fn cdef_frame(fi: &FrameInvariants, rec: &mut Frame, bc: &mut BlockContext) {
-    let bit_depth = 8;
-    let coeff_shift = bit_depth - 8;
+pub fn cdef_frame(fi: &FrameInvariants, rec: &mut Frame, bc: &mut BlockContext, bit_depth: usize) {
+    let coeff_shift = bit_depth as i32 - 8;
     let cdef_damping = fi.cdef_damping as i32;
 
     // Each filter block is 64x64, except right and/or bottom for non-multiple-of-64 sizes.

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -12,6 +12,7 @@
 use std::cmp;
 use context::*;
 use plane::*;
+use util::clamp;
 use FrameInvariants;
 use Frame;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -22,6 +22,7 @@ use partition::PredictionMode::*;
 use partition::TxType::*;
 use partition::*;
 use plane::*;
+use util::clamp;
 use std::*;
 
 use REF_CONTEXTS;
@@ -737,16 +738,6 @@ static mag_ref_offset_with_txclass: [[[usize; 2]; CONTEXT_MAG_POSITION_NUM]; 3] 
   [ [ 0, 1 ], [ 1, 0 ], [ 2, 0 ] ] ];
 
 // End of Level Map
-
-pub fn clamp(val: i32, min: i32, max: i32) -> i32 {
-  if val < min {
-    min
-  } else if val > max {
-    max
-  } else {
-    val
-  }
-}
 
 pub fn has_chroma(
   bo: &BlockOffset, bsize: BlockSize, subsampling_x: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ use clap::{App, Arg};
 use std::rc::Rc;
 use std::*;
 
-// for benchmarking purpose
 pub mod ec;
 pub mod partition;
 pub mod plane;
@@ -1791,8 +1790,8 @@ pub fn process_frame(sequence: &mut Sequence, fi: &mut FrameInvariants,
         y4m::Colorspace::C420jpeg |
         y4m::Colorspace::C420paldv |
         y4m::Colorspace::C420mpeg2 |
-        y4m::Colorspace::C420p10 => {}, //|
-        //y4m::Colorspace::C420p12 => {},
+        y4m::Colorspace::C420p10 |
+        y4m::Colorspace::C420p12 => {},
         _ => {
             panic!("Colorspace {:?} is not supported yet.", csp);
         },
@@ -1999,8 +1998,7 @@ mod test_encode_decode {
         encode_decode(w, h, speed, quantizer, limit, 10);
 
         // 12-bit
-        // TODO uncomment once y4m 0.3.0 is released and set in Cargo.toml
-        // encode_decode(w, h, speed, quantizer, limit, 12);
+        encode_decode(w, h, speed, quantizer, limit, 12);
     }
 
     fn compare_plane<T: Ord + std::fmt::Debug>(rec: &[T], rec_stride: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,6 @@ pub struct FrameInvariants {
     pub sb_height: usize,
     pub w_in_b: usize,
     pub h_in_b: usize,
-    pub bit_depth: usize,
     pub number: u64,
     pub show_frame: bool,
     pub showable_frame: bool,
@@ -320,7 +319,6 @@ impl FrameInvariants {
             sb_height: height.align_power_of_two_and_shift(6),
             w_in_b: 2 * width.align_power_of_two_and_shift(3), // MiCols, ((width+7)/8)<<3 >> MI_SIZE_LOG2
             h_in_b: 2 * height.align_power_of_two_and_shift(3), // MiRows, ((height+7)/8)<<3 >> MI_SIZE_LOG2
-            bit_depth: 8,
             number: 0,
             show_frame: true,
             showable_frame: true,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -372,15 +372,15 @@ impl PredictionMode {
     // above and left arrays include above-left sample
     // above array includes above-right samples
     // left array includes below-left samples
-    let above = &mut [127u16; 2 * MAX_TX_SIZE + 1][..B::W + B::H + 1];
-    let left = &mut [129u16; 2 * MAX_TX_SIZE + 1][..B::H + B::W + 1];
+    let bd = bit_depth;
+    let base = 128 << (bd - 8);
+
+    let above = &mut [(base - 1) as u16; 2 * MAX_TX_SIZE + 1][..B::W + B::H + 1];
+    let left = &mut [(base + 1) as u16; 2 * MAX_TX_SIZE + 1][..B::H + B::W + 1];
 
     let stride = dst.plane.cfg.stride;
     let x = dst.x;
     let y = dst.y;
-
-    let bd = bit_depth;
-    let base = 128 << (bd - 8);
 
     if y != 0 {
       if self != PredictionMode::H_PRED {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -436,6 +436,7 @@ impl PredictionMode {
       }
       if x == 0 && y == 0 {
         above[0] = base;
+        left[0] = base;
       }      
     }
 
@@ -445,7 +446,7 @@ impl PredictionMode {
 
     match self {
       PredictionMode::DC_PRED => match (x, y) {
-        (0, 0) => B::pred_dc_128(slice, stride),
+        (0, 0) => B::pred_dc_128(slice, stride, bit_depth),
         (_, 0) => B::pred_dc_left(slice, stride, above_slice, left_slice, bit_depth),
         (0, _) => B::pred_dc_top(slice, stride, above_slice, left_slice, bit_depth),
         _ => B::pred_dc(slice, stride, above_slice, left_slice)

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -355,20 +355,20 @@ use plane::*;
 use predict::*;
 
 impl PredictionMode {
-  pub fn predict_intra<'a>(self, dst: &'a mut PlaneMutSlice<'a>, tx_size: TxSize) {
+  pub fn predict_intra<'a>(self, dst: &'a mut PlaneMutSlice<'a>, tx_size: TxSize, bit_depth: usize) {
     assert!(self.is_intra());
 
     match tx_size {
-      TxSize::TX_4X4 => self.predict_intra_inner::<Block4x4>(dst),
-      TxSize::TX_8X8 => self.predict_intra_inner::<Block8x8>(dst),
-      TxSize::TX_16X16 => self.predict_intra_inner::<Block16x16>(dst),
-      TxSize::TX_32X32 => self.predict_intra_inner::<Block32x32>(dst),
+      TxSize::TX_4X4 => self.predict_intra_inner::<Block4x4>(dst, bit_depth),
+      TxSize::TX_8X8 => self.predict_intra_inner::<Block8x8>(dst, bit_depth),
+      TxSize::TX_16X16 => self.predict_intra_inner::<Block16x16>(dst, bit_depth),
+      TxSize::TX_32X32 => self.predict_intra_inner::<Block32x32>(dst, bit_depth),
       _ => unimplemented!()
     }
   }
 
   #[inline(always)]
-  fn predict_intra_inner<'a, B: Intra>(self, dst: &'a mut PlaneMutSlice<'a>) {
+  fn predict_intra_inner<'a, B: Intra>(self, dst: &'a mut PlaneMutSlice<'a>, bit_depth: usize) {
     // above and left arrays include above-left sample
     // above array includes above-right samples
     // left array includes below-left samples
@@ -378,8 +378,8 @@ impl PredictionMode {
     let stride = dst.plane.cfg.stride;
     let x = dst.x;
     let y = dst.y;
-    // TODO: pass bd (bitdepth) as a parameter
-    let bd = 8;
+
+    let bd = bit_depth;
     let base = 128 << (bd - 8);
 
     if y != 0 {
@@ -446,8 +446,8 @@ impl PredictionMode {
     match self {
       PredictionMode::DC_PRED => match (x, y) {
         (0, 0) => B::pred_dc_128(slice, stride),
-        (_, 0) => B::pred_dc_left(slice, stride, above_slice, left_slice),
-        (0, _) => B::pred_dc_top(slice, stride, above_slice, left_slice),
+        (_, 0) => B::pred_dc_left(slice, stride, above_slice, left_slice, bit_depth),
+        (0, _) => B::pred_dc_top(slice, stride, above_slice, left_slice, bit_depth),
         _ => B::pred_dc(slice, stride, above_slice, left_slice)
       },
       PredictionMode::H_PRED => match (x, y) {

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -197,10 +197,10 @@ pub trait Intra: Dim {
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_dc_128(output: &mut [u16], stride: usize) {
+  fn pred_dc_128(output: &mut [u16], stride: usize, bit_depth: usize) {
     for y in 0..Self::H {
       for x in 0..Self::W {
-        output[y * stride + x] = 128;
+        output[y * stride + x] = 128 << (bit_depth - 8);
       }
     }
   }

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -207,7 +207,7 @@ pub trait Intra: Dim {
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
   fn pred_dc_left(
-    output: &mut [u16], stride: usize, above: &[u16], left: &[u16]
+    output: &mut [u16], stride: usize, above: &[u16], left: &[u16], bit_depth: usize
   ) {
     unsafe {
       highbd_dc_left_predictor(
@@ -217,14 +217,14 @@ pub trait Intra: Dim {
         Self::H as libc::c_int,
         above.as_ptr(),
         left.as_ptr(),
-        8
+        bit_depth as libc::c_int
       );
     }
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
   fn pred_dc_top(
-    output: &mut [u16], stride: usize, above: &[u16], left: &[u16]
+    output: &mut [u16], stride: usize, above: &[u16], left: &[u16], bit_depth: usize
   ) {
     unsafe {
       highbd_dc_top_predictor(
@@ -234,7 +234,7 @@ pub trait Intra: Dim {
         Self::H as libc::c_int,
         above.as_ptr(),
         left.as_ptr(),
-        8
+        bit_depth as libc::c_int
       );
     }
   }
@@ -331,7 +331,6 @@ pub trait Intra: Dim {
 
         let output_index = r * stride + c;
 
-        // Clamp the output to the correct bit depth
         output[output_index] = this_pred as u16;
       }
     }
@@ -368,7 +367,6 @@ pub trait Intra: Dim {
 
         let output_index = r * stride + c;
 
-        // Clamp the output to the correct bit depth
         output[output_index] = this_pred as u16;
       }
     }
@@ -405,7 +403,6 @@ pub trait Intra: Dim {
 
         let output_index = r * stride + c;
 
-        // Clamp the output to the correct bit depth
         output[output_index] = this_pred as u16;
       }
     }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -115,7 +115,7 @@ fn compute_rd_cost(
   fi: &FrameInvariants, fs: &FrameState, w_y: usize, h_y: usize, w_uv: usize,
   h_uv: usize, bo: &BlockOffset, bit_cost: u32, bit_depth: usize
 ) -> f64 {
-  let q = dc_q(fi.config.quantizer) as f64;
+  let q = dc_q(fi.config.quantizer, bit_depth) as f64;
 
   // Convert q into Q0 precision, given that libaom quantizers are Q3
   let q0 = q / 8.0_f64;
@@ -213,7 +213,7 @@ pub fn rdo_mode_decision(
         let tell = wr.tell_frac();
         
         encode_block_a(seq, cw, wr, bsize, bo, skip);
-        encode_block_b(fi, fs, cw, wr, luma_mode, chroma_mode, bsize, bo, skip);
+        encode_block_b(fi, fs, cw, wr, luma_mode, chroma_mode, bsize, bo, skip, seq.bit_depth);
 
         let cost = wr.tell_frac() - tell;
         let rd = compute_rd_cost(
@@ -241,7 +241,7 @@ pub fn rdo_mode_decision(
       let mut wr: &mut Writer = &mut WriterCounter::new();
       let tell = wr.tell_frac();
       encode_block_a(seq, cw, wr, bsize, bo, skip);
-      encode_block_b(fi, fs, cw, wr, luma_mode, luma_mode, bsize, bo, skip);
+      encode_block_b(fi, fs, cw, wr, luma_mode, luma_mode, bsize, bo, skip, seq.bit_depth);
 
       let cost = wr.tell_frac() - tell;
       let rd = compute_rd_cost(

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -50,9 +50,9 @@ pub struct RDOPartitionOutput {
 }
 
 #[allow(unused)]
-fn cdef_dist_wxh_8x8(src1: &PlaneSlice, src2: &PlaneSlice) -> u64 {
-  //TODO: Handle high bit-depth here by setting coeff_shift
-  let coeff_shift = 0;
+fn cdef_dist_wxh_8x8(src1: &PlaneSlice, src2: &PlaneSlice, bit_depth: usize) -> u64 {
+  let coeff_shift = bit_depth - 8;
+  
   let mut sum_s: i32 = 0;
   let mut sum_d: i32 = 0;
   let mut sum_s2: i64 = 0;
@@ -80,7 +80,7 @@ fn cdef_dist_wxh_8x8(src1: &PlaneSlice, src2: &PlaneSlice) -> u64 {
 
 #[allow(unused)]
 fn cdef_dist_wxh(
-  src1: &PlaneSlice, src2: &PlaneSlice, w: usize, h: usize
+  src1: &PlaneSlice, src2: &PlaneSlice, w: usize, h: usize, bit_depth: usize
 ) -> u64 {
   assert!(w & 0x7 == 0);
   assert!(h & 0x7 == 0);
@@ -90,7 +90,8 @@ fn cdef_dist_wxh(
     for i in 0..w / 8 {
       sum += cdef_dist_wxh_8x8(
         &src1.subslice(i * 8, j * 8),
-        &src2.subslice(i * 8, j * 8)
+        &src2.subslice(i * 8, j * 8),
+        bit_depth
       )
     }
   }
@@ -112,7 +113,7 @@ fn sse_wxh(src1: &PlaneSlice, src2: &PlaneSlice, w: usize, h: usize) -> u64 {
 // Compute the rate-distortion cost for an encode
 fn compute_rd_cost(
   fi: &FrameInvariants, fs: &FrameState, w_y: usize, h_y: usize, w_uv: usize,
-  h_uv: usize, bo: &BlockOffset, bit_cost: u32
+  h_uv: usize, bo: &BlockOffset, bit_cost: u32, bit_depth: usize
 ) -> f64 {
   let q = dc_q(fi.config.quantizer) as f64;
 
@@ -137,7 +138,8 @@ fn compute_rd_cost(
       &fs.input.planes[0].slice(&po),
       &fs.rec.planes[0].slice(&po),
       w_y,
-      h_y
+      h_y,
+      bit_depth
     )
   } else {
     unimplemented!();
@@ -222,7 +224,8 @@ pub fn rdo_mode_decision(
           w_uv,
           h_uv,
           bo,
-          cost
+          cost,
+          seq.bit_depth
         );
 
         if rd < best_rd {
@@ -249,7 +252,8 @@ pub fn rdo_mode_decision(
         w_uv,
         h_uv,
         bo,
-        cost
+        cost,
+        seq.bit_depth
       );
 
       if rd < best_rd {
@@ -282,7 +286,7 @@ pub fn rdo_mode_decision(
 pub fn rdo_tx_type_decision(
   fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
   mode: PredictionMode, bsize: BlockSize, bo: &BlockOffset, tx_size: TxSize,
-  tx_set: TxSet
+  tx_set: TxSet, bit_depth: usize
 ) -> TxType {
   let mut best_type = TxType::DCT_DCT;
   let mut best_rd = std::f64::MAX;
@@ -315,11 +319,11 @@ pub fn rdo_tx_type_decision(
     let tell = wr.tell_frac();
     if is_inter {
       write_tx_tree(
-        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false,
+        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false, bit_depth
       );
     }  else {
       write_tx_blocks(
-        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false,
+        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false, bit_depth
       );
     }
 
@@ -332,7 +336,8 @@ pub fn rdo_tx_type_decision(
       w_uv,
       h_uv,
       bo,
-      cost
+      cost,
+      bit_depth
     );
 
     if rd < best_rd {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -95,44 +95,44 @@ extern "C" {
 
 pub fn forward_transform(
   input: &[i16], output: &mut [i32], stride: usize, tx_size: TxSize,
-  tx_type: TxType
+  tx_type: TxType, bit_depth: usize
 ) {
   match tx_size {
-    TxSize::TX_4X4 => fht4x4(input, output, stride, tx_type),
-    TxSize::TX_8X8 => fht8x8(input, output, stride, tx_type),
-    TxSize::TX_16X16 => fht16x16(input, output, stride, tx_type),
-    TxSize::TX_32X32 => fht32x32(input, output, stride, tx_type),
+    TxSize::TX_4X4 => fht4x4(input, output, stride, tx_type, bit_depth),
+    TxSize::TX_8X8 => fht8x8(input, output, stride, tx_type, bit_depth),
+    TxSize::TX_16X16 => fht16x16(input, output, stride, tx_type, bit_depth),
+    TxSize::TX_32X32 => fht32x32(input, output, stride, tx_type, bit_depth),
     _ => panic!("unimplemented tx size")
   }
 }
 
 pub fn inverse_transform_add(
   input: &[i32], output: &mut [u16], stride: usize, tx_size: TxSize,
-  tx_type: TxType
+  tx_type: TxType, bit_depth: usize
 ) {
   match tx_size {
-    TxSize::TX_4X4 => iht4x4_add(input, output, stride, tx_type),
-    TxSize::TX_8X8 => iht8x8_add(input, output, stride, tx_type),
-    TxSize::TX_16X16 => iht16x16_add(input, output, stride, tx_type),
-    TxSize::TX_32X32 => iht32x32_add(input, output, stride, tx_type),
+    TxSize::TX_4X4 => iht4x4_add(input, output, stride, tx_type, bit_depth),
+    TxSize::TX_8X8 => iht8x8_add(input, output, stride, tx_type, bit_depth),
+    TxSize::TX_16X16 => iht16x16_add(input, output, stride, tx_type, bit_depth),
+    TxSize::TX_32X32 => iht32x32_add(input, output, stride, tx_type, bit_depth),
     _ => panic!("unimplemented tx size")
   }
 }
 
-fn fht4x4(input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType) {
+fn fht4x4(input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType, bit_depth: usize) {
   unsafe {
     av1_fwd_txfm2d_4x4_c(
       input.as_ptr(),
       output.as_mut_ptr(),
       stride as libc::c_int,
       tx_type as libc::c_int,
-      8
+      bit_depth as libc::c_int
     );
   }
 }
 
 fn iht4x4_add(
-  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType
+  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType, bit_depth: usize
 ) {
   // SIMD code may assert for transform types beyond TxType::IDTX.
   if tx_type < TxType::IDTX {
@@ -142,7 +142,7 @@ fn iht4x4_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        8
+        bit_depth as libc::c_int
       );
     }
   } else {
@@ -152,26 +152,26 @@ fn iht4x4_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        8
+        bit_depth as libc::c_int
       );
     }
   }
 }
 
-fn fht8x8(input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType) {
+fn fht8x8(input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType, bit_depth: usize) {
   unsafe {
     av1_fwd_txfm2d_8x8_c(
       input.as_ptr(),
       output.as_mut_ptr(),
       stride as libc::c_int,
       tx_type as libc::c_int,
-      8
+      bit_depth as libc::c_int
     );
   }
 }
 
 fn iht8x8_add(
-  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType
+  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType, bit_depth: usize
 ) {
   // SIMD code may assert for transform types beyond TxType::IDTX.
   if tx_type < TxType::IDTX {
@@ -181,7 +181,7 @@ fn iht8x8_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        8
+        bit_depth as libc::c_int
       );
     }
   } else {
@@ -191,14 +191,14 @@ fn iht8x8_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        8
+        bit_depth as libc::c_int
       );
     }
   }
 }
 
 fn fht16x16(
-  input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType
+  input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType, bit_depth: usize
 ) {
   unsafe {
     av1_fwd_txfm2d_16x16_c(
@@ -206,13 +206,13 @@ fn fht16x16(
       output.as_mut_ptr(),
       stride as libc::c_int,
       tx_type as libc::c_int,
-      8
+      bit_depth as libc::c_int
     );
   }
 }
 
 fn iht16x16_add(
-  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType
+  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType, bit_depth: usize
 ) {
   unsafe {
     if tx_type < TxType::IDTX {
@@ -222,7 +222,7 @@ fn iht16x16_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        8
+        bit_depth as libc::c_int
       );
     } else {
       av1_inv_txfm2d_add_16x16_c(
@@ -230,14 +230,14 @@ fn iht16x16_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        8
+        bit_depth as libc::c_int
       );
     }
   }
 }
 
 fn fht32x32(
-  input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType
+  input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType, bit_depth: usize
 ) {
   unsafe {
     av1_fwd_txfm2d_32x32_c(
@@ -245,13 +245,13 @@ fn fht32x32(
       output.as_mut_ptr(),
       stride as libc::c_int,
       tx_type as libc::c_int,
-      8
+      bit_depth as libc::c_int
     );
   }
 }
 
 fn iht32x32_add(
-  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType
+  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType, bit_depth: usize
 ) {
   unsafe {
     if tx_type < TxType::IDTX {
@@ -261,7 +261,7 @@ fn iht32x32_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        8
+        bit_depth as libc::c_int
       );
     } else {
       av1_inv_txfm2d_add_32x32_c(
@@ -269,7 +269,7 @@ fn iht32x32_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        8
+        bit_depth as libc::c_int
       );
     }
   }

--- a/src/util.rs
+++ b/src/util.rs
@@ -77,3 +77,15 @@ impl Fixed for usize {
 pub fn is_aligned<T>(ptr: *const T, n: usize) -> bool {
   return ((ptr as usize) & ((1 << n) - 1)) == 0;
 }
+
+pub fn clamp<T: Ord>(input: T, min: T, max: T) -> T {
+  if input < min {
+      return min;
+  }
+  else if input > max {
+      return max;
+  }
+  else {
+      return input;
+  }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -78,7 +78,7 @@ pub fn is_aligned<T>(ptr: *const T, n: usize) -> bool {
   return ((ptr as usize) & ((1 << n) - 1)) == 0;
 }
 
-pub fn clamp<T: Ord>(input: T, min: T, max: T) -> T {
+pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
   if input < min {
       return min;
   }


### PR DESCRIPTION
* Handle high bit depth across the encoder
* Allow 10- and 12-bit 4:2:0 y4m input
* Add encode-decode test for high bit depth
* Add operations on high bit depth sequences in the build script (commented out by default)
* Update README.md
* Move `context::clamp()` to `util.rs` and make it generic

Closes #325.