### PR TITLE
[WIP] Add horz/vert (2:1 only) partitions to top-down partition rdo

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1948,6 +1948,7 @@ impl ContextWriter {
     if has_rows && has_cols {
       symbol_with_update!(self, w, p as u32, partition_cdf);
     } else if !has_rows && has_cols {
+      assert!(p == PartitionType::PARTITION_SPLIT || p == PartitionType::PARTITION_HORZ);
       assert!(bsize > BlockSize::BLOCK_8X8);
       let mut cdf = [0u16; 2];
       ContextWriter::partition_gather_vert_alike(
@@ -1957,6 +1958,7 @@ impl ContextWriter {
       );
       w.symbol((p == PartitionType::PARTITION_SPLIT) as u32, &cdf);
     } else {
+      assert!(p == PartitionType::PARTITION_SPLIT || p == PartitionType::PARTITION_VERT);
       assert!(bsize > BlockSize::BLOCK_8X8);
       let mut cdf = [0u16; 2];
       ContextWriter::partition_gather_horz_alike(

--- a/src/context.rs
+++ b/src/context.rs
@@ -3395,8 +3395,6 @@ impl ContextWriter {
       1
     } as usize;
 
-    assert!(tx_size <= TX_32X32 || tx_type == DCT_DCT);
-
     // Signal tx_type for luma plane only
     if plane == 0 {
       self.write_tx_type(

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2206,7 +2206,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
     // Always split if the current partition is too large
     let must_split = bo.x + bs as usize > fi.w_in_b ||
         bo.y + bs as usize > fi.h_in_b ||
-        bsize > BlockSize::BLOCK_64X64;
+        bsize.greater_than(BlockSize::BLOCK_64X64);
 
     // must_split overrides the minimum partition size when applicable
     let can_split = bsize > fi.min_partition_size || must_split;
@@ -2238,7 +2238,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
 
         let mut cost: f64 = 0.0;
 
-        if bsize >= BlockSize::BLOCK_8X8 {
+        if bsize.gte(BlockSize::BLOCK_8X8) {
             let w: &mut dyn Writer = if cw.bc.cdef_coded {w_post_cdef} else {w_pre_cdef};
             let tell = w.tell_frac();
             cw.write_partition(w, bo, partition, bsize);
@@ -2294,7 +2294,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
 
         rd_cost = 0.0;
 
-        if bsize >= BlockSize::BLOCK_8X8 {
+        if bsize.gte(BlockSize::BLOCK_8X8) {
             let w: &mut dyn Writer = if cw.bc.cdef_coded {w_post_cdef} else {w_pre_cdef};
             let tell = w.tell_frac();
             cw.write_partition(w, bo, partition, bsize);
@@ -2331,7 +2331,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
 
             partition = PartitionType::PARTITION_NONE;
 
-            if bsize >= BlockSize::BLOCK_8X8 {
+            if bsize.gte(BlockSize::BLOCK_8X8) {
                 let w: &mut dyn Writer = if cw.bc.cdef_coded {w_post_cdef} else {w_pre_cdef};
                 cw.write_partition(w, bo, partition, bsize);
             }
@@ -2363,7 +2363,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
 
     subsize = bsize.subsize(partition);
 
-    if bsize >= BlockSize::BLOCK_8X8 &&
+    if bsize.gte(BlockSize::BLOCK_8X8) &&
         (bsize == BlockSize::BLOCK_8X8 || partition != PartitionType::PARTITION_SPLIT) {
         cw.bc.update_partition_context(bo, subsize, bsize);
     }
@@ -2388,7 +2388,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
     // Always split if the current partition is too large
     let must_split = (bo.x + bsw as usize > fi.w_in_b ||
         bo.y + bsh as usize > fi.h_in_b ||
-        bsize > BlockSize::BLOCK_64X64) && is_square;
+        bsize.greater_than(BlockSize::BLOCK_64X64)) && is_square;
 
     let mut rdo_output = block_output.clone().unwrap_or(RDOOutput {
         part_type: PartitionType::PARTITION_INVALID,
@@ -2415,7 +2415,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
 
     let subsize = bsize.subsize(partition);
 
-    if bsize >= BlockSize::BLOCK_8X8 && is_square {
+    if bsize.gte(BlockSize::BLOCK_8X8) && is_square {
         let w: &mut dyn Writer = if cw.bc.cdef_coded {w_post_cdef} else {w_pre_cdef};
         cw.write_partition(w, bo, partition, bsize);
     }
@@ -2562,7 +2562,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
         _ => { assert!(false); },
     }
 
-    if bsize >= BlockSize::BLOCK_8X8 &&
+    if bsize.gte(BlockSize::BLOCK_8X8) &&
         (bsize == BlockSize::BLOCK_8X8 || partition != PartitionType::PARTITION_SPLIT) {
             cw.bc.update_partition_context(bo, subsize, bsize);
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2526,22 +2526,13 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
             else {
                 let hbsw = subsize.width_mi(); // Half the block size width in blocks
                 let hbsh = subsize.height_mi(); // Half the block size height in blocks
-
-                let p1 = BlockOffset{ x: bo.x + hbsw as usize, y: bo.y };
-                let p2 = BlockOffset{ x: bo.x, y: bo.y + hbsh as usize };
-                let p3 = BlockOffset{ x: bo.x + hbsw as usize, y: bo.y + hbsh as usize };
-
-                let mut partitions = vec![ bo ];
-
-                if partition == PARTITION_VERT || partition == PARTITION_SPLIT {
-                partitions.push(&p1);
-                };
-                if partition == PARTITION_HORZ || partition == PARTITION_SPLIT {
-                partitions.push(&p2);
-                };
-                if partition == PARTITION_SPLIT {
-                partitions.push(&p3);
-                };
+                let four_partitions = [
+                bo,
+                &BlockOffset{ x: bo.x + hbsw as usize, y: bo.y },
+                &BlockOffset{ x: bo.x, y: bo.y + hbsh as usize },
+                &BlockOffset{ x: bo.x + hbsw as usize, y: bo.y + hbsh as usize }
+                ];
+                let partitions = get_sub_partitions(&four_partitions, partition);
 
                 partitions.iter().for_each(|&offset| {
                         encode_partition_topdown(

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1709,6 +1709,8 @@ pub fn encode_tx_block(
     let rec = &mut fs.rec.planes[p];
     let PlaneConfig { stride, xdec, ydec, .. } = fs.input.planes[p].cfg;
 
+    assert!(tx_size.sqr() <= TxSize::TX_32X32 || tx_type == TxType::DCT_DCT);
+
     if mode.is_intra() {
       mode.predict_intra(&mut rec.mut_slice(po), tx_size, bit_depth, &ac, alpha);
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2382,7 +2382,6 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
     if bo.x >= cw.bc.cols || bo.y >= cw.bc.rows {
         return;
     }
-
     let bsw = bsize.width_mi();
     let bsh = bsize.height_mi();
     let is_square = bsize.is_sqr();
@@ -2401,10 +2400,8 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
     let mut split_vert = false;
     let mut split_horz = false;
     if must_split {
-        let mut cbw = fi.w_in_b - bo.x; // clipped block width, i.e. having effective pixels
-        if cbw > 16 { cbw = bsw; };
-        let mut cbh = fi.h_in_b - bo.y;
-        if cbh > 16 { cbh = bsh; };
+        let cbw = (fi.w_in_b - bo.x).min(bsw); // clipped block width, i.e. having effective pixels
+        let cbh = (fi.h_in_b - bo.y).min(bsh);
 
         if cbw == bsw/2 && cbh == bsh { split_vert = true; }
         if cbh == bsh/2 && cbw == bsw { split_horz = true; }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2419,7 +2419,9 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
             if split_vert { partition_types.push(PartitionType::PARTITION_VERT); };
         }
         else {
-            partition_types.append(&mut RAV1E_PARTITION_TYPES.to_vec());
+            //partition_types.append(&mut RAV1E_PARTITION_TYPES.to_vec());
+            partition_types.push(PartitionType::PARTITION_NONE);
+            partition_types.push(PartitionType::PARTITION_SPLIT);
         }
         rdo_output = rdo_partition_decision(seq, fi, fs, cw,
             w_pre_cdef, w_post_cdef, bsize, bo, &rdo_output, pmvs, &partition_types);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2383,7 +2383,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
 
     let bsw = bsize.width_mi();
     let bsh = bsize.height_mi();
-    let is_square = bsw == bsh;
+    let is_square = bsize.is_sqr();
 
     // Always split if the current partition is too large
     let must_split = (bo.x + bsw as usize > fi.w_in_b ||
@@ -2415,7 +2415,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
 
     let subsize = bsize.subsize(partition);
 
-    if bsize >= BlockSize::BLOCK_8X8 {
+    if bsize >= BlockSize::BLOCK_8X8 && is_square {
         let w: &mut dyn Writer = if cw.bc.cdef_coded {w_post_cdef} else {w_pre_cdef};
         cw.write_partition(w, bo, partition, bsize);
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2247,7 +2247,7 @@ fn encode_partition_bottomup(seq: &Sequence, fi: &FrameInvariants, fs: &mut Fram
             cost = (w.tell_frac() - tell) as f64 * get_lambda(fi, seq.bit_depth)/ ((1 << OD_BITRES) as f64);
         }
 
-        let pmv_idx = if bsize > BlockSize::BLOCK_32X32 {
+        let pmv_idx = if bsize.greater_than(BlockSize::BLOCK_32X32) {
             0
         } else {
             ((bo.x & 32) >> 5) + ((bo.y & 32) >> 4) + 1
@@ -2428,7 +2428,7 @@ fn encode_partition_topdown(seq: &Sequence, fi: &FrameInvariants, fs: &mut Frame
                     // The optimal prediction mode is known from a previous iteration
                     rdo_output.part_modes[0].clone()
                 } else {
-                    let pmv_idx = if bsize > BlockSize::BLOCK_32X32 {
+                    let pmv_idx = if bsize.greater_than(BlockSize::BLOCK_32X32) {
                         0
                     } else {
                         ((bo.x & 32) >> 5) + ((bo.y & 32) >> 4) + 1

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -218,6 +218,16 @@ impl BlockSize {
 
     (offset_x, offset_y)
   }
+  
+  pub fn greater_than(self, other: BlockSize) -> bool {
+    (self.width() > other.width() && self.height() >= other.height()) ||
+    (self.width() >= other.width() && self.height() > other.height())
+  }
+
+  pub fn gte(self, other: BlockSize) -> bool {
+    self.greater_than(other) ||
+    (self.width() == other.width() && self.height() == other.height())
+  }
 
   #[cfg_attr(rustfmt, rustfmt_skip)]
   const SUBSIZE_LOOKUP: [[BlockSize; BlockSize::BLOCK_SIZES_ALL];

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -719,8 +719,8 @@ pub const GLOBALMV_CTX_MASK: usize =
 pub const REFMV_CTX_MASK: usize = ((1 << (8 - REFMV_OFFSET)) - 1);
 
 pub static RAV1E_PARTITION_TYPES: &'static [PartitionType] =
-  &[PartitionType::PARTITION_NONE, /*PartitionType::PARTITION_HORZ,
-    PartitionType::PARTITION_VERT,*/ PartitionType::PARTITION_SPLIT];
+  &[PartitionType::PARTITION_NONE, PartitionType::PARTITION_HORZ,
+    PartitionType::PARTITION_VERT, PartitionType::PARTITION_SPLIT];
 
 pub static RAV1E_TX_TYPES: &'static [TxType] = &[
   TxType::DCT_DCT,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -709,7 +709,8 @@ pub const GLOBALMV_CTX_MASK: usize =
 pub const REFMV_CTX_MASK: usize = ((1 << (8 - REFMV_OFFSET)) - 1);
 
 pub static RAV1E_PARTITION_TYPES: &'static [PartitionType] =
-  &[PartitionType::PARTITION_NONE, PartitionType::PARTITION_SPLIT];
+  &[PartitionType::PARTITION_NONE, /*PartitionType::PARTITION_HORZ,
+    PartitionType::PARTITION_VERT,*/ PartitionType::PARTITION_SPLIT];
 
 pub static RAV1E_TX_TYPES: &'static [TxType] = &[
   TxType::DCT_DCT,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -911,7 +911,7 @@ pub fn rdo_partition_decision(
         let partitions = get_sub_partitions(&four_partitions, partition);
 
         let pmv_idxs = partitions.iter().map(|&offset| {
-          if subsize > BlockSize::BLOCK_32X32 {
+          if subsize.greater_than(BlockSize::BLOCK_32X32) {
               0
           } else {
               ((offset.x & 32) >> 5) + ((offset.y & 32) >> 4) + 1

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -288,8 +288,17 @@ pub fn rdo_tx_size_type(
     BlockSize::BLOCK_4X4 => TxSize::TX_4X4,
     BlockSize::BLOCK_8X8 => TxSize::TX_8X8,
     BlockSize::BLOCK_16X16 => TxSize::TX_16X16,
+    BlockSize::BLOCK_4X8 => TxSize::TX_4X8,
+    BlockSize::BLOCK_8X4 => TxSize::TX_8X4,
+    BlockSize::BLOCK_8X16 => TxSize::TX_8X16,
+    BlockSize::BLOCK_16X8 => TxSize::TX_16X8,
+    BlockSize::BLOCK_16X32 => TxSize::TX_16X32,
+    BlockSize::BLOCK_32X16 => TxSize::TX_32X16,
     BlockSize::BLOCK_32X32 => TxSize::TX_32X32,
-    _ => TxSize::TX_64X64
+    BlockSize::BLOCK_32X64 => TxSize::TX_32X64,
+    BlockSize::BLOCK_64X32 => TxSize::TX_64X32,
+    BlockSize::BLOCK_64X64 => TxSize::TX_64X64,
+    _ => unimplemented!()
   };
   cw.bc.set_tx_size(bo, tx_size);
   // Were we not hardcoded to TX_MODE_LARGEST, block tx size would be written here

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -36,6 +36,7 @@ use write_tx_tree;
 
 use std;
 use std::vec::Vec;
+use partition::PartitionType::*;
 
 #[derive(Clone)]
 pub struct RDOOutput {
@@ -858,9 +859,9 @@ pub fn rdo_partition_decision(
         let mode_decision = rdo_mode_decision(seq, fi, fs, cw, bsize, bo, spmvs, false).part_modes[0].clone();
         child_modes.push(mode_decision);
       }
-      PartitionType::PARTITION_SPLIT |
-      PartitionType::PARTITION_HORZ |
-      PartitionType::PARTITION_VERT => {
+      PARTITION_SPLIT |
+      PARTITION_HORZ |
+      PARTITION_VERT => {
         let subsize = bsize.subsize(partition);
 
         if subsize == BlockSize::BLOCK_INVALID {
@@ -880,13 +881,13 @@ pub fn rdo_partition_decision(
 
         let mut partitions = vec![ bo ];
 
-        if hbsw < bsize.width_mi() {
+        if partition == PARTITION_VERT || partition == PARTITION_SPLIT {
           partitions.push(&p1);
         };
-        if hbsh < bsize.height_mi() {
+        if partition == PARTITION_HORZ || partition == PARTITION_SPLIT {
           partitions.push(&p2);
         };
-        if hbsw < bsize.width_mi() && hbsh < bsize.height_mi() {
+        if partition == PARTITION_SPLIT {
           partitions.push(&p3);
         };
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -831,6 +831,23 @@ pub fn rdo_tx_type_decision(
   best_type
 }
 
+pub fn get_sub_partitions<'a>(four_partitions: &[&'a BlockOffset; 4],
+   partition: PartitionType) -> Vec<&'a BlockOffset> {
+  let mut partitions = vec![ four_partitions[0] ];
+
+  if partition == PARTITION_VERT || partition == PARTITION_SPLIT {
+    partitions.push(four_partitions[1]);
+  };
+  if partition == PARTITION_HORZ || partition == PARTITION_SPLIT {
+    partitions.push(four_partitions[2]);
+  };
+  if partition == PARTITION_SPLIT {
+    partitions.push(four_partitions[3]);
+  };
+
+  partitions
+}
+
 // RDO-based single level partitioning decision
 pub fn rdo_partition_decision(
   seq: &Sequence, fi: &FrameInvariants, fs: &mut FrameState,
@@ -883,22 +900,13 @@ pub fn rdo_partition_decision(
 
         let hbsw = subsize.width_mi(); // Half the block size width in blocks
         let hbsh = subsize.height_mi(); // Half the block size height in blocks
-
-        let p1 = BlockOffset{ x: bo.x + hbsw as usize, y: bo.y };
-        let p2 = BlockOffset{ x: bo.x, y: bo.y + hbsh as usize };
-        let p3 = BlockOffset{ x: bo.x + hbsw as usize, y: bo.y + hbsh as usize };
-
-        let mut partitions = vec![ bo ];
-
-        if partition == PARTITION_VERT || partition == PARTITION_SPLIT {
-          partitions.push(&p1);
-        };
-        if partition == PARTITION_HORZ || partition == PARTITION_SPLIT {
-          partitions.push(&p2);
-        };
-        if partition == PARTITION_SPLIT {
-          partitions.push(&p3);
-        };
+        let four_partitions = [
+          bo,
+          &BlockOffset{ x: bo.x + hbsw as usize, y: bo.y },
+          &BlockOffset{ x: bo.x, y: bo.y + hbsh as usize },
+          &BlockOffset{ x: bo.x + hbsw as usize, y: bo.y + hbsh as usize }
+        ];
+        let partitions = get_sub_partitions(&four_partitions, partition);
 
         let pmv_idxs = partitions.iter().map(|&offset| {
           if subsize > BlockSize::BLOCK_32X32 {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -327,6 +327,8 @@ pub fn rdo_tx_size_type(
       TxType::DCT_DCT
     };
 
+  assert!(tx_size.sqr() <= TxSize::TX_32X32 || tx_type == TxType::DCT_DCT);
+
   (tx_size, tx_type)
 }
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -858,7 +858,9 @@ pub fn rdo_partition_decision(
         let mode_decision = rdo_mode_decision(seq, fi, fs, cw, bsize, bo, spmvs, false).part_modes[0].clone();
         child_modes.push(mode_decision);
       }
-      PartitionType::PARTITION_SPLIT => {
+      PartitionType::PARTITION_SPLIT |
+      PartitionType::PARTITION_HORZ |
+      PartitionType::PARTITION_VERT => {
         let subsize = bsize.subsize(partition);
 
         if subsize == BlockSize::BLOCK_INVALID {
@@ -868,14 +870,25 @@ pub fn rdo_partition_decision(
         //pmv = best_pred_modes[0].mvs[0];
 
         assert!(best_pred_modes.len() <= 4);
-        let bs = bsize.width_mi();
-        let hbs = bs >> 1; // Half the block size in blocks
-        let partitions = [
-          bo,
-          &BlockOffset{ x: bo.x + hbs as usize, y: bo.y },
-          &BlockOffset{ x: bo.x, y: bo.y + hbs as usize },
-          &BlockOffset{ x: bo.x + hbs as usize, y: bo.y + hbs as usize }
-        ];
+
+        let hbsw = subsize.width_mi(); // Half the block size width in blocks
+        let hbsh = subsize.height_mi(); // Half the block size height in blocks
+
+        let p1 = BlockOffset{ x: bo.x + hbsw as usize, y: bo.y };
+        let p2 = BlockOffset{ x: bo.x, y: bo.y + hbsh as usize };
+        let p3 = BlockOffset{ x: bo.x + hbsw as usize, y: bo.y + hbsh as usize };
+
+        let mut partitions = vec![ bo ];
+
+        if hbsw < bsize.width_mi() {
+          partitions.push(&p1);
+        };
+        if hbsh < bsize.height_mi() {
+          partitions.push(&p2);
+        };
+        if hbsw < bsize.width_mi() && hbsh < bsize.height_mi() {
+          partitions.push(&p3);
+        };
 
         let pmv_idxs = partitions.iter().map(|&offset| {
           if subsize > BlockSize::BLOCK_32X32 {


### PR DESCRIPTION
Not complete yet.

TODO : 
- [x] Required to add rectangular transforms, i.e. 8x4, 4x8, 16x8, 8x16, 32x16, 16x32, 32x64, 64x32
- [x] Check the rectangular transforms work correctly with existing helper functions
- [x] Check currently enabled intra prediction code can also work for rectangular cases
- [x] Test top-down partition rdo with new partitions added
- [ ] Check with each of minimum block size
- [ ] Check both of intra and inter modes works correctly with rectangular block sizes/