### PR TITLE
Modify frame management to allow for deeper frame hierarchies

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -224,12 +224,16 @@ impl Context {
         return false;
       }
 
+      fn pos_to_lvl(pos: u64, pyramid_depth: u64) -> u64 {
+        pyramid_depth - (pos | (1 << pyramid_depth)).trailing_zeros() as u64
+      }
+
       let lvl = if !reorder {
         0
       } else if idx_in_group < pyramid_depth {
         idx_in_group
       } else {
-        pyramid_depth - (idx_in_group - pyramid_depth + 1).trailing_zeros() as u64
+        pos_to_lvl(idx_in_group - pyramid_depth + 1, pyramid_depth)
       };
 
       // Frames with lvl == 0 are stored in slots 0..4 and frames with higher values
@@ -276,7 +280,7 @@ impl Context {
         } else {
           if i == second_ref_frame - LAST_FRAME {
             let oh = self.fi.order_hint + (group_src_len as u32 >> lvl);
-            let lvl2 = pyramid_depth - oh.trailing_zeros().min(pyramid_depth as u32) as u64;
+            let lvl2 = pos_to_lvl(oh as u64, pyramid_depth);
             if lvl2 == 0 {
               ((oh >> pyramid_depth) % 4) as u8
             } else {
@@ -290,7 +294,7 @@ impl Context {
             }
           } else {
             let oh = self.fi.order_hint - (group_src_len as u32 >> lvl);
-            let lvl1 = pyramid_depth - oh.trailing_zeros().min(pyramid_depth as u32) as u64;
+            let lvl1 = pos_to_lvl(oh as u64, pyramid_depth);
             if lvl1 == 0 {
               ((oh >> pyramid_depth) % 4) as u8
             } else {

--- a/src/api.rs
+++ b/src/api.rs
@@ -262,7 +262,8 @@ impl Context {
       };
       let ref_in_previous_group = LAST3_FRAME;
 
-      self.fi.primary_ref_frame = (ref_in_previous_group - LAST_FRAME) as u32;
+      // reuse probability estimates from previous frames only in top level frames
+      self.fi.primary_ref_frame = if lvl > 0 { PRIMARY_REF_NONE } else { (ref_in_previous_group - LAST_FRAME) as u32 };
 
       assert!(group_src_len <= REF_FRAMES as u64);
       for i in 0..INTER_REFS_PER_FRAME {

--- a/src/api.rs
+++ b/src/api.rs
@@ -225,6 +225,13 @@ impl Context {
       }
 
       fn pos_to_lvl(pos: u64, pyramid_depth: u64) -> u64 {
+        // Derive level within pyramid for a frame with a given coding order position
+        // For example, with a pyramid of depth 2, the 2 least significant bits of the
+        // position determine the level:
+        // 00 -> 0
+        // 01 -> 2
+        // 10 -> 1
+        // 11 -> 2
         pyramid_depth - (pos | (1 << pyramid_depth)).trailing_zeros() as u64
       }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -276,7 +276,6 @@ impl Context {
       // reuse probability estimates from previous frames only in top level frames
       self.fi.primary_ref_frame = if lvl > 0 { PRIMARY_REF_NONE } else { (ref_in_previous_group - LAST_FRAME) as u32 };
 
-      assert!(group_src_len <= REF_FRAMES as u64);
       for i in 0..INTER_REFS_PER_FRAME {
         self.fi.ref_frames[i] = if lvl == 0 {
           if i == second_ref_frame - LAST_FRAME {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -236,7 +236,7 @@ impl Sequence {
             frame_id_length: 0,
             delta_frame_id_length: 0,
             use_128x128_superblock: false,
-            order_hint_bits_minus_1: 3,
+            order_hint_bits_minus_1: 5,
             force_screen_content_tools: 0,
             force_integer_mv: 2,
             still_picture: false,


### PR DESCRIPTION
Without increasing depth, yields the following when using frame reordering:

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -1.7571 | -2.3703 | -2.5057 |  -1.7010 | -1.7046 | -1.6254 |    -1.9372 |
