### PR TITLE
CfL RDO: rollback ContextWriter after luma reconstruction

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -292,10 +292,12 @@ pub fn rdo_mode_decision(
       let mut cfl = CFLParams::new();
       if chroma_mode == PredictionMode::UV_CFL_PRED {
         if !best_mode_chroma.is_intra() { continue; }
+        let cw_checkpoint = cw.checkpoint();
         let mut wr: &mut dyn Writer = &mut WriterCounter::new();
         write_tx_blocks(
           fi, fs, cw, wr, luma_mode, luma_mode, bo, bsize, tx_size, tx_type, false, seq.bit_depth, cfl, true
         );
+        cw.rollback(&cw_checkpoint);
         cfl = rdo_cfl_alpha(fs, bo, bsize, seq.bit_depth);
       }
 


### PR DESCRIPTION
Fix a small bias in RDO that favors UV_PRED_CFL.

[AWCY results](https://beta.arewecompressedyet.com/?job=master-14de53db77678da6fef5370c38c0583bde83dc31&job=rav1e-cfl-rdo-rollback%402018-08-31T07%3A01%3A38.825Z) at default speed:

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.0955 |  1.5592 |  1.0264 |  -0.1145 | -0.0963 | -0.1592 |     0.4496 |

Encoding time is about 1.5% lower.

[AWCY results](https://beta.arewecompressedyet.com/?job=master-14de53_s1%402018-08-30T23%3A18%3A37.272Z&job=rav1e-s1-cfl-rdo-rollback%402018-08-31T10%3A27%3A30.053Z) for speed 1:

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.0384 |  1.1941 |  1.1639 |  -0.0666 | -0.0558 | -0.0866 |     0.1283 |

[AWCY results](https://beta.arewecompressedyet.com/?job=master-14de53_s0%402018-08-30T23%3A18%3A15.976Z&job=rav1e-s0-cfl-rdo-rollback%402018-08-31T10%3A31%3A04.360Z) for speed 0:

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.1102 |  1.2385 |  0.9296 |  -0.1406 | -0.1298 | -0.1360 |     0.3239 |