### PR TITLE
Hierarchical motion estimation

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -10,6 +10,7 @@
 use context::CDFContext;
 use encoder::*;
 use partition::*;
+use plane::*;
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -293,6 +294,8 @@ impl Context {
 
       let mut fs = FrameState {
         input: Arc::new(Frame::new(self.fi.padded_w, self.fi.padded_h)), // dummy
+        input_hres: Plane::new(self.fi.padded_w/2, self.fi.padded_h/2, 1, 1, (128+8)/2, (128+8)/2),
+        input_qres: Plane::new(self.fi.padded_w/4, self.fi.padded_h/4, 2, 2, (128+8)/4, (128+8)/4),
         rec: Frame::new(self.fi.padded_w, self.fi.padded_h),
         qc: Default::default(),
         cdfs: CDFContext::new(0),
@@ -312,6 +315,8 @@ impl Context {
         if let Some(frame) = f {
           let mut fs = FrameState {
             input: frame,
+            input_hres: Plane::new(self.fi.padded_w/2, self.fi.padded_h/2, 1, 1, (128+8)/2, (128+8)/2),
+            input_qres: Plane::new(self.fi.padded_w/4, self.fi.padded_h/4, 2, 2, (128+8)/4, (128+8)/4),
             rec: Frame::new(self.fi.padded_w, self.fi.padded_h),
             qc: Default::default(),
             cdfs: CDFContext::new(0),

--- a/src/api.rs
+++ b/src/api.rs
@@ -294,8 +294,16 @@ impl Context {
 
       let mut fs = FrameState {
         input: Arc::new(Frame::new(self.fi.padded_w, self.fi.padded_h)), // dummy
-        input_hres: Plane::new(self.fi.padded_w/2, self.fi.padded_h/2, 1, 1, (128+8)/2, (128+8)/2),
-        input_qres: Plane::new(self.fi.padded_w/4, self.fi.padded_h/4, 2, 2, (128+8)/4, (128+8)/4),
+        input_hres: Plane::new(
+          self.fi.padded_w/2, self.fi.padded_h/2,
+          1, 1,
+          (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2
+        ),
+        input_qres: Plane::new(
+          self.fi.padded_w/4, self.fi.padded_h/4,
+          2, 2,
+          (MAX_SB_SIZE + SUBPEL_FILTER_SIZE)/4, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4
+        ),
         rec: Frame::new(self.fi.padded_w, self.fi.padded_h),
         qc: Default::default(),
         cdfs: CDFContext::new(0),
@@ -315,8 +323,16 @@ impl Context {
         if let Some(frame) = f {
           let mut fs = FrameState {
             input: frame,
-            input_hres: Plane::new(self.fi.padded_w/2, self.fi.padded_h/2, 1, 1, (128+8)/2, (128+8)/2),
-            input_qres: Plane::new(self.fi.padded_w/4, self.fi.padded_h/4, 2, 2, (128+8)/4, (128+8)/4),
+            input_hres: Plane::new(
+              self.fi.padded_w/2, self.fi.padded_h/2,
+              1, 1,
+              (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2
+            ),
+            input_qres: Plane::new(
+              self.fi.padded_w/4, self.fi.padded_h/4,
+              2, 2,
+              (MAX_SB_SIZE + SUBPEL_FILTER_SIZE)/4, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4
+            ),
             rec: Frame::new(self.fi.padded_w, self.fi.padded_h),
             qc: Default::default(),
             cdfs: CDFContext::new(0),

--- a/src/api.rs
+++ b/src/api.rs
@@ -7,10 +7,8 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use context::CDFContext;
 use encoder::*;
 use partition::*;
-use plane::*;
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -292,23 +290,7 @@ impl Context {
     if self.fi.show_existing_frame {
       self.idx = self.idx + 1;
 
-      let mut fs = FrameState {
-        input: Arc::new(Frame::new(self.fi.padded_w, self.fi.padded_h)), // dummy
-        input_hres: Plane::new(
-          self.fi.padded_w/2, self.fi.padded_h/2,
-          1, 1,
-          (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2
-        ),
-        input_qres: Plane::new(
-          self.fi.padded_w/4, self.fi.padded_h/4,
-          2, 2,
-          (MAX_SB_SIZE + SUBPEL_FILTER_SIZE)/4, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4
-        ),
-        rec: Frame::new(self.fi.padded_w, self.fi.padded_h),
-        qc: Default::default(),
-        cdfs: CDFContext::new(0),
-        deblock: Default::default(),
-      };
+      let mut fs = FrameState::new(&self.fi);
 
       let data = encode_frame(&mut self.seq, &mut self.fi, &mut fs);
 
@@ -321,23 +303,7 @@ impl Context {
         self.idx = self.idx + 1;
 
         if let Some(frame) = f {
-          let mut fs = FrameState {
-            input: frame,
-            input_hres: Plane::new(
-              self.fi.padded_w/2, self.fi.padded_h/2,
-              1, 1,
-              (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2
-            ),
-            input_qres: Plane::new(
-              self.fi.padded_w/4, self.fi.padded_h/4,
-              2, 2,
-              (MAX_SB_SIZE + SUBPEL_FILTER_SIZE)/4, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4
-            ),
-            rec: Frame::new(self.fi.padded_w, self.fi.padded_h),
-            qc: Default::default(),
-            cdfs: CDFContext::new(0),
-            deblock: Default::default(),
-          };
+          let mut fs = FrameState::new_with_frame(&self.fi, frame);
 
           let data = encode_frame(&mut self.seq, &mut self.fi, &mut fs);
           self.packet_data.extend(data);

--- a/src/context.rs
+++ b/src/context.rs
@@ -52,7 +52,7 @@ pub const MAX_MIB_SIZE: usize = (1 << MAX_MIB_SIZE_LOG2);
 pub const MAX_MIB_MASK: usize = (MAX_MIB_SIZE - 1);
 
 const MAX_SB_SIZE_LOG2: usize = 6;
-const MAX_SB_SIZE: usize = (1 << MAX_SB_SIZE_LOG2);
+pub const MAX_SB_SIZE: usize = (1 << MAX_SB_SIZE_LOG2);
 const MAX_SB_SQUARE: usize = (MAX_SB_SIZE * MAX_SB_SIZE);
 
 pub const MAX_TX_SIZE: usize = 32;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -28,8 +28,6 @@ use std::io;
 use std::io::*;
 use std::rc::Rc;
 
-pub const MAX_SB_SIZE: usize = 128;
-
 extern {
     pub fn av1_rtcd();
     pub fn aom_dsp_rtcd();
@@ -340,8 +338,12 @@ pub struct FrameState {
 
 impl FrameState {
     pub fn new(fi: &FrameInvariants) -> FrameState {
+        FrameState::new_with_frame(fi, Arc::new(Frame::new(fi.padded_w, fi.padded_h)))
+    }
+
+    pub fn new_with_frame(fi: &FrameInvariants, frame: Arc<Frame>) -> FrameState {
         FrameState {
-            input: Arc::new(Frame::new(fi.padded_w, fi.padded_h)),
+            input: frame,
             input_hres: Plane::new(
                 fi.padded_w/2, fi.padded_h/2,
                 1, 1,
@@ -530,27 +532,6 @@ impl FrameInvariants {
             use_tx_domain_distortion: use_tx_domain_distortion,
         }
     }
-
-    pub fn new_frame_state(&self) -> FrameState {
-        FrameState {
-            input: Arc::new(Frame::new(self.padded_w, self.padded_h)),
-            input_hres: Plane::new(
-                self.padded_w/2, self.padded_h/2,
-                1, 1,
-                (MAX_SB_SIZE + SUBPEL_FILTER_SIZE ) / 2, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2
-            ),
-            input_qres: Plane::new(
-                self.padded_w/4, self.padded_h/4,
-                2, 2,
-                (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4
-            ),
-            rec: Frame::new(self.padded_w, self.padded_h),
-            qc: Default::default(),
-            cdfs: CDFContext::new(0),
-            deblock: Default::default(),
-        }
-    }
-
 }
 
 impl fmt::Display for FrameInvariants{

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -28,6 +28,8 @@ use std::io;
 use std::io::*;
 use std::rc::Rc;
 
+pub const MAX_SB_SIZE: usize = 128;
+
 extern {
     pub fn av1_rtcd();
     pub fn aom_dsp_rtcd();
@@ -42,9 +44,21 @@ impl Frame {
     pub fn new(width: usize, height:usize) -> Frame {
         Frame {
             planes: [
-                Plane::new(width, height, 0, 0, 128+8, 128+8),
-                Plane::new(width/2, height/2, 1, 1, 64+8, 64+8),
-                Plane::new(width/2, height/2, 1, 1, 64+8, 64+8)
+                Plane::new(
+                    width, height,
+                    0, 0,
+                    MAX_SB_SIZE + SUBPEL_FILTER_SIZE, MAX_SB_SIZE + SUBPEL_FILTER_SIZE
+                ),
+                Plane::new(
+                    width/2, height/2,
+                    1, 1,
+                    MAX_SB_SIZE/2 + SUBPEL_FILTER_SIZE, MAX_SB_SIZE/2 + SUBPEL_FILTER_SIZE
+                ),
+                Plane::new(
+                    width/2, height/2,
+                    1, 1,
+                    MAX_SB_SIZE/2 + SUBPEL_FILTER_SIZE, MAX_SB_SIZE/2 + SUBPEL_FILTER_SIZE
+                )
             ]
         }
     }
@@ -328,8 +342,16 @@ impl FrameState {
     pub fn new(fi: &FrameInvariants) -> FrameState {
         FrameState {
             input: Arc::new(Frame::new(fi.padded_w, fi.padded_h)),
-            input_hres: Plane::new(fi.padded_w/2, fi.padded_h/2, 1, 1, (128+8)/2, (128+8)/2),
-            input_qres: Plane::new(fi.padded_w/4, fi.padded_h/4, 2, 2, (128+8)/4, (128+8)/4),
+            input_hres: Plane::new(
+                fi.padded_w/2, fi.padded_h/2,
+                1, 1,
+                (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2
+            ),
+            input_qres: Plane::new(
+                fi.padded_w/4, fi.padded_h/4,
+                2, 2,
+                (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4
+            ),
             rec: Frame::new(fi.padded_w, fi.padded_h),
             qc: Default::default(),
             cdfs: CDFContext::new(0),
@@ -512,8 +534,16 @@ impl FrameInvariants {
     pub fn new_frame_state(&self) -> FrameState {
         FrameState {
             input: Arc::new(Frame::new(self.padded_w, self.padded_h)),
-            input_hres: Plane::new(self.padded_w/2, self.padded_h/2, 1, 1, (128+8)/2, (128+8)/2),
-            input_qres: Plane::new(self.padded_w/4, self.padded_h/4, 2, 2, (128+8)/4, (128+8)/4),
+            input_hres: Plane::new(
+                self.padded_w/2, self.padded_h/2,
+                1, 1,
+                (MAX_SB_SIZE + SUBPEL_FILTER_SIZE ) / 2, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2
+            ),
+            input_qres: Plane::new(
+                self.padded_w/4, self.padded_h/4,
+                2, 2,
+                (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4
+            ),
             rec: Frame::new(self.padded_w, self.padded_h),
             qc: Default::default(),
             cdfs: CDFContext::new(0),

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2203,7 +2203,8 @@ fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameStat
             for i in 0..INTER_REFS_PER_FRAME {
                 let r = fi.ref_frames[i] as usize;
                 if pmvs[r].is_none() {
-                    pmvs[r] = estimate_motion_ss4(fi, fs, r, &bo);
+                    assert!(!sequence.use_128x128_superblock);
+                    pmvs[r] = estimate_motion_ss4(fi, fs, BlockSize::BLOCK_64X64, r, &bo);
                 }
             }
             frame_pmvs.push(pmvs);
@@ -2251,10 +2252,19 @@ fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameStat
                             None
                         };
 
-                        pmvs[1][r] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(0, 0), &[Some(pmv), pmv_w, pmv_n]);
-                        pmvs[2][r] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(8, 0), &[Some(pmv), pmv_e, pmv_n]);
-                        pmvs[3][r] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(0, 8), &[Some(pmv), pmv_w, pmv_s]);
-                        pmvs[4][r] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(8, 8), &[Some(pmv), pmv_e, pmv_s]);
+                        assert!(!sequence.use_128x128_superblock);
+                        pmvs[1][r] = estimate_motion_ss2(
+                            fi, fs, BlockSize::BLOCK_32X32, r, &sbo.block_offset(0, 0), &[Some(pmv), pmv_w, pmv_n]
+                        );
+                        pmvs[2][r] = estimate_motion_ss2(
+                            fi, fs, BlockSize::BLOCK_32X32, r, &sbo.block_offset(8, 0), &[Some(pmv), pmv_e, pmv_n]
+                        );
+                        pmvs[3][r] = estimate_motion_ss2(
+                            fi, fs, BlockSize::BLOCK_32X32, r, &sbo.block_offset(0, 8), &[Some(pmv), pmv_w, pmv_s]
+                        );
+                        pmvs[4][r] = estimate_motion_ss2(
+                            fi, fs, BlockSize::BLOCK_32X32, r, &sbo.block_offset(8, 8), &[Some(pmv), pmv_e, pmv_s]
+                        );
                     }
                 }
             }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -20,6 +20,7 @@ use rdo::*;
 use std::fmt;
 use transform::*;
 use util::*;
+use me::*;
 
 use bitstream_io::{BitWriter, BigEndian, LittleEndian};
 use std;
@@ -1805,7 +1806,8 @@ pub fn write_tx_tree(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Context
 
 fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
                              cw: &mut ContextWriter, w_pre_cdef: &mut dyn Writer, w_post_cdef: &mut dyn Writer,
-                             bsize: BlockSize, bo: &BlockOffset, pmv: &MotionVector) -> f64 {
+                             bsize: BlockSize, bo: &BlockOffset, pmvs: &[Option<MotionVector>; REF_FRAMES]
+) -> f64 {
     let mut rd_cost = std::f64::MAX;
 
     if bo.x >= cw.bc.cols || bo.y >= cw.bc.rows {
@@ -1855,7 +1857,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
             cw.write_partition(w, bo, partition, bsize);
             cost = (w.tell_frac() - tell) as f64 * get_lambda(fi, seq.bit_depth)/ ((1 << OD_BITRES) as f64);
         }
-        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, bsize, bo, pmv).part_modes[0].clone();
+        let mode_decision = rdo_mode_decision(seq, fi, fs, cw, bsize, bo, pmvs).part_modes[0].clone();
         let (mode_luma, mode_chroma) = (mode_decision.pred_mode_luma, mode_decision.pred_mode_chroma);
         let cfl = mode_decision.pred_cfl_params;
         {
@@ -1920,7 +1922,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
                     w_post_cdef,
                     subsize,
                     offset,
-                    &best_decision.mvs[0]
+                    pmvs//&best_decision.mvs[0]
                 )
             }).sum::<f64>();
 
@@ -1976,7 +1978,9 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
 
 fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
             cw: &mut ContextWriter, w_pre_cdef: &mut dyn Writer, w_post_cdef: &mut dyn Writer,
-            bsize: BlockSize, bo: &BlockOffset, block_output: &Option<RDOOutput>) {
+            bsize: BlockSize, bo: &BlockOffset, block_output: &Option<RDOOutput>,
+            pmvs: &[Option<MotionVector>; REF_FRAMES]
+) {
 
     if bo.x >= cw.bc.cols || bo.y >= cw.bc.rows {
         return;
@@ -2001,7 +2005,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
         partition = PartitionType::PARTITION_SPLIT;
     } else if bsize > fi.min_partition_size {
         // Blocks of sizes within the supported range are subjected to a partitioning decision
-        rdo_output = rdo_partition_decision(seq, fi, fs, cw, bsize, bo, &rdo_output);
+        rdo_output = rdo_partition_decision(seq, fi, fs, cw, bsize, bo, &rdo_output, pmvs);
         partition = rdo_output.part_type;
     } else {
         // Blocks of sizes below the supported range are encoded directly
@@ -2014,7 +2018,6 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
 
     let hbs = bs >> 1; // Half the block size in blocks
     let subsize = bsize.subsize(partition);
-    let pmv =  MotionVector { row: 0, col: 0 };
 
     if bsize >= BlockSize::BLOCK_8X8 {
         let w: &mut dyn Writer = if cw.bc.cdef_coded {w_post_cdef} else {w_pre_cdef};
@@ -2028,7 +2031,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
                     rdo_output.part_modes[0].clone()
                 } else {
                     // Make a prediction mode decision for blocks encoded with no rdo_partition_decision call (e.g. edges)
-                    rdo_mode_decision(seq, fi, fs, cw, bsize, bo, &pmv).part_modes[0].clone()
+                    rdo_mode_decision(seq, fi, fs, cw, bsize, bo, pmvs).part_modes[0].clone()
                 };
 
             let mut mode_luma = part_decision.pred_mode_luma;
@@ -2109,7 +2112,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
                         &Some(RDOOutput {
                             rd_cost: mode.rd_cost,
                             part_type: PartitionType::PARTITION_NONE,
-                            part_modes: vec![mode] }));
+                            part_modes: vec![mode] }), pmvs);
                 }
             }
             else {
@@ -2129,7 +2132,8 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
                             w_post_cdef,
                             subsize,
                             offset,
-                            &None
+                            &None,
+                            pmvs
                         );
                     });
             }
@@ -2172,17 +2176,25 @@ fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameStat
             cw.bc.cdef_coded = false;
             cw.bc.code_deltas = fi.delta_q_present;
 
+            // Do subsampled ME
+            let mut pmvs: [Option<MotionVector>; REF_FRAMES] = [None; REF_FRAMES];
+            for i in 0..INTER_REFS_PER_FRAME {
+                let r = fi.ref_frames[i] as usize;
+                if pmvs[r].is_none() {
+                    pmvs[r] = estimate_motion_ss4(fi, fs, r, &bo);
+                }
+            }
+
             // Encode SuperBlock
             if fi.config.speed == 0 {
-                let pmv = MotionVector { row: 0, col: 0 };
                 encode_partition_bottomup(sequence, fi, fs, &mut cw,
                                           &mut w_pre_cdef, &mut w_post_cdef,
-                                          BlockSize::BLOCK_64X64, &bo, &pmv);
+                                          BlockSize::BLOCK_64X64, &bo, &pmvs);
             }
             else {
                 encode_partition_topdown(sequence, fi, fs, &mut cw,
                                          &mut w_pre_cdef, &mut w_post_cdef,
-                                         BlockSize::BLOCK_64X64, &bo, &None);
+                                         BlockSize::BLOCK_64X64, &bo, &None, &pmvs);
             }
 
             // CDEF has to be decisded before loop restoration, but coded after

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1819,7 +1819,7 @@ pub fn write_tx_tree(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Context
 
 fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
                              cw: &mut ContextWriter, w_pre_cdef: &mut dyn Writer, w_post_cdef: &mut dyn Writer,
-                             bsize: BlockSize, bo: &BlockOffset, pmvs: &[Option<MotionVector>; 5*REF_FRAMES]
+                             bsize: BlockSize, bo: &BlockOffset, pmvs: &[[Option<MotionVector>; REF_FRAMES]; 5]
 ) -> f64 {
     let mut rd_cost = std::f64::MAX;
 
@@ -1876,7 +1876,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
         } else {
             ((bo.x & 32) >> 5) + ((bo.y & 32) >> 4) + 1
         };
-        let spmvs = &pmvs[REF_FRAMES*pmv_idx..REF_FRAMES*(pmv_idx+1)];
+        let spmvs = &pmvs[pmv_idx];
 
         let mode_decision = rdo_mode_decision(seq, fi, fs, cw, bsize, bo, spmvs).part_modes[0].clone();
         let (mode_luma, mode_chroma) = (mode_decision.pred_mode_luma, mode_decision.pred_mode_chroma);
@@ -2000,7 +2000,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
 fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
             cw: &mut ContextWriter, w_pre_cdef: &mut dyn Writer, w_post_cdef: &mut dyn Writer,
             bsize: BlockSize, bo: &BlockOffset, block_output: &Option<RDOOutput>,
-            pmvs: &[Option<MotionVector>; 5*REF_FRAMES]
+            pmvs: &[[Option<MotionVector>; REF_FRAMES]; 5]
 ) {
 
     if bo.x >= cw.bc.cols || bo.y >= cw.bc.rows {
@@ -2056,7 +2056,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
                     } else {
                         ((bo.x & 32) >> 5) + ((bo.y & 32) >> 4) + 1
                     };
-                    let spmvs = &pmvs[REF_FRAMES*pmv_idx..REF_FRAMES*(pmv_idx+1)];
+                    let spmvs = &pmvs[pmv_idx];
 
                     // Make a prediction mode decision for blocks encoded with no rdo_partition_decision call (e.g. edges)
                     rdo_mode_decision(seq, fi, fs, cw, bsize, bo, spmvs).part_modes[0].clone()
@@ -2224,12 +2224,12 @@ fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameStat
             cw.bc.code_deltas = fi.delta_q_present;
 
             // Do subsampled ME
-            let mut pmvs: [Option<MotionVector>; 5*REF_FRAMES] = [None; 5*REF_FRAMES];
+            let mut pmvs: [[Option<MotionVector>; REF_FRAMES]; 5] = [[None; REF_FRAMES]; 5];
             for i in 0..INTER_REFS_PER_FRAME {
                 let r = fi.ref_frames[i] as usize;
-                if pmvs[r].is_none() {
-                    pmvs[r] = frame_pmvs[sby * fi.sb_width + sbx][r];
-                    if let Some(pmv) = pmvs[r] {
+                if pmvs[0][r].is_none() {
+                    pmvs[0][r] = frame_pmvs[sby * fi.sb_width + sbx][r];
+                    if let Some(pmv) = pmvs[0][r] {
                         let pmv_w = if sbx > 0 {
                             frame_pmvs[sby * fi.sb_width + sbx - 1][r]
                         } else {
@@ -2251,10 +2251,10 @@ fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameStat
                             None
                         };
 
-                        pmvs[r + 1*REF_FRAMES] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(0, 0), &[Some(pmv), pmv_w, pmv_n]);
-                        pmvs[r + 2*REF_FRAMES] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(8, 0), &[Some(pmv), pmv_e, pmv_n]);
-                        pmvs[r + 3*REF_FRAMES] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(0, 8), &[Some(pmv), pmv_w, pmv_s]);
-                        pmvs[r + 4*REF_FRAMES] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(8, 8), &[Some(pmv), pmv_e, pmv_s]);
+                        pmvs[1][r] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(0, 0), &[Some(pmv), pmv_w, pmv_n]);
+                        pmvs[2][r] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(8, 0), &[Some(pmv), pmv_e, pmv_n]);
+                        pmvs[3][r] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(0, 8), &[Some(pmv), pmv_w, pmv_s]);
+                        pmvs[4][r] = estimate_motion_ss2(fi, fs, r, &sbo.block_offset(8, 8), &[Some(pmv), pmv_e, pmv_s]);
                     }
                 }
             }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -38,6 +38,8 @@ pub struct Frame {
     pub planes: [Plane; 3]
 }
 
+const FRAME_MARGIN: usize = 16 + SUBPEL_FILTER_SIZE;
+
 impl Frame {
     pub fn new(width: usize, height:usize) -> Frame {
         Frame {
@@ -45,17 +47,17 @@ impl Frame {
                 Plane::new(
                     width, height,
                     0, 0,
-                    MAX_SB_SIZE + SUBPEL_FILTER_SIZE, MAX_SB_SIZE + SUBPEL_FILTER_SIZE
+                    MAX_SB_SIZE + FRAME_MARGIN, MAX_SB_SIZE + FRAME_MARGIN
                 ),
                 Plane::new(
                     width/2, height/2,
                     1, 1,
-                    MAX_SB_SIZE/2 + SUBPEL_FILTER_SIZE, MAX_SB_SIZE/2 + SUBPEL_FILTER_SIZE
+                    MAX_SB_SIZE/2 + FRAME_MARGIN, MAX_SB_SIZE/2 + FRAME_MARGIN
                 ),
                 Plane::new(
                     width/2, height/2,
                     1, 1,
-                    MAX_SB_SIZE/2 + SUBPEL_FILTER_SIZE, MAX_SB_SIZE/2 + SUBPEL_FILTER_SIZE
+                    MAX_SB_SIZE/2 + FRAME_MARGIN, MAX_SB_SIZE/2 + FRAME_MARGIN
                 )
             ]
         }
@@ -347,12 +349,12 @@ impl FrameState {
             input_hres: Plane::new(
                 fi.padded_w/2, fi.padded_h/2,
                 1, 1,
-                (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 2
+                (MAX_SB_SIZE + FRAME_MARGIN) / 2, (MAX_SB_SIZE + FRAME_MARGIN) / 2
             ),
             input_qres: Plane::new(
                 fi.padded_w/4, fi.padded_h/4,
                 2, 2,
-                (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4, (MAX_SB_SIZE + SUBPEL_FILTER_SIZE) / 4
+                (MAX_SB_SIZE + FRAME_MARGIN) / 4, (MAX_SB_SIZE + FRAME_MARGIN) / 4
             ),
             rec: Frame::new(fi.padded_w, fi.padded_h),
             qc: Default::default(),

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -69,6 +69,8 @@ impl Frame {
 pub struct ReferenceFrame {
   pub order_hint: u32,
   pub frame: Frame,
+  pub input_hres: Plane,
+  pub input_qres: Plane,
   pub cdfs: CDFContext
 }
 
@@ -2297,7 +2299,15 @@ pub fn encode_frame(sequence: &mut Sequence, fi: &mut FrameInvariants, fs: &mut 
 }
 
 pub fn update_rec_buffer(fi: &mut FrameInvariants, fs: FrameState) {
-  let rfs = Rc::new(ReferenceFrame { order_hint: fi.order_hint, frame: fs.rec, cdfs: fs.cdfs } );
+  let rfs = Rc::new(
+    ReferenceFrame {
+      order_hint: fi.order_hint,
+      frame: fs.rec,
+      input_hres: fs.input_hres,
+      input_qres: fs.input_qres,
+      cdfs: fs.cdfs
+    }
+  );
   for i in 0..(REF_FRAMES as usize) {
     if (fi.refresh_frame_flags & (1 << i)) != 0 {
       fi.rec_buffer.frames[i] = Some(Rc::clone(&rfs));

--- a/src/me.rs
+++ b/src/me.rs
@@ -35,6 +35,18 @@ pub fn get_sad(
 
   sum
 }
+
+fn get_mv_range(fi: &FrameInvariants, bo: &BlockOffset, blk_w: usize, blk_h: usize) -> (isize, isize, isize, isize) {
+  let border_w = 128 + blk_w as isize * 8;
+  let border_h = 128 + blk_h as isize * 8;
+  let mvx_min = -(bo.x as isize) * (8 * MI_SIZE) as isize - border_w;
+  let mvx_max = (fi.w_in_b - bo.x - blk_w / MI_SIZE) as isize * (8 * MI_SIZE) as isize + border_w;
+  let mvy_min = -(bo.y as isize) * (8 * MI_SIZE) as isize - border_h;
+  let mvy_max = (fi.h_in_b - bo.y - blk_h / MI_SIZE) as isize * (8 * MI_SIZE) as isize + border_h;
+
+  (mvx_min, mvx_max, mvy_min, mvy_max)
+}
+
 pub fn motion_estimation(
   fi: &FrameInvariants, fs: &FrameState, bsize: BlockSize,
   bo: &BlockOffset, ref_frame: usize, pmv: &MotionVector
@@ -48,12 +60,7 @@ pub fn motion_estimation(
       let range = 16;
       let blk_w = bsize.width();
       let blk_h = bsize.height();
-      let border_w = 128 + blk_w as isize * 8;
-      let border_h = 128 + blk_h as isize * 8;
-      let mvx_min = -(bo.x as isize) * (8 * MI_SIZE) as isize - border_w;
-      let mvx_max = (fi.w_in_b - bo.x - blk_w / MI_SIZE) as isize * (8 * MI_SIZE) as isize + border_w;
-      let mvy_min = -(bo.y as isize) * (8 * MI_SIZE) as isize - border_h;
-      let mvy_max = (fi.h_in_b - bo.y - blk_h / MI_SIZE) as isize * (8 * MI_SIZE) as isize + border_h;
+      let (mvx_min, mvx_max, mvy_min, mvy_max) = get_mv_range(fi, bo, blk_w, blk_h);
       let x_lo = po.x + ((-range + (pmv.col / 8) as isize).max(mvx_min / 8));
       let x_hi = po.x + ((range + (pmv.col / 8) as isize).min(mvx_max / 8));
       let y_lo = po.y + ((-range + (pmv.row / 8) as isize).max(mvy_min / 8));
@@ -158,12 +165,7 @@ pub fn estimate_motion_ss4(
     let range = 64 * fi.me_range_scale as isize;
     let blk_w = 64;
     let blk_h = 64;
-    let border_w = 128 + blk_w as isize * 8;
-    let border_h = 128 + blk_h as isize * 8;
-    let mvx_min = -(bo.x as isize) * (8 * MI_SIZE) as isize - border_w;
-    let mvx_max = (fi.w_in_b - bo.x - blk_w / MI_SIZE) as isize * (8 * MI_SIZE) as isize + border_w;
-    let mvy_min = -(bo.y as isize) * (8 * MI_SIZE) as isize - border_h;
-    let mvy_max = (fi.h_in_b - bo.y - blk_h / MI_SIZE) as isize * (8 * MI_SIZE) as isize + border_h;
+    let (mvx_min, mvx_max, mvy_min, mvy_max) = get_mv_range(fi, bo, blk_w, blk_h);
     let x_lo = po.x + (((-range).max(mvx_min / 8)) >> 2);
     let x_hi = po.x + (((range).min(mvx_max / 8)) >> 2);
     let y_lo = po.y + (((-range).max(mvy_min / 8)) >> 2);
@@ -194,12 +196,7 @@ pub fn estimate_motion_ss2(
     let range = 16;
     let blk_w = 32;
     let blk_h = 32;
-    let border_w = 128 + blk_w as isize * 8;
-    let border_h = 128 + blk_h as isize * 8;
-    let mvx_min = -(bo.x as isize) * (8 * MI_SIZE) as isize - border_w;
-    let mvx_max = (fi.w_in_b - bo.x - blk_w / MI_SIZE) as isize * (8 * MI_SIZE) as isize + border_w;
-    let mvy_min = -(bo.y as isize) * (8 * MI_SIZE) as isize - border_h;
-    let mvy_max = (fi.h_in_b - bo.y - blk_h / MI_SIZE) as isize * (8 * MI_SIZE) as isize + border_h;
+    let (mvx_min, mvx_max, mvy_min, mvy_max) = get_mv_range(fi, bo, blk_w, blk_h);
 
     let mut lowest_sad = 16 * 16 * 4096 as u32;
     let mut best_mv = MotionVector { row: 0, col: 0 };

--- a/src/me.rs
+++ b/src/me.rs
@@ -143,8 +143,8 @@ pub fn estimate_motion_ss4(
 ) -> Option<MotionVector> {
   if let Some(ref rec) = fi.rec_buffer.frames[ref_idx] {
     let po = PlaneOffset {
-      x: (bo.x as isize) << BLOCK_TO_PLANE_SHIFT >> 2,
-      y: (bo.y as isize) << BLOCK_TO_PLANE_SHIFT >> 2
+      x: (bo.x as isize).min(fi.w_in_b as isize - 64/4) << BLOCK_TO_PLANE_SHIFT >> 2,
+      y: (bo.y as isize).min(fi.h_in_b as isize - 64/4) << BLOCK_TO_PLANE_SHIFT >> 2
     };
     let range = 32 * fi.me_range_scale as isize;
     let blk_w = 64 >> 2;
@@ -191,8 +191,8 @@ pub fn estimate_motion_ss2(
 ) -> Option<MotionVector> {
   if let Some(ref rec) = fi.rec_buffer.frames[ref_idx] {
     let po = PlaneOffset {
-      x: (bo.x as isize) << BLOCK_TO_PLANE_SHIFT >> 1,
-      y: (bo.y as isize) << BLOCK_TO_PLANE_SHIFT >> 1
+      x: (bo.x as isize).min(fi.w_in_b as isize - 32/4) << BLOCK_TO_PLANE_SHIFT >> 1,
+      y: (bo.y as isize).min(fi.h_in_b as isize - 32/4) << BLOCK_TO_PLANE_SHIFT >> 1
     };
     let range = 16 * fi.me_range_scale as isize;
     let blk_w = 32 >> 1;

--- a/src/me.rs
+++ b/src/me.rs
@@ -194,7 +194,7 @@ pub fn estimate_motion_ss2(
       x: (bo.x as isize).min(fi.w_in_b as isize - 32/4) << BLOCK_TO_PLANE_SHIFT >> 1,
       y: (bo.y as isize).min(fi.h_in_b as isize - 32/4) << BLOCK_TO_PLANE_SHIFT >> 1
     };
-    let range = 16 * fi.me_range_scale as isize;
+    let range = 16;
     let blk_w = 32;
     let blk_h = 32;
     let border_w = 128 + blk_w as isize * 8;

--- a/src/me.rs
+++ b/src/me.rs
@@ -146,9 +146,9 @@ pub fn estimate_motion_ss4(
       x: (bo.x as isize).min(fi.w_in_b as isize - 64/4) << BLOCK_TO_PLANE_SHIFT >> 2,
       y: (bo.y as isize).min(fi.h_in_b as isize - 64/4) << BLOCK_TO_PLANE_SHIFT >> 2
     };
-    let range = 32 * fi.me_range_scale as isize;
-    let blk_w = 64 >> 2;
-    let blk_h = 64 >> 2;
+    let range = 64 * fi.me_range_scale as isize;
+    let blk_w = 64;
+    let blk_h = 64;
     let border_w = 128 + blk_w as isize * 8;
     let border_h = 128 + blk_h as isize * 8;
     let mvx_min = -(bo.x as isize) * (8 * MI_SIZE) as isize - border_w;
@@ -168,7 +168,7 @@ pub fn estimate_motion_ss4(
         let plane_org = fs.input_qres.slice(&po);
         let plane_ref = rec.input_qres.slice(&PlaneOffset { x, y });
 
-        let sad = get_sad(&plane_org, &plane_ref, blk_h, blk_w);
+        let sad = get_sad(&plane_org, &plane_ref, blk_h >> 2, blk_w >> 2);
 
         if sad < lowest_sad {
           lowest_sad = sad;
@@ -195,8 +195,8 @@ pub fn estimate_motion_ss2(
       y: (bo.y as isize).min(fi.h_in_b as isize - 32/4) << BLOCK_TO_PLANE_SHIFT >> 1
     };
     let range = 16 * fi.me_range_scale as isize;
-    let blk_w = 32 >> 1;
-    let blk_h = 32 >> 1;
+    let blk_w = 32;
+    let blk_h = 32;
     let border_w = 128 + blk_w as isize * 8;
     let border_h = 128 + blk_h as isize * 8;
     let mvx_min = -(bo.x as isize) * (8 * MI_SIZE) as isize - border_w;
@@ -216,7 +216,7 @@ pub fn estimate_motion_ss2(
         let plane_org = fs.input_hres.slice(&po);
         let plane_ref = rec.input_hres.slice(&PlaneOffset { x, y });
 
-        let sad = get_sad(&plane_org, &plane_ref, blk_h, blk_w);
+        let sad = get_sad(&plane_org, &plane_ref, blk_h >> 1, blk_w >> 1);
 
         if sad < lowest_sad {
           lowest_sad = sad;

--- a/src/me.rs
+++ b/src/me.rs
@@ -194,7 +194,7 @@ pub fn estimate_motion_ss2(
       x: (bo.x as isize) << BLOCK_TO_PLANE_SHIFT >> 1,
       y: (bo.y as isize) << BLOCK_TO_PLANE_SHIFT >> 1
     };
-    let range = 32;
+    let range = 16 * fi.me_range_scale as isize;
     let blk_w = 32 >> 1;
     let blk_h = 32 >> 1;
     let border_w = 128 + blk_w as isize * 8;

--- a/src/me.rs
+++ b/src/me.rs
@@ -45,7 +45,7 @@ pub fn motion_estimation(
         x: (bo.x as isize) << BLOCK_TO_PLANE_SHIFT,
         y: (bo.y as isize) << BLOCK_TO_PLANE_SHIFT
       };
-      let range = 32 * fi.me_range_scale as isize;
+      let range = 16;
       let blk_w = bsize.width();
       let blk_h = bsize.height();
       let border_w = 128 + blk_w as isize * 8;
@@ -135,6 +135,54 @@ pub fn motion_estimation(
     }
 
     None => MotionVector { row: 0, col: 0 }
+  }
+}
+
+pub fn estimate_motion_ss4(
+  fi: &FrameInvariants, fs: &FrameState, ref_idx: usize, bo: &BlockOffset
+) -> Option<MotionVector> {
+  if let Some(ref rec) = fi.rec_buffer.frames[ref_idx] {
+    let po = PlaneOffset {
+      x: (bo.x as isize) << BLOCK_TO_PLANE_SHIFT >> 2,
+      y: (bo.y as isize) << BLOCK_TO_PLANE_SHIFT >> 2
+    };
+    let range = 32 * fi.me_range_scale as isize;
+    let blk_w = 64 >> 2;
+    let blk_h = 64 >> 2;
+    let border_w = 128 + blk_w as isize * 8;
+    let border_h = 128 + blk_h as isize * 8;
+    let mvx_min = -(bo.x as isize) * (8 * MI_SIZE) as isize - border_w;
+    let mvx_max = (fi.w_in_b - bo.x - blk_w / MI_SIZE) as isize * (8 * MI_SIZE) as isize + border_w;
+    let mvy_min = -(bo.y as isize) * (8 * MI_SIZE) as isize - border_h;
+    let mvy_max = (fi.h_in_b - bo.y - blk_h / MI_SIZE) as isize * (8 * MI_SIZE) as isize + border_h;
+    let x_lo = po.x + (((-range).max(mvx_min / 8)) >> 2);
+    let x_hi = po.x + (((range).min(mvx_max / 8)) >> 2);
+    let y_lo = po.y + (((-range).max(mvy_min / 8)) >> 2);
+    let y_hi = po.y + (((range).min(mvy_max / 8)) >> 2);
+
+    let mut lowest_sad = 16 * 16 * 4096 as u32;
+    let mut best_mv = MotionVector { row: 0, col: 0 };
+
+    for y in y_lo..y_hi {
+      for x in x_lo..x_hi {
+        let plane_org = fs.input_qres.slice(&po);
+        let plane_ref = rec.input_qres.slice(&PlaneOffset { x, y });
+
+        let sad = get_sad(&plane_org, &plane_ref, blk_h, blk_w);
+
+        if sad < lowest_sad {
+          lowest_sad = sad;
+          best_mv = MotionVector {
+            row: 32 * (y as i16 - po.y as i16),
+            col: 32 * (x as i16 - po.x as i16)
+          }
+        }
+      }
+    }
+
+    Some(best_mv)
+  } else {
+    None
   }
 }
 

--- a/src/me.rs
+++ b/src/me.rs
@@ -163,11 +163,11 @@ fn adjust_bo(bo: &BlockOffset, fi: &FrameInvariants, blk_w: usize, blk_h: usize)
 }
 
 pub fn estimate_motion_ss4(
-  fi: &FrameInvariants, fs: &FrameState, ref_idx: usize, bo: &BlockOffset
+  fi: &FrameInvariants, fs: &FrameState, bsize: BlockSize, ref_idx: usize, bo: &BlockOffset
 ) -> Option<MotionVector> {
   if let Some(ref rec) = fi.rec_buffer.frames[ref_idx] {
-    let blk_w = 64;
-    let blk_h = 64;
+    let blk_w = bsize.width();
+    let blk_h = bsize.height();
     let bo_adj = adjust_bo(bo, fi, blk_w, blk_h);
     let po = PlaneOffset {
       x: (bo_adj.x as isize) << BLOCK_TO_PLANE_SHIFT >> 2,
@@ -180,7 +180,7 @@ pub fn estimate_motion_ss4(
     let y_lo = po.y + (((-range).max(mvy_min / 8)) >> 2);
     let y_hi = po.y + (((range).min(mvy_max / 8)) >> 2);
 
-    let mut lowest_sad = 16 * 16 * 4096 as u32;
+    let mut lowest_sad = ((blk_w >> 2) * (blk_h >> 2) * 4096) as u32;
     let mut best_mv = MotionVector { row: 0, col: 0 };
 
     full_search(
@@ -195,11 +195,11 @@ pub fn estimate_motion_ss4(
 }
 
 pub fn estimate_motion_ss2(
-  fi: &FrameInvariants, fs: &FrameState, ref_idx: usize, bo: &BlockOffset, pmvs: &[Option<MotionVector>; 3]
+  fi: &FrameInvariants, fs: &FrameState, bsize: BlockSize, ref_idx: usize, bo: &BlockOffset, pmvs: &[Option<MotionVector>; 3]
 ) -> Option<MotionVector> {
   if let Some(ref rec) = fi.rec_buffer.frames[ref_idx] {
-    let blk_w = 32;
-    let blk_h = 32;
+    let blk_w = bsize.width();
+    let blk_h = bsize.height();
     let bo_adj = adjust_bo(bo, fi, blk_w, blk_h);
     let po = PlaneOffset {
       x: (bo_adj.x as isize) << BLOCK_TO_PLANE_SHIFT >> 1,
@@ -208,7 +208,7 @@ pub fn estimate_motion_ss2(
     let range = 16;
     let (mvx_min, mvx_max, mvy_min, mvy_max) = get_mv_range(fi, &bo_adj, blk_w, blk_h);
 
-    let mut lowest_sad = 16 * 16 * 4096 as u32;
+    let mut lowest_sad = ((blk_w >> 1) * (blk_h >> 1) * 4096) as u32;
     let mut best_mv = MotionVector { row: 0, col: 0 };
 
     for omv in pmvs.iter() {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -689,7 +689,9 @@ pub enum MvSubpelPrecision {
   MV_SUBPEL_HIGH_PRECISION
 }
 
-const SUBPEL_FILTERS: [[[i32; 8]; 16]; 6] = [
+pub const SUBPEL_FILTER_SIZE: usize = 8;
+
+const SUBPEL_FILTERS: [[[i32; SUBPEL_FILTER_SIZE]; 16]; 6] = [
   [
     [0, 0, 0, 128, 0, 0, 0, 0],
     [0, 2, -6, 126, 8, -2, 0, 0],

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -218,6 +218,29 @@ impl Plane {
       }
     }
   }
+
+  pub fn downsample_from(&mut self, src: &Plane) {
+    let width = self.cfg.width;
+    let height = self.cfg.height;
+
+    assert!(width * 2 == src.cfg.width);
+    assert!(height * 2 == src.cfg.height);
+
+    for row in 0..height {
+      let mut dst_slice = self.mut_slice(&PlaneOffset{ x: 0, y: row as isize });
+      let mut dst = dst_slice.as_mut_slice();
+
+      for col in 0..width {
+        let mut sum = 0;
+        sum = sum + src.p(2*col, 2*row);
+        sum = sum + src.p(2*col+1, 2*row);
+        sum = sum + src.p(2*col, 2*row+1);
+        sum = sum + src.p(2*col+1, 2*row+1);
+        let avg = (sum + 2) >> 2;
+        dst[col] = avg;
+      }
+    }
+  }
 }
 
 #[derive(Clone, Copy)]

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -796,7 +796,7 @@ pub fn rdo_tx_type_decision(
 pub fn rdo_partition_decision(
   seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
   cw: &mut ContextWriter, bsize: BlockSize, bo: &BlockOffset,
-  cached_block: &RDOOutput, pmvs: &[Option<MotionVector>; 5*REF_FRAMES]
+  cached_block: &RDOOutput, pmvs: &[[Option<MotionVector>; REF_FRAMES]; 5]
 ) -> RDOOutput {
   let max_rd = std::f64::MAX;
 
@@ -822,7 +822,7 @@ pub fn rdo_partition_decision(
         }
 
         let pmv_idx = ((bo.x & 32) >> 5) + ((bo.y & 32) >> 4) + 1;
-        let spmvs = &pmvs[REF_FRAMES*pmv_idx..REF_FRAMES*(pmv_idx+1)];
+        let spmvs = &pmvs[pmv_idx];
 
         let mode_decision = cached_block
           .part_modes
@@ -863,7 +863,7 @@ pub fn rdo_partition_decision(
             .iter().zip(pmv_idxs)
             .map(|(&offset, pmv_idx)| {
               rdo_mode_decision(seq, fi, fs, cw, subsize, &offset,
-                &pmvs[REF_FRAMES*pmv_idx..REF_FRAMES*(pmv_idx+1)])
+                &pmvs[pmv_idx])
                 .part_modes[0]
                 .clone()
             }).collect::<Vec<_>>()


### PR DESCRIPTION
Motion estimation is initially done on 64x64 blocks which are downsampled to 16x16. A refinement step is then done on 32x32 blocks which are downsampled to 16x16.
Hierarchical motion estimation provides better run times when using large search ranges