### PR TITLE
Refractoring travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,6 @@ addons:
     packages:
       - nasm
 
-before_install:
-    - wget -O cmake.sh https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh
-    - sudo sh cmake.sh --skip-license --exclude-subdir --prefix=/usr
-    - sudo rm -fR /usr/local/cmake*
-    - hash -r
-    - which cmake
-    - cmake --version
-    - wget https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/nasm-2.13.03.tar.xz
-    - tar -xvf nasm-2.13.03.tar.xz
-    - cd nasm-2.13.03
-    - ./configure
-    - make
-    - sudo make install
-    - nasm --version
 script:
     - |
         cargo build --verbose &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 language: rust
-addons:
-  apt:
-    packages:
-      - nasm
 
+before_install:
+    - wget -O cmake.sh https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh
+    - sudo sh cmake.sh --skip-license --exclude-subdir --prefix=/usr
+    - sudo rm -fR /usr/local/cmake*
+    - hash -r
+    - which cmake
+    - cmake --version
+    - wget https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/nasm-2.13.03.tar.xz
+    - tar -xvf nasm-2.13.03.tar.xz
+    - cd nasm-2.13.03
+    - ./configure
+    - make
+    - sudo make install
+    - nasm --version
 script:
     - |
         cargo build --verbose &&

--- a/build.rs
+++ b/build.rs
@@ -11,12 +11,12 @@ extern crate nasm_rs;
 
 use std::env;
 use std::fs;
-use std::fs::File;
-use std::io::Write;
 use std::path::Path;
 
 fn main() {
-    if cfg!(target_arch = "x86_64") {
+    #[cfg(target_arch = "x86_64")] {
+        use std::fs::File;
+        use std::io::Write;
         let out_dir = env::var("OUT_DIR").unwrap();
         {
             let dest_path = Path::new(&out_dir).join("config.asm");


### PR DESCRIPTION
Hi!

I was just reading the .travis.yml and didn't understand why you installed nasm with apt and build it in the before_script section. Hence, I tried to remove the addons part and travis seems to have no particular issue to build and test the package.

So I make this PR to remove 3 useless lines (I guess) of your project, but i'm still wandering why you can't install nasm with apt only.