### PR TITLE
Output PSNR for each frame and average for video

### DIFF
--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -77,7 +77,8 @@ fn main() {
 
   let mut progress = ProgressInfo::new(
     framerate,
-    if cli.limit == 0 { None } else { Some(cli.limit) }
+    if cli.limit == 0 { None } else { Some(cli.limit) },
+      cfg.enc.show_psnr
   );
 
   ctx.set_frames_to_be_coded(cli.limit as u64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod cdef;
 pub mod lrf;
 pub mod encoder;
 pub mod me;
+pub mod metrics;
 pub mod scan_order;
 pub mod scenechange;
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,33 @@
+use encoder::Frame;
+use plane::Plane;
+
+/// Calculates the PSNR for a `Frame` by comparing the original (uncompressed) to the compressed
+/// version of the frame. Higher PSNR is better--PSNR is capped at 100 in order to avoid skewed
+/// statistics from e.g. all black frames, which would otherwise show a PSNR of infinity.
+///
+/// See https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio for more details.
+pub fn calculate_frame_psnr(original: &Frame, compressed: &Frame, bit_depth: usize) -> (f64, f64, f64) {
+  (calculate_plane_psnr(&original.planes[0], &compressed.planes[0], bit_depth),
+    calculate_plane_psnr(&original.planes[1], &compressed.planes[1], bit_depth),
+    calculate_plane_psnr(&original.planes[2], &compressed.planes[2], bit_depth))
+}
+
+/// Calculate the PSNR for a `Plane` by comparing the original (uncompressed) to the compressed
+/// version.
+fn calculate_plane_psnr(original: &Plane, compressed: &Plane, bit_depth: usize) -> f64 {
+  let mse = calculate_plane_mse(original, compressed);
+  if mse <= 0.0000000001 {
+    return 100.0;
+  }
+  let max = ((1 << bit_depth) - 1) as f64;
+  20.0 * max.log10() - 10.0 * mse.log10()
+}
+
+/// Calculate the mean squared error for a `Plane` by comparing the original (uncompressed)
+/// to the compressed version.
+fn calculate_plane_mse(original: &Plane, compressed: &Plane) -> f64 {
+  original.iter().zip(compressed.iter())
+    .map(|(a, b)| (a as i32 - b as i32).abs() as u64)
+    .map(|err| err * err)
+    .sum::<u64>() as f64 / (original.cfg.width * original.cfg.height) as f64
+}

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -241,6 +241,54 @@ impl Plane {
       }
     }
   }
+
+  /// Iterates over the pixels in the `Plane`, skipping stride data.
+  pub fn iter(&self) -> PlaneIter {
+    PlaneIter::new(self)
+  }
+}
+
+#[derive(Debug)]
+pub struct PlaneIter<'a> {
+  plane: &'a Plane,
+  y: usize,
+  x: usize,
+}
+
+impl<'a> PlaneIter<'a> {
+  pub fn new(plane: &'a Plane) -> Self {
+    PlaneIter {
+      plane,
+      y: 0,
+      x: 0,
+    }
+  }
+
+  fn width(&self) -> usize {
+    self.plane.cfg.width
+  }
+
+  fn height(&self) -> usize {
+    self.plane.cfg.height
+  }
+}
+
+impl<'a> Iterator for PlaneIter<'a> {
+  type Item = u16;
+
+  fn next(&mut self) -> Option<<Self as Iterator>::Item> {
+    if self.y == self.height() - 1 && self.x == self.width() - 1 {
+      return None;
+    }
+    let pixel = self.plane.p(self.x, self.y);
+    if self.x == self.width() - 1 {
+      self.x = 0;
+      self.y += 1;
+    } else {
+      self.x += 1;
+    }
+    Some(pixel)
+  }
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
In verbose mode, will output planar PSNR for each frame. Will always
output planar and average PSNR for the whole video in the summary at the
end.

Closes #672 

Example:

```
╰─ target/release/rav1e ~/bbb_480p.y4m -o /dev/null -v --limit 40 -s 10
848x480 @ 60/1 fps
Frame 0 - Key frame - 131 bytes - PSNR: Y: 100.0000  U: 100.0000  V: 100.0000 - encoded 1/40 frames, 4.07 fps, 61.41 Kb/s, est. size: 0.00 MB
Frame 1 - Inter frame - 91 bytes - PSNR: Y: 100.0000  U: 100.0000  V: 100.0000 - encoded 2/40 frames, 2.87 fps, 52.03 Kb/s, est. size: 0.00 MB
Frame 2 - Inter frame - 85 bytes - PSNR: Y: 100.0000  U: 100.0000  V: 100.0000 - encoded 3/40 frames, 2.53 fps, 47.97 Kb/s, est. size: 0.00 MB
Frame 3 - Inter frame - 84 bytes - PSNR: Y: 100.0000  U: 100.0000  V: 100.0000 - encoded 4/40 frames, 2.51 fps, 45.82 Kb/s, est. size: 0.00 MB
Frame 4 - Inter frame - 1641 bytes - PSNR: Y: 51.2651  U: 52.2472  V: 50.1439 - encoded 5/40 frames, 2.51 fps, 190.50 Kb/s, est. size: 0.02 MB
Frame 5 - Inter frame - 3273 bytes - PSNR: Y: 47.9366  U: 47.9742  V: 46.8061 - encoded 6/40 frames, 2.48 fps, 414.45 Kb/s, est. size: 0.03 MB
Frame 6 - Inter frame - 3491 bytes - PSNR: Y: 45.8777  U: 46.1659  V: 45.0159 - encoded 7/40 frames, 2.44 fps, 589.02 Kb/s, est. size: 0.05 MB
Frame 7 - Inter frame - 4018 bytes - PSNR: Y: 44.6466  U: 45.2705  V: 44.0905 - encoded 8/40 frames, 2.41 fps, 750.82 Kb/s, est. size: 0.06 MB
Frame 8 - Inter frame - 4387 bytes - PSNR: Y: 43.4497  U: 44.4991  V: 43.3398 - encoded 9/40 frames, 2.38 fps, 895.88 Kb/s, est. size: 0.07 MB
Frame 9 - Inter frame - 4493 bytes - PSNR: Y: 42.5359  U: 43.9069  V: 42.8617 - encoded 10/40 frames, 2.35 fps, 1016.91 Kb/s, est. size: 0.08 MB
Frame 10 - Inter frame - 4531 bytes - PSNR: Y: 41.6504  U: 43.4325  V: 42.4695 - encoded 11/40 frames, 2.31 fps, 1117.54 Kb/s, est. size: 0.09 MB
Frame 11 - Inter frame - 4935 bytes - PSNR: Y: 40.9025  U: 43.0021  V: 42.0051 - encoded 12/40 frames, 2.29 fps, 1217.19 Kb/s, est. size: 0.10 MB
Frame 12 - Inter frame - 4664 bytes - PSNR: Y: 40.3948  U: 42.7337  V: 41.7678 - encoded 13/40 frames, 2.27 fps, 1291.73 Kb/s, est. size: 0.11 MB
Frame 13 - Inter frame - 1207 bytes - PSNR: Y: 40.3278  U: 42.9166  V: 41.9544 - encoded 14/40 frames, 2.33 fps, 1239.88 Kb/s, est. size: 0.10 MB
Frame 14 - Inter frame - 859 bytes - PSNR: Y: 40.5262  U: 42.9388  V: 42.0143 - encoded 15/40 frames, 2.39 fps, 1184.06 Kb/s, est. size: 0.10 MB
Frame 15 - Inter frame - 1390 bytes - PSNR: Y: 40.4339  U: 43.0014  V: 42.0923 - encoded 16/40 frames, 2.43 fps, 1150.78 Kb/s, est. size: 0.09 MB
Frame 16 - Inter frame - 1591 bytes - PSNR: Y: 40.4575  U: 42.9875  V: 42.0892 - encoded 17/40 frames, 2.48 fps, 1126.96 Kb/s, est. size: 0.09 MB
Frame 17 - Inter frame - 1492 bytes - PSNR: Y: 40.4630  U: 43.0033  V: 42.0985 - encoded 18/40 frames, 2.52 fps, 1103.20 Kb/s, est. size: 0.09 MB
Frame 18 - Inter frame - 1367 bytes - PSNR: Y: 40.4909  U: 42.9930  V: 42.0896 - encoded 19/40 frames, 2.56 fps, 1078.86 Kb/s, est. size: 0.09 MB
Frame 19 - Inter frame - 1361 bytes - PSNR: Y: 40.4822  U: 43.0003  V: 42.1152 - encoded 20/40 frames, 2.61 fps, 1056.82 Kb/s, est. size: 0.09 MB
Frame 20 - Inter frame - 1025 bytes - PSNR: Y: 40.4871  U: 42.9953  V: 42.1107 - encoded 21/40 frames, 2.64 fps, 1029.38 Kb/s, est. size: 0.08 MB
Frame 21 - Inter frame - 765 bytes - PSNR: Y: 40.4886  U: 43.0191  V: 42.1389 - encoded 22/40 frames, 2.68 fps, 998.88 Kb/s, est. size: 0.08 MB
Frame 22 - Inter frame - 524 bytes - PSNR: Y: 40.4776  U: 43.0466  V: 42.1248 - encoded 23/40 frames, 2.72 fps, 966.13 Kb/s, est. size: 0.08 MB
Frame 23 - Inter frame - 562 bytes - PSNR: Y: 40.4984  U: 43.0241  V: 42.1178 - encoded 24/40 frames, 2.75 fps, 936.86 Kb/s, est. size: 0.08 MB
Frame 24 - Inter frame - 781 bytes - PSNR: Y: 40.5030  U: 43.0470  V: 42.1452 - encoded 25/40 frames, 2.78 fps, 914.02 Kb/s, est. size: 0.07 MB
Frame 25 - Inter frame - 1298 bytes - PSNR: Y: 40.5374  U: 43.0399  V: 42.1613 - encoded 26/40 frames, 2.81 fps, 902.27 Kb/s, est. size: 0.07 MB
Frame 26 - Inter frame - 1564 bytes - PSNR: Y: 40.5363  U: 43.0240  V: 42.0992 - encoded 27/40 frames, 2.84 fps, 896.01 Kb/s, est. size: 0.07 MB
Frame 27 - Inter frame - 1467 bytes - PSNR: Y: 40.5258  U: 43.0376  V: 42.1128 - encoded 28/40 frames, 2.87 fps, 888.57 Kb/s, est. size: 0.07 MB
Frame 28 - Inter frame - 1317 bytes - PSNR: Y: 40.5361  U: 43.0078  V: 42.0975 - encoded 29/40 frames, 2.89 fps, 879.21 Kb/s, est. size: 0.07 MB
Frame 29 - Inter frame - 1362 bytes - PSNR: Y: 40.5209  U: 43.0041  V: 42.1012 - encoded 30/40 frames, 2.91 fps, 871.19 Kb/s, est. size: 0.07 MB
Frame 30 - Inter frame - 1130 bytes - PSNR: Y: 40.5195  U: 43.0554  V: 42.1510 - encoded 31/40 frames, 2.94 fps, 860.17 Kb/s, est. size: 0.07 MB
Frame 31 - Inter frame - 774 bytes - PSNR: Y: 40.5357  U: 43.0879  V: 42.1675 - encoded 32/40 frames, 2.96 fps, 844.63 Kb/s, est. size: 0.07 MB
Frame 32 - Inter frame - 358 bytes - PSNR: Y: 40.5156  U: 43.0761  V: 42.1550 - encoded 33/40 frames, 2.96 fps, 824.12 Kb/s, est. size: 0.07 MB
Frame 33 - Inter frame - 427 bytes - PSNR: Y: 40.5702  U: 43.1104  V: 42.1842 - encoded 34/40 frames, 2.98 fps, 805.77 Kb/s, est. size: 0.07 MB
Frame 34 - Inter frame - 975 bytes - PSNR: Y: 40.5359  U: 43.1113  V: 42.1918 - encoded 35/40 frames, 2.99 fps, 795.80 Kb/s, est. size: 0.06 MB
Frame 35 - Inter frame - 1223 bytes - PSNR: Y: 40.5168  U: 43.0845  V: 42.1665 - encoded 36/40 frames, 3.01 fps, 789.62 Kb/s, est. size: 0.06 MB
Frame 36 - Inter frame - 1502 bytes - PSNR: Y: 40.5495  U: 43.0696  V: 42.1254 - encoded 37/40 frames, 3.02 fps, 787.31 Kb/s, est. size: 0.06 MB
Frame 37 - Inter frame - 1588 bytes - PSNR: Y: 40.5220  U: 43.0492  V: 42.1196 - encoded 38/40 frames, 3.03 fps, 786.18 Kb/s, est. size: 0.06 MB
Frame 38 - Inter frame - 1489 bytes - PSNR: Y: 40.5324  U: 43.0797  V: 42.1448 - encoded 39/40 frames, 3.04 fps, 783.92 Kb/s, est. size: 0.06 MB
Frame 39 - Inter frame - 1490 bytes - PSNR: Y: 40.5124  U: 43.0320  V: 42.1241 - encoded 40/40 frames, 3.05 fps, 781.78 Kb/s, est. size: 0.06 MB

Key Frames:      1    avg size:     131 B
Inter:          39    avg size:    1707 B
Intra Only:      0    avg size:       0 B
Switch:          0    avg size:       0 B
Mean PSNR: Y: 47.3066  U: 49.2769  V: 48.3923  Avg: 48.3252
```