### PR TITLE
Fix conflict with user API change in FrameState::window

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -257,7 +257,7 @@ impl FrameState {
 
     pub fn window(&self, sbo: &SuperBlockOffset) -> FrameState {
         FrameState {
-            input: self.input.window(sbo),
+            input: Arc::new(self.input.window(sbo)),
             rec: self.rec.window(sbo),
             qc: self.qc.clone(),
             cdfs: self.cdfs.clone()


### PR DESCRIPTION
Resolve build error:
```
error[E0308]: mismatched types
  --> src/encoder.rs:260:20
    |
260 |            input: self.input.window(sbo),
    |                    ^^^^^^^^^^^^^^^^^^^^^^ expected struct `std::sync::Arc`, found struct `encoder::Frame`
    |
    = note: expected type `std::sync::Arc<encoder::Frame>`
              found type `encoder::Frame`
```