### PR TITLE
Unbreak non-x86_64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,12 +11,12 @@ extern crate nasm_rs;
 
 use std::env;
 use std::fs;
-use std::fs::File;
-use std::io::Write;
 use std::path::Path;
 
 fn main() {
-    if cfg!(target_arch = "x86_64") {
+    #[cfg(target_arch = "x86_64")] {
+        use std::fs::File;
+        use std::io::Write;
         let out_dir = env::var("OUT_DIR").unwrap();
         {
             let dest_path = Path::new(&out_dir).join("config.asm");


### PR DESCRIPTION
The rust compiler DCE works in a different way so conditionals on `cfg!`
should not be used if the code in the branches may not compile.

While at it move the `use` statements where they are needed to avoid
warnings.

Fix #657