### PR TITLE
Add 1/8th pel motion refinement step

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -340,7 +340,7 @@ impl FrameInvariants {
             showable_frame: true,
             error_resilient: true,
             intra_only: false,
-            allow_high_precision_mv: false,
+            allow_high_precision_mv: true,
             frame_type: FrameType::KEY,
             show_existing_frame: false,
             use_reduced_tx_set,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -340,7 +340,7 @@ impl FrameInvariants {
             showable_frame: true,
             error_resilient: true,
             intra_only: false,
-            allow_high_precision_mv: true,
+            allow_high_precision_mv: false,
             frame_type: FrameType::KEY,
             show_existing_frame: false,
             use_reduced_tx_set,

--- a/src/me.rs
+++ b/src/me.rs
@@ -59,7 +59,12 @@ pub fn motion_estimation(fi: &FrameInvariants, fs: &mut FrameState, bsize: Block
       let mode = PredictionMode::NEWMV;
       let mut tmp_plane = Plane::new(blk_w, blk_h, 0, 0);
 
-      for step in [4, 2].iter() {
+      let mut steps = vec![4, 2];
+      if fi.allow_high_precision_mv {
+        steps.push(1);
+      }
+
+      for step in steps {
         let center_mv_h = best_mv;
         for i in 0..3 {
           for j in 0..3 {


### PR DESCRIPTION
Currently this feature yields an average loss of about 1 percent BD rate, so keep it disabled by default