### PR TITLE
Deblock2

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -13,6 +13,7 @@ use std::cmp;
 use context::*;
 use plane::*;
 use util::clamp;
+use util::msb;
 use FrameInvariants;
 use Frame;
 
@@ -23,10 +24,6 @@ pub struct CdefDirections {
 
 pub const CDEF_VERY_LARGE: u16 = 30000;
 const CDEF_SEC_STRENGTHS: u8 = 4;
-
-fn msb(x: i32) -> i32 {
-    31 ^ (x.leading_zeros() as i32)
-}
 
 // Instead of dividing by n between 2 and 8, we multiply by 3*5*7*8/n.
 // The output is then 840 times larger, but we don't care for finding

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -261,7 +261,7 @@ pub fn rdo_mode_decision(
 
 
           encode_block_a(seq, cw, wr, bsize, bo, skip);
-          encode_block_b(fi, fs, cw, wr, luma_mode, chroma_mode, ref_frame, mv, bsize, bo, skip, seq.bit_depth, cfl);
+          encode_block_b(seq, fi, fs, cw, wr, luma_mode, chroma_mode, ref_frame, mv, bsize, bo, skip, seq.bit_depth, cfl);
 
           let cost = wr.tell_frac() - tell;
           let rd = compute_rd_cost(

--- a/src/util.rs
+++ b/src/util.rs
@@ -209,3 +209,9 @@ pub trait ILog : PrimInt {
 }
 
 impl<T> ILog for T where T: PrimInt {}
+
+pub fn msb(x: i32) -> i32 {
+    debug_assert!(x>0);
+    31 ^ (x.leading_zeros() as i32)
+}
+


### PR DESCRIPTION
Previous PRs added frame-level loop-deblocking filter parameter coding and storage.  This PR adds all the block-level delta adjustment storage, management and parameter coding.

As yet, no actual deblocking filter, just all the support infrastructure.  No functional change to current encoder.