### PR TITLE
Fix low_latency mode which was broken in #718

### DIFF
--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -82,15 +82,16 @@ fn main() {
 
   loop {
     match process_frame(&mut ctx, &mut cli.io.output, &mut y4m_dec, y4m_enc.as_mut()) {
-      Ok(Some(frame_info)) => {
-        progress.add_frame(frame_info);
-        let _ = if cli.verbose {
-          writeln!(err, "{} - {}", frame_info, progress)
-        } else {
-          write!(err, "\r{}                    ", progress)
-        };
+      Ok(frame_info) => {
+        for frame in frame_info {
+          progress.add_frame(frame);
+          let _ = if cli.verbose {
+            writeln!(err, "{} - {}", frame, progress)
+          } else {
+            write!(err, "\r{}                    ", progress)
+          };
+        }
       },
-      Ok(_) => (),
       Err(_) => break,
     };
 

--- a/src/bin/rav1repl.rs
+++ b/src/bin/rav1repl.rs
@@ -77,8 +77,7 @@ fn main() {
         match line.split_whitespace().next() {
           Some("process_frame") => {
             match process_frame(&mut ctx, &mut io.output, &mut y4m_dec, y4m_enc.as_mut()) {
-              Ok(Some(frame_info)) => eprintln!("{}", frame_info),
-              Ok(_) => (),
+              Ok(Some(frame_info)) => frame_info.iter().for_each(|frame| eprintln!("{}", frame)),
               Err(_) => break,
             };
 


### PR DESCRIPTION
Fixes #720

```
─ rav1e --low_latency false -o /dev/null -v ~/bbb_480p.y4m
854x480 @ 24/1 fps
Frame 0 - Key frame - 183 bytes - encoded 1 frames, inf fps, 34.31 Kb/s
Frame 1 - Inter frame - 364 bytes - encoded 2 frames, 0.40 fps, 51.28 Kb/s
Frame 2 - Inter frame - 5 bytes - encoded 3 frames, 0.60 fps, 34.50 Kb/s
Frame 3 - Inter frame - 63 bytes - encoded 4 frames, 0.80 fps, 28.83 Kb/s
Frame 4 - Inter frame - 5 bytes - encoded 5 frames, 1.00 fps, 23.25 Kb/s
Frame 5 - Inter frame - 632 bytes - encoded 6 frames, 0.60 fps, 39.12 Kb/s
Frame 6 - Inter frame - 5 bytes - encoded 7 frames, 0.70 fps, 33.67 Kb/s
Frame 7 - Inter frame - 181 bytes - encoded 8 frames, 0.80 fps, 33.70 Kb/s
Frame 8 - Inter frame - 5 bytes - encoded 9 frames, 0.90 fps, 30.06 Kb/s
Frame 9 - Inter frame - 781 bytes - encoded 10 frames, 0.62 fps, 41.70 Kb/s
Frame 10 - Inter frame - 5 bytes - encoded 11 frames, 0.69 fps, 37.99 Kb/s
Frame 11 - Inter frame - 217 bytes - encoded 12 frames, 0.75 fps, 38.22 Kb/s
Frame 12 - Inter frame - 5 bytes - encoded 13 frames, 0.81 fps, 35.35 Kb/s
Frame 13 - Inter frame - 1034 bytes - encoded 14 frames, 0.64 fps, 46.67 Kb/s
Frame 14 - Inter frame - 5 bytes - encoded 15 frames, 0.68 fps, 43.62 Kb/s
Frame 15 - Inter frame - 192 bytes - encoded 16 frames, 0.73 fps, 43.15 Kb/s
Frame 16 - Inter frame - 5 bytes - encoded 17 frames, 0.77 fps, 40.67 Kb/s
Frame 17 - Inter frame - 1313 bytes - encoded 18 frames, 0.64 fps, 52.08 Kb/s
Frame 18 - Inter frame - 5 bytes - encoded 19 frames, 0.68 fps, 49.39 Kb/s
Frame 19 - Inter frame - 218 bytes - encoded 20 frames, 0.71 fps, 48.96 Kb/s
Frame 20 - Inter frame - 5 bytes - encoded 21 frames, 0.75 fps, 46.68 Kb/s
Frame 21 - Inter frame - 1733 bytes - encoded 22 frames, 0.65 fps, 59.33 Kb/s
Frame 22 - Inter frame - 5 bytes - encoded 23 frames, 0.68 fps, 56.79 Kb/s
Frame 23 - Inter frame - 241 bytes - encoded 24 frames, 0.71 fps, 56.30 Kb/s
Frame 24 - Inter frame - 5 bytes - encoded 25 frames, 0.74 fps, 54.09 Kb/s
Frame 25 - Inter frame - 2417 bytes - encoded 26 frames, 0.60 fps, 69.44 Kb/s
Frame 26 - Inter frame - 5 bytes - encoded 27 frames, 0.63 fps, 66.90 Kb/s
Frame 27 - Inter frame - 241 bytes - encoded 28 frames, 0.65 fps, 66.13 Kb/s
Frame 28 - Inter frame - 5 bytes - encoded 29 frames, 0.67 fps, 63.88 Kb/s
Frame 29 - Inter frame - 355 bytes - encoded 30 frames, 0.70 fps, 63.97 Kb/s
Frame 30 - Key frame - 2967 bytes - encoded 31 frames, 0.72 fps, 79.85 Kb/s
Frame 31 - Inter frame - 3492 bytes - encoded 32 frames, 0.64 fps, 97.82 Kb/s
Frame 32 - Inter frame - 5 bytes - encoded 33 frames, 0.66 fps, 94.88 Kb/s
Frame 33 - Inter frame - 223 bytes - encoded 34 frames, 0.68 fps, 93.32 Kb/s
Frame 34 - Inter frame - 5 bytes - encoded 35 frames, 0.70 fps, 90.68 Kb/s
Frame 35 - Inter frame - 4914 bytes - encoded 36 frames, 0.64 fps, 113.75 Kb/s
Frame 36 - Inter frame - 5 bytes - encoded 37 frames, 0.66 fps, 110.71 Kb/s
```