### PR TITLE
Make building libaom optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,11 @@ autobins = false
 
 [features]
 repl = ["rustyline", "binaries"]
-comparative_bench = []
-decode_test = ["bindgen"]
+comparative_bench = ["aom"]
+decode_test = ["bindgen", "aom"]
 binaries = ["y4m", "clap"]
 default = ["binaries"]
+aom = ["cmake"]
 
 [dependencies]
 bitstream-io = "0.8"
@@ -25,7 +26,7 @@ backtrace = "0.3"
 num-traits = "0.2"
 
 [build-dependencies]
-cmake = "0.1.32"
+cmake = { version = "0.1", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.build-dependencies]
 nasm-rs = { git = "https://github.com/tdaede/nasm-rs.git" }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Automated AppVeyor builds can be found [here](https://ci.appveyor.com/project/td
 
 # Building
 
+**rav1e** can optionally use a local copy of `libaom` to run some extended tests and some `x86_64`-specific optimizations require a recent version of NASM.
+
+## Internal libaom setup
+
 This repository uses a git submodule. To initialize it, run:
 
 ```

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -40,6 +40,7 @@ fn write_b(c: &mut Criterion) {
 }
 
 fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
+  #[cfg(feature = "aom")]
   unsafe {
     av1_rtcd();
     aom_dsp_rtcd();
@@ -51,7 +52,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
   let fc = CDFContext::new(fi.base_q_idx);
   let bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
   let mut fs = FrameState::new(&fi);
-  // For now, restoration unit size is locked to superblock size. 
+  // For now, restoration unit size is locked to superblock size.
   let rc = RestorationContext::new(fi.sb_width, fi.sb_height);
   let mut cw = ContextWriter::new(fc, bc, rc);
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -83,6 +83,7 @@ impl Config {
     );
     let seq = Sequence::new(&self.frame_info);
 
+    #[cfg(feature = "aom")]
     unsafe {
       av1_rtcd();
       aom_dsp_rtcd();

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -113,10 +113,6 @@ pub fn process_frame(
   y4m_dec: &mut y4m::Decoder<'_, Box<dyn Read>>,
   mut y4m_enc: Option<&mut y4m::Encoder<'_, Box<dyn Write>>>
 ) -> bool {
-  unsafe {
-    av1_rtcd();
-    aom_dsp_rtcd();
-  }
   let width = y4m_dec.get_width();
   let height = y4m_dec.get_height();
   let y4m_bits = y4m_dec.get_bit_depth();

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -11,6 +11,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
 #![cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 
+#[cfg(all(target_arch = "x86_64", not(windows)))]
 use libc;
 use num_traits::*;
 
@@ -586,7 +587,7 @@ impl Intra<u16> for Block8x8 {}
 impl Intra<u16> for Block16x16 {}
 impl Intra<u16> for Block32x32 {}
 
-#[cfg(test)]
+#[cfg(all(test, feature = "aom"))]
 pub mod test {
   use super::*;
   use rand::{ChaChaRng, Rng, SeedableRng};


### PR DESCRIPTION
Currently we use it only for the tests. Once `dav1d` API is stable enough I would use it for the decode tests.

- [x] make building aom optional
- [x] evaluate the lack of coverage (this PR will tell us)

from 
```
real	2m44.705s
user	10m28.276s
sys	0m47.549s
```
to
```
real	0m59.245s
user	2m39.561s
sys	0m7.051s
```
