### PR TITLE
Transform domain distortion for RDO-based mode decision

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -92,7 +92,8 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
               false,
               8,
               ac,
-              0
+              0,
+              false
             );
           }
         }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -496,7 +496,7 @@ impl FrameInvariants {
             rec_buffer: ReferenceFramesSet::new(),
             base_q_idx: config.quantizer as u8,
             me_range_scale: 1,
-            use_tx_domain_distortion: true,
+            use_tx_domain_distortion: use_tx_domain_distortion,
         }
     }
 
@@ -1660,7 +1660,7 @@ pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
               fi, fs, cw, w, 0, &tx_bo, luma_mode, tx_size, tx_type, bsize, &po,
               skip, bit_depth, ac, 0, for_rdo_use
             );
-            assert!(!for_rdo_use || dist >= 0);
+            assert!(!fi.use_tx_domain_distortion || !for_rdo_use || skip || dist >= 0);
             tx_dist += dist;
         }
     }
@@ -1714,7 +1714,7 @@ pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
                     let (_, dist) =
                     encode_tx_block(fi, fs, cw, w, p, &tx_bo, chroma_mode, uv_tx_size, uv_tx_type,
                                     plane_bsize, &po, skip, bit_depth, ac, alpha, for_rdo_use);
-                    assert!(!for_rdo_use || dist >= 0);
+                    assert!(!fi.use_tx_domain_distortion || !for_rdo_use || skip || dist >= 0);
                     tx_dist += dist;
                 }
             }
@@ -1744,7 +1744,7 @@ pub fn write_tx_tree(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Context
       fi, fs, cw, w, 0, &bo, luma_mode, tx_size, tx_type, bsize, &po, skip,
       bit_depth, ac, 0, for_rdo_use
     );
-    assert!(!for_rdo_use || skip || dist >= 0);
+    assert!(!fi.use_tx_domain_distortion || !for_rdo_use || skip || dist >= 0);
     tx_dist += dist;
 
     if luma_only { return tx_dist };
@@ -1785,7 +1785,7 @@ pub fn write_tx_tree(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Context
             let (_, dist) =
             encode_tx_block(fi, fs, cw, w, p, &tx_bo, luma_mode, uv_tx_size, uv_tx_type,
                             plane_bsize, &po, skip, bit_depth, ac, 0, for_rdo_use);
-            assert!(!for_rdo_use || skip || dist >= 0);
+            assert!(!fi.use_tx_domain_distortion || !for_rdo_use || skip || dist >= 0);
             tx_dist += dist;
         }
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -446,6 +446,8 @@ impl FrameInvariants {
         }
         let use_reduced_tx_set = config.speed > 1;
 
+        let use_tx_domain_distortion = config.tune == Tune::Psnr && true;
+
         FrameInvariants {
             width,
             height,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -445,8 +445,7 @@ impl FrameInvariants {
             }
         }
         let use_reduced_tx_set = config.speed > 1;
-
-        let use_tx_domain_distortion = config.tune == Tune::Psnr && true;
+        let use_tx_domain_distortion = config.tune == Tune::Psnr && config.speed >= 1;
 
         FrameInvariants {
             width,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1370,7 +1370,7 @@ pub fn encode_tx_block(
     if !fi.use_tx_domain_distortion || !for_rdo_use {
         inverse_transform_add(rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);
     } else {
-        //inverse_transform_add(rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);
+        inverse_transform_add(rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);
 
         // Store tx-domain distortion of this block
         tx_dist = coeffs

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1371,7 +1371,7 @@ pub fn encode_tx_block(
     //if !fi.use_tx_domain_distortion {
         inverse_transform_add(rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);
     } else {
-        inverse_transform_add(rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);
+        //inverse_transform_add(rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);
 
         // Store tx-domain distortion of this block
         tx_dist = coeffs
@@ -1647,6 +1647,7 @@ pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
     let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
     let ac = &mut [0i16; 32 * 32];
     let mut tx_dist: i64 = 0;
+    let do_chroma = has_chroma(bo, bsize, xdec, ydec);
 
     fs.qc.update(fi.base_q_idx, tx_size, luma_mode.is_intra(), bit_depth);
 
@@ -1681,7 +1682,7 @@ pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
     let mut bw_uv = (bw * tx_size.width_mi()) >> xdec;
     let mut bh_uv = (bh * tx_size.height_mi()) >> ydec;
 
-    if (bw_uv == 0 || bh_uv == 0) && has_chroma(bo, bsize, xdec, ydec) {
+    if (bw_uv == 0 || bh_uv == 0) && do_chroma {
         bw_uv = 1;
         bh_uv = 1;
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1390,7 +1390,7 @@ pub fn encode_tx_block(
         let mut diff: i64 = 0;
         let mut diff_mean: i64 = 0;
         let tx_dist_scale_bits = 2*(3 - get_log_tx_scale(tx_size));
-        let tx_dist_scale_offset = 1 << (tx_dist_scale_bits - 1);
+        let tx_dist_scale_rounding_offset = 1 << (tx_dist_scale_bits - 1);
 
         dist = sse_wxh(
             &fs.input.planes[p].slice(po),
@@ -1400,21 +1400,20 @@ pub fn encode_tx_block(
             );
         assert!(tx_size.area() >= 16);
 
-        diff = (dist as i64 - ((tx_dist + tx_dist_scale_offset) >> tx_dist_scale_bits) as i64) as i64;
+        diff = (dist as i64 - ((tx_dist + tx_dist_scale_rounding_offset) >> tx_dist_scale_bits) as i64) as i64;
         diff_mean = (diff / tx_size.area() as i64) as i64;
-        let tmp = 0;
 
-        // Check the residual (i.e. prediction error) vectors in pixel- and tx-domain
-        let pix_vec_len = ss_i16(residual);
-        let pix_vec_len_sqrt = (pix_vec_len as f64).sqrt();
-        let tx_vec_len = (ss_i32(coeffs) + tx_dist_scale_offset as u64) >> tx_dist_scale_bits;
+        // Compare the residual (i.e. prediction error) vectors in pixel- and tx-domain
+        //let pix_vec_len = ss_i16(residual);
+        //let pix_vec_len_sqrt = (pix_vec_len as f64).sqrt();
+        let tx_vec_len = (ss_i32(coeffs) + tx_dist_scale_rounding_offset as u64) >> tx_dist_scale_bits;
         let tx_vec_len_sqrt = (tx_vec_len as f64).sqrt();
-        let diff_residue : i64 = (pix_vec_len as i64 - tx_vec_len as i64) as i64;
-        let diff_residue_mean = diff_residue / tx_size.area() as i64;
-        let diff_residue_sqrt : i64 = (pix_vec_len_sqrt - tx_vec_len_sqrt) as i64;
+        //let diff_residue : i64 = (pix_vec_len as i64 - tx_vec_len as i64) as i64;
+        //let diff_residue_mean = diff_residue / tx_size.area() as i64;
+        //let diff_residue_sqrt : i64 = (pix_vec_len_sqrt - tx_vec_len_sqrt) as i64;
         //assert!(diff_mean == 0);
         //assert!(diff_residue_mean == 0);
-        assert!(diff_residue_sqrt == 0);
+        //assert!(diff_residue_sqrt <= 2);
     }
     has_coeff
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1401,7 +1401,7 @@ pub fn encode_tx_block(
 
         diff = (dist as i64 - (tx_dist >> tx_dist_scale_bits) as i64) as i64;
         diff_mean = (diff / tx_size.area() as i64) as i64;
-
+        let tmp = 0;
     }
     has_coeff
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1367,7 +1367,8 @@ pub fn encode_tx_block(
 
     let mut tx_dist: u64 = 0;
 
-    if !fi.use_tx_domain_distortion || !for_rdo_use {
+    //if !fi.use_tx_domain_distortion || !for_rdo_use {
+    if !fi.use_tx_domain_distortion {
         inverse_transform_add(rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);
     } else {
         inverse_transform_add(rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1371,7 +1371,7 @@ pub fn encode_tx_block(
     //if !fi.use_tx_domain_distortion {
         inverse_transform_add(rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);
     } else {
-        //inverse_transform_add(rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);
+        inverse_transform_add(rcoeffs, &mut rec.mut_slice(po).as_mut_slice(), stride, tx_size, tx_type, bit_depth);
 
         // Store tx-domain distortion of this block
         tx_dist = coeffs

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1592,9 +1592,9 @@ pub fn encode_block_b(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
     motion_compensate(fi, fs, cw, luma_mode, ref_frames, mvs, bsize, bo, bit_depth, false);
 
     if is_inter {
-      write_tx_tree(fi, fs, cw, w, luma_mode, bo, bsize, tx_size, tx_type, skip, bit_depth, false, false)
+      write_tx_tree(fi, fs, cw, w, luma_mode, bo, bsize, tx_size, tx_type, skip, bit_depth, false, for_rdo_use)
     } else {
-      write_tx_blocks(fi, fs, cw, w, luma_mode, chroma_mode, bo, bsize, tx_size, tx_type, skip, bit_depth, cfl, false, false)
+      write_tx_blocks(fi, fs, cw, w, luma_mode, chroma_mode, bo, bsize, tx_size, tx_type, skip, bit_depth, cfl, false, for_rdo_use)
     }
 }
 

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -128,15 +128,15 @@ impl QuantizationContext {
   }
 
   #[inline]
-  pub fn quantize(&self, coeffs: &mut [i32]) {
-    coeffs[0] <<= self.log_tx_scale;
-    coeffs[0] += coeffs[0].signum() * self.dc_offset;
-    coeffs[0] = divu_pair(coeffs[0], self.dc_mul_add);
+  pub fn quantize(&self, coeffs: &[i32], qcoeffs: &mut [i32]) {
+    qcoeffs[0] = coeffs[0] << self.log_tx_scale;
+    qcoeffs[0] += qcoeffs[0].signum() * self.dc_offset;
+    qcoeffs[0] = divu_pair(coeffs[0], self.dc_mul_add);
 
-    for c in coeffs[1..].iter_mut() {
-      *c <<= self.log_tx_scale;
-      *c += c.signum() * self.ac_offset;
-      *c = divu_pair(*c, self.ac_mul_add);
+    for (qc, c) in qcoeffs.iter_mut().zip(coeffs.iter()) {
+      *qc = *c << self.log_tx_scale;
+      *qc += qc.signum() * self.ac_offset;
+      *qc = divu_pair(*c, self.ac_mul_add);
     }
   }
 }

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -13,7 +13,7 @@
 use partition::TxSize;
 use std::mem;
 
-fn get_log_tx_scale(tx_size: TxSize) -> i32 {
+pub fn get_log_tx_scale(tx_size: TxSize) -> i32 {
   match tx_size {
     TxSize::TX_64X64 => 2,
     TxSize::TX_32X32 => 1,

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -131,12 +131,12 @@ impl QuantizationContext {
   pub fn quantize(&self, coeffs: &[i32], qcoeffs: &mut [i32]) {
     qcoeffs[0] = coeffs[0] << self.log_tx_scale;
     qcoeffs[0] += qcoeffs[0].signum() * self.dc_offset;
-    qcoeffs[0] = divu_pair(coeffs[0], self.dc_mul_add);
+    qcoeffs[0] = divu_pair(qcoeffs[0], self.dc_mul_add);
 
     for (qc, c) in qcoeffs.iter_mut().zip(coeffs.iter()) {
       *qc = *c << self.log_tx_scale;
       *qc += qc.signum() * self.ac_offset;
-      *qc = divu_pair(*c, self.ac_mul_add);
+      *qc = divu_pair(*qc, self.ac_mul_add);
     }
   }
 }

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -133,7 +133,7 @@ impl QuantizationContext {
     qcoeffs[0] += qcoeffs[0].signum() * self.dc_offset;
     qcoeffs[0] = divu_pair(qcoeffs[0], self.dc_mul_add);
 
-    for (qc, c) in qcoeffs.iter_mut().zip(coeffs.iter()) {
+    for (qc, c) in qcoeffs[1..].iter_mut().zip(coeffs[1..].iter()) {
       *qc = *c << self.log_tx_scale;
       *qc += qc.signum() * self.ac_offset;
       *qc = divu_pair(*qc, self.ac_mul_add);

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -635,25 +635,13 @@ pub fn rdo_mode_decision(
         best.tx_type,
         0,
         &Vec::new(),
-        true
+        false // For CFL, luma should be always reconstructed.
       );
 
       let cost = wr.tell_frac() - tell;
-      let rd = if fi.use_tx_domain_distortion {
-        compute_tx_rd_cost(
-          fi,
-          fs,
-          w,
-          h,
-          is_chroma_block,
-          bo,
-          cost,
-          tx_dist,
-          seq.bit_depth,
-          best.skip,
-          false
-        )
-      } else {
+
+      // For CFL, tx-domain distortion is not an option.
+      let rd = 
         compute_rd_cost(
           fi,
           fs,
@@ -664,8 +652,7 @@ pub fn rdo_mode_decision(
           cost,
           seq.bit_depth,
           false
-        )
-      };
+        );
 
       if rd < best.rd {
         best.rd = rd;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -160,12 +160,21 @@ fn compute_rd_cost(
   // Compute distortion
   let po = bo.plane_offset(&fs.input.planes[0].cfg);
   let mut distortion = if fi.config.tune == Tune::Psnr {
-    sse_wxh(
-      &fs.input.planes[0].slice(&po),
-      &fs.rec.planes[0].slice(&po),
-      w_y,
-      h_y
-    )
+    if fi.use_tx_domain_distortion {
+      sse_wxh(
+        &fs.input.planes[0].slice(&po),
+        &fs.rec.planes[0].slice(&po),
+        w_y,
+        h_y
+      )
+    } else {
+      sse_wxh(
+        &fs.input.planes[0].slice(&po),
+        &fs.rec.planes[0].slice(&po),
+        w_y,
+        h_y
+      )
+    }
   } else if fi.config.tune == Tune::Psychovisual {
     cdef_dist_wxh(
       &fs.input.planes[0].slice(&po),

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -491,7 +491,8 @@ pub fn rdo_mode_decision(
           tx_size,
           tx_type,
           mode_context,
-          mv_stack
+          mv_stack,
+          true
         );
 
         let cost = wr.tell_frac() - tell;
@@ -606,7 +607,8 @@ pub fn rdo_mode_decision(
       false,
       seq.bit_depth,
       CFLParams::new(),
-      true
+      true,
+      false
     );
     cw.rollback(&cw_checkpoint);
     if let Some(cfl) = rdo_cfl_alpha(fs, bo, bsize, seq.bit_depth) {
@@ -633,7 +635,8 @@ pub fn rdo_mode_decision(
         best.tx_size,
         best.tx_type,
         0,
-        &Vec::new()
+        &Vec::new(),
+        true
       );
 
       let cost = wr.tell_frac() - tell;
@@ -774,12 +777,12 @@ pub fn rdo_tx_type_decision(
     let tell = wr.tell_frac();
     let tx_dist = if is_inter {
       write_tx_tree(
-        fi, fs, cw, wr, mode, bo, bsize, tx_size, tx_type, false, bit_depth, true
+        fi, fs, cw, wr, mode, bo, bsize, tx_size, tx_type, false, bit_depth, true, true
       )
     }  else {
       let cfl = CFLParams::new(); // Unused
       write_tx_blocks(
-        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false, bit_depth, cfl, true
+        fi, fs, cw, wr, mode, mode, bo, bsize, tx_size, tx_type, false, bit_depth, cfl, true, true
       )
     };
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -113,7 +113,7 @@ fn cdef_dist_wxh(
 }
 
 // Sum of Squared Error for a wxh block
-fn sse_wxh(
+pub fn sse_wxh(
   src1: &PlaneSlice<'_>, src2: &PlaneSlice<'_>, w: usize, h: usize
 ) -> u64 {
   assert!(w & (MI_SIZE - 1) == 0);

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -492,7 +492,7 @@ pub fn rdo_mode_decision(
           tx_type,
           mode_context,
           mv_stack,
-          true
+          false
         );
 
         let cost = wr.tell_frac() - tell;
@@ -636,7 +636,7 @@ pub fn rdo_mode_decision(
         best.tx_type,
         0,
         &Vec::new(),
-        true
+        false
       );
 
       let cost = wr.tell_frac() - tell;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -138,6 +138,16 @@ pub fn sse_wxh(
   sse
 }
 
+// vector length of i16 vector
+pub fn ss_i16(src: &[i16]) -> u64 {
+  src.iter().map(|&a| (a * a) as u64).sum::<u64>()
+}
+
+// vector length of i32 vector
+pub fn ss_i32(src: &[i32]) -> u64 {
+  src.iter().map(|&a| (a * a) as u64).sum::<u64>()
+}
+
 pub fn get_lambda(fi: &FrameInvariants, bit_depth: usize) -> f64 {
   let q = dc_q(fi.base_q_idx, bit_depth) as f64;
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -140,7 +140,7 @@ pub fn sse_wxh(
 
 // vector length of i16 vector
 pub fn ss_i16(src: &[i16]) -> u64 {
-  src.iter().map(|&a| (a * a) as u64).sum::<u64>()
+  src.iter().map(|&a| (a as i32 * a as i32) as u64).sum::<u64>()
 }
 
 // vector length of i32 vector

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -138,16 +138,6 @@ pub fn sse_wxh(
   sse
 }
 
-// vector length of i16 vector
-pub fn ss_i16(src: &[i16]) -> u64 {
-  src.iter().map(|&a| (a as i32 * a as i32) as u64).sum::<u64>()
-}
-
-// vector length of i32 vector
-pub fn ss_i32(src: &[i32]) -> u64 {
-  src.iter().map(|&a| (a * a) as u64).sum::<u64>()
-}
-
 pub fn get_lambda(fi: &FrameInvariants, bit_depth: usize) -> f64 {
   let q = dc_q(fi.base_q_idx, bit_depth) as f64;
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -231,7 +231,7 @@ fn compute_rd_cost(
 // Compute the rate-distortion cost for an encode
 fn compute_tx_rd_cost(
   fi: &FrameInvariants, fs: &FrameState, w_y: usize, h_y: usize,
-  is_chroma_block: bool, bo: &BlockOffset, bit_cost: u32, tx_dist: u64,
+  is_chroma_block: bool, bo: &BlockOffset, bit_cost: u32, tx_dist: i64,
   bit_depth: usize,
   skip: bool, luma_only: bool
 ) -> f64 {
@@ -243,7 +243,6 @@ fn compute_tx_rd_cost(
   let mut distortion = if skip {
     let po = bo.plane_offset(&fs.input.planes[0].cfg);
 
-    //TODO: Repalce this function for tx domain distortion
     sse_wxh(
       &fs.input.planes[0].slice(&po),
       &fs.rec.planes[0].slice(&po),
@@ -251,7 +250,8 @@ fn compute_tx_rd_cost(
       h_y
     )
   } else {
-    tx_dist
+    assert!(tx_dist >= 0);
+    tx_dist as u64
   };
 
   if !luma_only {
@@ -272,7 +272,6 @@ fn compute_tx_rd_cost(
         for p in 1..3 {
           let po = bo.plane_offset(&fs.input.planes[p].cfg);
 
-          //TODO: Repalce this function for tx domain distortion
           distortion += sse_wxh(
             &fs.input.planes[p].slice(&po),
             &fs.rec.planes[p].slice(&po),
@@ -492,7 +491,7 @@ pub fn rdo_mode_decision(
           tx_type,
           mode_context,
           mv_stack,
-          false
+          true
         );
 
         let cost = wr.tell_frac() - tell;
@@ -636,7 +635,7 @@ pub fn rdo_mode_decision(
         best.tx_type,
         0,
         &Vec::new(),
-        false
+        true
       );
 
       let cost = wr.tell_frac() - tell;


### PR DESCRIPTION
Enabled when speed >= 1.

[For 5 frames AWCY](https://beta.arewecompressedyet.com/?job=master-e06321d_s3_5f%402018-10-23T18%3A53%3A09.943Z&job=test8_tx_dist_5f%402018-10-25T23%3A13%3A04.088Z), 

|   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000 |
|   ---: |    ---: |    ---: |     ---: |   ---: |    ---: |       ---: |
| 0.1717 |  0.2794 |  0.1181 |   0.1141 | 0.1624 |  0.1534 |     0.6118 |

Currently, it causes regression of 0.17% for PSNR bd rate, with 44 (unit is probably sec?) --> 36 speed improvement, ~20% down. It also hurts CIEDE 2000 by 0.6%.

For now, the code is hard-coded to always use tx-domain distortion.
[Full AWCY results](https://beta.arewecompressedyet.com/?job=master-e06321d177cc14b1aa09952a4bb26f7f61512f5e&job=test8_tx_dist%402018-10-25T23%3A26%3A00.243Z)

|   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000 |
|   ---: |    ---: |    ---: |     ---: |   ---: |    ---: |       ---: |
| 0.3438 |  0.4575 |  0.3697 |   0.2728 | 0.2712 |  0.2613 |     0.5521 |

584 --> 505 (sec), ~ 14% down.
