### PR TITLE
Output correct units for prediction benchmarks

### DIFF
--- a/benches/comparative/predict.rs
+++ b/benches/comparative/predict.rs
@@ -70,20 +70,16 @@ fn predict_intra_4x4_aom(
   let mut rng = ChaChaRng::from_seed([0; 32]);
   let (mut block, above_context, left_context) = generate_block(&mut rng);
 
-  b.iter(|| {
-    for _ in 0..MAX_ITER {
-      unsafe {
-        predictor(
-          block.as_mut_ptr(),
-          BLOCK_SIZE.width() as libc::ptrdiff_t,
-          4,
-          4,
-          above_context.as_ptr(),
-          left_context.as_ptr(),
-          8
-        );
-      }
-    }
+  b.iter(|| unsafe {
+    predictor(
+      block.as_mut_ptr(),
+      BLOCK_SIZE.width() as libc::ptrdiff_t,
+      4,
+      4,
+      above_context.as_ptr(),
+      left_context.as_ptr(),
+      8
+    );
   })
 }
 
@@ -190,19 +186,15 @@ pub fn intra_cfl_4x4_aom(b: &mut Bencher) {
   let ac: Vec<i16> = (0..(32 * 32)).map(|_| rng.gen()).collect();
   let alpha = -1 as i16;
 
-  b.iter(|| {
-    for _ in 0..MAX_ITER {
-      unsafe {
-        cfl_predict_hbd_c(
-          ac.as_ptr(),
-          block.as_mut_ptr(),
-          BLOCK_SIZE.width() as libc::ptrdiff_t,
-          alpha as libc::c_int,
-          8,
-          4,
-          4
-        );
-      }
-    }
+  b.iter(|| unsafe {
+    cfl_predict_hbd_c(
+      ac.as_ptr(),
+      block.as_mut_ptr(),
+      BLOCK_SIZE.width() as libc::ptrdiff_t,
+      alpha as libc::c_int,
+      8,
+      4,
+      4
+    );
   })
 }

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -12,7 +12,6 @@ use rand::{ChaChaRng, Rng, SeedableRng};
 use rav1e::partition::BlockSize;
 use rav1e::predict::{Block4x4, Intra};
 
-pub const MAX_ITER: usize = 50000;
 pub const BLOCK_SIZE: BlockSize = BlockSize::BLOCK_32X32;
 
 pub fn generate_block(rng: &mut ChaChaRng) -> (Vec<u16>, Vec<u16>, Vec<u16>) {
@@ -54,29 +53,16 @@ pub fn intra_dc_4x4(b: &mut Bencher) {
   let (mut block, above, left) = generate_block(&mut ra);
 
   b.iter(|| {
-    for _ in 0..MAX_ITER {
-      Block4x4::pred_dc(
-        &mut block,
-        BLOCK_SIZE.width(),
-        &above[..4],
-        &left[..4]
-      );
-    }
+    Block4x4::pred_dc(&mut block, BLOCK_SIZE.width(), &above[..4], &left[..4]);
   })
 }
 
 pub fn intra_dc_128_4x4_u8(b: &mut Bencher) {
   let mut ra = ChaChaRng::from_seed([0; 32]);
-  let (mut block, above, left) = generate_block_u8(&mut ra);
+  let (mut block, _above, _left) = generate_block_u8(&mut ra);
 
   b.iter(|| {
-    for _ in 0..MAX_ITER {
-      Block4x4::pred_dc_128(
-        &mut block,
-        BLOCK_SIZE.width(),
-        8
-      );
-    }
+    Block4x4::pred_dc_128(&mut block, BLOCK_SIZE.width(), 8);
   })
 }
 
@@ -85,14 +71,12 @@ pub fn intra_dc_left_4x4(b: &mut Bencher) {
   let (mut block, above, left) = generate_block(&mut ra);
 
   b.iter(|| {
-    for _ in 0..MAX_ITER {
-      Block4x4::pred_dc_left(
-        &mut block,
-        BLOCK_SIZE.width(),
-        &above[..4],
-        &left[..4]
-      );
-    }
+    Block4x4::pred_dc_left(
+      &mut block,
+      BLOCK_SIZE.width(),
+      &above[..4],
+      &left[..4]
+    );
   })
 }
 
@@ -101,14 +85,12 @@ pub fn intra_dc_top_4x4(b: &mut Bencher) {
   let (mut block, above, left) = generate_block(&mut ra);
 
   b.iter(|| {
-    for _ in 0..MAX_ITER {
-      Block4x4::pred_dc_top(
-        &mut block,
-        BLOCK_SIZE.width(),
-        &above[..4],
-        &left[..4]
-      );
-    }
+    Block4x4::pred_dc_top(
+      &mut block,
+      BLOCK_SIZE.width(),
+      &above[..4],
+      &left[..4]
+    );
   })
 }
 
@@ -117,9 +99,7 @@ pub fn intra_h_4x4(b: &mut Bencher) {
   let (mut block, _above, left) = generate_block(&mut rng);
 
   b.iter(|| {
-    for _ in 0..MAX_ITER {
-      Block4x4::pred_h(&mut block, BLOCK_SIZE.width(), &left[..4]);
-    }
+    Block4x4::pred_h(&mut block, BLOCK_SIZE.width(), &left[..4]);
   })
 }
 
@@ -128,9 +108,7 @@ pub fn intra_v_4x4(b: &mut Bencher) {
   let (mut block, above, _left) = generate_block(&mut rng);
 
   b.iter(|| {
-    for _ in 0..MAX_ITER {
-      Block4x4::pred_v(&mut block, BLOCK_SIZE.width(), &above[..4]);
-    }
+    Block4x4::pred_v(&mut block, BLOCK_SIZE.width(), &above[..4]);
   })
 }
 
@@ -140,15 +118,13 @@ pub fn intra_paeth_4x4(b: &mut Bencher) {
   let above_left = unsafe { *above.as_ptr().offset(-1) };
 
   b.iter(|| {
-    for _ in 0..MAX_ITER {
-      Block4x4::pred_paeth(
-        &mut block,
-        BLOCK_SIZE.width(),
-        &above[..4],
-        &left[..4],
-        above_left
-      );
-    }
+    Block4x4::pred_paeth(
+      &mut block,
+      BLOCK_SIZE.width(),
+      &above[..4],
+      &left[..4],
+      above_left
+    );
   })
 }
 
@@ -157,14 +133,12 @@ pub fn intra_smooth_4x4(b: &mut Bencher) {
   let (mut block, above, left) = generate_block(&mut rng);
 
   b.iter(|| {
-    for _ in 0..MAX_ITER {
-      Block4x4::pred_smooth(
-        &mut block,
-        BLOCK_SIZE.width(),
-        &above[..4],
-        &left[..4]
-      );
-    }
+    Block4x4::pred_smooth(
+      &mut block,
+      BLOCK_SIZE.width(),
+      &above[..4],
+      &left[..4]
+    );
   })
 }
 
@@ -173,14 +147,12 @@ pub fn intra_smooth_h_4x4(b: &mut Bencher) {
   let (mut block, above, left) = generate_block(&mut rng);
 
   b.iter(|| {
-    for _ in 0..MAX_ITER {
-      Block4x4::pred_smooth_h(
-        &mut block,
-        BLOCK_SIZE.width(),
-        &above[..4],
-        &left[..4]
-      );
-    }
+    Block4x4::pred_smooth_h(
+      &mut block,
+      BLOCK_SIZE.width(),
+      &above[..4],
+      &left[..4]
+    );
   })
 }
 
@@ -189,14 +161,12 @@ pub fn intra_smooth_v_4x4(b: &mut Bencher) {
   let (mut block, above, left) = generate_block(&mut rng);
 
   b.iter(|| {
-    for _ in 0..MAX_ITER {
-      Block4x4::pred_smooth_v(
-        &mut block,
-        BLOCK_SIZE.width(),
-        &above[..4],
-        &left[..4]
-      );
-    }
+    Block4x4::pred_smooth_v(
+      &mut block,
+      BLOCK_SIZE.width(),
+      &above[..4],
+      &left[..4]
+    );
   })
 }
 
@@ -207,8 +177,6 @@ pub fn intra_cfl_4x4(b: &mut Bencher) {
   let alpha = -1 as i16;
 
   b.iter(|| {
-    for _ in 0..MAX_ITER {
-      Block4x4::pred_cfl(&mut block, BLOCK_SIZE.width(), &ac, alpha, 8);
-    }
+    Block4x4::pred_cfl(&mut block, BLOCK_SIZE.width(), &ac, alpha, 8);
   })
 }

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -34,18 +34,35 @@ pub fn generate_block_u8(rng: &mut ChaChaRng) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
   (block, above_context, left_context)
 }
 
+pub fn bench_pred_fn<F>(c: &mut Criterion, id: &str, f: F)
+where
+  F: FnMut(&mut Bencher) + 'static
+{
+  let b = Benchmark::new(id, f);
+  c.bench(
+    id,
+    if id.ends_with("_4x4_u8") {
+      b.throughput(Throughput::Bytes(16))
+    } else if id.ends_with("_4x4") {
+      b.throughput(Throughput::Bytes(32))
+    } else {
+      b
+    }
+  );
+}
+
 pub fn pred_bench(c: &mut Criterion) {
-  c.bench_function("intra_dc_4x4", |b| intra_dc_4x4(b));
-  c.bench_function("intra_dc_128_4x4_u8", |b| intra_dc_128_4x4_u8(b));
-  c.bench_function("intra_dc_left_4x4", |b| intra_dc_left_4x4(b));
-  c.bench_function("intra_dc_top_4x4", |b| intra_dc_top_4x4(b));
-  c.bench_function("intra_h_4x4", |b| intra_h_4x4(b));
-  c.bench_function("intra_v_4x4", |b| intra_v_4x4(b));
-  c.bench_function("intra_paeth_4x4", |b| intra_paeth_4x4(b));
-  c.bench_function("intra_smooth_4x4", |b| intra_smooth_4x4(b));
-  c.bench_function("intra_smooth_h_4x4", |b| intra_smooth_h_4x4(b));
-  c.bench_function("intra_smooth_v_4x4", |b| intra_smooth_v_4x4(b));
-  c.bench_function("intra_cfl_4x4", |b| intra_cfl_4x4(b));
+  bench_pred_fn(c, "intra_dc_4x4", intra_dc_4x4);
+  bench_pred_fn(c, "intra_dc_128_4x4_u8", intra_dc_128_4x4_u8);
+  bench_pred_fn(c, "intra_dc_left_4x4", intra_dc_left_4x4);
+  bench_pred_fn(c, "intra_dc_top_4x4", intra_dc_top_4x4);
+  bench_pred_fn(c, "intra_h_4x4", intra_h_4x4);
+  bench_pred_fn(c, "intra_v_4x4", intra_v_4x4);
+  bench_pred_fn(c, "intra_paeth_4x4", intra_paeth_4x4);
+  bench_pred_fn(c, "intra_smooth_4x4", intra_smooth_4x4);
+  bench_pred_fn(c, "intra_smooth_h_4x4", intra_smooth_h_4x4);
+  bench_pred_fn(c, "intra_smooth_v_4x4", intra_smooth_v_4x4);
+  bench_pred_fn(c, "intra_cfl_4x4", intra_cfl_4x4);
 }
 
 pub fn intra_dc_4x4(b: &mut Bencher) {


### PR DESCRIPTION
Remove the `MAX_ITER` loops that pre-date moving to criterion-rs, so that time units match singular calls. Annotate the number of output bytes to measure prediction throughput.