### PR TITLE
Adds --low_latency and --keyint command line options

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -31,8 +31,8 @@ impl Ratio {
 
 #[derive(Copy, Clone, Debug)]
 pub struct EncoderConfig {
-  pub compound: bool,
   pub key_frame_interval: u64,
+  pub low_latency: bool,
   pub quantizer: usize,
   pub speed: usize,
   pub tune: Tune
@@ -40,7 +40,7 @@ pub struct EncoderConfig {
 
 impl Default for EncoderConfig {
   fn default() -> Self {
-    EncoderConfig { compound: false, key_frame_interval: 30, quantizer: 100, speed: 0, tune: Tune::Psnr,  }
+    EncoderConfig { key_frame_interval: 30, low_latency: false, quantizer: 100, speed: 0, tune: Tune::Psnr  }
   }
 }
 
@@ -65,7 +65,7 @@ impl Config {
   pub fn parse(&mut self, key: &str, value: &str) -> Result<(), EncoderStatus> {
     use self::EncoderStatus::*;
     match key {
-      "compound" => self.enc.compound = value.parse().map_err(|_e| ParseError)?,
+      "low_latency" => self.enc.low_latency = value.parse().map_err(|_e| ParseError)?,
       "key_frame_interval" => self.enc.key_frame_interval = value.parse().map_err(|_e| ParseError)?,
       "quantizer" => self.enc.quantizer = value.parse().map_err(|_e| ParseError)?,
       "speed" => self.enc.speed = value.parse().map_err(|_e| ParseError)?,
@@ -180,7 +180,7 @@ impl Context {
   pub fn frame_properties(&mut self, idx: u64) -> bool {
     let key_frame_interval: u64 = self.fi.config.key_frame_interval;
 
-    let reorder = self.fi.config.compound;
+    let reorder = self.fi.config.low_latency;
     let multiref = reorder || self.fi.config.speed <= 2;
 
     let pyramid_depth = if reorder { 2 } else { 0 };

--- a/src/api.rs
+++ b/src/api.rs
@@ -31,6 +31,8 @@ impl Ratio {
 
 #[derive(Copy, Clone, Debug)]
 pub struct EncoderConfig {
+  pub compound: bool,
+  pub key_frame_interval: u64,
   pub quantizer: usize,
   pub speed: usize,
   pub tune: Tune
@@ -38,7 +40,7 @@ pub struct EncoderConfig {
 
 impl Default for EncoderConfig {
   fn default() -> Self {
-    EncoderConfig { quantizer: 100, speed: 0, tune: Tune::Psnr }
+    EncoderConfig { compound: false, key_frame_interval: 30, quantizer: 100, speed: 0, tune: Tune::Psnr,  }
   }
 }
 
@@ -63,10 +65,12 @@ impl Config {
   pub fn parse(&mut self, key: &str, value: &str) -> Result<(), EncoderStatus> {
     use self::EncoderStatus::*;
     match key {
-        "quantizer" => self.enc.quantizer = value.parse().map_err(|_e| ParseError)?,
-        "speed" => self.enc.speed = value.parse().map_err(|_e| ParseError)?,
-        "tune" => self.enc.tune = value.parse().map_err(|_e| ParseError)?,
-        _ => return Err(InvalidKey)
+      "compound" => self.enc.compound = value.parse().map_err(|_e| ParseError)?,
+      "key_frame_interval" => self.enc.key_frame_interval = value.parse().map_err(|_e| ParseError)?,
+      "quantizer" => self.enc.quantizer = value.parse().map_err(|_e| ParseError)?,
+      "speed" => self.enc.speed = value.parse().map_err(|_e| ParseError)?,
+      "tune" => self.enc.tune = value.parse().map_err(|_e| ParseError)?,
+      _ => return Err(InvalidKey)
     }
 
     Ok(())
@@ -174,9 +178,9 @@ impl Context {
   }
 
   pub fn frame_properties(&mut self, idx: u64) -> bool {
-    let key_frame_interval: u64 = 30;
+    let key_frame_interval: u64 = self.fi.config.key_frame_interval;
 
-    let reorder = false;
+    let reorder = self.fi.config.compound;
     let multiref = reorder || self.fi.config.speed <= 2;
 
     let pyramid_depth = if reorder { 2 } else { 0 };

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -57,9 +57,9 @@ pub fn parse_cli() -> (EncoderIO, EncoderConfig, usize) {
         .takes_value(true)
         .default_value("30")
     ).arg(
-      Arg::with_name("COMPOUND")
-        .help("Compount mode. true or false")
-        .long("compound")
+      Arg::with_name("LOW_LATENCY")
+        .help("low latency mode. true or false")
+        .long("low_latency")
         .takes_value(true)
         .default_value("false")
     ).arg(
@@ -86,8 +86,8 @@ pub fn parse_cli() -> (EncoderIO, EncoderConfig, usize) {
   };
 
   let config = EncoderConfig {
-    compound: matches.value_of("COMPOUND").unwrap().parse().unwrap(),
     key_frame_interval: matches.value_of("KEYFRAME_INTERVAL").unwrap().parse().unwrap(),
+    low_latency: matches.value_of("LOW_LATENCY").unwrap().parse().unwrap(),
     quantizer: matches.value_of("QP").unwrap().parse().unwrap(),
     speed: matches.value_of("SPEED").unwrap().parse().unwrap(),
     tune: matches.value_of("TUNE").unwrap().parse().unwrap()

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -53,7 +53,8 @@ pub fn parse_cli() -> (EncoderIO, EncoderConfig, usize) {
     ).arg(
       Arg::with_name("KEYFRAME_INTERVAL")
         .help("Keyframe interval")
-        .long("keyframe_interval")
+        .short("I")
+        .long("keyint")
         .takes_value(true)
         .default_value("30")
     ).arg(

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -51,6 +51,18 @@ pub fn parse_cli() -> (EncoderIO, EncoderConfig, usize) {
         .takes_value(true)
         .default_value("3")
     ).arg(
+      Arg::with_name("KEYFRAME_INTERVAL")
+        .help("Keyframe interval")
+        .long("keyframe_interval")
+        .takes_value(true)
+        .default_value("30")
+    ).arg(
+      Arg::with_name("COMPOUND")
+        .help("Compount mode. true or false")
+        .long("compound")
+        .takes_value(true)
+        .default_value("false")
+    ).arg(
       Arg::with_name("TUNE")
         .help("Quality tuning (Will enforce partition sizes >= 8x8)")
         .long("tune")
@@ -74,6 +86,8 @@ pub fn parse_cli() -> (EncoderIO, EncoderConfig, usize) {
   };
 
   let config = EncoderConfig {
+    compound: matches.value_of("COMPOUND").unwrap().parse().unwrap(),
+    key_frame_interval: matches.value_of("KEYFRAME_INTERVAL").unwrap().parse().unwrap(),
     quantizer: matches.value_of("QP").unwrap().parse().unwrap(),
     speed: matches.value_of("SPEED").unwrap().parse().unwrap(),
     tune: matches.value_of("TUNE").unwrap().parse().unwrap()


### PR DESCRIPTION
* adds --compound as boolean to enable reordering
* adds --keyframe_interval which I think could be useful to specify other value than 30, say, for when encoding 60fps videos. 