### PR TITLE
Move cli-specific code where it belongs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Thomas Daede <tdaede@xiph.org>"]
 build = "build.rs"
 include = ["/src/**", "/aom_build/**", "/Cargo.toml"]
 autobenches = false
+autobins = false
 
 [features]
 repl = ["rustyline"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ autobins = false
 repl = ["rustyline", "binaries"]
 comparative_bench = []
 decode_test = ["bindgen"]
-binaries = ["y4m"]
+binaries = ["y4m", "clap"]
 default = ["binaries"]
 
 [dependencies]
 bitstream-io = "0.6"
-clap = "2"
+clap = { version = "2", optional = true }
 libc = "0.2"
 rand = "0.5"
 rustyline = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ autobenches = false
 autobins = false
 
 [features]
-repl = ["rustyline"]
+repl = ["rustyline", "binaries"]
 comparative_bench = []
 decode_test = ["bindgen"]
+binaries = ["y4m"]
+default = ["binaries"]
 
 [dependencies]
 bitstream-io = "0.6"
@@ -18,7 +20,7 @@ clap = "2"
 libc = "0.2"
 rand = "0.5"
 rustyline = { version = "1", optional = true }
-y4m = "0.3"
+y4m = { version = "0.3", optional = true }
 enum-iterator-derive = "0.1.1"
 backtrace = "0.3"
 num-traits = "0.2"

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -1,0 +1,111 @@
+use y4m;
+use rav1e::*;
+use std::io::prelude::*;
+use std::slice;
+
+/// Encode and write a frame.
+pub fn process_frame(sequence: &mut Sequence, fi: &mut FrameInvariants,
+                     output_file: &mut Write,
+                     y4m_dec: &mut y4m::Decoder<Box<Read>>,
+                     y4m_enc: Option<&mut y4m::Encoder<Box<Write>>>) -> bool {
+    unsafe {
+        av1_rtcd();
+        aom_dsp_rtcd();
+    }
+    let width = fi.width;
+    let height = fi.height;
+    let y4m_bits = y4m_dec.get_bit_depth();
+    let y4m_bytes = y4m_dec.get_bytes_per_sample();
+    let csp = y4m_dec.get_colorspace();
+
+    match csp {
+        y4m::Colorspace::C420 |
+        y4m::Colorspace::C420jpeg |
+        y4m::Colorspace::C420paldv |
+        y4m::Colorspace::C420mpeg2 |
+        y4m::Colorspace::C420p10 |
+        y4m::Colorspace::C420p12 => {},
+        _ => {
+            panic!("Colorspace {:?} is not supported yet.", csp);
+        },
+    }
+    match y4m_dec.read_frame() {
+        Ok(y4m_frame) => {
+            let y4m_y = y4m_frame.get_y_plane();
+            let y4m_u = y4m_frame.get_u_plane();
+            let y4m_v = y4m_frame.get_v_plane();
+            eprintln!("{}", fi);
+            let mut fs = FrameState::new(&fi);
+            fs.input.planes[0].copy_from_raw_u8(&y4m_y, width * y4m_bytes, y4m_bytes);
+            fs.input.planes[1].copy_from_raw_u8(&y4m_u, width * y4m_bytes / 2, y4m_bytes);
+            fs.input.planes[2].copy_from_raw_u8(&y4m_v, width * y4m_bytes / 2, y4m_bytes);
+
+            match y4m_bits {
+                8 | 10 | 12 => {},
+                _ => panic! ("unknown input bit depth!"),
+            }
+
+            let packet = encode_frame(sequence, fi, &mut fs);
+            write_ivf_frame(output_file, fi.number, packet.as_ref());
+            if let Some(mut y4m_enc) = y4m_enc {
+                let pitch_y = if sequence.bit_depth > 8 {
+                    width * 2
+                } else {
+                    width
+                };
+                let pitch_uv = pitch_y / 2;
+
+                let (mut rec_y, mut rec_u, mut rec_v) = (
+                    vec![128u8; pitch_y * height],
+                    vec![128u8; pitch_uv * (height / 2)],
+                    vec![128u8; pitch_uv * (height / 2)]);
+
+                let (stride_y, stride_u, stride_v) = (
+                    fs.rec.planes[0].cfg.stride,
+                    fs.rec.planes[1].cfg.stride,
+                    fs.rec.planes[2].cfg.stride);
+
+                for (line, line_out) in fs.rec.planes[0].data.chunks(stride_y).zip(rec_y.chunks_mut(pitch_y)) {
+                    if sequence.bit_depth > 8 {
+                        unsafe {
+                            line_out.copy_from_slice(
+                                slice::from_raw_parts::<u8>(line.as_ptr() as (*const u8), pitch_y));
+                        }
+                    } else {
+                        line_out.copy_from_slice(
+                            &line.iter().map(|&v| v as u8).collect::<Vec<u8>>()[..pitch_y]);
+                    }
+                }
+                for (line, line_out) in fs.rec.planes[1].data.chunks(stride_u).zip(rec_u.chunks_mut(pitch_uv)) {
+                    if sequence.bit_depth > 8 {
+                        unsafe {
+                            line_out.copy_from_slice(
+                                slice::from_raw_parts::<u8>(line.as_ptr() as (*const u8), pitch_uv));
+                        }
+                    } else {
+                        line_out.copy_from_slice(
+                            &line.iter().map(|&v| v as u8).collect::<Vec<u8>>()[..pitch_uv]);
+                    }
+                }
+                for (line, line_out) in fs.rec.planes[2].data.chunks(stride_v).zip(rec_v.chunks_mut(pitch_uv)) {
+                    if sequence.bit_depth > 8 {
+                        unsafe {
+                            line_out.copy_from_slice(
+                                slice::from_raw_parts::<u8>(line.as_ptr() as (*const u8), pitch_uv));
+                        }
+                    } else {
+                        line_out.copy_from_slice(
+                            &line.iter().map(|&v| v as u8).collect::<Vec<u8>>()[..pitch_uv]);
+                    }
+                }
+
+                let rec_frame = y4m::Frame::new([&rec_y, &rec_u, &rec_v], None);
+                y4m_enc.write_frame(&rec_frame).unwrap();
+            }
+
+            update_rec_buffer(fi, fs);
+            true
+        },
+        _ => false
+    }
+}

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -1,7 +1,96 @@
 use y4m;
 use rav1e::*;
+use std::fs::File;
+use std::io;
 use std::io::prelude::*;
 use std::slice;
+use clap::{App, Arg};
+
+pub struct EncoderIO {
+    pub input: Box<Read>,
+    pub output: Box<Write>,
+    pub rec: Option<Box<Write>>,
+}
+
+pub trait FromCli {
+    fn from_cli() -> (EncoderIO, EncoderConfig);
+}
+
+impl FromCli for EncoderConfig {
+    fn from_cli() -> (EncoderIO, EncoderConfig) {
+        let matches = App::new("rav1e")
+            .version("0.1.0")
+            .about("AV1 video encoder")
+           .arg(Arg::with_name("INPUT")
+                .help("Uncompressed YUV4MPEG2 video input")
+                .required(true)
+                .index(1))
+            .arg(Arg::with_name("OUTPUT")
+                .help("Compressed AV1 in IVF video output")
+                .short("o")
+                .long("output")
+                .required(true)
+                .takes_value(true))
+            .arg(Arg::with_name("RECONSTRUCTION")
+                .short("r")
+                .takes_value(true))
+            .arg(Arg::with_name("LIMIT")
+                .help("Maximum number of frames to encode")
+                .short("l")
+                .long("limit")
+                .takes_value(true)
+                .default_value("0"))
+            .arg(Arg::with_name("QP")
+                .help("Quantizer (0-255)")
+                .long("quantizer")
+                .takes_value(true)
+                .default_value("100"))
+            .arg(Arg::with_name("SPEED")
+                .help("Speed level (0(slow)-10(fast))")
+                .short("s")
+                .long("speed")
+                .takes_value(true)
+                .default_value("3"))
+            .arg(Arg::with_name("TUNE")
+                .help("Quality tuning (Will enforce partition sizes >= 8x8)")
+                .long("tune")
+                .possible_values(&Tune::variants())
+                .default_value("psnr")
+                .case_insensitive(true))
+            .get_matches();
+
+
+        let io = EncoderIO {
+            input: match matches.value_of("INPUT").unwrap() {
+                "-" => Box::new(io::stdin()) as Box<Read>,
+                f => Box::new(File::open(&f).unwrap()) as Box<Read>
+            },
+            output: match matches.value_of("OUTPUT").unwrap() {
+                "-" => Box::new(io::stdout()) as Box<Write>,
+                f => Box::new(File::create(&f).unwrap()) as Box<Write>
+            },
+            rec: matches.value_of("RECONSTRUCTION").map(|f| {
+                Box::new(File::create(&f).unwrap()) as Box<Write>
+            })
+        };
+
+        let config = EncoderConfig {
+            limit: matches.value_of("LIMIT").unwrap().parse().unwrap(),
+            quantizer: matches.value_of("QP").unwrap().parse().unwrap(),
+            speed: matches.value_of("SPEED").unwrap().parse().unwrap(),
+            tune: matches.value_of("TUNE").unwrap().parse().unwrap()
+        };
+
+        // Validate arguments
+        if config.quantizer == 0 {
+            unimplemented!();
+        } else if config.quantizer > 255 || config.speed > 10 {
+            panic!("argument out of range");
+        }
+
+        (io, config)
+    }
+}
 
 /// Encode and write a frame.
 pub fn process_frame(sequence: &mut Sequence, fi: &mut FrameInvariants,

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -10,6 +10,9 @@
 extern crate rav1e;
 extern crate y4m;
 
+mod common;
+use common::*;
+
 use rav1e::*;
 
 fn main() {

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -9,6 +9,7 @@
 
 extern crate rav1e;
 extern crate y4m;
+extern crate clap;
 
 mod common;
 use common::*;

--- a/src/bin/rav1repl.rs
+++ b/src/bin/rav1repl.rs
@@ -11,6 +11,10 @@ extern crate rustyline;
 extern crate y4m;
 
 extern crate rav1e;
+
+mod common;
+use common::*;
+
 use rav1e::*;
 
 use rustyline::error::ReadlineError;

--- a/src/bin/rav1repl.rs
+++ b/src/bin/rav1repl.rs
@@ -9,6 +9,7 @@
 
 extern crate rustyline;
 extern crate y4m;
+extern crate clap;
 
 extern crate rav1e;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ extern crate backtrace;
 extern crate clap;
 extern crate libc;
 extern crate rand;
-extern crate y4m;
 
 #[macro_use]
 extern crate enum_iterator_derive;
@@ -1756,7 +1755,7 @@ fn write_tile_group_header(tile_start_and_end_present_flag: bool) ->
     buf.clone()
 }
 
-fn encode_frame(sequence: &mut Sequence, fi: &mut FrameInvariants, fs: &mut FrameState) -> Vec<u8> {
+pub fn encode_frame(sequence: &mut Sequence, fi: &mut FrameInvariants, fs: &mut FrameState) -> Vec<u8> {
     let mut packet = Vec::new();
     //write_uncompressed_header(&mut packet, sequence, fi).unwrap();
     write_obus(&mut packet, sequence, fi).unwrap();
@@ -1804,114 +1803,6 @@ pub fn update_rec_buffer(fi: &mut FrameInvariants, fs: FrameState) {
     }
   }
 }
-
-/// Encode and write a frame.
-pub fn process_frame(sequence: &mut Sequence, fi: &mut FrameInvariants,
-                     output_file: &mut Write,
-                     y4m_dec: &mut y4m::Decoder<Box<Read>>,
-                     y4m_enc: Option<&mut y4m::Encoder<Box<Write>>>) -> bool {
-    unsafe {
-        av1_rtcd();
-        aom_dsp_rtcd();
-    }
-    let width = fi.width;
-    let height = fi.height;
-    let y4m_bits = y4m_dec.get_bit_depth();
-    let y4m_bytes = y4m_dec.get_bytes_per_sample();
-    let csp = y4m_dec.get_colorspace();
-
-    match csp {
-        y4m::Colorspace::C420 |
-        y4m::Colorspace::C420jpeg |
-        y4m::Colorspace::C420paldv |
-        y4m::Colorspace::C420mpeg2 |
-        y4m::Colorspace::C420p10 |
-        y4m::Colorspace::C420p12 => {},
-        _ => {
-            panic!("Colorspace {:?} is not supported yet.", csp);
-        },
-    }
-    match y4m_dec.read_frame() {
-        Ok(y4m_frame) => {
-            let y4m_y = y4m_frame.get_y_plane();
-            let y4m_u = y4m_frame.get_u_plane();
-            let y4m_v = y4m_frame.get_v_plane();
-            eprintln!("{}", fi);
-            let mut fs = FrameState::new(&fi);
-            fs.input.planes[0].copy_from_raw_u8(&y4m_y, width * y4m_bytes, y4m_bytes);
-            fs.input.planes[1].copy_from_raw_u8(&y4m_u, width * y4m_bytes / 2, y4m_bytes);
-            fs.input.planes[2].copy_from_raw_u8(&y4m_v, width * y4m_bytes / 2, y4m_bytes);
-
-            match y4m_bits {
-                8 | 10 | 12 => {},
-                _ => panic! ("unknown input bit depth!"),
-            }
-
-            let packet = encode_frame(sequence, fi, &mut fs);
-            write_ivf_frame(output_file, fi.number, packet.as_ref());
-            if let Some(mut y4m_enc) = y4m_enc {
-                let pitch_y = if sequence.bit_depth > 8 {
-                    width * 2
-                } else {
-                    width
-                };
-                let pitch_uv = pitch_y / 2;
-
-                let (mut rec_y, mut rec_u, mut rec_v) = (
-                    vec![128u8; pitch_y * height],
-                    vec![128u8; pitch_uv * (height / 2)],
-                    vec![128u8; pitch_uv * (height / 2)]);
-                
-                let (stride_y, stride_u, stride_v) = (
-                    fs.rec.planes[0].cfg.stride,
-                    fs.rec.planes[1].cfg.stride,
-                    fs.rec.planes[2].cfg.stride);
-
-                for (line, line_out) in fs.rec.planes[0].data.chunks(stride_y).zip(rec_y.chunks_mut(pitch_y)) {
-                    if sequence.bit_depth > 8 {
-                        unsafe { 
-                            line_out.copy_from_slice(
-                                slice::from_raw_parts::<u8>(line.as_ptr() as (*const u8), pitch_y)); 
-                        }
-                    } else {
-                        line_out.copy_from_slice(
-                            &line.iter().map(|&v| v as u8).collect::<Vec<u8>>()[..pitch_y]);
-                    }
-                }
-                for (line, line_out) in fs.rec.planes[1].data.chunks(stride_u).zip(rec_u.chunks_mut(pitch_uv)) {
-                    if sequence.bit_depth > 8 {
-                        unsafe { 
-                            line_out.copy_from_slice(
-                                slice::from_raw_parts::<u8>(line.as_ptr() as (*const u8), pitch_uv)); 
-                        }
-                    } else {
-                        line_out.copy_from_slice(
-                            &line.iter().map(|&v| v as u8).collect::<Vec<u8>>()[..pitch_uv]);
-                    }
-                }
-                for (line, line_out) in fs.rec.planes[2].data.chunks(stride_v).zip(rec_v.chunks_mut(pitch_uv)) {
-                    if sequence.bit_depth > 8 {
-                        unsafe { 
-                            line_out.copy_from_slice(
-                                slice::from_raw_parts::<u8>(line.as_ptr() as (*const u8), pitch_uv)); 
-                        }
-                    } else {
-                        line_out.copy_from_slice(
-                            &line.iter().map(|&v| v as u8).collect::<Vec<u8>>()[..pitch_uv]);
-                    }
-                }
-
-                let rec_frame = y4m::Frame::new([&rec_y, &rec_u, &rec_v], None);
-                y4m_enc.write_frame(&rec_frame).unwrap();
-            }
-
-            update_rec_buffer(fi, fs);
-            true
-        },
-        _ => false
-    }
-}
-
 
 // #[cfg(test)]
 #[cfg(feature="decode_test")]
@@ -2008,8 +1899,8 @@ mod test_encode_decode {
         }
     }
 
-    static DIMENSIONS: &[(usize, usize)] = &[/*(2, 2), (4, 4),*/ (8, 8), 
-        (16, 16), (32, 32), (64, 64), (128, 128), (256, 256), 
+    static DIMENSIONS: &[(usize, usize)] = &[/*(2, 2), (4, 4),*/ (8, 8),
+        (16, 16), (32, 32), (64, 64), (128, 128), (256, 256),
         (512, 512), (1024, 1024), (2048, 2048)];
 
     #[test]
@@ -2018,7 +1909,7 @@ mod test_encode_decode {
         let quantizer = 100;
         let limit = 1;
         let speed = 4;
-        
+
         for (w, h) in DIMENSIONS.iter() {
             encode_decode(*w, *h, speed, quantizer, limit, 8);
         }
@@ -2092,7 +1983,7 @@ mod test_encode_decode {
                 let dec = unsafe {
                     let data = *img_plane.0 as *const u16;
                     let size = dec_stride * h;
-                
+
                     slice::from_raw_parts(data, size)
                 };
 
@@ -2105,7 +1996,7 @@ mod test_encode_decode {
                 let dec = unsafe {
                     let data = *img_plane.0 as *const u8;
                     let size = dec_stride * h;
-                
+
                     slice::from_raw_parts(data, size)
                 };
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,115 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+// Imported from clap, to avoid to depend directly to the crate
+macro_rules! _clap_count_exprs {
+    () => { 0 };
+    ($e:expr) => { 1 };
+    ($e:expr, $($es:expr),+) => { 1 + _clap_count_exprs!($($es),*) };
+}
+macro_rules! arg_enum {
+    (@as_item $($i:item)*) => ($($i)*);
+    (@impls ( $($tts:tt)* ) -> ($e:ident, $($v:ident),+)) => {
+        arg_enum!(@as_item
+        $($tts)*
+
+        impl ::std::str::FromStr for $e {
+            type Err = String;
+
+            fn from_str(s: &str) -> ::std::result::Result<Self,Self::Err> {
+                #[allow(deprecated, unused_imports)]
+                use ::std::ascii::AsciiExt;
+                match s {
+                    $(stringify!($v) |
+                    _ if s.eq_ignore_ascii_case(stringify!($v)) => Ok($e::$v)),+,
+                    _ => Err({
+                        let v = vec![
+                            $(stringify!($v),)+
+                        ];
+                        format!("valid values: {}",
+                            v.join(" ,"))
+                    }),
+                }
+            }
+        }
+        impl ::std::fmt::Display for $e {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                match *self {
+                    $($e::$v => write!(f, stringify!($v)),)+
+                }
+            }
+        }
+        impl $e {
+            #[allow(dead_code)]
+            pub fn variants() -> [&'static str; _clap_count_exprs!($(stringify!($v)),+)] {
+                [
+                    $(stringify!($v),)+
+                ]
+            }
+        });
+    };
+    ($(#[$($m:meta),+])+ pub enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
+        arg_enum!(@impls
+            ($(#[$($m),+])+
+            pub enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
+    ($(#[$($m:meta),+])+ pub enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
+        arg_enum!(@impls
+            ($(#[$($m),+])+
+            pub enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
+    ($(#[$($m:meta),+])+ enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
+        arg_enum!(@impls
+            ($(#[$($m),+])+
+             enum $e {
+                 $($v$(=$val)*),+
+             }) -> ($e, $($v),+)
+        );
+    };
+    ($(#[$($m:meta),+])+ enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
+        arg_enum!(@impls
+            ($(#[$($m),+])+
+            enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
+    (pub enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
+        arg_enum!(@impls
+            (pub enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
+    (pub enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
+        arg_enum!(@impls
+            (pub enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
+    (enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
+        arg_enum!(@impls
+            (enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
+    (enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
+        arg_enum!(@impls
+            (enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
+}
+
 #[repr(align(16))]
 struct Align16;
 


### PR DESCRIPTION
That's a preliminary to the actual user API patch.
This way we:
- can optionally build rav1e w/out the cli
- have 2 dependencies optional as well (`y4m` is sort of tiny, but `clap` is relatively big)
