### PR TITLE
Move deblocking fitler to by-MI rather than by by-SB

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1999,7 +1999,7 @@ fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameStat
     /* TODO: Don't apply if lossless */
     deblock_filter_optimize(fi, fs, &mut cw.bc, bit_depth);
     if fs.deblock.levels[0] != 0 || fs.deblock.levels[1] != 0 {
-        deblock_filter_frame(fi, fs, &mut cw.bc, bit_depth);
+        deblock_filter_frame(fs, &mut cw.bc, bit_depth);
     }
     /* TODO: Don't apply if lossless */
     if sequence.enable_cdef {


### PR DESCRIPTION
No reason for the top level deblocking to be chunking thinks by SB in
the final filter.  There are fewer checks and corner-cases needed to
simply make full-frame passes.