### PR TITLE
Correct the comment on the const TX_SIZE_SQR_CONTEXTS

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -75,7 +75,7 @@ pub const KF_MODE_CONTEXTS: usize = 5;
 
 pub const EXT_PARTITION_TYPES: usize = 10;
 
-pub const TX_SIZE_SQR_CONTEXTS: usize = TxSize::TX_SIZES as usize - 1; // 64X64 is currently unused
+pub const TX_SIZE_SQR_CONTEXTS: usize = 4; // Coded tx_size <= 32x32, so is the # of CDF contexts from tx sizes
 
 pub const TX_SETS: usize = 9;
 pub const TX_SETS_INTRA: usize = 3;


### PR DESCRIPTION
The maximum size of tx block coded by level map coder is 32x32.
Hence the # of CDF contexts from square tx size is always 4, regardless
of whether 64x64 tx is enabled or not.