### PR TITLE
Enable 2:1 and 4:1 rectangular intra prediction function calls"

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -836,6 +836,37 @@ impl PredictionMode {
         self.predict_intra_inner::<Block32x32>(dst, bit_depth, ac, alpha),
       TxSize::TX_64X64 =>
         self.predict_intra_inner::<Block64x64>(dst, bit_depth, ac, alpha),
+
+      TxSize::TX_4X8 =>
+        self.predict_intra_inner::<Block4x8>(dst, bit_depth, ac, alpha),
+      TxSize::TX_8X4 =>
+        self.predict_intra_inner::<Block8x4>(dst, bit_depth, ac, alpha),
+      TxSize::TX_8X16 =>
+        self.predict_intra_inner::<Block8x16>(dst, bit_depth, ac, alpha),
+      TxSize::TX_16X8 =>
+        self.predict_intra_inner::<Block16x8>(dst, bit_depth, ac, alpha),
+      TxSize::TX_16X32 =>
+        self.predict_intra_inner::<Block16x32>(dst, bit_depth, ac, alpha),
+      TxSize::TX_32X16 =>
+        self.predict_intra_inner::<Block32x16>(dst, bit_depth, ac, alpha),
+      TxSize::TX_32X64 =>
+        self.predict_intra_inner::<Block32x64>(dst, bit_depth, ac, alpha),
+      TxSize::TX_64X32 =>
+        self.predict_intra_inner::<Block64x32>(dst, bit_depth, ac, alpha),
+
+      TxSize::TX_4X16 =>
+        self.predict_intra_inner::<Block4x16>(dst, bit_depth, ac, alpha),
+      TxSize::TX_16X4 =>
+        self.predict_intra_inner::<Block16x4>(dst, bit_depth, ac, alpha),
+      TxSize::TX_8X32 =>
+        self.predict_intra_inner::<Block8x32>(dst, bit_depth, ac, alpha),
+      TxSize::TX_32X8 =>
+        self.predict_intra_inner::<Block32x8>(dst, bit_depth, ac, alpha),
+      TxSize::TX_16X64 =>
+        self.predict_intra_inner::<Block16x64>(dst, bit_depth, ac, alpha),
+      TxSize::TX_64X16 =>
+        self.predict_intra_inner::<Block64x16>(dst, bit_depth, ac, alpha),
+
       _ => unimplemented!()
     }
   }

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -148,6 +148,103 @@ impl Dim for Block64x64 {
   const H: usize = 64;
 }
 
+pub struct Block4x8;
+
+impl Dim for Block4x8 {
+  const W: usize = 4;
+  const H: usize = 8;
+}
+
+pub struct Block8x4;
+
+impl Dim for Block8x4 {
+  const W: usize = 8;
+  const H: usize = 4;
+}
+
+pub struct Block8x16;
+
+impl Dim for Block8x16 {
+  const W: usize = 8;
+  const H: usize = 16;
+}
+
+pub struct Block16x8;
+
+impl Dim for Block16x8 {
+  const W: usize = 16;
+  const H: usize = 8;
+}
+
+pub struct Block16x32;
+
+impl Dim for Block16x32 {
+  const W: usize = 16;
+  const H: usize = 32;
+}
+
+pub struct Block32x16;
+
+impl Dim for Block32x16 {
+  const W: usize = 32;
+  const H: usize = 16;
+}
+
+pub struct Block32x64;
+
+impl Dim for Block32x64 {
+  const W: usize = 32;
+  const H: usize = 64;
+}
+pub struct Block64x32;
+
+impl Dim for Block64x32 {
+  const W: usize = 64;
+  const H: usize = 32;
+}
+
+pub struct Block4x16;
+
+impl Dim for Block4x16 {
+  const W: usize = 4;
+  const H: usize = 16;
+}
+
+pub struct Block16x4;
+
+impl Dim for Block16x4 {
+  const W: usize = 16;
+  const H: usize = 4;
+}
+
+pub struct Block8x32;
+
+impl Dim for Block8x32 {
+  const W: usize = 8;
+  const H: usize = 32;
+}
+
+pub struct Block32x8;
+
+impl Dim for Block32x8 {
+  const W: usize = 32;
+  const H: usize = 8;
+}
+
+pub struct Block16x64;
+
+impl Dim for Block16x64 {
+  const W: usize = 16;
+  const H: usize = 64;
+}
+
+pub struct Block64x16;
+
+impl Dim for Block64x16 {
+  const W: usize = 64;
+  const H: usize = 16;
+}
+
 #[inline(always)]
 fn get_scaled_luma_q0(alpha_q3: i16, ac_pred_q3: i16) -> i32 {
   let scaled_luma_q6 = (alpha_q3 as i32) * (ac_pred_q3 as i32);
@@ -657,11 +754,43 @@ impl Intra<u8> for Block16x16 {}
 impl Intra<u8> for Block32x32 {}
 impl Intra<u8> for Block64x64 {}
 
+impl Intra<u8> for Block4x8 {}
+impl Intra<u8> for Block8x4 {}
+impl Intra<u8> for Block8x16 {}
+impl Intra<u8> for Block16x8 {}
+impl Intra<u8> for Block16x32 {}
+impl Intra<u8> for Block32x16 {}
+impl Intra<u8> for Block32x64 {}
+impl Intra<u8> for Block64x32 {}
+
+impl Intra<u8> for Block4x16 {}
+impl Intra<u8> for Block16x4 {}
+impl Intra<u8> for Block8x32 {}
+impl Intra<u8> for Block32x8 {}
+impl Intra<u8> for Block16x64 {}
+impl Intra<u8> for Block64x16 {}
+
 impl Intra<u16> for Block4x4 {}
 impl Intra<u16> for Block8x8 {}
 impl Intra<u16> for Block16x16 {}
 impl Intra<u16> for Block32x32 {}
 impl Intra<u16> for Block64x64 {}
+
+impl Intra<u16> for Block4x8 {}
+impl Intra<u16> for Block8x4 {}
+impl Intra<u16> for Block8x16 {}
+impl Intra<u16> for Block16x8 {}
+impl Intra<u16> for Block16x32 {}
+impl Intra<u16> for Block32x16 {}
+impl Intra<u16> for Block32x64 {}
+impl Intra<u16> for Block64x32 {}
+
+impl Intra<u16> for Block4x16 {}
+impl Intra<u16> for Block16x4 {}
+impl Intra<u16> for Block8x32 {}
+impl Intra<u16> for Block32x8 {}
+impl Intra<u16> for Block16x64 {}
+impl Intra<u16> for Block64x16 {}
 
 #[cfg(all(test, feature = "aom"))]
 pub mod test {


### PR DESCRIPTION
Straightforward addition of 15 more 2:1 and 4:! rectangular
sized intra predictions, following current trait approach.