### PR TITLE
Re-eliminate pkg-config dependency under MinGW

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ num-traits = "0.2"
 
 [build-dependencies]
 cmake = "0.1.32"
-pkg-config = "0.3.12"
 
 [target.'cfg(unix)'.build-dependencies]
+pkg-config = "0.3.12"
 bindgen = { version = "0.37", optional = true }
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 // build.rs
 
 extern crate cmake;
+#[cfg(unix)]
 extern crate pkg_config;
 #[cfg(unix)]
 #[cfg(feature = "decode_test")]
@@ -38,20 +39,12 @@ fn main() {
     let _ = fs::remove_file(dst.join("build/CMakeCache.txt"));
 
     #[cfg(windows)] {
-        if dst.join("lib/pkgconfig").join("aom.pc").exists() {
-            env::set_var("PKG_CONFIG_PATH", dst.join("lib/pkgconfig"));
-            pkg_config::Config::new().statik(true).probe("aom").unwrap();
-        } else { // MSVC
-            let bin_dir = if debug {
-                "Debug"
-            } else {
-                "Release"
-            };
-            println!("cargo:rustc-link-search=native={}", dst.join("build").join(bin_dir).to_str().unwrap());
-            println!("cargo:rustc-link-lib=static=aom");
-        }
+        println!("cargo:rustc-link-search=native={}", dst.join("build").to_str().unwrap());
+        println!("cargo:rustc-link-search=native={}", dst.join("build/Debug").to_str().unwrap());
+        println!("cargo:rustc-link-search=native={}", dst.join("build/Release").to_str().unwrap());
+        println!("cargo:rustc-link-lib=static=aom");
     }
-    
+
     #[cfg(unix)] {
         env::set_var("PKG_CONFIG_PATH", dst.join("lib/pkgconfig"));
         let _libs = pkg_config::Config::new().statik(true).probe("aom").unwrap();


### PR DESCRIPTION
On MinGW, the "no_build_target(cfg!(windows))" line unfortunately
prevents out/lib/pkgconfig/aom.pc from being created, causing the
"// MSVC" code branch to be taken which results in a linker error
(-laom not found).

Rather than fixing pkg-config, we can pass an absolute path to
libaom.a like we already do to aom.lib for MSVC. This has the
benefit that rav1e can be compiled with MinGW directly from cmd,
where pkg-config usually isn't available.

Tested on:
* MinGW-Builds 8.1.0 (cmd, msys2 terminal)
* Visual Studio 2017 15.8.1 (cmd, msys2 terminal)
