### PR TITLE
Remove unused EnumIterator derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ libc = "0.2"
 rand = "0.5"
 rustyline = { version = "1", optional = true }
 y4m = { version = "0.3", optional = true }
-enum-iterator-derive = "0.1.1"
 backtrace = "0.3"
 num-traits = "0.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,6 @@ extern crate backtrace;
 extern crate libc;
 extern crate rand;
 
-#[macro_use]
-extern crate enum_iterator_derive;
-
 extern crate num_traits;
 
 use std::io::prelude::*;
@@ -389,7 +386,7 @@ impl fmt::Display for FrameInvariants{
 }
 
 #[allow(dead_code,non_camel_case_types)]
-#[derive(Debug,PartialEq,EnumIterator,Clone,Copy)]
+#[derive(Debug,PartialEq,Clone,Copy)]
 pub enum FrameType {
     KEY,
     INTER,
@@ -400,7 +397,7 @@ pub enum FrameType {
 //const REFERENCE_MODES: usize = 3;
 
 #[allow(dead_code,non_camel_case_types)]
-#[derive(Debug,PartialEq,EnumIterator)]
+#[derive(Debug,PartialEq)]
 pub enum ReferenceMode {
   SINGLE = 0,
   COMPOUND = 1,


### PR DESCRIPTION
I originally wanted to update this outdated dependency, but turns out it was unused.