### PR TITLE
Implement Chroma-from-Luma

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -113,7 +113,8 @@ benchmark_group!(
   predict::intra_paeth_4x4,
   predict::intra_smooth_4x4,
   predict::intra_smooth_h_4x4,
-  predict::intra_smooth_v_4x4
+  predict::intra_smooth_v_4x4,
+  predict::intra_cfl_4x4
 );
 
 #[cfg(feature = "comparative_bench")]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -69,6 +69,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
 
   let sbx = 0;
   let sby = 0;
+  let ac = &[0i16; 32 * 32];
 
   b.iter(|| {
     for &mode in RAV1E_INTRA_MODES {
@@ -96,7 +97,9 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
               tx_size.block_size(),
               &po,
               false,
-              8
+              8,
+              ac,
+              0
             );
           }
         }

--- a/benches/comparative/mod.rs
+++ b/benches/comparative/mod.rs
@@ -26,5 +26,7 @@ benchmark_group!(
   predict::intra_smooth_h_4x4_native,
   predict::intra_smooth_h_4x4_aom,
   predict::intra_smooth_v_4x4_native,
-  predict::intra_smooth_v_4x4_aom
+  predict::intra_smooth_v_4x4_aom,
+  predict::intra_cfl_4x4_native,
+  predict::intra_cfl_4x4_aom
 );

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -100,3 +100,16 @@ pub fn intra_smooth_v_4x4(b: &mut Bencher) {
     }
   })
 }
+
+pub fn intra_cfl_4x4(b: &mut Bencher) {
+  let mut rng = ChaChaRng::from_seed([0; 32]);
+  let (mut block, _above, _left) = generate_block(&mut rng);
+  let ac: Vec<i16> = (0..(32 * 32)).map(|_| rng.gen()).collect();
+  let alpha = -1 as i16;
+
+  b.iter(|| {
+    for _ in 0..MAX_ITER {
+      Block4x4::pred_cfl(&mut block, BLOCK_SIZE.width(), &ac, alpha, 8);
+    }
+  })
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1685,8 +1685,8 @@ pub struct CFLParams {
 impl CFLParams {
   pub fn new() -> CFLParams {
     CFLParams {
-      sign: [CFL_SIGN_ZERO; 2],
-      scale: [0u8; 2]
+      sign: [CFL_SIGN_NEG, CFL_SIGN_ZERO],
+      scale: [1, 0]
     }
   }
   pub fn joint_sign(&self) -> u32 {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1155,7 +1155,9 @@ pub fn encode_tx_block(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Conte
     let PlaneConfig { stride, xdec, ydec, .. } = fs.input.planes[p].cfg;
 
     if mode.is_intra() {
-      mode.predict_intra(&mut rec.mut_slice(po), tx_size, bit_depth);
+      // TODO: plumb ac buffer and alpha parameter
+      let ac = [0i16; 32 * 32];
+      mode.predict_intra(&mut rec.mut_slice(po), tx_size, bit_depth, &ac, 0);
     }
 
     if skip { return false; }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1202,7 +1202,8 @@ pub fn encode_block_b(fi: &FrameInvariants, fs: &mut FrameState,
                  cw: &mut ContextWriter, w: &mut dyn Writer,
                  luma_mode: PredictionMode, chroma_mode: PredictionMode,
                  ref_frame: usize, mv: MotionVector,
-                 bsize: BlockSize, bo: &BlockOffset, skip: bool, bit_depth: usize) {
+                 bsize: BlockSize, bo: &BlockOffset, skip: bool, bit_depth: usize,
+                 cfl: &CFLParams) {
     let is_inter = !luma_mode.is_intra();
     if is_inter { assert!(luma_mode == chroma_mode); };
 
@@ -1269,8 +1270,7 @@ pub fn encode_block_b(fi: &FrameInvariants, fs: &mut FrameState,
         cw.write_intra_uv_mode(w, chroma_mode, luma_mode, bsize);
         if chroma_mode.is_cfl() {
           assert!(bsize.cfl_allowed());
-          let cfl = CFLParams::new();
-          cw.write_cfl_alphas(w, &cfl);
+          cw.write_cfl_alphas(w, cfl);
         }
         if chroma_mode.is_directional() && bsize >= BlockSize::BLOCK_8X8 {
             cw.write_angle_delta(w, 0, chroma_mode);
@@ -1352,7 +1352,7 @@ pub fn encode_block_b(fi: &FrameInvariants, fs: &mut FrameState,
       }
       write_tx_tree(fi, fs, cw, w, luma_mode, bo, bsize, tx_size, tx_type, skip, bit_depth); // i.e. var-tx if inter mode
     } else {
-      write_tx_blocks(fi, fs, cw, w, luma_mode, chroma_mode, bo, bsize, tx_size, tx_type, skip, bit_depth);
+      write_tx_blocks(fi, fs, cw, w, luma_mode, chroma_mode, bo, bsize, tx_size, tx_type, skip, bit_depth, cfl);
     }
 }
 
@@ -1391,7 +1391,8 @@ fn luma_ac(
 pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
                        cw: &mut ContextWriter, w: &mut dyn Writer,
                        luma_mode: PredictionMode, chroma_mode: PredictionMode, bo: &BlockOffset,
-                       bsize: BlockSize, tx_size: TxSize, tx_type: TxType, skip: bool, bit_depth: usize) {
+                       bsize: BlockSize, tx_size: TxSize, tx_type: TxType, skip: bool, bit_depth: usize,
+                       cfl: &CFLParams) {
     let bw = bsize.width_mi() / tx_size.width_mi();
     let bh = bsize.height_mi() / tx_size.height_mi();
 
@@ -1441,7 +1442,6 @@ pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
     }
 
     if bw_uv > 0 && bh_uv > 0 {
-        let cfl = CFLParams::new();
         let uv_tx_type = uv_intra_mode_to_tx_type_context(chroma_mode);
         fs.qc.update(fi.config.quantizer, uv_tx_size, true, bit_depth);
 
@@ -1575,6 +1575,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
         }
         let mode_decision = rdo_mode_decision(seq, fi, fs, cw, bsize, bo).part_modes[0].clone();
         let (mode_luma, mode_chroma) = (mode_decision.pred_mode_luma, mode_decision.pred_mode_chroma);
+        let cfl = &CFLParams::new();
         let ref_frame = mode_decision.ref_frame;
         let mv = mode_decision.mv;
         let skip = mode_decision.skip;
@@ -1584,7 +1585,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
         cdef_coded = encode_block_a(seq, cw, if cdef_coded  {w_post_cdef} else {w_pre_cdef},
                                    bsize, bo, skip);
         encode_block_b(fi, fs, cw, if cdef_coded  {w_post_cdef} else {w_pre_cdef},
-                       mode_luma, mode_chroma, ref_frame, mv, bsize, bo, skip, seq.bit_depth);
+                       mode_luma, mode_chroma, ref_frame, mv, bsize, bo, skip, seq.bit_depth, cfl);
 
         best_decision = mode_decision;
     }
@@ -1629,6 +1630,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
 
             // FIXME: redundant block re-encode
             let (mode_luma, mode_chroma) = (best_decision.pred_mode_luma, best_decision.pred_mode_chroma);
+            let cfl = &CFLParams::new();
             let ref_frame = best_decision.ref_frame;
             let mv = best_decision.mv;
             let skip = best_decision.skip;
@@ -1636,7 +1638,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
             cdef_coded = encode_block_a(seq, cw, if cdef_coded {w_post_cdef} else {w_pre_cdef},
                                        bsize, bo, skip);
             encode_block_b(fi, fs, cw, if cdef_coded {w_post_cdef} else {w_pre_cdef},
-                          mode_luma, mode_chroma, ref_frame, mv, bsize, bo, skip, seq.bit_depth);
+                          mode_luma, mode_chroma, ref_frame, mv, bsize, bo, skip, seq.bit_depth, cfl);
         }
     }
 
@@ -1707,6 +1709,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
                 };
 
             let (mode_luma, mode_chroma) = (part_decision.pred_mode_luma, part_decision.pred_mode_chroma);
+            let cfl = &CFLParams::new();
             let skip = part_decision.skip;
             let ref_frame = part_decision.ref_frame;
             let mv = part_decision.mv;
@@ -1716,7 +1719,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
             cdef_coded = encode_block_a(seq, cw, if cdef_coded  {w_post_cdef} else {w_pre_cdef},
                          bsize, bo, skip);
             encode_block_b(fi, fs, cw, if cdef_coded  {w_post_cdef} else {w_pre_cdef},
-                          mode_luma, mode_chroma, ref_frame, mv, bsize, bo, skip, seq.bit_depth);
+                          mode_luma, mode_chroma, ref_frame, mv, bsize, bo, skip, seq.bit_depth, cfl);
         },
         PartitionType::PARTITION_SPLIT => {
             if rdo_output.part_modes.len() >= 4 {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1264,6 +1264,10 @@ pub fn encode_block_b(fi: &FrameInvariants, fs: &mut FrameState,
 
     if has_chroma(bo, bsize, xdec, ydec) && !is_inter {
         cw.write_intra_uv_mode(w, chroma_mode, luma_mode, bsize);
+        if chroma_mode.is_cfl() {
+          assert!(bsize.cfl_allowed());
+          cw.write_cfl_alphas(w, 0, 0, 0);
+        }
         if chroma_mode.is_directional() && bsize >= BlockSize::BLOCK_8X8 {
             cw.write_angle_delta(w, 0, chroma_mode);
         }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -410,20 +410,30 @@ use plane::*;
 use predict::*;
 
 impl PredictionMode {
-  pub fn predict_intra<'a>(self, dst: &'a mut PlaneMutSlice<'a>, tx_size: TxSize, bit_depth: usize) {
+  pub fn predict_intra<'a>(
+    self, dst: &'a mut PlaneMutSlice<'a>, tx_size: TxSize, bit_depth: usize,
+    ac: &[i16], alpha: i16
+  ) {
     assert!(self.is_intra());
 
     match tx_size {
-      TxSize::TX_4X4 => self.predict_intra_inner::<Block4x4>(dst, bit_depth),
-      TxSize::TX_8X8 => self.predict_intra_inner::<Block8x8>(dst, bit_depth),
-      TxSize::TX_16X16 => self.predict_intra_inner::<Block16x16>(dst, bit_depth),
-      TxSize::TX_32X32 => self.predict_intra_inner::<Block32x32>(dst, bit_depth),
+      TxSize::TX_4X4 =>
+        self.predict_intra_inner::<Block4x4>(dst, bit_depth, ac, alpha),
+      TxSize::TX_8X8 =>
+        self.predict_intra_inner::<Block8x8>(dst, bit_depth, ac, alpha),
+      TxSize::TX_16X16 =>
+        self.predict_intra_inner::<Block16x16>(dst, bit_depth, ac, alpha),
+      TxSize::TX_32X32 =>
+        self.predict_intra_inner::<Block32x32>(dst, bit_depth, ac, alpha),
       _ => unimplemented!()
     }
   }
 
   #[inline(always)]
-  fn predict_intra_inner<'a, B: Intra>(self, dst: &'a mut PlaneMutSlice<'a>, bit_depth: usize) {
+  fn predict_intra_inner<'a, B: Intra>(
+    self, dst: &'a mut PlaneMutSlice<'a>, bit_depth: usize,
+    ac: &[i16], alpha: i16
+  ) {
     // above and left arrays include above-left sample
     // above array includes above-right samples
     // left array includes below-left samples
@@ -500,7 +510,7 @@ impl PredictionMode {
     let left_slice = &left[1..B::H + 1];
 
     match self {
-      PredictionMode::DC_PRED => match (x, y) {
+      PredictionMode::DC_PRED | PredictionMode::UV_CFL_PRED => match (x, y) {
         (0, 0) => B::pred_dc_128(slice, stride, bit_depth),
         (_, 0) => B::pred_dc_left(slice, stride, above_slice, left_slice, bit_depth),
         (0, _) => B::pred_dc_top(slice, stride, above_slice, left_slice, bit_depth),
@@ -525,6 +535,9 @@ impl PredictionMode {
       PredictionMode::SMOOTH_V_PRED =>
         B::pred_smooth_v(slice, stride, above_slice, left_slice),
       _ => unimplemented!()
+    }
+    if self == PredictionMode::UV_CFL_PRED {
+      B::pred_cfl(slice, stride, &ac, alpha, bit_depth);
     }
   }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -334,6 +334,7 @@ pub enum PredictionMode {
   SMOOTH_V_PRED,
   SMOOTH_H_PRED,
   PAETH_PRED,
+  UV_CFL_PRED,
   NEARESTMV,
   NEARMV,
   GLOBALMV,
@@ -529,6 +530,10 @@ impl PredictionMode {
 
   pub fn is_intra(self) -> bool {
     return self < PredictionMode::NEARESTMV;
+  }
+
+  pub fn is_cfl(self) -> bool {
+    self == PredictionMode::UV_CFL_PRED
   }
 
   pub fn is_directional(self) -> bool {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -144,6 +144,10 @@ impl BlockSize {
   pub fn is_sqr(self) -> bool {
     self.width_log2() == self.height_log2()
   }
+
+  pub fn is_sub8x8(self) -> bool {
+    self.width_log2().min(self.height_log2()) < 3
+  }
 }
 
 /// Transform Size

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -236,6 +236,7 @@ pub fn rdo_mode_decision(
     };
 
     // Find the best chroma prediction mode for the current luma prediction mode
+    let cfl = &CFLParams::new();
     for &chroma_mode in &mode_set_chroma {
       for &skip in &[false, true] {
         // Don't skip when using intra modes
@@ -246,7 +247,7 @@ pub fn rdo_mode_decision(
 
 
         encode_block_a(seq, cw, wr, bsize, bo, skip);
-        encode_block_b(fi, fs, cw, wr, luma_mode, chroma_mode, ref_frame, mv, bsize, bo, skip, seq.bit_depth);
+        encode_block_b(fi, fs, cw, wr, luma_mode, chroma_mode, ref_frame, mv, bsize, bo, skip, seq.bit_depth, cfl);
 
         let cost = wr.tell_frac() - tell;
         let rd = compute_rd_cost(
@@ -326,8 +327,9 @@ pub fn rdo_tx_type_decision(
         fi, fs, cw, wr, mode, bo, bsize, tx_size, tx_type, false, bit_depth
       );
     }  else {
+      let cfl = &CFLParams::new();
       write_tx_blocks(
-        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false, bit_depth
+        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false, bit_depth, cfl
       );
     }
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -228,6 +228,10 @@ pub fn rdo_mode_decision(
       mode_set_chroma.push(PredictionMode::DC_PRED);
     }
 
+    if is_chroma_block && luma_mode.is_intra() && bsize.cfl_allowed() && !bsize.is_sub8x8() {
+      mode_set_chroma.push(PredictionMode::UV_CFL_PRED);
+    }
+
     let ref_frame = if luma_mode.is_intra() { INTRA_FRAME } else { LAST_FRAME };
     let mv = if luma_mode != PredictionMode::NEWMV {
       MotionVector { row: 0, col: 0 }


### PR DESCRIPTION
- [X] Rust native chroma-from-luma predictor
- [X] Write CfL parameters to bitstream
- [X] Combine `pred_dc` and `pred_cfl` to implement `UV_CFL_PRED`
- [X] Rust native luma subsampling (4:2:0 only)
- [X] Subsample luma and plumb to chroma writer
- [ ] Handle sub8x8 cases for luma subsampling
- [ ] Store CfL parameters in encoder context
- [ ] Search CfL parameters 