### PR TITLE
Add Appveyor configuration for MSVC 64-bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+os: Visual Studio 2017
+
+environment:
+    matrix:   
+    - channel: stable
+      target: x86_64-pc-windows-msvc
+
+install:
+    - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+    - appveyor DownloadFile http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe -FileName yasm.exe
+    - rustup-init -yv --default-toolchain %channel% --default-host %target%
+    - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
+    - rustc -vV
+    - cargo -vV
+
+build: false
+
+test:
+    - git submodule update --init
+    - cargo test --verbose
+    - cargo bench --verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,4 +18,3 @@ build: false
 test:
     - git submodule update --init
     - cargo test --verbose
-    - cargo bench --verbose


### PR DESCRIPTION
For #457. Currently just runs `cargo test`.

To set up CI checks and for non-MSVC or 32-bit builds, please perform the necessary adjustments in a future PR.