### PR TITLE
[WIP] Fix rdo_tx_type_decision() to use chroma prediction mode if intra

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1188,7 +1188,7 @@ pub fn encode_block_b(fi: &FrameInvariants, fs: &mut FrameState,
 
     let tx_type = if tx_set > TxSet::TX_SET_DCTONLY && fi.config.speed <= 3 && !skip {
         // FIXME: there is one redundant transform type decision per encoded block
-        rdo_tx_type_decision(fi, fs, cw, luma_mode, bsize, bo, tx_size, tx_set, bit_depth)
+        rdo_tx_type_decision(fi, fs, cw, luma_mode, chroma_mode, bsize, bo, tx_size, tx_set, bit_depth)
     } else {
         TxType::DCT_DCT
     };

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -279,7 +279,7 @@ pub fn rdo_mode_decision(
 // RDO-based intra frame transform type decision
 pub fn rdo_tx_type_decision(
   fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
-  mode: PredictionMode, bsize: BlockSize, bo: &BlockOffset, tx_size: TxSize,
+  luma_mode: PredictionMode, chroma_mode: PredictionMode, bsize: BlockSize, bo: &BlockOffset, tx_size: TxSize,
   tx_set: TxSet, bit_depth: usize
 ) -> TxType {
   let mut best_type = TxType::DCT_DCT;
@@ -292,7 +292,7 @@ pub fn rdo_tx_type_decision(
   let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
   let is_chroma_block = has_chroma(bo, bsize, xdec, ydec);
 
-  let is_inter = !mode.is_intra();
+  let is_inter = !luma_mode.is_intra();
 
   let cw_checkpoint = cw.checkpoint();
 
@@ -306,11 +306,11 @@ pub fn rdo_tx_type_decision(
     let tell = wr.tell_frac();
     if is_inter {
       write_tx_tree(
-        fi, fs, cw, wr, mode, bo, bsize, tx_size, tx_type, false, bit_depth
+        fi, fs, cw, wr, luma_mode, bo, bsize, tx_size, tx_type, false, bit_depth
       );
     }  else {
       write_tx_blocks(
-        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false, bit_depth
+        fi, fs, cw, wr, luma_mode, chroma_mode, bo, bsize, tx_size, tx_type, false, bit_depth
       );
     }
 


### PR DESCRIPTION
Change in AWCY, so doing this harm the PSNR!?
Anyway, since this patch affect the intra block only, let me run on awcy with intra frame only.

I've also realized that the recent change of chroma intra pred mode RDO only search
for luma's pred mode and DC_PRED, so mostly luma mode == chroma mode, which makes
this patch almost not useful. 

Default -s 3:
master-7fe6aecf37ad0a99d552113fd5de9a580f0872dd -> tx_type_rdo_use_chroma_pred_2fa0ce

  PSNR | PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000
0.0016 | -0.0641 |  0.0061 |   0.0117 | 0.0047 |  0.0039 |    -0.0594

-s 0:
master-7fe6aec_s0_subset1 -> tx_type_rdo_use_chroma_pred_2fa0ce_s0_subset1@2018-08-21T21:58:06.640Z

  PSNR | PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000
0.0028 |     N/A |  0.0343 |   0.0043 | 0.0056 |  0.0129 |    -0.0014

So, it seems not useful at all to me!

This signify me that including chroma tx distortion everr useful, so testing it.