### PR TITLE
Cleanup unneeded return statements identified by clippy

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1288,7 +1288,7 @@ impl BlockContext {
     }
   }
 
-  pub fn for_each<F>(&mut self, bo: &BlockOffset, bsize: BlockSize, f: F) -> ()
+  pub fn for_each<F>(&mut self, bo: &BlockOffset, bsize: BlockSize, f: F)
   where
     F: Fn(&mut Block) -> ()
   {
@@ -1982,10 +1982,9 @@ impl ContextWriter {
     ];
 
     if ref_frame >= REF_FRAMES {
-      return ([ ref_frame_map[ref_frame - REF_FRAMES][0],
-               ref_frame_map[ref_frame - REF_FRAMES][1] ], 2)
+      ([ ref_frame_map[ref_frame - REF_FRAMES][0], ref_frame_map[ref_frame - REF_FRAMES][1] ], 2)
     } else {
-      return ([ ref_frame, 0 ], 1)
+      ([ ref_frame, 0 ], 1)
     }
   }
 
@@ -2572,8 +2571,7 @@ impl ContextWriter {
       return 0;
     }
 
-    let mode_context = self.setup_mvref_list(bo, ref_frames, mv_stack, bsize, is_sec_rect, fi, is_compound);
-    mode_context
+    self.setup_mvref_list(bo, ref_frames, mv_stack, bsize, is_sec_rect, fi, is_compound)
   }
 
   pub fn fill_neighbours_ref_counts(&mut self, bo: &BlockOffset) {
@@ -3085,7 +3083,7 @@ impl ContextWriter {
         // if (row + col < 2) return ctx + 1;
         // if (row + col < 4) return 5 + ctx + 1;
         // return 21 + ctx;
-        return ctx + av1_nz_map_ctx_offset[tx_size as usize][cmp::min(row, 4)][cmp::min(col, 4)] as usize;
+        ctx + av1_nz_map_ctx_offset[tx_size as usize][cmp::min(row, 4)][cmp::min(col, 4)] as usize
       }
       TX_CLASS_HORIZ => {
         let row = coeff_idx >> bwl;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -805,7 +805,7 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
 
           self.write_bit(true)?; // trailing bit
           self.byte_align()?;
-          return Ok((()));
+          return Ok(());
         }
         self.write_bit(false)?; // show_existing_frame=0
         self.write(2, fi.frame_type as u32)?;
@@ -1237,7 +1237,7 @@ fn aom_uleb_size_in_bytes(mut value: u64) -> usize {
     value = value >> 7;
     if value == 0 { break; }
   }
-  return size;
+  size
 }
 
 fn aom_uleb_encode(mut value: u64, coded_value: &mut [u8]) -> usize {
@@ -1814,7 +1814,7 @@ pub fn write_tx_tree(fi: &FrameInvariants, fs: &mut FrameState, cw: &mut Context
         }
     }
 
-    return tx_dist
+    tx_dist
 }
 
 fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -384,7 +384,7 @@ impl TxSize {
   }
 
   pub fn width_index(self) -> usize {
-    return self.width_log2() - Self::smallest_width_log2();
+    self.width_log2() - Self::smallest_width_log2()
   }
 
   pub fn smallest_width_log2() -> usize {
@@ -402,7 +402,7 @@ impl TxSize {
   }
 
   pub fn height_index(self) -> usize {
-    return self.height_log2() - Self::smallest_height_log2();
+    self.height_log2() - Self::smallest_height_log2()
   }
 
   pub fn smallest_height_log2() -> usize {
@@ -936,7 +936,7 @@ impl PredictionMode {
   }
 
   pub fn is_intra(self) -> bool {
-    return self < PredictionMode::NEARESTMV;
+    self < PredictionMode::NEARESTMV
   }
 
   pub fn is_cfl(self) -> bool {

--- a/src/util.rs
+++ b/src/util.rs
@@ -194,16 +194,16 @@ impl Fixed for usize {
 
 /// Check alignment.
 pub fn is_aligned<T>(ptr: *const T, n: usize) -> bool {
-  return ((ptr as usize) & ((1 << n) - 1)) == 0;
+  ((ptr as usize) & ((1 << n) - 1)) == 0
 }
 
 pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
   if input < min {
-    return min;
+    min
   } else if input > max {
-    return max;
+    max
   } else {
-    return input;
+    input
   }
 }
 


### PR DESCRIPTION
It is more idiomatic in Rust to omit the `return` keyword when possible.
This is a purely stylistic lint and has no effect on performance.