### PR TITLE
[WIP] User api

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,149 @@
+use encoder::*;
+use context::CDFContext;
+use partition::LAST_FRAME;
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+// TODO: use the num crate?
+#[derive(Clone, Copy, Debug)]
+pub struct Ratio {
+  pub num: usize,
+  pub den: usize
+}
+
+impl Ratio {
+  pub fn new(num: usize, den: usize) -> Self {
+    Ratio { num, den }
+  }
+}
+
+/// Here we store all the information we might receive from the cli
+#[derive(Clone, Copy, Debug)]
+pub struct Config {
+  pub width: usize,
+  pub height: usize,
+  pub bit_depth: usize,
+  pub chroma_sampling: ChromaSampling,
+  pub timebase: Ratio,
+  pub enc: EncoderConfig
+}
+
+impl Config {
+  pub fn new_context(&self) -> Context {
+    let fi = FrameInvariants::new(self.width, self.height, self.enc.clone());
+    let seq = Sequence::new(
+      self.width,
+      self.height,
+      self.bit_depth,
+      self.chroma_sampling
+    );
+
+    unsafe {
+        av1_rtcd();
+        aom_dsp_rtcd();
+    }
+
+    Context { fi, seq, frame_q: VecDeque::new() }
+  }
+}
+
+pub struct Context {
+  fi: FrameInvariants,
+  seq: Sequence,
+  //    timebase: Ratio,
+  frame_q: VecDeque<Option<Arc<Frame>>> //    packet_q: VecDeque<Packet>
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum EncoderStatus {
+  /// The encoder needs more Frames to produce an output Packet
+  NeedMoreData,
+  /// There are enough Frames queue
+  EnoughData,
+  ///
+  Failure
+}
+
+pub struct Packet {
+  pub data: Vec<u8>,
+  pub rec: Frame,
+  pub number: usize
+}
+
+impl Context {
+  pub fn new_frame(&self) -> Arc<Frame> {
+    Arc::new(Frame::new(self.fi.padded_w, self.fi.padded_h))
+  }
+
+  pub fn send_frame<F>(&mut self, frame: F) -> Result<(), EncoderStatus>
+  where
+    F: Into<Option<Arc<Frame>>>
+  {
+    self.frame_q.push_back(frame.into());
+    Ok(())
+  }
+
+  pub fn receive_packet(&mut self) -> Result<Packet, EncoderStatus> {
+    let f = self.frame_q.pop_front().ok_or(EncoderStatus::NeedMoreData)?;
+    if let Some(frame) = f {
+      let mut fs = FrameState {
+        input: frame,
+        rec: Frame::new(self.fi.padded_w, self.fi.padded_h),
+        qc: Default::default(),
+        cdfs: CDFContext::new(0),
+      };
+
+      self.fi.frame_type = if self.fi.number % 30 == 0 {
+        FrameType::KEY
+      } else {
+        FrameType::INTER
+      };
+
+      self.fi.refresh_frame_flags = if self.fi.frame_type == FrameType::KEY {
+        ALL_REF_FRAMES_MASK
+      } else {
+        1
+      };
+
+      self.fi.intra_only = self.fi.frame_type == FrameType::KEY
+        || self.fi.frame_type == FrameType::INTRA_ONLY;
+      // self.fi.use_prev_frame_mvs =
+      //  !(self.fi.intra_only || self.fi.error_resilient);
+
+      self.fi.base_q_idx = if self.fi.frame_type == FrameType::KEY {
+        let q_boost = 15;
+        self.fi.config.quantizer.max(1 + q_boost).min(255 + q_boost) - q_boost
+      } else {
+        self.fi.config.quantizer.max(1).min(255)
+      } as u8;
+
+      self.fi.primary_ref_frame = if self.fi.intra_only || self.fi.error_resilient {
+        PRIMARY_REF_NONE
+      } else {
+        (LAST_FRAME - LAST_FRAME) as u32
+      };
+
+      let data = encode_frame(&mut self.seq, &mut self.fi, &mut fs);
+
+      let number = self.fi.number as usize;
+
+      self.fi.number += 1;
+
+      fs.rec.pad();
+
+      // TODO avoid the clone by having rec Arc.
+      let rec = fs.rec.clone();
+
+      update_rec_buffer(&mut self.fi, fs);
+
+      Ok(Packet { data, rec, number })
+    } else {
+      unimplemented!("Flushing not implemented")
+    }
+  }
+
+  pub fn flush(&mut self) {
+    self.frame_q.push_back(None);
+  }
+}

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -3,6 +3,7 @@ use rav1e::*;
 use std::fs::File;
 use std::io;
 use std::io::prelude::*;
+use std::sync::Arc;
 use std::slice;
 use y4m;
 
@@ -125,9 +126,12 @@ pub fn process_frame(sequence: &mut Sequence, fi: &mut FrameInvariants,
             let y4m_v = y4m_frame.get_v_plane();
             eprintln!("{}", fi);
             let mut fs = FrameState::new(&fi);
-            fs.input.planes[0].copy_from_raw_u8(&y4m_y, width * y4m_bytes, y4m_bytes);
-            fs.input.planes[1].copy_from_raw_u8(&y4m_u, width * y4m_bytes / 2, y4m_bytes);
-            fs.input.planes[2].copy_from_raw_u8(&y4m_v, width * y4m_bytes / 2, y4m_bytes);
+            {
+                let input = Arc::get_mut(&mut fs.input).unwrap();
+                input.planes[0].copy_from_raw_u8(&y4m_y, width * y4m_bytes, y4m_bytes);
+                input.planes[1].copy_from_raw_u8(&y4m_u, width * y4m_bytes / 2, y4m_bytes);
+                input.planes[2].copy_from_raw_u8(&y4m_v, width * y4m_bytes / 2, y4m_bytes);
+            }
 
             match y4m_bits {
                 8 | 10 | 12 => {},

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -225,9 +225,11 @@ impl Sequence {
     }
 }
 
+use std::sync::Arc;
+
 #[derive(Debug)]
 pub struct FrameState {
-    pub input: Frame,
+    pub input: Arc<Frame>,
     pub rec: Frame,
     pub qc: QuantizationContext,
     pub cdfs: CDFContext,
@@ -236,7 +238,7 @@ pub struct FrameState {
 impl FrameState {
     pub fn new(fi: &FrameInvariants) -> FrameState {
         FrameState {
-            input: Frame::new(fi.padded_w, fi.padded_h),
+            input: Arc::new(Frame::new(fi.padded_w, fi.padded_h)),
             rec: Frame::new(fi.padded_w, fi.padded_h),
             qc: Default::default(),
             cdfs: CDFContext::new(0),
@@ -394,7 +396,7 @@ impl FrameInvariants {
 
     pub fn new_frame_state(&self) -> FrameState {
         FrameState {
-            input: Frame::new(self.padded_w, self.padded_h),
+            input: Arc::new(Frame::new(self.padded_w, self.padded_h)),
             rec: Frame::new(self.padded_w, self.padded_h),
             qc: Default::default(),
             cdfs: CDFContext::new(0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ pub mod cdef;
 pub mod encoder;
 pub mod me;
 
+mod api;
+
+pub use api::*;
 pub use encoder::*;
 
 // #[cfg(test)]

--- a/src/test_encode_decode.rs
+++ b/src/test_encode_decode.rs
@@ -10,6 +10,7 @@ use super::*;
 use rand::{ChaChaRng, Rng, SeedableRng};
 use std::collections::VecDeque;
 use std::mem;
+use std::sync::Arc;
 
     fn fill_frame(ra: &mut ChaChaRng, frame: &mut Frame) {
         for plane in frame.planes.iter_mut() {
@@ -217,7 +218,7 @@ use std::mem;
 
         for _ in 0 .. limit {
             let mut fs = fi.new_frame_state();
-            fill_frame(&mut ra, &mut fs.input);
+            fill_frame(&mut ra, Arc::get_mut(&mut fs.input).unwrap());
 
             fi.frame_type = if fi.number % 30 == 0 { FrameType::KEY } else { FrameType::INTER };
             fi.refresh_frame_flags = if fi.frame_type == FrameType::KEY { ALL_REF_FRAMES_MASK } else { 1 };

--- a/src/test_encode_decode.rs
+++ b/src/test_encode_decode.rs
@@ -57,24 +57,28 @@ use std::sync::Arc;
     }
 
     fn setup_encoder(w: usize, h: usize, speed: usize, quantizer: usize,
-        bit_depth: usize, chroma_sampling: ChromaSampling) -> (FrameInvariants, Sequence) {
+        bit_depth: usize, chroma_sampling: ChromaSampling) -> Context {
         unsafe {
             av1_rtcd();
             aom_dsp_rtcd();
         }
 
-        let config = EncoderConfig {
+        let enc = EncoderConfig {
             quantizer: quantizer,
             speed: speed,
             ..Default::default()
         };
-        let mut fi = FrameInvariants::new(w, h, config);
 
-        fi.use_reduced_tx_set = true;
-        // fi.min_partition_size =
-        let seq = Sequence::new(w, h, bit_depth, chroma_sampling);
+        let cfg = Config {
+            width: w,
+            height: h,
+            bit_depth,
+            chroma_sampling,
+            timebase: Ratio::new(1, 1000),
+            enc,
+        };
 
-        (fi, seq)
+        cfg.new_context()
     }
 
     // TODO: support non-multiple-of-16 dimensions
@@ -208,7 +212,7 @@ use std::sync::Arc;
         let mut ra = ChaChaRng::from_seed([0; 32]);
 
         let mut dec = setup_decoder(w, h);
-        let (mut fi, mut seq) = setup_encoder(w, h, speed, quantizer, bit_depth, ChromaSampling::Cs420);
+        let mut ctx = setup_encoder(w, h, speed, quantizer, bit_depth, ChromaSampling::Cs420);
 
         println!("Encoding {}x{} speed {} quantizer {}", w, h, speed, quantizer);
 
@@ -217,27 +221,20 @@ use std::sync::Arc;
         let mut rec_fifo = VecDeque::new();
 
         for _ in 0 .. limit {
-            let mut fs = fi.new_frame_state();
-            fill_frame(&mut ra, Arc::get_mut(&mut fs.input).unwrap());
+            let mut input = ctx.new_frame();
+            fill_frame(&mut ra, Arc::get_mut(&mut input).unwrap());
 
-            fi.frame_type = if fi.number % 30 == 0 { FrameType::KEY } else { FrameType::INTER };
-            fi.refresh_frame_flags = if fi.frame_type == FrameType::KEY { ALL_REF_FRAMES_MASK } else { 1 };
+            let _ = ctx.send_frame(input);
+            let pkt = ctx.receive_packet().unwrap();
+            println!("Encoded packet {}", pkt.number);
 
-            fi.intra_only = fi.frame_type == FrameType::KEY || fi.frame_type == FrameType::INTRA_ONLY;
-            fi.use_prev_frame_mvs = !(fi.intra_only || fi.error_resilient);
-            println!("Encoding frame {}", fi.number);
-            let packet = encode_frame(&mut seq, &mut fi, &mut fs);
-            println!("Encoded.");
+            rec_fifo.push_back(pkt.rec.clone());
 
-            fs.rec.pad();
-
-            rec_fifo.push_back(fs.rec.clone());
-
-            update_rec_buffer(&mut fi, fs);
+            let packet = pkt.data;
 
             let mut corrupted_count = 0;
             unsafe {
-                println!("Decoding frame {}", fi.number);
+                println!("Decoding frame {}", pkt.number);
                 let ret = aom_codec_decode(&mut dec.dec, packet.as_ptr(), packet.len(), ptr::null_mut());
                 println!("Decoded. -> {}", ret);
                 if ret != 0 {
@@ -276,7 +273,5 @@ use std::sync::Arc;
             }
 
             assert_eq!(corrupted_count, 0);
-
-            fi.number += 1;
         }
     }


### PR DESCRIPTION
See issue https://github.com/xiph/rav1e/issues/410

API:
- [x] `Config` struct with all the configuration items
  - [ ] `FromStr` to parse a x264-like string
  - [ ] `Display` to produce a x264-like string
  - [ ] `parse_option(o: &str)` to update the configuration using a x264-like `key:value` string
  - [x] `new_context() -> Context` 
- [x] `Context`: opaque struct embedding the existing FrameInvariants, Sequence
  - [x] `new_frame() -> Arc<Frame>`
  - [ ] `receive_obu_header() -> Vec<u8>`
  - [x] `send_frame(frame: Arc<Frame>)`/`receive_packet() -> Packet`
  - [ ] flush support
- [ ] Packet
  - [x] data buffer
  - [ ] user private data
  - [ ] timestamp

Usage:
- [x] rav1e/rav1repl
- [x] decode_test

Refactor:
- [x] Arc the input frame
- [ ] Arc the reconstructed frame