### PR TITLE
[WIP]Fix for top-down RDO search not updating mode

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -269,6 +269,8 @@ pub fn rdo_mode_decision(
     }
   }
 
+  cw.bc.set_mode(bo, bsize, best_mode_luma);
+
   assert!(best_rd >= 0_f64);
 
   RDOOutput {


### PR DESCRIPTION
AWCY Results for subset1 at --speed=1

master_s1@2018-08-14T20:42:35.057Z -> fix_topdown_rdo_mode_update_s1@2018-08-15T20:06:31.213Z

   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-0.1532 | -0.2611.    |     N/A        |  -0.1801 | -0.1267 | -0.1137 |    -0.2634