### PR TITLE
Add support for compound mode

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -179,7 +179,7 @@ impl Context {
     let reorder = true;
     let multiref = reorder || self.fi.config.speed <= 2;
 
-    let pyramid_depth = if reorder { 1 } else { 0 };
+    let pyramid_depth = if reorder { 2 } else { 0 };
     let group_src_len = 1 << pyramid_depth;
     let group_len = group_src_len + if reorder { pyramid_depth } else { 0 };
     let segment_len = 1 + (key_frame_interval - 1 + group_src_len - 1) / group_src_len * group_len;

--- a/src/api.rs
+++ b/src/api.rs
@@ -264,7 +264,7 @@ impl Context {
         } as u8) & 7;
       }
 
-      self.fi.reference_mode = if multiref && reorder && idx_in_group != 0 {
+      self.fi.reference_mode = if multiref && reorder && idx_in_group != 0 && false {
         ReferenceMode::SELECT
       } else {
         ReferenceMode::SINGLE

--- a/src/api.rs
+++ b/src/api.rs
@@ -270,6 +270,7 @@ impl Context {
         ReferenceMode::SINGLE
       };
       self.fi.number = segment_idx * key_frame_interval + self.fi.order_hint as u64;
+      self.fi.me_range_scale = (group_src_len >> lvl) as u8;
     }
 
     true

--- a/src/api.rs
+++ b/src/api.rs
@@ -176,7 +176,7 @@ impl Context {
   pub fn frame_properties(&mut self, idx: u64) -> bool {
     let key_frame_interval: u64 = 30;
 
-    let reorder = true;
+    let reorder = false;
     let multiref = reorder || self.fi.config.speed <= 2;
 
     let pyramid_depth = if reorder { 2 } else { 0 };
@@ -264,7 +264,7 @@ impl Context {
         } as u8) & 7;
       }
 
-      self.fi.reference_mode = if multiref && reorder && idx_in_group != 0 && false {
+      self.fi.reference_mode = if multiref && reorder && idx_in_group != 0 {
         ReferenceMode::SELECT
       } else {
         ReferenceMode::SINGLE

--- a/src/api.rs
+++ b/src/api.rs
@@ -176,7 +176,7 @@ impl Context {
   pub fn frame_properties(&mut self, idx: u64) -> bool {
     let key_frame_interval: u64 = 30;
 
-    let reorder = false;
+    let reorder = true;
     let multiref = reorder || self.fi.config.speed <= 2;
 
     let pyramid_depth = if reorder { 1 } else { 0 };
@@ -264,6 +264,11 @@ impl Context {
         } as u8) & 7;
       }
 
+      self.fi.reference_mode = if multiref && reorder && idx_in_group != 0 {
+        ReferenceMode::SELECT
+      } else {
+        ReferenceMode::SINGLE
+      };
       self.fi.number = segment_idx * key_frame_interval + self.fi.order_hint as u64;
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -2086,7 +2086,12 @@ impl ContextWriter {
             mv_stack.push(mv_cand);
           }
 
-          if blk.mode == PredictionMode::NEWMV {
+          if blk.mode == PredictionMode::NEW_NEWMV ||
+            blk.mode == PredictionMode::NEAREST_NEWMV ||
+            blk.mode == PredictionMode::NEW_NEARESTMV ||
+            blk.mode == PredictionMode::NEAR_NEWMV ||
+            blk.mode == PredictionMode::NEW_NEARMV ||
+            blk.mode == PredictionMode::NEWMV {
             *newmv_count += 1;
           }
 
@@ -2135,7 +2140,7 @@ impl ContextWriter {
         let cand_ref = blk.ref_frames[cand_list];
         if cand_ref > INTRA_FRAME && cand_ref != NONE_FRAME {
           let mut mv = blk.mv[cand_list];
-          if fi.ref_frame_sign_bias[blk.ref_frames[cand_list] - LAST_FRAME] !=
+          if fi.ref_frame_sign_bias[cand_ref - LAST_FRAME] !=
             fi.ref_frame_sign_bias[ref_frames[0] - LAST_FRAME] {
             mv.row = -mv.row;
             mv.col = -mv.col;

--- a/src/context.rs
+++ b/src/context.rs
@@ -2489,6 +2489,8 @@ impl ContextWriter {
       let mvy_max = (self.bc.rows - bo.y - blk_h / MI_SIZE) as isize * (8 * MI_SIZE) as isize + border_h;
       mv.this_mv.row = (mv.this_mv.row as isize).max(mvy_min).min(mvy_max) as i16;
       mv.this_mv.col = (mv.this_mv.col as isize).max(mvx_min).min(mvx_max) as i16;
+      mv.comp_mv.row = (mv.comp_mv.row as isize).max(mvy_min).min(mvy_max) as i16;
+      mv.comp_mv.col = (mv.comp_mv.col as isize).max(mvx_min).min(mvx_max) as i16;
     }
 
     mode_context

--- a/src/context.rs
+++ b/src/context.rs
@@ -2470,6 +2470,8 @@ impl ContextWriter {
             mv_stack.push(mv_cand);
           }
         }
+
+        assert!(mv_stack.len() == 2);
       }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1468,8 +1468,7 @@ impl BlockContext {
 
     for y in 0..bh {
       for x in 0..bw {
-        self.blocks[bo.y + y as usize][bo.x + x as usize].ref_frames[0] = r[0];
-        self.blocks[bo.y + y as usize][bo.x + x as usize].ref_frames[1] = r[1];
+        self.blocks[bo.y + y as usize][bo.x + x as usize].ref_frames = *r;
       }
     }
   }
@@ -1480,8 +1479,7 @@ impl BlockContext {
 
     for y in 0..bh {
       for x in 0..bw {
-        self.blocks[bo.y + y as usize][bo.x + x as usize].mv[0] = mvs[0];
-        self.blocks[bo.y + y as usize][bo.x + x as usize].mv[1] = mvs[1];
+        self.blocks[bo.y + y as usize][bo.x + x as usize].mv = *mvs;
       }
     }
   }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -421,6 +421,7 @@ pub struct FrameInvariants {
     pub ref_frame_sign_bias: [bool; INTER_REFS_PER_FRAME],
     pub rec_buffer: ReferenceFramesSet,
     pub base_q_idx: u8,
+    pub me_range_scale: u8,
 }
 
 impl FrameInvariants {
@@ -489,6 +490,7 @@ impl FrameInvariants {
             ref_frame_sign_bias: [false; INTER_REFS_PER_FRAME],
             rec_buffer: ReferenceFramesSet::new(),
             base_q_idx: config.quantizer as u8,
+            me_range_scale: 1,
         }
     }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1403,8 +1403,6 @@ pub fn encode_block_b(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
     cw.bc.set_ref_frames(bo, bsize, ref_frames);
     cw.bc.set_motion_vectors(bo, bsize, mvs);
 
-    if ref_frames[1] != NONE_FRAME { assert!(luma_mode == PredictionMode::NEW_NEWMV); }
-
     //write_q_deltas();
     if cw.bc.code_deltas && fs.deblock.block_deltas_enabled && (bsize < sb_size || !skip) {
         cw.write_block_deblock_deltas(w, bo, fs.deblock.block_delta_multi);
@@ -1419,7 +1417,6 @@ pub fn encode_block_b(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
 
             // NOTE: Until rav1e supports other inter modes than GLOBALMV
             if luma_mode >= PredictionMode::NEAREST_NEARESTMV {
-                assert!(luma_mode == PredictionMode::NEW_NEWMV);
                 cw.write_compound_mode(w, luma_mode, mode_context);
             } else {
                 cw.write_inter_mode(w, luma_mode, mode_context);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -262,7 +262,7 @@ impl Sequence {
         let mut forward_hint = 0;
         let mut backward_hint = 0;
         for i in 0..INTER_REFS_PER_FRAME {
-          if let Some(ref rec) = fi.rec_buffer.frames[fi.ref_frames[i]] {
+          if let Some(ref rec) = fi.rec_buffer.frames[fi.ref_frames[i] as usize] {
             let ref_hint = rec.order_hint;
             if self.get_relative_dist(ref_hint, fi.order_hint) < 0 {
               if forward_idx < 0 || self.get_relative_dist(ref_hint, forward_hint) > 0 {
@@ -286,7 +286,7 @@ impl Sequence {
           let mut second_forward_idx: isize = -1;
           let mut second_forward_hint = 0;
           for i in 0..INTER_REFS_PER_FRAME {
-            if let Some(ref rec) = fi.rec_buffer.frames[fi.ref_frames[i]] {
+            if let Some(ref rec) = fi.rec_buffer.frames[fi.ref_frames[i] as usize] {
               let ref_hint = rec.order_hint;
               if self.get_relative_dist(ref_hint, forward_hint) < 0 {
                 if second_forward_idx < 0 || self.get_relative_dist(ref_hint, second_forward_hint) > 0 {
@@ -1344,27 +1344,27 @@ pub fn motion_compensate(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Con
 
       if some_use_intra {
         luma_mode.predict_inter(fi, p, &po, &mut rec.mut_slice(&po), plane_bsize.width(),
-        plane_bsize.height(), ref_frames[0], &mvs[0], bit_depth);
+          plane_bsize.height(), ref_frames, &mvs, bit_depth);
       } else {
         assert!(xdec == 1 && ydec == 1);
         // TODO: these are only valid for 4:2:0
-        let mv0 = &cw.bc.at(&bo.with_offset(-1,-1)).mv[0];
-        let rf0 = cw.bc.at(&bo.with_offset(-1,-1)).ref_frames[0];
-        let mv1 = &cw.bc.at(&bo.with_offset(0,-1)).mv[0];
-        let rf1 = cw.bc.at(&bo.with_offset(0,-1)).ref_frames[0];
+        let mv0 = &cw.bc.at(&bo.with_offset(-1,-1)).mv;
+        let rf0 = &cw.bc.at(&bo.with_offset(-1,-1)).ref_frames;
+        let mv1 = &cw.bc.at(&bo.with_offset(0,-1)).mv;
+        let rf1 = &cw.bc.at(&bo.with_offset(0,-1)).ref_frames;
         let po1 = PlaneOffset { x: po.x+2, y: po.y };
-        let mv2 = &cw.bc.at(&bo.with_offset(-1,0)).mv[0];
-        let rf2 = cw.bc.at(&bo.with_offset(-1,0)).ref_frames[0];
+        let mv2 = &cw.bc.at(&bo.with_offset(-1,0)).mv;
+        let rf2 = &cw.bc.at(&bo.with_offset(-1,0)).ref_frames;
         let po2 = PlaneOffset { x: po.x, y: po.y+2 };
         let po3 = PlaneOffset { x: po.x+2, y: po.y+2 };
         luma_mode.predict_inter(fi, p, &po, &mut rec.mut_slice(&po), 2, 2, rf0, mv0, bit_depth);
         luma_mode.predict_inter(fi, p, &po1, &mut rec.mut_slice(&po1), 2, 2, rf1, mv1, bit_depth);
         luma_mode.predict_inter(fi, p, &po2, &mut rec.mut_slice(&po2), 2, 2, rf2, mv2, bit_depth);
-        luma_mode.predict_inter(fi, p, &po3, &mut rec.mut_slice(&po3), 2, 2, ref_frames[0], &mvs[0], bit_depth);
+        luma_mode.predict_inter(fi, p, &po3, &mut rec.mut_slice(&po3), 2, 2, ref_frames, mvs, bit_depth);
       }
     } else {
       luma_mode.predict_inter(fi, p, &po, &mut rec.mut_slice(&po), plane_bsize.width(),
-      plane_bsize.height(), ref_frames[0], &mvs[0], bit_depth);
+        plane_bsize.height(), ref_frames, &mvs, bit_depth);
     }
   }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -218,7 +218,7 @@ impl Sequence {
             frame_id_length: 0,
             delta_frame_id_length: 0,
             use_128x128_superblock: false,
-            order_hint_bits_minus_1: 1,
+            order_hint_bits_minus_1: 3,
             force_screen_content_tools: 0,
             force_integer_mv: 2,
             still_picture: false,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1765,7 +1765,8 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
           rd_cost = mode_decision.rd_cost + cost;
 
           let mut mv_stack = Vec::new();
-          let mode_context = cw.find_mvrefs(bo, ref_frames[0], &mut mv_stack, bsize, false, fi);
+          let is_compound = ref_frames[1] != NONE_FRAME;
+          let mode_context = cw.find_mvrefs(bo, ref_frames, &mut mv_stack, bsize, false, fi, is_compound);
 
           cdef_coded = encode_block_a(seq, cw, if cdef_coded  {w_post_cdef} else {w_pre_cdef},
                                      bsize, bo, skip);
@@ -1845,7 +1846,8 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
             cw.bc.set_tx_size(bo, tx_size);
 
             let mut mv_stack = Vec::new();
-            let mode_context = cw.find_mvrefs(bo, ref_frames[0], &mut mv_stack, bsize, false, fi);
+            let is_compound = ref_frames[1] != NONE_FRAME;
+            let mode_context = cw.find_mvrefs(bo, ref_frames, &mut mv_stack, bsize, false, fi, is_compound);
 
             cdef_coded = encode_block_a(seq, cw, if cdef_coded {w_post_cdef} else {w_pre_cdef},
                                        bsize, bo, skip);
@@ -1938,7 +1940,8 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
                 rdo_tx_size_type(seq, fi, fs, cw, bsize, bo, mode_luma, ref_frames, mvs, skip);
 
             let mut mv_stack = Vec::new();
-            let mode_context = cw.find_mvrefs(bo, ref_frames[0], &mut mv_stack, bsize, false, fi);
+            let is_compound = ref_frames[1] != NONE_FRAME;
+            let mode_context = cw.find_mvrefs(bo, ref_frames, &mut mv_stack, bsize, false, fi, is_compound);
 
             if !mode_luma.is_intra() && mode_luma != PredictionMode::GLOBALMV {
               mode_luma = PredictionMode::NEWMV;

--- a/src/entropymode.rs
+++ b/src/entropymode.rs
@@ -899,7 +899,7 @@ pub static default_refmv_cdf: [[u16; cdf_size!(2)]; REFMV_MODE_CONTEXTS] = [
 pub static default_drl_cdf: [[u16; cdf_size!(2)]; DRL_MODE_CONTEXTS] =
   [cdf!(13104), cdf!(24560), cdf!(18945)];
 
-pub static default_inter_compound_mode_cdf: [[u16;
+pub static default_compound_mode_cdf: [[u16;
   cdf_size!(INTER_COMPOUND_MODES)];
   INTER_MODE_CONTEXTS] = [
   cdf!(7760, 13823, 15808, 17641, 19156, 20666, 26891),

--- a/src/entropymode.rs
+++ b/src/entropymode.rs
@@ -1125,7 +1125,7 @@ pub static default_obmc_cdf: [[u16; cdf_size!(2)];
 pub static default_intra_inter_cdf: [[u16; cdf_size!(2)];
   INTRA_INTER_CONTEXTS] = [cdf!(806), cdf!(16662), cdf!(20186), cdf!(26538)];
 
-pub static default_comp_inter_cdf: [[u16; cdf_size!(2)]; COMP_INTER_CONTEXTS] =
+pub static default_comp_mode_cdf: [[u16; cdf_size!(2)]; COMP_INTER_CONTEXTS] =
   [cdf!(26828), cdf!(24035), cdf!(12031), cdf!(10640), cdf!(2901)];
 
 pub static default_comp_ref_type_cdf: [[u16; cdf_size!(2)];

--- a/src/me.rs
+++ b/src/me.rs
@@ -45,7 +45,7 @@ pub fn motion_estimation(
         x: (bo.x as isize) << BLOCK_TO_PLANE_SHIFT,
         y: (bo.y as isize) << BLOCK_TO_PLANE_SHIFT
       };
-      let range = 64 as isize;
+      let range = 32 * fi.me_range_scale as isize;
       let blk_w = bsize.width();
       let blk_h = bsize.height();
       let border_w = 128 + blk_w as isize * 8;

--- a/src/me.rs
+++ b/src/me.rs
@@ -113,7 +113,8 @@ pub fn motion_estimation(
                 &mut tmp_plane.mut_slice(&PlaneOffset { x: 0, y: 0 });
 
               mode.predict_inter(
-                fi, 0, &po, tmp_slice, blk_w, blk_h, ref_frame, &cand_mv, 8,
+                fi, 0, &po, tmp_slice, blk_w, blk_h, &[ref_frame, NONE_FRAME],
+                &[cand_mv, MotionVector{ row: 0, col: 0 }], 8,
               );
             }
 

--- a/src/me.rs
+++ b/src/me.rs
@@ -45,7 +45,7 @@ pub fn motion_estimation(
         x: (bo.x as isize) << BLOCK_TO_PLANE_SHIFT,
         y: (bo.y as isize) << BLOCK_TO_PLANE_SHIFT
       };
-      let range = 32 as isize;
+      let range = 64 as isize;
       let blk_w = bsize.width();
       let blk_h = bsize.height();
       let border_w = 128 + blk_w as isize * 8;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -980,12 +980,12 @@ impl PredictionMode {
           let rec_cfg = &rec.frame.planes[p].cfg;
           let shift_row = 3 + rec_cfg.ydec;
           let shift_col = 3 + rec_cfg.xdec;
-          let row_offset = mvs[0].row as i32 >> shift_row;
-          let col_offset = mvs[0].col as i32 >> shift_col;
+          let row_offset = mvs[i].row as i32 >> shift_row;
+          let col_offset = mvs[i].col as i32 >> shift_col;
           let row_frac =
-            (mvs[0].row as i32 - (row_offset << shift_row)) << (4 - shift_row);
+            (mvs[i].row as i32 - (row_offset << shift_row)) << (4 - shift_row);
           let col_frac =
-            (mvs[0].col as i32 - (col_offset << shift_col)) << (4 - shift_col);
+            (mvs[i].col as i32 - (col_offset << shift_col)) << (4 - shift_col);
           let ref_stride = rec_cfg.stride;
 
           let max_sample_val = ((1 << bit_depth) - 1) as i32;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -1016,7 +1016,7 @@ impl PredictionMode {
                     val = val << shifts.2;
                     if i == 1 {
                       val = val + slice[output_index] as i32 - 32768;
-                      val = val >> shifts.2 + 1;
+                      val = round_shift(val, shifts.2 + 1);
                       val = val.max(0).min(max_sample_val);
                     } else {
                       val = val + 32768;
@@ -1044,7 +1044,7 @@ impl PredictionMode {
                   let mut val = round_shift(sum, shifts.0 + shifts.1 - 7);
                   if is_compound && i == 1 {
                     val = val + slice[output_index] as i32 - 32768;
-                    val = val >> shifts.2 + 1;
+                    val = round_shift(val, shifts.2 + 1);
                     val = val.max(0).min(max_sample_val);
                   } else if !is_compound {
                     val = val.max(0).min(max_sample_val);
@@ -1073,7 +1073,7 @@ impl PredictionMode {
                   let mut val = round_shift(round_shift(sum, shifts.0) << 7, shifts.1);
                   if is_compound && i == 1 {
                     val = val + slice[output_index] as i32 - 32768;
-                    val = val >> shifts.2 + 1;
+                    val = round_shift(val, shifts.2 + 1);
                     val = val.max(0).min(max_sample_val);
                   } else if !is_compound {
                     val = val.max(0).min(max_sample_val);
@@ -1117,7 +1117,7 @@ impl PredictionMode {
                     let mut val = round_shift(sum, shifts.1);
                     if is_compound && i == 1 {
                       val = val + slice[output_index] as i32 - 32768;
-                      val = val >> shifts.2 + 1;
+                      val = round_shift(val, shifts.2 + 1);
                       val = val.max(0).min(max_sample_val);
                     } else if !is_compound {
                       val = val.max(0).min(max_sample_val);

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -965,21 +965,22 @@ impl PredictionMode {
   pub fn predict_inter<'a>(
     self, fi: &FrameInvariants, p: usize, po: &PlaneOffset,
     dst: &'a mut PlaneMutSlice<'a>, width: usize, height: usize,
-    ref_frame: usize, mv: &MotionVector, bit_depth: usize
+    ref_frames: &[usize; 2], mvs: &[MotionVector; 2], bit_depth: usize
   ) {
     assert!(!self.is_intra());
+    assert!(ref_frames[1] == NONE_FRAME);
 
-    match fi.rec_buffer.frames[fi.ref_frames[ref_frame - LAST_FRAME] as usize] {
+    match fi.rec_buffer.frames[fi.ref_frames[ref_frames[0] - LAST_FRAME] as usize] {
       Some(ref rec) => {
         let rec_cfg = &rec.frame.planes[p].cfg;
         let shift_row = 3 + rec_cfg.ydec;
         let shift_col = 3 + rec_cfg.xdec;
-        let row_offset = mv.row as i32 >> shift_row;
-        let col_offset = mv.col as i32 >> shift_col;
+        let row_offset = mvs[0].row as i32 >> shift_row;
+        let col_offset = mvs[0].col as i32 >> shift_col;
         let row_frac =
-          (mv.row as i32 - (row_offset << shift_row)) << (4 - shift_row);
+          (mvs[0].row as i32 - (row_offset << shift_row)) << (4 - shift_row);
         let col_frac =
-          (mv.col as i32 - (col_offset << shift_col)) << (4 - shift_col);
+          (mvs[0].col as i32 - (col_offset << shift_col)) << (4 - shift_col);
         let ref_stride = rec_cfg.stride;
 
         let stride = dst.plane.cfg.stride;

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -50,6 +50,14 @@ pub static RAV1E_INTER_MODES_MINIMAL: &'static [PredictionMode] = &[
   PredictionMode::NEWMV
 ];
 
+pub static RAV1E_INTER_COMPOUND_MODES: &'static [PredictionMode] = &[
+  PredictionMode::GLOBAL_GLOBALMV,
+  PredictionMode::NEAREST_NEARESTMV,
+  PredictionMode::NEW_NEWMV,
+  PredictionMode::NEAREST_NEWMV,
+  PredictionMode::NEW_NEARESTMV
+];
+
 // Weights are quadratic from '1' to '1 / block_size', scaled by 2^sm_weight_log2_scale.
 const sm_weight_log2_scale: u8 = 8;
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -414,8 +414,8 @@ pub fn rdo_mode_decision(
           false
         );
 
-        //if rd < best.rd {
-        if rd < best.rd || luma_mode == PredictionMode::NEW_NEWMV {
+        if rd < best.rd {
+        //if rd < best.rd || luma_mode == PredictionMode::NEW_NEWMV {
           best.rd = rd;
           best.mode_luma = luma_mode;
           best.mode_chroma = chroma_mode;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -355,8 +355,7 @@ pub fn rdo_mode_decision(
     ref_frames_set.push(ref_frames);
     let mv0 = mvs_from_me[0][0];
     let mv1 = mvs_from_me[1][1];
-    //mvs_from_me.push([mv0, mv1]);
-    mvs_from_me.push([MotionVector{row:0,col:0};2]);
+    mvs_from_me.push([mv0, mv1]);
     let mut mv_stack: Vec<CandidateMV> = Vec::new();
     mode_contexts.push(cw.find_mvrefs(bo, &ref_frames, &mut mv_stack, bsize, false, fi, true));
     mode_set.push((PredictionMode::NEW_NEWMV, ref_frames_set.len() - 1));

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -23,7 +23,7 @@ use motion_compensate;
 use partition::*;
 use plane::*;
 use cdef::*;
-use predict::{RAV1E_INTRA_MODES, RAV1E_INTRA_MODES_MINIMAL, RAV1E_INTER_MODES_MINIMAL};
+use predict::{RAV1E_INTRA_MODES, RAV1E_INTRA_MODES_MINIMAL, RAV1E_INTER_MODES_MINIMAL, RAV1E_INTER_COMPOUND_MODES};
 use quantize::dc_q;
 use std;
 use std::f64;
@@ -367,11 +367,9 @@ pub fn rdo_mode_decision(
         mvs_from_me.push([mv0, mv1]);
         let mut mv_stack: Vec<CandidateMV> = Vec::new();
         mode_contexts.push(cw.find_mvrefs(bo, &ref_frames, &mut mv_stack, bsize, false, fi, true));
-        mode_set.push((PredictionMode::GLOBAL_GLOBALMV, ref_frames_set.len() - 1));
-        mode_set.push((PredictionMode::NEAREST_NEARESTMV, ref_frames_set.len() - 1));
-        mode_set.push((PredictionMode::NEW_NEWMV, ref_frames_set.len() - 1));
-        mode_set.push((PredictionMode::NEAREST_NEWMV, ref_frames_set.len() - 1));
-        mode_set.push((PredictionMode::NEW_NEARESTMV, ref_frames_set.len() - 1));
+        for &x in RAV1E_INTER_COMPOUND_MODES {
+          mode_set.push((x, ref_frames_set.len() - 1));
+        }
         mv_stacks.push(mv_stack);
       }
     }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -327,7 +327,8 @@ pub fn rdo_mode_decision(
 
   for (i, &ref_frame) in ref_frame_set.iter().enumerate() {
     let mut mvs: Vec<CandidateMV> = Vec::new();
-    mode_contexts.push(cw.find_mvrefs(bo, ref_frame, &mut mvs, bsize, false, fi));
+    let ref_frames = [ref_frame, NONE_FRAME];
+    mode_contexts.push(cw.find_mvrefs(bo, &ref_frames, &mut mvs, bsize, false, fi, false));
 
     if fi.frame_type == FrameType::INTER {
       for &x in RAV1E_INTER_MODES_MINIMAL {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -360,8 +360,11 @@ pub fn rdo_mode_decision(
     mvs_from_me.push([mv0, mv1]);
     let mut mv_stack: Vec<CandidateMV> = Vec::new();
     mode_contexts.push(cw.find_mvrefs(bo, &ref_frames, &mut mv_stack, bsize, false, fi, true));
-    mode_set.push((PredictionMode::NEW_NEWMV, ref_frames_set.len() - 1));
+    mode_set.push((PredictionMode::GLOBAL_GLOBALMV, ref_frames_set.len() - 1));
     mode_set.push((PredictionMode::NEAREST_NEARESTMV, ref_frames_set.len() - 1));
+    mode_set.push((PredictionMode::NEW_NEWMV, ref_frames_set.len() - 1));
+    mode_set.push((PredictionMode::NEAREST_NEWMV, ref_frames_set.len() - 1));
+    mode_set.push((PredictionMode::NEW_NEARESTMV, ref_frames_set.len() - 1));
     mv_stacks.push(mv_stack);
   }
 
@@ -458,6 +461,8 @@ pub fn rdo_mode_decision(
       PredictionMode::NEAR1MV | PredictionMode::NEAR2MV =>
           [mv_stacks[i][luma_mode as usize - PredictionMode::NEAR0MV as usize + 1].this_mv,
           mv_stacks[i][luma_mode as usize - PredictionMode::NEAR0MV as usize + 1].comp_mv],
+      PredictionMode::NEAREST_NEWMV => [mv_stacks[i][0].this_mv, mvs_from_me[i][1]],
+      PredictionMode::NEW_NEARESTMV => [mvs_from_me[i][0], mv_stacks[i][0].comp_mv],
       _ => [MotionVector { row: 0, col: 0 }; 2]
     };
     let mode_set_chroma = vec![luma_mode];

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -353,8 +353,10 @@ pub fn rdo_mode_decision(
     // FIXME make this more flexible and less hardcoded
     let ref_frames = [LAST_FRAME, ALTREF_FRAME];
     ref_frames_set.push(ref_frames);
+    assert!(ref_frames_set[0][0] == ref_frames[0]);
+    assert!(ref_frames_set[1][0] == ref_frames[1]);
     let mv0 = mvs_from_me[0][0];
-    let mv1 = mvs_from_me[1][1];
+    let mv1 = mvs_from_me[1][0];
     mvs_from_me.push([mv0, mv1]);
     let mut mv_stack: Vec<CandidateMV> = Vec::new();
     mode_contexts.push(cw.find_mvrefs(bo, &ref_frames, &mut mv_stack, bsize, false, fi, true));
@@ -412,8 +414,8 @@ pub fn rdo_mode_decision(
           false
         );
 
-        if rd < best.rd {
-        //if rd < best.rd || luma_mode == PredictionMode::NEW_NEWMV {
+        //if rd < best.rd {
+        if rd < best.rd || luma_mode == PredictionMode::NEW_NEWMV {
           best.rd = rd;
           best.mode_luma = luma_mode;
           best.mode_chroma = chroma_mode;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -355,7 +355,8 @@ pub fn rdo_mode_decision(
     ref_frames_set.push(ref_frames);
     let mv0 = mvs_from_me[0][0];
     let mv1 = mvs_from_me[1][1];
-    mvs_from_me.push([mv0, mv1]);
+    //mvs_from_me.push([mv0, mv1]);
+    mvs_from_me.push([MotionVector{row:0,col:0};2]);
     let mut mv_stack: Vec<CandidateMV> = Vec::new();
     mode_contexts.push(cw.find_mvrefs(bo, &ref_frames, &mut mv_stack, bsize, false, fi, true));
     mode_set.push((PredictionMode::NEW_NEWMV, ref_frames_set.len() - 1));
@@ -413,6 +414,7 @@ pub fn rdo_mode_decision(
         );
 
         if rd < best.rd {
+        //if rd < best.rd || luma_mode == PredictionMode::NEW_NEWMV {
           best.rd = rd;
           best.mode_luma = luma_mode;
           best.mode_chroma = chroma_mode;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -361,6 +361,7 @@ pub fn rdo_mode_decision(
     let mut mv_stack: Vec<CandidateMV> = Vec::new();
     mode_contexts.push(cw.find_mvrefs(bo, &ref_frames, &mut mv_stack, bsize, false, fi, true));
     mode_set.push((PredictionMode::NEW_NEWMV, ref_frames_set.len() - 1));
+    mode_set.push((PredictionMode::NEAREST_NEARESTMV, ref_frames_set.len() - 1));
     mv_stacks.push(mv_stack);
   }
 
@@ -444,7 +445,7 @@ pub fn rdo_mode_decision(
   mode_set.iter().for_each(|&(luma_mode, i)| {
     let mvs = match luma_mode {
       PredictionMode::NEWMV | PredictionMode::NEW_NEWMV => mvs_from_me[i],
-      PredictionMode::NEARESTMV => if mv_stacks[i].len() > 0 {
+      PredictionMode::NEARESTMV | PredictionMode::NEAREST_NEARESTMV => if mv_stacks[i].len() > 0 {
         [mv_stacks[i][0].this_mv, mv_stacks[i][0].comp_mv]
       } else {
         [MotionVector { row: 0, col: 0 }; 2]


### PR DESCRIPTION
Compound mode is used in conjunction with frame reordering. It is limited to the case where one forward and one backward reference are used.