### PR TITLE
Remove BLOCK_128X32 and BLOCK_32X128 #592

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -127,17 +127,15 @@ static ss_size_lookup: [[[BlockSize; 2]; 2]; BlockSize::BLOCK_SIZES_ALL] = [
   [  [ BLOCK_32X64, BLOCK_32X32 ], [BLOCK_16X64, BLOCK_16X32 ] ],
   [  [ BLOCK_64X32, BLOCK_64X16 ], [BLOCK_32X32, BLOCK_32X16 ] ],
   [  [ BLOCK_64X64, BLOCK_64X32 ], [BLOCK_32X64, BLOCK_32X32 ] ],
-  [  [ BLOCK_64X128, BLOCK_64X64 ], [ BLOCK_32X128, BLOCK_32X64 ] ],
-  [  [ BLOCK_128X64, BLOCK_128X32 ], [ BLOCK_64X64, BLOCK_64X32 ] ],
+  [  [ BLOCK_64X128, BLOCK_64X64 ], [ BLOCK_INVALID, BLOCK_32X64 ] ],
+  [  [ BLOCK_128X64, BLOCK_INVALID ], [ BLOCK_64X64, BLOCK_64X32 ] ],
   [  [ BLOCK_128X128, BLOCK_128X64 ], [ BLOCK_64X128, BLOCK_64X64 ] ],
   [  [ BLOCK_4X16, BLOCK_4X8 ], [BLOCK_4X16, BLOCK_4X8 ] ],
   [  [ BLOCK_16X4, BLOCK_16X4 ], [BLOCK_8X4, BLOCK_8X4 ] ],
   [  [ BLOCK_8X32, BLOCK_8X16 ], [BLOCK_INVALID, BLOCK_4X16 ] ],
   [  [ BLOCK_32X8, BLOCK_INVALID ], [BLOCK_16X8, BLOCK_16X4 ] ],
   [  [ BLOCK_16X64, BLOCK_16X32 ], [BLOCK_INVALID, BLOCK_8X32 ] ],
-  [  [ BLOCK_64X16, BLOCK_INVALID ], [BLOCK_32X16, BLOCK_32X8 ] ],
-  [  [ BLOCK_32X128, BLOCK_32X64 ], [ BLOCK_INVALID, BLOCK_16X64 ] ],
-  [  [ BLOCK_128X32, BLOCK_INVALID ], [ BLOCK_64X32, BLOCK_64X16 ] ],
+  [  [ BLOCK_64X16, BLOCK_INVALID ], [BLOCK_32X16, BLOCK_32X8 ] ]
 ];
 
 pub fn get_plane_block_size(bsize: BlockSize, subsampling_x: usize, subsampling_y: usize)
@@ -170,9 +168,7 @@ static partition_context_lookup: [[u8; 2]; BlockSize::BLOCK_SIZES_ALL] = [
   [ 30, 24 ],  // 8X32  - {0b11110, 0b11000}
   [ 24, 30 ],  // 32X8  - {0b11000, 0b11110}
   [ 28, 16 ],  // 16X64 - {0b11100, 0b10000}
-  [ 16, 28 ],  // 64X16 - {0b10000, 0b11100}
-  [ 24, 0 ],   // 32X128- {0b11000, 0b00000}
-  [ 0, 24 ],   // 128X32- {0b00000, 0b11000}
+  [ 16, 28 ]   // 64X16 - {0b10000, 0b11100}
 ];
 
 static size_group_lookup: [u8; BlockSize::BLOCK_SIZES_ALL] = [
@@ -185,11 +181,11 @@ static size_group_lookup: [u8; BlockSize::BLOCK_SIZES_ALL] = [
   3, 3, 3, 3, 0,
   0, 1,
   1, 2,
-  2, 3, 3
+  2
 ];
 
 static num_pels_log2_lookup: [u8; BlockSize::BLOCK_SIZES_ALL] = [
-  4, 5, 5, 6, 7, 7, 8, 9, 9, 10, 11, 11, 12, 13, 13, 14, 6, 6, 8, 8, 10, 10, 12, 12];
+  4, 5, 5, 6, 7, 7, 8, 9, 9, 10, 11, 11, 12, 13, 13, 14, 6, 6, 8, 8, 10, 10];
 
 pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; EXT_PARTITION_TYPES] =
 [
@@ -209,9 +205,7 @@ pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; EXT_PARTITI
     // 4X16,       16X4,          8X32
     BLOCK_4X16,    BLOCK_16X4,    BLOCK_8X32,
     // 32X8,       16X64,         64X16
-    BLOCK_32X8,    BLOCK_16X64,   BLOCK_64X16,
-    // 32x128,     128x32
-    BLOCK_32X128,  BLOCK_128X32
+    BLOCK_32X8,    BLOCK_16X64,   BLOCK_64X16
   ], [  // PARTITION_HORZ
     //                            4X4
                                   BLOCK_INVALID,
@@ -228,9 +222,7 @@ pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; EXT_PARTITI
     // 4X16,       16X4,          8X32
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     // 32X8,       16X64,         64X16
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-    // 32x128,     128x32
-    BLOCK_INVALID, BLOCK_INVALID
+    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
   ], [  // PARTITION_VERT
     //                            4X4
                                   BLOCK_INVALID,
@@ -247,9 +239,7 @@ pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; EXT_PARTITI
     // 4X16,       16X4,          8X32
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     // 32X8,       16X64,         64X16
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-    // 32x128,     128x32
-    BLOCK_INVALID, BLOCK_INVALID
+    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
   ], [  // PARTITION_SPLIT
     //                            4X4
                                   BLOCK_INVALID,
@@ -266,9 +256,7 @@ pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; EXT_PARTITI
     // 4X16,       16X4,          8X32
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     // 32X8,       16X64,         64X16
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-    // 32x128,     128x32
-    BLOCK_INVALID, BLOCK_INVALID
+    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
   ], [  // PARTITION_HORZ_A
     //                            4X4
                                   BLOCK_INVALID,
@@ -286,8 +274,6 @@ pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; EXT_PARTITI
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     // 32X8,       16X64,         64X16
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-    // 32x128,     128x32
-    BLOCK_INVALID, BLOCK_INVALID
   ], [  // PARTITION_HORZ_B
     //                            4X4
                                   BLOCK_INVALID,
@@ -304,9 +290,7 @@ pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; EXT_PARTITI
     // 4X16,       16X4,          8X32
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     // 32X8,       16X64,         64X16
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-    // 32x128,     128x32
-    BLOCK_INVALID, BLOCK_INVALID
+    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
   ], [  // PARTITION_VERT_A
     //                            4X4
                                   BLOCK_INVALID,
@@ -323,9 +307,7 @@ pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; EXT_PARTITI
     // 4X16,       16X4,          8X32
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     // 32X8,       16X64,         64X16
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-    // 32x128,     128x32
-    BLOCK_INVALID, BLOCK_INVALID
+    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
   ], [  // PARTITION_VERT_B
     //                            4X4
                                   BLOCK_INVALID,
@@ -342,9 +324,7 @@ pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; EXT_PARTITI
     // 4X16,       16X4,          8X32
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     // 32X8,       16X64,         64X16
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-    // 32x128,     128x32
-    BLOCK_INVALID, BLOCK_INVALID
+    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
   ], [  // PARTITION_HORZ_4
     //                            4X4
                                   BLOCK_INVALID,
@@ -357,13 +337,11 @@ pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; EXT_PARTITI
     // 32X64,      64X32,         64X64
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X16,
     // 64x128,     128x64,        128x128
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_128X32,
+    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     // 4X16,       16X4,          8X32
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     // 32X8,       16X64,         64X16
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-    // 32x128,     128x32
-    BLOCK_INVALID, BLOCK_INVALID
+    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
   ], [  // PARTITION_VERT_4
     //                            4X4
                                   BLOCK_INVALID,
@@ -376,13 +354,11 @@ pub static subsize_lookup: [[BlockSize; BlockSize::BLOCK_SIZES_ALL]; EXT_PARTITI
     // 32X64,      64X32,         64X64
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X64,
     // 64x128,     128x64,        128x128
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_32X128,
+    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     // 4X16,       16X4,          8X32
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     // 32X8,       16X64,         64X16
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-    // 32x128,     128x32
-    BLOCK_INVALID, BLOCK_INVALID
+    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
   ]
 ];
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -92,28 +92,24 @@ pub enum BlockSize {
   BLOCK_32X8,
   BLOCK_16X64,
   BLOCK_64X16,
-  BLOCK_32X128,
-  BLOCK_128X32,
   BLOCK_INVALID
 }
 
 impl BlockSize {
-  pub const BLOCK_SIZES_ALL: usize = 24;
+  pub const BLOCK_SIZES_ALL: usize = 22;
 
   const BLOCK_SIZE_WIDTH_LOG2: [usize; BlockSize::BLOCK_SIZES_ALL] =
-    [2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 2, 4, 3, 5, 4, 6, 5, 7];
+    [2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 2, 4, 3, 5, 4, 6];
 
   const BLOCK_SIZE_HEIGHT_LOG2: [usize; BlockSize::BLOCK_SIZES_ALL] =
-    [2, 3, 2, 3, 4, 3, 4, 5, 4, 5, 6, 5, 6, 7, 6, 7, 4, 2, 5, 3, 6, 4, 7, 5];
+    [2, 3, 2, 3, 4, 3, 4, 5, 4, 5, 6, 5, 6, 7, 6, 7, 4, 2, 5, 3, 6, 4];
 
   pub const MI_SIZE_WIDE: [usize; BlockSize::BLOCK_SIZES_ALL] = [
-    1, 1, 2, 2, 2, 4, 4, 4, 8, 8, 8, 16, 16, 16, 32, 32, 1, 4, 2, 8, 4, 16, 8,
-    32,
+    1, 1, 2, 2, 2, 4, 4, 4, 8, 8, 8, 16, 16, 16, 32, 32, 1, 4, 2, 8, 4, 16
   ];
 
   pub const MI_SIZE_HIGH: [usize; BlockSize::BLOCK_SIZES_ALL] = [
-    1, 2, 1, 2, 4, 2, 4, 8, 4, 8, 16, 8, 16, 32, 16, 32, 4, 1, 8, 2, 16, 4,
-    32, 8,
+    1, 2, 1, 2, 4, 2, 4, 8, 4, 8, 16, 8, 16, 32, 16, 32, 4, 1, 8, 2, 16, 4
   ];
 
   pub fn cfl_allowed(self) -> bool {


### PR DESCRIPTION
BLOCK_SIZES is 22, and BLOCK_128X32 and BLOCK_32X128 do not exist in the AV1 spec.  This PR removes them.  Tests pass and the nyancat video seems to work. Issue #592 
