### PR TITLE
Fix rav1repl compilation

### DIFF
--- a/src/bin/rav1repl.rs
+++ b/src/bin/rav1repl.rs
@@ -77,7 +77,7 @@ fn main() {
         match line.split_whitespace().next() {
           Some("process_frame") => {
             match process_frame(&mut ctx, &mut io.output, &mut y4m_dec, y4m_enc.as_mut()) {
-              Ok(Some(frame_info)) => frame_info.iter().for_each(|frame| eprintln!("{}", frame)),
+              Ok(frame_info) => frame_info.iter().for_each(|frame| eprintln!("{}", frame)),
               Err(_) => break,
             };
 

--- a/src/bin/rav1repl.rs
+++ b/src/bin/rav1repl.rs
@@ -22,7 +22,7 @@ use rustyline::error::ReadlineError;
 use rustyline::Editor;
 
 fn main() {
-  let (mut io, enc, _) = parse_cli();
+  let CliOptions{mut io, enc, ..} = parse_cli();
   let mut y4m_dec = y4m::decode(&mut io.input).unwrap();
   let width = y4m_dec.get_width();
   let height = y4m_dec.get_height();


### PR DESCRIPTION
Some recent commits changed some return types, but usage was not updated in `rav1repl`.