### PR TITLE
Luma only motion compensate if tx_type_rdo()

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1258,14 +1258,15 @@ pub fn encode_tx_block(
 
 pub fn motion_compensate(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
                          luma_mode: PredictionMode, ref_frame: usize, mv: MotionVector,
-                         bsize: BlockSize, bo: &BlockOffset, bit_depth: usize) {
+                         bsize: BlockSize, bo: &BlockOffset, bit_depth: usize,
+                         luma_only: bool) {
   if luma_mode.is_intra() { return; }
 
   let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
 
   // Inter mode prediction can take place once for a whole partition,
   // instead of each tx-block.
-  let num_planes = 1 + if has_chroma(bo, bsize, xdec, ydec) { 2 } else { 0 };
+  let num_planes = 1 + if !luma_only && has_chroma(bo, bsize, xdec, ydec) { 2 } else { 0 };
 
   for p in 0..num_planes {
     let plane_bsize = if p == 0 { bsize }
@@ -1438,7 +1439,7 @@ pub fn encode_block_b(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
         }
     }
 
-    motion_compensate(fi, fs, cw, luma_mode, ref_frame, mv, bsize, bo, bit_depth);
+    motion_compensate(fi, fs, cw, luma_mode, ref_frame, mv, bsize, bo, bit_depth, false);
 
     if is_inter {
       write_tx_tree(fi, fs, cw, w, luma_mode, bo, bsize, tx_size, tx_type, skip, bit_depth, false);

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -581,7 +581,7 @@ pub fn rdo_tx_type_decision(
       continue;
     }
 
-    motion_compensate(fi, fs, cw, mode, ref_frame, mv, bsize, bo, bit_depth);
+    motion_compensate(fi, fs, cw, mode, ref_frame, mv, bsize, bo, bit_depth, true);
 
     let mut wr: &mut dyn Writer = &mut WriterCounter::new();
     let tell = wr.tell_frac();


### PR DESCRIPTION
There is no change in coding encoding behavior as shown in [AWCY run](https://beta.arewecompressedyet.com/?job=master-2c6a3f51e8f5964aae403246c8389fa57b164121&job=luma_only_mc_if_tx_type_rdo%402018-09-17T16%3A19%3A21.474Z)