### PR TITLE
Remove outdated info from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ rav1e is an experimental AV1 video encoder. It is designed to eventually cover a
 
 * Intra and inter frames
 * 64x64 superblocks
-* 4x4 to 32x32 RDO-selected square blocks
+* 4x4 to 64x64 RDO-selected square blocks
 * DC, H, V, Paeth, and smooth prediction modes
 * 4x4 DCT and ADST transforms
 * 8-, 10- and 12-bit depth color

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ The fastest and safest AV1 encoder.
 
 rav1e is an experimental AV1 video encoder. It is designed to eventually cover all use cases, though in its current form it is most suitable for cases where libaom (the reference encoder) is too slow.
 
-rav1e temporarily uses libaom's transforms and CDF initialization tables, but is otherwise an independent implementation.
-
 # Features
 
 * Intra and inter frames


### PR DESCRIPTION
rav1e is no longer dependent on libaom unless running the comparative bench suite.