### PR TITLE
Loop restoration filter beginnings

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -51,7 +51,9 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
   let fc = CDFContext::new(fi.base_q_idx);
   let bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
   let mut fs = FrameState::new(&fi);
-  let mut cw = ContextWriter::new(fc, bc);
+  // For now, restoration unit size is locked to superblock size. 
+  let rc = RestorationContext::new(fi.sb_width, fi.sb_height);
+  let mut cw = ContextWriter::new(fc, bc, rc);
 
   let tx_type = TxType::DCT_DCT;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -16,6 +16,7 @@ ignore = [
     # "src/ec.rs", # Clean
     "src/lib.rs", # Did not clean yet to avoid conflicts with open PRs.
     "src/cdef.rs", # Did not try to clean yet.
+    "src/lrf.rs", # Did not try to clean yet.
     # "src/deblock.rs", # Clean
     # "src/partition.rs", # Clean
     # "src/plane.rs", # Clean

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2105,7 +2105,9 @@ fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameStat
     };
 
     let bc = BlockContext::new(fi.w_in_b, fi.h_in_b);
-    let mut cw = ContextWriter::new(fc,  bc);
+    // For now, restoration unit size is locked to superblock size. 
+    let rc = RestorationContext::new(fi.sb_width, fi.sb_height);
+    let mut cw = ContextWriter::new(fc, bc, rc);
 
     for sby in 0..fi.sb_height {
         cw.bc.reset_left_contexts();
@@ -2138,7 +2140,7 @@ fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameStat
                 cw.bc.set_cdef(&sbo, cdef_index);
             }
 
-            // loop restoration must be decided last... but coded first.
+            // loop restoration must be decided last but coded before anything else
             if sequence.enable_restoration {
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod entropymode;
 pub mod token_cdfs;
 pub mod deblock;
 pub mod cdef;
+pub mod lrf;
 pub mod encoder;
 pub mod me;
 pub mod scan_order;

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -14,3 +14,11 @@ pub const RESTORE_SWITCHABLE: u8 = 1;
 pub const RESTORE_WIENER: u8 = 2;
 pub const RESTORE_SGRPROJ: u8 = 3;
 
+
+pub const WIENER_TAPS_MIN: [i8; 3] = [ -5, -23, -17 ];
+pub const WIENER_TAPS_MID: [i8; 3] = [ 3, -7, 15 ];
+pub const WIENER_TAPS_MAX: [i8; 3] = [ 10, 8, 46 ];
+
+pub const SGR_XQD_MIN: [i8; 2] = [ -96, -32 ];
+pub const SGR_XQD_MID: [i8; 2] = [ -32, 31 ];
+pub const SGR_XQD_MAX: [i8; 2] = [ 31, 95 ];

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+#![allow(safe_extern_statics)]
+
+pub const RESTORE_NONE: u8 = 0;
+pub const RESTORE_SWITCHABLE: u8 = 1;
+pub const RESTORE_WIENER: u8 = 2;
+pub const RESTORE_SGRPROJ: u8 = 3;
+


### PR DESCRIPTION
No functional change, but some added infrastructure and a Writer flow change in shared code menas I probably want to get this in sooner rather than later to avoid surprises.

Aside from adding RestorationUnits and a RestorationContext, coding the loop restoration parameters requires yet one more temporary Writer in the tile encode loop, as for each LRU the filter params have to be decided last, but written first.