### PR TITLE
Refactor speed level to act as an initialization preset

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -47,7 +47,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
     aom_dsp_rtcd();
   }
   let config =
-    EncoderConfig { quantizer: qindex, speed: 10, ..Default::default() };
+    EncoderConfig { quantizer: qindex, speed_settings: SpeedSettings::from_preset(10), ..Default::default() };
   let mut fi = FrameInvariants::new(1024, 1024, config);
   let mut w = ec::WriterEncoder::new();
   let fc = CDFContext::new(fi.base_q_idx);
@@ -113,7 +113,7 @@ fn cdef_frame(c: &mut Criterion) {
 
 fn cdef_frame_bench(b: &mut Bencher, w: usize, h: usize) {
   let config =
-    EncoderConfig { quantizer: 100, speed: 10, ..Default::default() };
+    EncoderConfig { quantizer: 100, speed_settings: SpeedSettings::from_preset(10), ..Default::default() };
   let fi = FrameInvariants::new(w, h, config);
   let mut bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
   let mut fs = FrameState::new(&fi);
@@ -135,7 +135,7 @@ fn cfl_rdo(c: &mut Criterion) {
 
 fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
   let config =
-    EncoderConfig { quantizer: 100, speed: 10, ..Default::default() };
+    EncoderConfig { quantizer: 100, speed_settings: SpeedSettings::from_preset(10), ..Default::default() };
   let fi = FrameInvariants::new(1024, 1024, config);
   let mut fs = FrameState::new(&fi);
   let offset = BlockOffset { x: 1, y: 1 };

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -1343,7 +1343,7 @@ pub fn deblock_filter_optimize(
   fi: &FrameInvariants, fs: &mut FrameState, bc: &mut BlockContext,
   bit_depth: usize
 ) {
-  if fi.config.speed > 3 {
+  if fi.config.speed_settings.fast_deblock {
     let q = ac_q(fi.base_q_idx, bit_depth) as i32;
     let level = clamp(
       match bit_depth {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -467,11 +467,7 @@ impl FrameInvariants {
         // Speed level decides the minimum partition size, i.e. higher speed --> larger min partition size,
         // with exception that SBs on right or bottom frame borders split down to BLOCK_4X4.
         // At speed = 0, RDO search is exhaustive.
-        let mut min_partition_size = if config.speed <= 1 { BlockSize::BLOCK_4X4 }
-                                 else if config.speed <= 2 { BlockSize::BLOCK_8X8 }
-                                 else if config.speed <= 3 { BlockSize::BLOCK_16X16 }
-                                 else if config.speed <= 4 { BlockSize::BLOCK_32X32 }
-                                 else { BlockSize::BLOCK_64X64 };
+        let mut min_partition_size = config.speed_settings.min_block_size;
 
         if config.tune == Tune::Psychovisual {
             if min_partition_size < BlockSize::BLOCK_8X8 {
@@ -480,8 +476,8 @@ impl FrameInvariants {
                 println!("If tune=Psychovisual is used, min partition size is enforced to 8x8");
             }
         }
-        let use_reduced_tx_set = config.speed > 1;
-        let use_tx_domain_distortion = config.tune == Tune::Psnr && config.speed >= 1;
+        let use_reduced_tx_set = config.speed_settings.reduced_tx_set;
+        let use_tx_domain_distortion = config.tune == Tune::Psnr && config.speed_settings.tx_domain_distortion;
 
         FrameInvariants {
             width,
@@ -2275,7 +2271,7 @@ fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameStat
             }
 
             // Encode SuperBlock
-            if fi.config.speed == 0 {
+            if fi.config.speed_settings.encode_bottomup {
                 encode_partition_bottomup(sequence, fi, fs, &mut cw,
                                           &mut w_pre_cdef, &mut w_post_cdef,
                                           BlockSize::BLOCK_64X64, &bo, &pmvs);

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -38,6 +38,7 @@ use FrameType;
 use Tune;
 use Sequence;
 use encoder::ReferenceMode;
+use api::PredictionModesSetting;
 
 #[derive(Clone)]
 pub struct RDOOutput {
@@ -289,7 +290,7 @@ pub fn rdo_tx_size_type(
   let tx_set = get_tx_set(tx_size, is_inter, fi.use_reduced_tx_set);
 
   let tx_type =
-    if tx_set > TxSet::TX_SET_DCTONLY && fi.config.speed <= 3 && !skip {
+    if tx_set > TxSet::TX_SET_DCTONLY && fi.config.speed_settings.rdo_tx_decision && !skip {
       rdo_tx_type_decision(
         fi,
         fs,
@@ -356,8 +357,8 @@ pub fn rdo_mode_decision(
 
   // Exclude complex prediction modes at higher speed levels
   let intra_mode_set = if (fi.frame_type == FrameType::KEY
-    && fi.config.speed <= 3)
-    || (fi.frame_type == FrameType::INTER && fi.config.speed <= 1)
+    && fi.config.speed_settings.prediction_modes >= PredictionModesSetting::ComplexKeyframes)
+    || (fi.frame_type == FrameType::INTER && fi.config.speed_settings.prediction_modes >= PredictionModesSetting::ComplexAll)
   {
     RAV1E_INTRA_MODES
   } else {
@@ -409,7 +410,7 @@ pub fn rdo_mode_decision(
       if mv_stack.len() >= 2 {
         mode_set.push((PredictionMode::GLOBALMV, i));
       }
-      let include_near_mvs = fi.config.speed <= 2;
+      let include_near_mvs = fi.config.speed_settings.include_near_mvs;
       if include_near_mvs {
         if mv_stack.len() >= 3 {
           mode_set.push((PredictionMode::NEAR1MV, i));

--- a/src/test_encode_decode.rs
+++ b/src/test_encode_decode.rs
@@ -79,7 +79,8 @@ fn setup_encoder(
     aom_dsp_rtcd();
   }
 
-  let enc = EncoderConfig { quantizer, speed, ..Default::default() };
+  let mut enc = EncoderConfig::with_speed_preset(speed);
+  enc.quantizer = quantizer;
 
   let cfg = Config {
     frame_info: FrameInfo { width: w, height: h, bit_depth, chroma_sampling },


### PR DESCRIPTION
This opens the path to finer control by the user over the encoding
options, and centralizes the speed preset logic in one location.

Closes #290