### PR TITLE
Revert "Enable and test high bit depth input (#437)"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "aom"]
 	path = aom_build/aom
 	url = https://gitlab.xiph.org/xiph/aom-rav1e.git
-	branch = rav1e_16b
+	branch = rav1e_15b

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = "2"
 libc = "0.2"
 rand = "0.5"
 rustyline = { version = "1", optional = true }
-y4m = "0.3"
+y4m = "0.2"
 enum-iterator-derive = "0.1.1"
 backtrace = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ rav1e temporarily uses libaom's transforms and CDF initialization tables, but is
 * 4x4 to 32x32 RDO-selected square blocks
 * DC, H, V, Paeth, and smooth prediction modes
 * 4x4 DCT and ADST transforms
-* 8-, 10- and 12-bit depth color
 * Variable speed settings
 * ~10 fps encoding @ 480p
 
@@ -39,7 +38,7 @@ On Windows, pkg-config is not required. A Perl distribution such as Strawberry P
 
 # Compressing video
 
-Input videos must be in y4m format and have 4:2:0 chroma subsampling.
+Input videos must be 8-bit 4:2:0, in y4m format.
 
 ```
 cargo run --release --bin rav1e -- input.y4m -o output.ivf

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -73,7 +73,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
   b.iter(|| {
     for &mode in RAV1E_INTRA_MODES {
       let sbo = SuperBlockOffset { x: sbx, y: sby };
-      fs.qc.update(fi.config.quantizer, tx_size, mode.is_intra(), 8);
+      fs.qc.update(fi.config.quantizer, tx_size, mode.is_intra());
       for p in 1..3 {
         for by in 0..8 {
           for bx in 0..8 {
@@ -95,8 +95,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
               tx_type,
               tx_size.block_size(),
               &po,
-              false,
-              8
+              false
             );
           }
         }

--- a/build.sh
+++ b/build.sh
@@ -7,12 +7,7 @@ set -e
 
 if [[ -z "${SEQ}" ]]; then
   SEQ=nyan.y4m
-  SEQ10=nyan10.y4m
-  SEQ12=nyan12.y4m
-  
   wget -nc https://mf4.xiph.org/~ltrudeau/videos/nyan.y4m
-  #wget -nc https://people.xiph.org/~tdaede/nyan10.y4m
-  #wget -nc https://people.xiph.org/~tdaede/nyan12.y4m
 fi
 
 
@@ -92,12 +87,3 @@ ${AOM_TEST}/aomdec $ENC_FILE -o $DEC_FILE
 # Show decoded sequence
 # --pause
 mpv --loop $DEC_FILE
-
-# Repeat for high bit depth clips
-#cargo run --bin rav1e --release -- $SEQ10 -o $ENC_FILE -s 3
-#${AOM_TEST}/aomdec $ENC_FILE -o $DEC_FILE
-#mpv --loop $DEC_FILE
-
-#cargo run --bin rav1e --release -- $SEQ12 -o $ENC_FILE -s 3
-#${AOM_TEST}/aomdec $ENC_FILE -o $DEC_FILE
-#mpv --loop $DEC_FILE

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -18,17 +18,14 @@ fn main() {
   let width = y4m_dec.get_width();
   let height = y4m_dec.get_height();
   let framerate = y4m_dec.get_framerate();
-  let bit_depth = y4m_dec.get_bit_depth();
   let mut y4m_enc = match io.rec.as_mut() {
     Some(rec) =>
-      Some(y4m::encode(width, height, framerate)
-		.with_colorspace(y4m_dec.get_colorspace()).write_header(rec).unwrap()),
+      Some(y4m::encode(width, height, framerate).write_header(rec).unwrap()),
     None => None
   };
 
   let mut fi = FrameInvariants::new(width, height, config);
-  
-  let mut sequence = Sequence::new(width, height, bit_depth);
+  let mut sequence = Sequence::new(width, height);
   write_ivf_header(
     &mut io.output,
     width,

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -12,7 +12,6 @@
 use std::cmp;
 use context::*;
 use plane::*;
-use util::clamp;
 use FrameInvariants;
 use Frame;
 
@@ -192,8 +191,9 @@ fn adjust_strength(strength: i32, var: i32) -> i32 {
 // CDEF parameters are stored for each 64 by 64 block of pixels.
 // The CDEF filter is applied on each 8 by 8 block of pixels.
 // Reference: http://av1-spec.argondesign.com/av1-spec/av1-spec.html#cdef-process
-pub fn cdef_frame(fi: &FrameInvariants, rec: &mut Frame, bc: &mut BlockContext, bit_depth: usize) {
-    let coeff_shift = bit_depth as i32 - 8;
+pub fn cdef_frame(fi: &FrameInvariants, rec: &mut Frame, bc: &mut BlockContext) {
+    let bit_depth = 8;
+    let coeff_shift = bit_depth - 8;
     let cdef_damping = fi.cdef_damping as i32;
 
     // Each filter block is 64x64, except right and/or bottom for non-multiple-of-64 sizes.

--- a/src/context.rs
+++ b/src/context.rs
@@ -22,7 +22,6 @@ use partition::PredictionMode::*;
 use partition::TxType::*;
 use partition::*;
 use plane::*;
-use util::clamp;
 use std::*;
 
 use REF_CONTEXTS;
@@ -738,6 +737,16 @@ static mag_ref_offset_with_txclass: [[[usize; 2]; CONTEXT_MAG_POSITION_NUM]; 3] 
   [ [ 0, 1 ], [ 1, 0 ], [ 2, 0 ] ] ];
 
 // End of Level Map
+
+pub fn clamp(val: i32, min: i32, max: i32) -> i32 {
+  if val < min {
+    min
+  } else if val > max {
+    max
+  } else {
+    val
+  }
+}
 
 pub fn has_chroma(
   bo: &BlockOffset, bsize: BlockSize, subsampling_x: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use clap::{App, Arg};
 use std::rc::Rc;
 use std::*;
 
+// for benchmarking purpose
 pub mod ec;
 pub mod partition;
 pub mod plane;
@@ -110,11 +111,6 @@ impl Default for Tune {
 pub struct Sequence {
   // OBU Sequence header of AV1
     pub profile: u8,
-    pub num_bits_width: u32,
-    pub num_bits_height: u32,
-    pub bit_depth: usize,
-    pub max_frame_width: u32,
-    pub max_frame_height: u32,
     pub frame_id_numbers_present_flag: bool,
     pub frame_id_length: u32,
     pub delta_frame_id_length: u32,
@@ -128,7 +124,7 @@ pub struct Sequence {
                                      // 2 - adaptive
     pub still_picture: bool,               // Video is a single frame still picture
     pub reduced_still_picture_hdr: bool,   // Use reduced header for still picture
-    pub monochrome: bool,                  // Monochrome video
+    pub monochrome: bool,                  // Monochorme video
     pub enable_filter_intra: bool,         // enables/disables filterintra
     pub enable_intra_edge_filter: bool,    // enables/disables corner/edge/upsampling
     pub enable_interintra_compound: bool,  // enables/disables interintra_compound
@@ -164,13 +160,11 @@ pub struct Sequence {
 }
 
 impl Sequence {
-    pub fn new(width: usize, height: usize, bit_depth: usize) -> Sequence {
+    pub fn new(width: usize, height: usize) -> Sequence {
         let width_bits = 32 - (width as u32).leading_zeros();
         let height_bits = 32 - (height as u32).leading_zeros();
         assert!(width_bits <= 16);
         assert!(height_bits <= 16);
-
-        let profile = if bit_depth == 12 { 2 } else { 0 };
 
         let mut operating_point_idc = [0 as u16; MAX_NUM_OPERATING_POINTS];
         let mut level = [[1, 2 as usize]; MAX_NUM_OPERATING_POINTS];
@@ -184,12 +178,7 @@ impl Sequence {
         }
 
         Sequence {
-            profile: profile,
-            num_bits_width: width_bits,
-            num_bits_height: height_bits,
-            bit_depth: bit_depth,
-            max_frame_width: width as u32,
-            max_frame_height: height as u32,
+            profile: 0,
             frame_id_numbers_present_flag: false,
             frame_id_length: 0,
             delta_frame_id_length: 0,
@@ -615,6 +604,8 @@ impl<'a> UncompressedHeader for BitWriter<'a, BE> {
 
         self.write_color_config(seq)?;
 
+        self.write(1,0)?; // separate uv delta q
+
         self.write_bit(seq.film_grain_params_present)?;
 
         self.write_bit(true)?; // add_trailing_bits
@@ -686,36 +677,18 @@ impl<'a> UncompressedHeader for BitWriter<'a, BE> {
     }
 
     fn write_color_config(&mut self, seq: &mut Sequence) -> Result<(), std::io::Error> {
-        let high_bd = seq.bit_depth > 8;
-
-        self.write_bit(high_bd)?; // high bit depth
-
-        if seq.bit_depth == 12 {
-            self.write_bit(true)?; // 12-bit
-        }
-
-        self.write_bit(seq.monochrome)?; // monochrome?
-        self.write_bit(false)?; // No color description present
+        self.write_bit(false)?; // 8 bit video
+        self.write_bit(seq.monochrome)?; 	// monochrome?
+        self.write_bit(false)?;  					// No color description present
 
         if seq.monochrome {
             assert!(false);
         }
-
         self.write_bit(false)?; // color range
 
-        if seq.bit_depth == 12 {
-            // always subsampling in both directions, as we only process 4:2:0
-            let subsampling_x = true;
-            self.write_bit(subsampling_x)?;
-
-            if subsampling_x {
-                self.write_bit(true)?; // subsampling_y
-            }
+        if true { // subsampling_x == 1 && cm->subsampling_y == 1
+            self.write(2,0)?; // chroma_sample_position == AOM_CSP_UNKNOWN
         }
-
-        self.write(2, 0)?; // chroma_sample_position == AOM_CSP_UNKNOWN
-
-        self.write_bit(false)?; // separate uv delta q
 
         Ok(())
     }
@@ -730,7 +703,7 @@ impl<'a> UncompressedHeader for BitWriter<'a, BE> {
       } else {
         if fi.show_existing_frame {
           self.write_bit(true)?; // show_existing_frame=1
-          self.write(3, 0)?; // show last frame
+          self.write(3,0)?; // show last frame
 
           //TODO:
           /* temporal_point_info();
@@ -1029,14 +1002,12 @@ impl<'a> UncompressedHeader for BitWriter<'a, BE> {
         self.write(height_bits, (fi.height - 1) as u16)?;
         Ok(())
     }
-
     fn write_loop_filter(&mut self) -> Result<(), std::io::Error> {
         self.write(6,0)?; // loop filter level 0
         self.write(6,0)?; // loop filter level 1
         self.write(3,0)?; // loop filter sharpness
         self.write_bit(false) // loop filter deltas enabled
     }
-
     fn write_frame_cdef(&mut self, seq: &Sequence, fi: &FrameInvariants) -> Result<(), std::io::Error> {
         if seq.enable_cdef {
             assert!(fi.cdef_damping >= 3);
@@ -1188,12 +1159,12 @@ fn diff(dst: &mut [i16], src1: &PlaneSlice, src2: &PlaneSlice, width: usize, hei
 // dequantize, inverse-transform.
 pub fn encode_tx_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter, w: &mut Writer,
                   p: usize, bo: &BlockOffset, mode: PredictionMode, tx_size: TxSize, tx_type: TxType,
-                  plane_bsize: BlockSize, po: &PlaneOffset, skip: bool, bit_depth: usize) -> bool {
+                  plane_bsize: BlockSize, po: &PlaneOffset, skip: bool) -> bool {
     let rec = &mut fs.rec.planes[p];
     let PlaneConfig { stride, xdec, ydec, .. } = fs.input.planes[p].cfg;
 
     if mode.is_intra() {
-      mode.predict_intra(&mut rec.mut_slice(po), tx_size, bit_depth);
+      mode.predict_intra(&mut rec.mut_slice(po), tx_size);
     }
 
     if skip { return false; }
@@ -1209,16 +1180,16 @@ pub fn encode_tx_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Conte
          tx_size.width(),
          tx_size.height());
 
-    forward_transform(&residual.array, coeffs, tx_size.width(), tx_size, tx_type, bit_depth);
+    forward_transform(&residual.array, coeffs, tx_size.width(), tx_size, tx_type);
     fs.qc.quantize(coeffs);
 
     let has_coeff = cw.write_coeffs_lv_map(w, p, bo, &coeffs, tx_size, tx_type, plane_bsize, xdec, ydec,
                             fi.use_reduced_tx_set);
 
     // Reconstruct
-    dequantize(fi.config.quantizer, &coeffs, &mut rcoeffs.array, tx_size, bit_depth);
+    dequantize(fi.config.quantizer, &coeffs, &mut rcoeffs.array, tx_size);
 
-    inverse_transform_add(&rcoeffs.array, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);
+    inverse_transform_add(&rcoeffs.array, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type);
     has_coeff
 }
 
@@ -1236,7 +1207,7 @@ fn encode_block_a(seq: &Sequence,
 fn encode_block_b(fi: &FrameInvariants, fs: &mut FrameState,
                  cw: &mut ContextWriter, w: &mut Writer,
                  luma_mode: PredictionMode, chroma_mode: PredictionMode,
-                 bsize: BlockSize, bo: &BlockOffset, skip: bool, bit_depth: usize) {
+                 bsize: BlockSize, bo: &BlockOffset, skip: bool) {
     let is_inter = !luma_mode.is_intra();
 
     if fi.frame_type == FrameType::INTER {
@@ -1294,7 +1265,7 @@ fn encode_block_b(fi: &FrameInvariants, fs: &mut FrameState,
 
     let tx_type = if tx_set > TxSet::TX_SET_DCTONLY && fi.config.speed <= 3 {
         // FIXME: there is one redundant transform type decision per encoded block
-        rdo_tx_type_decision(fi, fs, cw, luma_mode, bsize, bo, tx_size, tx_set, bit_depth)
+        rdo_tx_type_decision(fi, fs, cw, luma_mode, bsize, bo, tx_size, tx_set)
     } else {
         TxType::DCT_DCT
     };
@@ -1313,22 +1284,22 @@ fn encode_block_b(fi: &FrameInvariants, fs: &mut FrameState,
 
             luma_mode.predict_inter(fi, p, &po, &mut rec.mut_slice(&po), plane_bsize);
         }
-        write_tx_tree(fi, fs, cw, w, luma_mode, chroma_mode, bo, bsize, tx_size, tx_type, skip, bit_depth); // i.e. var-tx if inter mode
+        write_tx_tree(fi, fs, cw, w, luma_mode, chroma_mode, bo, bsize, tx_size, tx_type, skip); // i.e. var-tx if inter mode
     } else {
-        write_tx_blocks(fi, fs, cw, w, luma_mode, chroma_mode, bo, bsize, tx_size, tx_type, skip, bit_depth);
+        write_tx_blocks(fi, fs, cw, w, luma_mode, chroma_mode, bo, bsize, tx_size, tx_type, skip);
     }
 }
 
 pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
                        cw: &mut ContextWriter, w: &mut Writer,
                        luma_mode: PredictionMode, chroma_mode: PredictionMode, bo: &BlockOffset,
-                       bsize: BlockSize, tx_size: TxSize, tx_type: TxType, skip: bool, bit_depth: usize) {
+                       bsize: BlockSize, tx_size: TxSize, tx_type: TxType, skip: bool) {
     let bw = bsize.width_mi() / tx_size.width_mi();
     let bh = bsize.height_mi() / tx_size.height_mi();
 
     let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
 
-    fs.qc.update(fi.config.quantizer, tx_size, luma_mode.is_intra(), bit_depth);
+    fs.qc.update(fi.config.quantizer, tx_size, luma_mode.is_intra());
 
     for by in 0..bh {
         for bx in 0..bw {
@@ -1338,7 +1309,7 @@ pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
             };
 
             let po = tx_bo.plane_offset(&fs.input.planes[0].cfg);
-            encode_tx_block(fi, fs, cw, w, 0, &tx_bo, luma_mode, tx_size, tx_type, bsize, &po, skip, bit_depth);
+            encode_tx_block(fi, fs, cw, w, 0, &tx_bo, luma_mode, tx_size, tx_type, bsize, &po, skip);
         }
     }
 
@@ -1365,7 +1336,7 @@ pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
 
     if bw_uv > 0 && bh_uv > 0 {
         let uv_tx_type = uv_intra_mode_to_tx_type_context(chroma_mode);
-        fs.qc.update(fi.config.quantizer, uv_tx_size, chroma_mode.is_intra(), bit_depth);
+        fs.qc.update(fi.config.quantizer, uv_tx_size, chroma_mode.is_intra());
 
         for p in 1..3 {
             for by in 0..bh_uv {
@@ -1383,7 +1354,7 @@ pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
                     po.y += by * uv_tx_size.height();
 
                     encode_tx_block(fi, fs, cw, w, p, &tx_bo, chroma_mode, uv_tx_size, uv_tx_type,
-                                    plane_bsize, &po, skip, bit_depth);
+                                    plane_bsize, &po, skip);
                 }
             }
         }
@@ -1394,16 +1365,16 @@ pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
 // but only one tx block exist for a inter mode partition.
 pub fn write_tx_tree(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter, w: &mut Writer,
                        luma_mode: PredictionMode, chroma_mode: PredictionMode, bo: &BlockOffset,
-                       bsize: BlockSize, tx_size: TxSize, tx_type: TxType, skip: bool, bit_depth: usize) {
+                       bsize: BlockSize, tx_size: TxSize, tx_type: TxType, skip: bool) {
     let bw = bsize.width_mi() / tx_size.width_mi();
     let bh = bsize.height_mi() / tx_size.height_mi();
 
     let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
 
-    fs.qc.update(fi.config.quantizer, tx_size, luma_mode.is_intra(), bit_depth);
+    fs.qc.update(fi.config.quantizer, tx_size, luma_mode.is_intra());
 
     let po = bo.plane_offset(&fs.input.planes[0].cfg);
-    let has_coeff = encode_tx_block(fi, fs, cw, w, 0, &bo, luma_mode, tx_size, tx_type, bsize, &po, skip, bit_depth);
+    let has_coeff = encode_tx_block(fi, fs, cw, w, 0, &bo, luma_mode, tx_size, tx_type, bsize, &po, skip);
 
     // these are only valid for 4:2:0
     let uv_tx_size = match bsize {
@@ -1429,7 +1400,7 @@ pub fn write_tx_tree(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Context
     if bw_uv > 0 && bh_uv > 0 {
         let uv_tx_type = if has_coeff {tx_type} else {TxType::DCT_DCT}; // if inter mode, uv_tx_type == tx_type
 
-        fs.qc.update(fi.config.quantizer, uv_tx_size, chroma_mode.is_intra(), bit_depth);
+        fs.qc.update(fi.config.quantizer, uv_tx_size, chroma_mode.is_intra());
 
         for p in 1..3 {
             let tx_bo = BlockOffset {
@@ -1440,7 +1411,7 @@ pub fn write_tx_tree(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Context
             let po = bo.plane_offset(&fs.input.planes[p].cfg);
 
             encode_tx_block(fi, fs, cw, w, p, &tx_bo, chroma_mode, uv_tx_size, uv_tx_type,
-                            plane_bsize, &po, skip, bit_depth);
+                            plane_bsize, &po, skip);
         }
     }
 }
@@ -1497,7 +1468,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
         cdef_coded = encode_block_a(seq, cw, if cdef_coded  {w_post_cdef} else {w_pre_cdef},
                                    bsize, bo, skip);
         encode_block_b(fi, fs, cw, if cdef_coded  {w_post_cdef} else {w_pre_cdef},
-                       mode_luma, mode_chroma, bsize, bo, skip, seq.bit_depth);
+                       mode_luma, mode_chroma, bsize, bo, skip);
 
         best_decision = mode_decision;
     }
@@ -1547,7 +1518,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
             cdef_coded = encode_block_a(seq, cw, if cdef_coded {w_post_cdef} else {w_pre_cdef},
                                        bsize, bo, skip);
             encode_block_b(fi, fs, cw, if cdef_coded {w_post_cdef} else {w_pre_cdef},
-                          mode_luma, mode_chroma, bsize, bo, skip, seq.bit_depth);
+                          mode_luma, mode_chroma, bsize, bo, skip);
         }
     }
 
@@ -1625,7 +1596,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
             cdef_coded = encode_block_a(seq, cw, if cdef_coded  {w_post_cdef} else {w_pre_cdef},
                          bsize, bo, skip);
             encode_block_b(fi, fs, cw, if cdef_coded  {w_post_cdef} else {w_pre_cdef},
-                          mode_luma, mode_chroma, bsize, bo, skip, seq.bit_depth);
+                          mode_luma, mode_chroma, bsize, bo, skip);
         },
         PartitionType::PARTITION_SPLIT => {
             if rdo_output.part_modes.len() >= 4 {
@@ -1702,7 +1673,7 @@ fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameStat
     }
     /* TODO: Don't apply if lossless */
     if sequence.enable_cdef {
-        cdef_frame(fi, &mut fs.rec, &mut cw.bc, sequence.bit_depth);
+        cdef_frame(fi, &mut fs.rec, &mut cw.bc);
     }
 
     let mut h = w.done();
@@ -1785,14 +1756,11 @@ pub fn process_frame(sequence: &mut Sequence, fi: &mut FrameInvariants,
     let y4m_bits = y4m_dec.get_bit_depth();
     let y4m_bytes = y4m_dec.get_bytes_per_sample();
     let csp = y4m_dec.get_colorspace();
-
     match csp {
         y4m::Colorspace::C420 |
         y4m::Colorspace::C420jpeg |
         y4m::Colorspace::C420paldv |
-        y4m::Colorspace::C420mpeg2 |
-        y4m::Colorspace::C420p10 |
-        y4m::Colorspace::C420p12 => {},
+        y4m::Colorspace::C420mpeg2 => {},
         _ => {
             panic!("Colorspace {:?} is not supported yet.", csp);
         },
@@ -1804,34 +1772,42 @@ pub fn process_frame(sequence: &mut Sequence, fi: &mut FrameInvariants,
             let y4m_v = y4m_frame.get_v_plane();
             eprintln!("{}", fi);
             let mut fs = FrameState::new(&fi);
-            fs.input.planes[0].copy_from_raw_u8(&y4m_y, width * y4m_bytes, y4m_bytes);
-            fs.input.planes[1].copy_from_raw_u8(&y4m_u, width * y4m_bytes / 2, y4m_bytes);
-            fs.input.planes[2].copy_from_raw_u8(&y4m_v, width * y4m_bytes / 2, y4m_bytes);
+            fs.input.planes[0].copy_from_raw_u8(&y4m_y, width*y4m_bytes, y4m_bytes);
+            fs.input.planes[1].copy_from_raw_u8(&y4m_u, width*y4m_bytes/2, y4m_bytes);
+            fs.input.planes[2].copy_from_raw_u8(&y4m_v, width*y4m_bytes/2, y4m_bytes);
 
+            // We cannot currently encode > 8 bit input!
             match y4m_bits {
-                8 | 10 | 12 => {},
+                8 => {},
+                10 | 12 => {
+                    for plane in 0..3 {
+                        for row in fs.input.planes[plane].data.chunks_mut(fs.rec.planes[plane].cfg.stride) {
+                            for col in row.iter_mut() { *col >>= y4m_bits-8 }
+                        }
+                    }
+                },
                 _ => panic! ("unknown input bit depth!"),
             }
 
             let packet = encode_frame(sequence, fi, &mut fs);
             write_ivf_frame(output_file, fi.number, packet.as_ref());
             if let Some(mut y4m_enc) = y4m_enc {
-                let mut rec_y = vec![128 as u8; width * height];
-                let mut rec_u = vec![128 as u8; width * height / 4];
-                let mut rec_v = vec![128 as u8; width * height / 4];
+                let mut rec_y = vec![128 as u8; width*height];
+                let mut rec_u = vec![128 as u8; width*height/4];
+                let mut rec_v = vec![128 as u8; width*height/4];
                 for (y, line) in rec_y.chunks_mut(width).enumerate() {
                     for (x, pixel) in line.iter_mut().enumerate() {
                         let stride = fs.rec.planes[0].cfg.stride;
                         *pixel = fs.rec.planes[0].data[y*stride+x] as u8;
                     }
                 }
-                for (y, line) in rec_u.chunks_mut(width / 2).enumerate() {
+                for (y, line) in rec_u.chunks_mut(width/2).enumerate() {
                     for (x, pixel) in line.iter_mut().enumerate() {
                         let stride = fs.rec.planes[1].cfg.stride;
                         *pixel = fs.rec.planes[1].data[y*stride+x] as u8;
                     }
                 }
-                for (y, line) in rec_v.chunks_mut(width / 2).enumerate() {
+                for (y, line) in rec_v.chunks_mut(width/2).enumerate() {
                     for (x, pixel) in line.iter_mut().enumerate() {
                         let stride = fs.rec.planes[2].cfg.stride;
                         *pixel = fs.rec.planes[2].data[y*stride+x] as u8;
@@ -1905,7 +1881,7 @@ mod test_encode_decode {
 
     }
 
-    fn setup_encoder(w: usize, h: usize, speed: usize, quantizer: usize, bit_depth: usize) -> (FrameInvariants, Sequence) {
+    fn setup_encoder(w: usize, h: usize, speed: usize, quantizer: usize) -> (FrameInvariants, Sequence) {
         unsafe {
             av1_rtcd();
             aom_dsp_rtcd();
@@ -1920,7 +1896,7 @@ mod test_encode_decode {
 
         fi.use_reduced_tx_set = true;
         // fi.min_partition_size =
-        let seq = Sequence::new(w, h, bit_depth);
+        let seq = Sequence::new(w, h);
 
         (fi, seq)
     }
@@ -1938,7 +1914,7 @@ mod test_encode_decode {
 
         for b in DIMENSION_OFFSETS.iter() {
             for s in 0 .. 10 {
-                encode_decode(w + b.0, h + b.1, s, quantizer, limit, 8);
+                encode_decode(w + b.0, h + b.1, s, quantizer, limit);
             }
         }
     }
@@ -1955,7 +1931,7 @@ mod test_encode_decode {
         let speed = 4;
         
         for (w, h) in DIMENSIONS.iter() {
-            encode_decode(*w, *h, speed, quantizer, limit, 8);
+            encode_decode(*w, *h, speed, quantizer, limit);
         }
     }
 
@@ -1969,7 +1945,7 @@ mod test_encode_decode {
 
         for b in DIMENSION_OFFSETS.iter() {
             for &q in [80, 100, 120].iter() {
-                encode_decode(w + b.0, h + b.1, speed, q, limit, 8);
+                encode_decode(w + b.0, h + b.1, speed, q, limit);
             }
         }
     }
@@ -1983,27 +1959,11 @@ mod test_encode_decode {
         let speed = 0;
         let qindex = 100;
 
-        encode_decode(w, h, speed, qindex, limit, 8);
+        encode_decode(w, h, speed, qindex, limit);
     }
 
-    #[test]
-    #[ignore]
-    fn high_bd() {
-        let quantizer = 100;
-        let limit = 3; // Include inter frames
-        let speed = 0; // Test as many tools as possible
-        let w = 64;
-        let h = 80;
-
-        // 10-bit
-        encode_decode(w, h, speed, quantizer, limit, 10);
-
-        // 12-bit
-        encode_decode(w, h, speed, quantizer, limit, 12);
-    }
-
-    fn compare_plane<T: Ord + std::fmt::Debug>(rec: &[T], rec_stride: usize,
-                     dec: &[T], dec_stride: usize,
+    fn compare_plane(rec: &[u8], rec_stride: usize,
+                     dec: &[u8], dec_stride: usize,
                      width: usize, height: usize) {
         for line in rec.chunks(rec_stride)
             .zip(dec.chunks(dec_stride)).take(height) {
@@ -2011,7 +1971,7 @@ mod test_encode_decode {
         }
     }
 
-    fn compare_img(img: *const aom_image_t, frame: &Frame, bit_depth: usize) {
+    fn compare_img(img: *const aom_image_t, frame: &Frame) {
         use std::slice;
         let img = unsafe { *img };
         let img_iter = img.planes.iter().zip(img.stride.iter());
@@ -2020,43 +1980,26 @@ mod test_encode_decode {
             let w = frame_plane.cfg.width;
             let h = frame_plane.cfg.height;
             let rec_stride = frame_plane.cfg.stride;
+            let dec_stride = *img_plane.1 as usize;
 
-            if bit_depth > 8 {
-                let dec_stride = *img_plane.1 as usize / 2;
+            let dec = unsafe {
+                let data = *img_plane.0 as *const u8;
+                let size = dec_stride * h;
+                slice::from_raw_parts(data, size)
+            };
 
-                let dec = unsafe {
-                    let data = *img_plane.0 as *const u16;
-                    let size = dec_stride * h;
-                
-                    slice::from_raw_parts(data, size)
-                };
+            let rec: Vec<u8> = frame_plane.data.iter().map(|&v| v as u8).collect();
 
-                let rec: Vec<u16> = frame_plane.data.iter().map(|&v| v).collect();
-
-                compare_plane::<u16>(&rec[..], rec_stride, dec, dec_stride, w, h);
-            } else {
-                let dec_stride = *img_plane.1 as usize;
-
-                let dec = unsafe {
-                    let data = *img_plane.0 as *const u8;
-                    let size = dec_stride * h;
-                
-                    slice::from_raw_parts(data, size)
-                };
-
-                let rec: Vec<u8> = frame_plane.data.iter().map(|&v| v as u8).collect();
-
-                compare_plane::<u8>(&rec[..], rec_stride, dec, dec_stride, w, h);
-            }
+            compare_plane(&rec[..], rec_stride, dec, dec_stride, w, h);
         }
     }
 
-    fn encode_decode(w: usize, h: usize, speed: usize, quantizer: usize, limit: usize, bit_depth: usize) {
+    fn encode_decode(w:usize, h:usize, speed: usize, quantizer: usize, limit: usize) {
         use std::ptr;
         let mut ra = ChaChaRng::from_seed([0; 32]);
 
         let mut dec = setup_decoder(w, h);
-        let (mut fi, mut seq) = setup_encoder(w, h, speed, quantizer, bit_depth);
+        let (mut fi, mut seq) = setup_encoder(w, h, speed, quantizer);
 
         println!("Encoding {}x{} speed {} quantizer {}", w, h, speed, quantizer);
 
@@ -2116,7 +2059,7 @@ mod test_encode_decode {
                         corrupted_count += corrupted;
 
                         let rec = rec_fifo.pop_front().unwrap();
-                        compare_img(img, &rec, bit_depth);
+                        compare_img(img, &rec);
                     }
                 }
             }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -355,32 +355,32 @@ use plane::*;
 use predict::*;
 
 impl PredictionMode {
-  pub fn predict_intra<'a>(self, dst: &'a mut PlaneMutSlice<'a>, tx_size: TxSize, bit_depth: usize) {
+  pub fn predict_intra<'a>(self, dst: &'a mut PlaneMutSlice<'a>, tx_size: TxSize) {
     assert!(self.is_intra());
 
     match tx_size {
-      TxSize::TX_4X4 => self.predict_intra_inner::<Block4x4>(dst, bit_depth),
-      TxSize::TX_8X8 => self.predict_intra_inner::<Block8x8>(dst, bit_depth),
-      TxSize::TX_16X16 => self.predict_intra_inner::<Block16x16>(dst, bit_depth),
-      TxSize::TX_32X32 => self.predict_intra_inner::<Block32x32>(dst, bit_depth),
+      TxSize::TX_4X4 => self.predict_intra_inner::<Block4x4>(dst),
+      TxSize::TX_8X8 => self.predict_intra_inner::<Block8x8>(dst),
+      TxSize::TX_16X16 => self.predict_intra_inner::<Block16x16>(dst),
+      TxSize::TX_32X32 => self.predict_intra_inner::<Block32x32>(dst),
       _ => unimplemented!()
     }
   }
 
   #[inline(always)]
-  fn predict_intra_inner<'a, B: Intra>(self, dst: &'a mut PlaneMutSlice<'a>, bit_depth: usize) {
+  fn predict_intra_inner<'a, B: Intra>(self, dst: &'a mut PlaneMutSlice<'a>) {
     // above and left arrays include above-left sample
     // above array includes above-right samples
     // left array includes below-left samples
-    let bd = bit_depth;
-    let base = 128 << (bd - 8);
-
-    let above = &mut [(base - 1) as u16; 2 * MAX_TX_SIZE + 1][..B::W + B::H + 1];
-    let left = &mut [(base + 1) as u16; 2 * MAX_TX_SIZE + 1][..B::H + B::W + 1];
+    let above = &mut [127u16; 2 * MAX_TX_SIZE + 1][..B::W + B::H + 1];
+    let left = &mut [129u16; 2 * MAX_TX_SIZE + 1][..B::H + B::W + 1];
 
     let stride = dst.plane.cfg.stride;
     let x = dst.x;
     let y = dst.y;
+    // TODO: pass bd (bitdepth) as a parameter
+    let bd = 8;
+    let base = 128 << (bd - 8);
 
     if y != 0 {
       if self != PredictionMode::H_PRED {
@@ -436,7 +436,6 @@ impl PredictionMode {
       }
       if x == 0 && y == 0 {
         above[0] = base;
-        left[0] = base;
       }      
     }
 
@@ -446,9 +445,9 @@ impl PredictionMode {
 
     match self {
       PredictionMode::DC_PRED => match (x, y) {
-        (0, 0) => B::pred_dc_128(slice, stride, bit_depth),
-        (_, 0) => B::pred_dc_left(slice, stride, above_slice, left_slice, bit_depth),
-        (0, _) => B::pred_dc_top(slice, stride, above_slice, left_slice, bit_depth),
+        (0, 0) => B::pred_dc_128(slice, stride),
+        (_, 0) => B::pred_dc_left(slice, stride, above_slice, left_slice),
+        (0, _) => B::pred_dc_top(slice, stride, above_slice, left_slice),
         _ => B::pred_dc(slice, stride, above_slice, left_slice)
       },
       PredictionMode::H_PRED => match (x, y) {

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -197,17 +197,17 @@ pub trait Intra: Dim {
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_dc_128(output: &mut [u16], stride: usize, bit_depth: usize) {
+  fn pred_dc_128(output: &mut [u16], stride: usize) {
     for y in 0..Self::H {
       for x in 0..Self::W {
-        output[y * stride + x] = 128 << (bit_depth - 8);
+        output[y * stride + x] = 128;
       }
     }
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
   fn pred_dc_left(
-    output: &mut [u16], stride: usize, above: &[u16], left: &[u16], bit_depth: usize
+    output: &mut [u16], stride: usize, above: &[u16], left: &[u16]
   ) {
     unsafe {
       highbd_dc_left_predictor(
@@ -217,14 +217,14 @@ pub trait Intra: Dim {
         Self::H as libc::c_int,
         above.as_ptr(),
         left.as_ptr(),
-        bit_depth as libc::c_int
+        8
       );
     }
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
   fn pred_dc_top(
-    output: &mut [u16], stride: usize, above: &[u16], left: &[u16], bit_depth: usize
+    output: &mut [u16], stride: usize, above: &[u16], left: &[u16]
   ) {
     unsafe {
       highbd_dc_top_predictor(
@@ -234,7 +234,7 @@ pub trait Intra: Dim {
         Self::H as libc::c_int,
         above.as_ptr(),
         left.as_ptr(),
-        bit_depth as libc::c_int
+        8
       );
     }
   }
@@ -331,6 +331,7 @@ pub trait Intra: Dim {
 
         let output_index = r * stride + c;
 
+        // Clamp the output to the correct bit depth
         output[output_index] = this_pred as u16;
       }
     }
@@ -367,6 +368,7 @@ pub trait Intra: Dim {
 
         let output_index = r * stride + c;
 
+        // Clamp the output to the correct bit depth
         output[output_index] = this_pred as u16;
       }
     }
@@ -403,6 +405,7 @@ pub trait Intra: Dim {
 
         let output_index = r * stride + c;
 
+        // Clamp the output to the correct bit depth
         output[output_index] = this_pred as u16;
       }
     }

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -10,16 +10,10 @@
 #![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
 
 use partition::TxSize;
-use std::mem;
 
 extern {
   static dc_qlookup_Q3: [i16; 256];
-  static dc_qlookup_10_Q3: [i16; 256];
-  static dc_qlookup_12_Q3: [i16; 256];
-
-  static ac_qlookup_Q3: [i16; 256];  
-  static ac_qlookup_10_Q3: [i16; 256];
-  static ac_qlookup_12_Q3: [i16; 256];
+  static ac_qlookup_Q3: [i16; 256];
 }
 
 fn get_tx_scale(tx_size: TxSize) -> u8 {
@@ -30,26 +24,12 @@ fn get_tx_scale(tx_size: TxSize) -> u8 {
   }
 }
 
-pub fn dc_q(qindex: usize, bit_depth: usize) -> i16 {
-  let &table = match bit_depth {
-    8 => &dc_qlookup_Q3,
-    10 => &dc_qlookup_10_Q3,
-    12 => &dc_qlookup_12_Q3,
-    _ => unimplemented!()
-  };
-
-  table[qindex]
+pub fn dc_q(qindex: usize) -> i16 {
+  unsafe { dc_qlookup_Q3[qindex] }
 }
 
-pub fn ac_q(qindex: usize, bit_depth: usize) -> i16 {
-  let &table = match bit_depth {
-    8 => &ac_qlookup_Q3,
-    10 => &ac_qlookup_10_Q3,
-    12 => &ac_qlookup_12_Q3,
-    _ => unimplemented!()
-  };
-
-  table[qindex]
+pub fn ac_q(qindex: usize) -> i16 {
+  unsafe { ac_qlookup_Q3[qindex] }
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -63,6 +43,8 @@ pub struct QuantizationContext {
   ac_offset: i32,
   ac_mul_add: (u32, u32, u32)
 }
+
+use std::mem;
 
 fn divu_gen(d: u32) -> (u32, u32, u32) {
   let nbits = (mem::size_of_val(&d) as u64) * 8;
@@ -119,13 +101,13 @@ mod test {
 }
 
 impl QuantizationContext {
-  pub fn update(&mut self, qindex: usize, tx_size: TxSize, is_intra: bool, bit_depth: usize) {
+  pub fn update(&mut self, qindex: usize, tx_size: TxSize, is_intra: bool) {
     self.tx_scale = get_tx_scale(tx_size) as i32;
 
-    self.dc_quant = dc_q(qindex, bit_depth) as u32;
+    self.dc_quant = dc_q(qindex) as u32;
     self.dc_mul_add = divu_gen(self.dc_quant);
 
-    self.ac_quant = ac_q(qindex, bit_depth) as u32;
+    self.ac_quant = ac_q(qindex) as u32;
     self.ac_mul_add = divu_gen(self.ac_quant);
 
     self.dc_offset = self.dc_quant as i32 * (if is_intra {21} else {15}) / 64;
@@ -146,11 +128,11 @@ impl QuantizationContext {
   }
 }
 
-pub fn quantize_in_place(qindex: usize, coeffs: &mut [i32], tx_size: TxSize, bit_depth: usize) {
+pub fn quantize_in_place(qindex: usize, coeffs: &mut [i32], tx_size: TxSize) {
   let tx_scale = get_tx_scale(tx_size) as i32;
 
-  let dc_quant = dc_q(qindex, bit_depth) as i32;
-  let ac_quant = ac_q(qindex, bit_depth) as i32;
+  let dc_quant = dc_q(qindex) as i32;
+  let ac_quant = ac_q(qindex) as i32;
 
   // using 21/64=0.328125 as rounding offset. To be tuned
   let dc_offset = dc_quant * 21 / 64 as i32;
@@ -168,12 +150,12 @@ pub fn quantize_in_place(qindex: usize, coeffs: &mut [i32], tx_size: TxSize, bit
 }
 
 pub fn dequantize(
-  qindex: usize, coeffs: &[i32], rcoeffs: &mut [i32], tx_size: TxSize, bit_depth: usize
+  qindex: usize, coeffs: &[i32], rcoeffs: &mut [i32], tx_size: TxSize
 ) {
   let tx_scale = get_tx_scale(tx_size) as i32;
 
-  rcoeffs[0] = (coeffs[0] * dc_q(qindex, bit_depth) as i32) / tx_scale;
-  let ac_quant = ac_q(qindex, bit_depth) as i32;
+  rcoeffs[0] = (coeffs[0] * dc_q(qindex) as i32) / tx_scale;
+  let ac_quant = ac_q(qindex) as i32;
 
   for (r, &c) in rcoeffs.iter_mut().zip(coeffs.iter()).skip(1) {
     *r = c * ac_quant / tx_scale;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -50,9 +50,9 @@ pub struct RDOPartitionOutput {
 }
 
 #[allow(unused)]
-fn cdef_dist_wxh_8x8(src1: &PlaneSlice, src2: &PlaneSlice, bit_depth: usize) -> u64 {
-  let coeff_shift = bit_depth - 8;
-  
+fn cdef_dist_wxh_8x8(src1: &PlaneSlice, src2: &PlaneSlice) -> u64 {
+  //TODO: Handle high bit-depth here by setting coeff_shift
+  let coeff_shift = 0;
   let mut sum_s: i32 = 0;
   let mut sum_d: i32 = 0;
   let mut sum_s2: i64 = 0;
@@ -80,7 +80,7 @@ fn cdef_dist_wxh_8x8(src1: &PlaneSlice, src2: &PlaneSlice, bit_depth: usize) -> 
 
 #[allow(unused)]
 fn cdef_dist_wxh(
-  src1: &PlaneSlice, src2: &PlaneSlice, w: usize, h: usize, bit_depth: usize
+  src1: &PlaneSlice, src2: &PlaneSlice, w: usize, h: usize
 ) -> u64 {
   assert!(w & 0x7 == 0);
   assert!(h & 0x7 == 0);
@@ -90,8 +90,7 @@ fn cdef_dist_wxh(
     for i in 0..w / 8 {
       sum += cdef_dist_wxh_8x8(
         &src1.subslice(i * 8, j * 8),
-        &src2.subslice(i * 8, j * 8),
-        bit_depth
+        &src2.subslice(i * 8, j * 8)
       )
     }
   }
@@ -113,9 +112,9 @@ fn sse_wxh(src1: &PlaneSlice, src2: &PlaneSlice, w: usize, h: usize) -> u64 {
 // Compute the rate-distortion cost for an encode
 fn compute_rd_cost(
   fi: &FrameInvariants, fs: &FrameState, w_y: usize, h_y: usize, w_uv: usize,
-  h_uv: usize, bo: &BlockOffset, bit_cost: u32, bit_depth: usize
+  h_uv: usize, bo: &BlockOffset, bit_cost: u32
 ) -> f64 {
-  let q = dc_q(fi.config.quantizer, bit_depth) as f64;
+  let q = dc_q(fi.config.quantizer) as f64;
 
   // Convert q into Q0 precision, given that libaom quantizers are Q3
   let q0 = q / 8.0_f64;
@@ -138,8 +137,7 @@ fn compute_rd_cost(
       &fs.input.planes[0].slice(&po),
       &fs.rec.planes[0].slice(&po),
       w_y,
-      h_y,
-      bit_depth
+      h_y
     )
   } else {
     unimplemented!();
@@ -213,7 +211,7 @@ pub fn rdo_mode_decision(
         let tell = wr.tell_frac();
         
         encode_block_a(seq, cw, wr, bsize, bo, skip);
-        encode_block_b(fi, fs, cw, wr, luma_mode, chroma_mode, bsize, bo, skip, seq.bit_depth);
+        encode_block_b(fi, fs, cw, wr, luma_mode, chroma_mode, bsize, bo, skip);
 
         let cost = wr.tell_frac() - tell;
         let rd = compute_rd_cost(
@@ -224,8 +222,7 @@ pub fn rdo_mode_decision(
           w_uv,
           h_uv,
           bo,
-          cost,
-          seq.bit_depth
+          cost
         );
 
         if rd < best_rd {
@@ -241,7 +238,7 @@ pub fn rdo_mode_decision(
       let mut wr: &mut Writer = &mut WriterCounter::new();
       let tell = wr.tell_frac();
       encode_block_a(seq, cw, wr, bsize, bo, skip);
-      encode_block_b(fi, fs, cw, wr, luma_mode, luma_mode, bsize, bo, skip, seq.bit_depth);
+      encode_block_b(fi, fs, cw, wr, luma_mode, luma_mode, bsize, bo, skip);
 
       let cost = wr.tell_frac() - tell;
       let rd = compute_rd_cost(
@@ -252,8 +249,7 @@ pub fn rdo_mode_decision(
         w_uv,
         h_uv,
         bo,
-        cost,
-        seq.bit_depth
+        cost
       );
 
       if rd < best_rd {
@@ -286,7 +282,7 @@ pub fn rdo_mode_decision(
 pub fn rdo_tx_type_decision(
   fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
   mode: PredictionMode, bsize: BlockSize, bo: &BlockOffset, tx_size: TxSize,
-  tx_set: TxSet, bit_depth: usize
+  tx_set: TxSet
 ) -> TxType {
   let mut best_type = TxType::DCT_DCT;
   let mut best_rd = std::f64::MAX;
@@ -319,11 +315,11 @@ pub fn rdo_tx_type_decision(
     let tell = wr.tell_frac();
     if is_inter {
       write_tx_tree(
-        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false, bit_depth
+        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false,
       );
     }  else {
       write_tx_blocks(
-        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false, bit_depth
+        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false,
       );
     }
 
@@ -336,8 +332,7 @@ pub fn rdo_tx_type_decision(
       w_uv,
       h_uv,
       bo,
-      cost,
-      bit_depth
+      cost
     );
 
     if rd < best_rd {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -95,44 +95,44 @@ extern "C" {
 
 pub fn forward_transform(
   input: &[i16], output: &mut [i32], stride: usize, tx_size: TxSize,
-  tx_type: TxType, bit_depth: usize
+  tx_type: TxType
 ) {
   match tx_size {
-    TxSize::TX_4X4 => fht4x4(input, output, stride, tx_type, bit_depth),
-    TxSize::TX_8X8 => fht8x8(input, output, stride, tx_type, bit_depth),
-    TxSize::TX_16X16 => fht16x16(input, output, stride, tx_type, bit_depth),
-    TxSize::TX_32X32 => fht32x32(input, output, stride, tx_type, bit_depth),
+    TxSize::TX_4X4 => fht4x4(input, output, stride, tx_type),
+    TxSize::TX_8X8 => fht8x8(input, output, stride, tx_type),
+    TxSize::TX_16X16 => fht16x16(input, output, stride, tx_type),
+    TxSize::TX_32X32 => fht32x32(input, output, stride, tx_type),
     _ => panic!("unimplemented tx size")
   }
 }
 
 pub fn inverse_transform_add(
   input: &[i32], output: &mut [u16], stride: usize, tx_size: TxSize,
-  tx_type: TxType, bit_depth: usize
+  tx_type: TxType
 ) {
   match tx_size {
-    TxSize::TX_4X4 => iht4x4_add(input, output, stride, tx_type, bit_depth),
-    TxSize::TX_8X8 => iht8x8_add(input, output, stride, tx_type, bit_depth),
-    TxSize::TX_16X16 => iht16x16_add(input, output, stride, tx_type, bit_depth),
-    TxSize::TX_32X32 => iht32x32_add(input, output, stride, tx_type, bit_depth),
+    TxSize::TX_4X4 => iht4x4_add(input, output, stride, tx_type),
+    TxSize::TX_8X8 => iht8x8_add(input, output, stride, tx_type),
+    TxSize::TX_16X16 => iht16x16_add(input, output, stride, tx_type),
+    TxSize::TX_32X32 => iht32x32_add(input, output, stride, tx_type),
     _ => panic!("unimplemented tx size")
   }
 }
 
-fn fht4x4(input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType, bit_depth: usize) {
+fn fht4x4(input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType) {
   unsafe {
     av1_fwd_txfm2d_4x4_c(
       input.as_ptr(),
       output.as_mut_ptr(),
       stride as libc::c_int,
       tx_type as libc::c_int,
-      bit_depth as libc::c_int
+      8
     );
   }
 }
 
 fn iht4x4_add(
-  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType, bit_depth: usize
+  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType
 ) {
   // SIMD code may assert for transform types beyond TxType::IDTX.
   if tx_type < TxType::IDTX {
@@ -142,7 +142,7 @@ fn iht4x4_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        bit_depth as libc::c_int
+        8
       );
     }
   } else {
@@ -152,26 +152,26 @@ fn iht4x4_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        bit_depth as libc::c_int
+        8
       );
     }
   }
 }
 
-fn fht8x8(input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType, bit_depth: usize) {
+fn fht8x8(input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType) {
   unsafe {
     av1_fwd_txfm2d_8x8_c(
       input.as_ptr(),
       output.as_mut_ptr(),
       stride as libc::c_int,
       tx_type as libc::c_int,
-      bit_depth as libc::c_int
+      8
     );
   }
 }
 
 fn iht8x8_add(
-  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType, bit_depth: usize
+  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType
 ) {
   // SIMD code may assert for transform types beyond TxType::IDTX.
   if tx_type < TxType::IDTX {
@@ -181,7 +181,7 @@ fn iht8x8_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        bit_depth as libc::c_int
+        8
       );
     }
   } else {
@@ -191,14 +191,14 @@ fn iht8x8_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        bit_depth as libc::c_int
+        8
       );
     }
   }
 }
 
 fn fht16x16(
-  input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType, bit_depth: usize
+  input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType
 ) {
   unsafe {
     av1_fwd_txfm2d_16x16_c(
@@ -206,13 +206,13 @@ fn fht16x16(
       output.as_mut_ptr(),
       stride as libc::c_int,
       tx_type as libc::c_int,
-      bit_depth as libc::c_int
+      8
     );
   }
 }
 
 fn iht16x16_add(
-  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType, bit_depth: usize
+  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType
 ) {
   unsafe {
     if tx_type < TxType::IDTX {
@@ -222,7 +222,7 @@ fn iht16x16_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        bit_depth as libc::c_int
+        8
       );
     } else {
       av1_inv_txfm2d_add_16x16_c(
@@ -230,14 +230,14 @@ fn iht16x16_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        bit_depth as libc::c_int
+        8
       );
     }
   }
 }
 
 fn fht32x32(
-  input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType, bit_depth: usize
+  input: &[i16], output: &mut [i32], stride: usize, tx_type: TxType
 ) {
   unsafe {
     av1_fwd_txfm2d_32x32_c(
@@ -245,13 +245,13 @@ fn fht32x32(
       output.as_mut_ptr(),
       stride as libc::c_int,
       tx_type as libc::c_int,
-      bit_depth as libc::c_int
+      8
     );
   }
 }
 
 fn iht32x32_add(
-  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType, bit_depth: usize
+  input: &[i32], output: &mut [u16], stride: usize, tx_type: TxType
 ) {
   unsafe {
     if tx_type < TxType::IDTX {
@@ -261,7 +261,7 @@ fn iht32x32_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        bit_depth as libc::c_int
+        8
       );
     } else {
       av1_inv_txfm2d_add_32x32_c(
@@ -269,7 +269,7 @@ fn iht32x32_add(
         output.as_mut_ptr(),
         stride as libc::c_int,
         tx_type as libc::c_int,
-        bit_depth as libc::c_int
+        8
       );
     }
   }

--- a/src/util.rs
+++ b/src/util.rs
@@ -77,15 +77,3 @@ impl Fixed for usize {
 pub fn is_aligned<T>(ptr: *const T, n: usize) -> bool {
   return ((ptr as usize) & ((1 << n) - 1)) == 0;
 }
-
-pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
-  if input < min {
-      return min;
-  }
-  else if input > max {
-      return max;
-  }
-  else {
-      return input;
-  }
-}


### PR DESCRIPTION
This reverts commit 8c5453501423ff67f9d973a2a1cc1df7e24e02b2.
Since 8c5453501423ff67f9d973a2a1cc1df7e24e02b2 has broken encoder, causing desync (in 1st frame) btw enc and dec for the test:
./target/release/rav1e nyan.y4m -o test.ivf -r test_rec.y4m --quantizer=10 --speed=0 --limit=5
