### PR TITLE
[WIP] Avoid redundant MC during tx_type RDO

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1258,14 +1258,14 @@ pub fn encode_tx_block(
 
 pub fn motion_compensate(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
                          luma_mode: PredictionMode, ref_frame: usize, mv: MotionVector,
-                         bsize: BlockSize, bo: &BlockOffset, bit_depth: usize) {
+                         bsize: BlockSize, bo: &BlockOffset, bit_depth: usize, luma_only: bool) {
   if luma_mode.is_intra() { return; }
 
   let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
 
   // Inter mode prediction can take place once for a whole partition,
   // instead of each tx-block.
-  let num_planes = 1 + if has_chroma(bo, bsize, xdec, ydec) { 2 } else { 0 };
+  let num_planes = 1 + if has_chroma(bo, bsize, xdec, ydec) && !luma_only { 2 } else { 0 };
 
   for p in 0..num_planes {
     let plane_bsize = if p == 0 { bsize }
@@ -1438,7 +1438,7 @@ pub fn encode_block_b(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
         }
     }
 
-    motion_compensate(fi, fs, cw, luma_mode, ref_frame, mv, bsize, bo, bit_depth);
+    motion_compensate(fi, fs, cw, luma_mode, ref_frame, mv, bsize, bo, bit_depth, false);
 
     if is_inter {
       write_tx_tree(fi, fs, cw, w, luma_mode, bo, bsize, tx_size, tx_type, skip, bit_depth, false);

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -494,22 +494,18 @@ pub fn rdo_cfl_alpha(
 fn save_mc_blk(dst: &mut [u16], src: &PlaneSlice<'_>, width: usize, height: usize) {
   let src_stride = src.plane.cfg.stride;
 
-  for (l, s) in dst.chunks_mut(width).take(height)
+  for (line_dst, s) in dst.chunks_mut(width).take(height)
                    .zip(src.as_slice().chunks(src_stride)) {
-    for (r, v) in l.iter_mut().zip(s) {
-      *r = *v as u16;
-    }
+    line_dst.copy_from_slice(&s[..width]);
   }
 }
 
 fn restore_mc_blk<'a>(dst: &'a mut PlaneMutSlice<'a>, src: &[u16], width: usize, height: usize) {
   let dst_stride = dst.plane.cfg.stride;
 
-  for (l, s) in dst.as_mut_slice().chunks_mut(dst_stride).take(height)
+  for (line_dst, s) in dst.as_mut_slice().chunks_mut(dst_stride).take(height)
                    .zip(src.chunks(width)) {
-    for (r, v) in l.iter_mut().zip(s) {
-      *r = *v;
-    }
+    line_dst[..width].copy_from_slice(s);
   }
 }
 


### PR DESCRIPTION
Not much change for default speed -s 3
[AWCY results at speed 3](https://beta.arewecompressedyet.com/?job=test_mc_blk_copy%402018-09-05T18%3A11%3A40.342Z&job=master-2fab8c39b51a4db293148ff7eb38b86f824be28c)

Not much change at speed 2 as well, [AWCY results at speed 2](https://beta.arewecompressedyet.com/?job=test_mc_blk_copy_s2%402018-09-05T21%3A16%3A24.127Z&job=master-2fab8c_s2%402018-09-05T21%3A16%3A12.820Z)

[AWCY results at speed 0](https://beta.arewecompressedyet.com/?job=test_mc_blk_copy_s0%402018-09-05T18%3A12%3A01.694Z&job=master-2fab8c_s0%402018-09-05T18%3A09%3A12.922Z) will come soon.

However, hope that as more tx_type is used (upto 16, currently rav1e uses 7), this patch helps more.