### PR TITLE
Make the default Intra impl not use libaom

### DIFF
--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -27,6 +27,7 @@ pub fn generate_block(rng: &mut ChaChaRng) -> (Vec<u16>, Vec<u16>, Vec<u16>) {
 
 pub fn pred_bench(c: &mut Criterion) {
   c.bench_function("intra_dc_4x4", |b| intra_dc_4x4(b));
+  c.bench_function("intra_dc_top_4x4", |b| intra_dc_top_4x4(b));
   c.bench_function("intra_h_4x4", |b| intra_h_4x4(b));
   c.bench_function("intra_v_4x4", |b| intra_v_4x4(b));
   c.bench_function("intra_paeth_4x4", |b| intra_paeth_4x4(b));
@@ -43,6 +44,22 @@ pub fn intra_dc_4x4(b: &mut Bencher) {
   b.iter(|| {
     for _ in 0..MAX_ITER {
       Block4x4::pred_dc(
+        &mut block,
+        BLOCK_SIZE.width(),
+        &above[..4],
+        &left[..4]
+      );
+    }
+  })
+}
+
+pub fn intra_dc_top_4x4(b: &mut Bencher) {
+  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let (mut block, above, left) = generate_block(&mut ra);
+
+  b.iter(|| {
+    for _ in 0..MAX_ITER {
+      Block4x4::pred_dc_top(
         &mut block,
         BLOCK_SIZE.width(),
         &above[..4],

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -27,6 +27,7 @@ pub fn generate_block(rng: &mut ChaChaRng) -> (Vec<u16>, Vec<u16>, Vec<u16>) {
 
 pub fn pred_bench(c: &mut Criterion) {
   c.bench_function("intra_dc_4x4", |b| intra_dc_4x4(b));
+  c.bench_function("intra_dc_left_4x4", |b| intra_dc_left_4x4(b));
   c.bench_function("intra_dc_top_4x4", |b| intra_dc_top_4x4(b));
   c.bench_function("intra_h_4x4", |b| intra_h_4x4(b));
   c.bench_function("intra_v_4x4", |b| intra_v_4x4(b));
@@ -44,6 +45,22 @@ pub fn intra_dc_4x4(b: &mut Bencher) {
   b.iter(|| {
     for _ in 0..MAX_ITER {
       Block4x4::pred_dc(
+        &mut block,
+        BLOCK_SIZE.width(),
+        &above[..4],
+        &left[..4]
+      );
+    }
+  })
+}
+
+pub fn intra_dc_left_4x4(b: &mut Bencher) {
+  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let (mut block, above, left) = generate_block(&mut ra);
+
+  b.iter(|| {
+    for _ in 0..MAX_ITER {
+      Block4x4::pred_dc_left(
         &mut block,
         BLOCK_SIZE.width(),
         &above[..4],

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -920,7 +920,7 @@ impl PredictionMode {
       PredictionMode::DC_PRED | PredictionMode::UV_CFL_PRED => match (x, y) {
         (0, 0) => B::pred_dc_128(slice, stride, bit_depth),
         (_, 0) =>
-          B::pred_dc_left(slice, stride, above_slice, left_slice, bit_depth),
+          B::pred_dc_left(slice, stride, above_slice, left_slice),
         (0, _) =>
           B::pred_dc_top(slice, stride, above_slice, left_slice),
         _ => B::pred_dc(slice, stride, above_slice, left_slice)

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -922,7 +922,7 @@ impl PredictionMode {
         (_, 0) =>
           B::pred_dc_left(slice, stride, above_slice, left_slice, bit_depth),
         (0, _) =>
-          B::pred_dc_top(slice, stride, above_slice, left_slice, bit_depth),
+          B::pred_dc_top(slice, stride, above_slice, left_slice),
         _ => B::pred_dc(slice, stride, above_slice, left_slice)
       },
       PredictionMode::H_PRED => match (x, y) {


### PR DESCRIPTION
Prerequisite to predict u8/u16 generic in a simpler way and also address part of #654