### PR TITLE
Make simpler to pass options to criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,15 @@ criterion = "0.2"
 
 [[bin]]
 name = "rav1e"
+bench = false
 
 [[bin]]
 name = "rav1repl"
 required-features = ["repl"]
+bench = false
+
+[lib]
+bench = false
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
I noticed it while running some analysis with [critcmp](https://github.com/BurntSushi/critcmp).

Alex suggested to manually disable the impossible inline-benchmarks in https://github.com/rust-lang/cargo/issues/6156.

