### PR TITLE
Avoid testing same MV multiple times in RDO loop

### DIFF
--- a/src/predict.rs
+++ b/src/predict.rs
@@ -43,10 +43,7 @@ pub static RAV1E_INTRA_MODES_MINIMAL: &'static [PredictionMode] = &[
 ];
 
 pub static RAV1E_INTER_MODES_MINIMAL: &'static [PredictionMode] = &[
-  PredictionMode::GLOBALMV,
-  PredictionMode::NEARESTMV,
-  PredictionMode::NEAR0MV,
-  PredictionMode::NEWMV
+  PredictionMode::NEARESTMV
 ];
 
 pub static RAV1E_INTER_COMPOUND_MODES: &'static [PredictionMode] = &[

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -402,13 +402,25 @@ pub fn rdo_mode_decision(
       for &x in RAV1E_INTER_MODES_MINIMAL {
         mode_set.push((x, i));
       }
-      if fi.config.speed <= 2 {
+      if mv_stack.len() >= 1 {
+        mode_set.push((PredictionMode::NEAR0MV, i));
+      }
+      if mv_stack.len() >= 2 {
+        mode_set.push((PredictionMode::GLOBALMV, i));
+      }
+      let include_near_mvs = fi.config.speed <= 2;
+      if include_near_mvs {
         if mv_stack.len() >= 3 {
           mode_set.push((PredictionMode::NEAR1MV, i));
         }
         if mv_stack.len() >= 4 {
           mode_set.push((PredictionMode::NEAR2MV, i));
         }
+      }
+      if !mv_stack.iter().take(if include_near_mvs {4} else {2})
+        .any(|ref x| x.this_mv.row == mvs_from_me[i][0].row && x.this_mv.col == mvs_from_me[i][0].col)
+        && (mvs_from_me[i][0].row != 0 || mvs_from_me[i][0].col != 0) {
+        mode_set.push((PredictionMode::NEWMV, i));
       }
     }
     mv_stacks.push(mv_stack);


### PR DESCRIPTION
Reduces encoder runtime by about 5% at default speed setting