### PR TITLE
Pass small copy types by value

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -49,7 +49,7 @@ fn get_mv_range(fi: &FrameInvariants, bo: &BlockOffset, blk_w: usize, blk_h: usi
 
 pub fn motion_estimation(
   fi: &FrameInvariants, fs: &FrameState, bsize: BlockSize,
-  bo: &BlockOffset, ref_frame: usize, pmv: &MotionVector
+  bo: &BlockOffset, ref_frame: usize, pmv: MotionVector
 ) -> MotionVector {
   match fi.rec_buffer.frames[fi.ref_frames[ref_frame - LAST_FRAME] as usize] {
     Some(ref rec) => {
@@ -109,7 +109,7 @@ pub fn motion_estimation(
 
               mode.predict_inter(
                 fi, 0, &po, tmp_slice, blk_w, blk_h, &[ref_frame, NONE_FRAME],
-                &[cand_mv, MotionVector{ row: 0, col: 0 }], 8,
+                [cand_mv, MotionVector{ row: 0, col: 0 }], 8,
               );
             }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -950,7 +950,7 @@ impl PredictionMode {
   pub fn predict_inter<'a>(
     self, fi: &FrameInvariants, p: usize, po: &PlaneOffset,
     dst: &'a mut PlaneMutSlice<'a>, width: usize, height: usize,
-    ref_frames: &[usize; 2], mvs: &[MotionVector; 2], bit_depth: usize
+    ref_frames: &[usize; 2], mvs: [MotionVector; 2], bit_depth: usize
   ) {
     assert!(!self.is_intra());
 


### PR DESCRIPTION
It is more performant to pass small types which implement `Copy` by
value, because they can be passed directly through registers. Clippy is
conservative with this lint and optimizes for 32-bit architectures. The
setting can be overridden in `clippy.toml` if we choose to further
optimize for 64-bit architectures.