### PR TITLE
Change the default key frame interval from 30 to 60

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -47,7 +47,7 @@ impl Default for EncoderConfig {
 impl EncoderConfig {
   pub fn with_speed_preset(speed: usize) -> Self {
     EncoderConfig {
-      key_frame_interval: 60,
+      key_frame_interval: 240,
       low_latency: true,
       quantizer: 100,
       tune: Tune::Psnr,

--- a/src/api.rs
+++ b/src/api.rs
@@ -47,7 +47,7 @@ impl Default for EncoderConfig {
 impl EncoderConfig {
   pub fn with_speed_preset(speed: usize) -> Self {
     EncoderConfig {
-      key_frame_interval: 30,
+      key_frame_interval: 60,
       low_latency: true,
       quantizer: 100,
       tune: Tune::Psnr,

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -74,7 +74,7 @@ pub fn parse_cli() -> CliOptions {
         .short("I")
         .long("keyint")
         .takes_value(true)
-        .default_value("30")
+        .default_value("60")
     ).arg(
       Arg::with_name("LOW_LATENCY")
         .help("low latency mode. true or false")

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -74,7 +74,7 @@ pub fn parse_cli() -> CliOptions {
         .short("I")
         .long("keyint")
         .takes_value(true)
-        .default_value("60")
+        .default_value("240")
     ).arg(
       Arg::with_name("LOW_LATENCY")
         .help("low latency mode. true or false")


### PR DESCRIPTION
gop size 30 to 60

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -9.2210 | -5.3204 | -5.1895 |  -9.3851 | -9.5071 | -9.4011 |    -7.9515 |

master@2018-11-23T19:28:56.273Z -> master_gop_size_60@2018-11-26T18:00:26.878Z