### PR TITLE
Enable CfL on sub-8x8 partitions

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1361,7 +1361,11 @@ fn luma_ac(
 ) {
   let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
   let plane_bsize = get_plane_block_size(bsize, xdec, ydec);
-  let po = bo.plane_offset(&fs.input.planes[0].cfg);
+  let po = if bsize.is_sub8x8() {
+    bo.with_offset(-1, -1).plane_offset(&fs.input.planes[0].cfg)
+  } else {
+    bo.plane_offset(&fs.input.planes[0].cfg)
+  };
   let rec = &fs.rec.planes[0];
   let luma = &rec.slice(&po);
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -228,7 +228,7 @@ pub fn rdo_mode_decision(
       mode_set_chroma.push(PredictionMode::DC_PRED);
     }
 
-    if is_chroma_block && luma_mode.is_intra() && bsize.cfl_allowed() && !bsize.is_sub8x8() {
+    if is_chroma_block && luma_mode.is_intra() && bsize.cfl_allowed() {
       mode_set_chroma.push(PredictionMode::UV_CFL_PRED);
     }
 


### PR DESCRIPTION
The current restrictions of square partitions and 4:2:0 yield only one sub-8x8 case to be handled.