### PR TITLE
Set the chroma sample position based on Y4M color space

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -159,7 +159,8 @@ pub struct FrameInfo {
   pub width: usize,
   pub height: usize,
   pub bit_depth: usize,
-  pub chroma_sampling: ChromaSampling
+  pub chroma_sampling: ChromaSampling,
+  pub chroma_sample_position: ChromaSamplePosition
 }
 
 /// Contain all the encoder configuration

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -153,6 +153,24 @@ fn parse_config(matches: &ArgMatches) -> EncoderConfig {
   cfg
 }
 
+pub fn map_y4m_color_space(color_space: y4m::Colorspace) -> (ChromaSampling, ChromaSamplePosition) {
+  match color_space {
+    y4m::Colorspace::C420jpeg
+    | y4m::Colorspace::C420paldv => (ChromaSampling::Cs420, ChromaSamplePosition::Unknown),
+    y4m::Colorspace::C420mpeg2 => (ChromaSampling::Cs420, ChromaSamplePosition::Vertical),
+    y4m::Colorspace::C420
+    | y4m::Colorspace::C420p10
+    | y4m::Colorspace::C420p12 => (ChromaSampling::Cs420, ChromaSamplePosition::Colocated),
+    y4m::Colorspace::C422
+    | y4m::Colorspace::C422p10
+    | y4m::Colorspace::C422p12 => (ChromaSampling::Cs422, ChromaSamplePosition::Colocated),
+    y4m::Colorspace::C444
+    | y4m::Colorspace::C444p10
+    | y4m::Colorspace::C444p12 => (ChromaSampling::Cs444, ChromaSamplePosition::Colocated),
+    _ => panic!("Chroma characteristics unknown for the specified color space.")
+  }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct FrameSummary {
   /// Frame size in bytes

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -36,26 +36,26 @@ fn main() {
     None => None
   };
 
-  let chroma_sampling = match color_space {
+  let (chroma_sampling, chroma_sample_position) = match color_space {
+    y4m::Colorspace::C420jpeg
+    | y4m::Colorspace::C420paldv => (ChromaSampling::Cs420, ChromaSamplePosition::Unknown),
+    y4m::Colorspace::C420mpeg2 => (ChromaSampling::Cs420, ChromaSamplePosition::Vertical),
     y4m::Colorspace::C420
-    | y4m::Colorspace::C420jpeg
-    | y4m::Colorspace::C420paldv
-    | y4m::Colorspace::C420mpeg2
     | y4m::Colorspace::C420p10
-    | y4m::Colorspace::C420p12 => ChromaSampling::Cs420,
+    | y4m::Colorspace::C420p12 => (ChromaSampling::Cs420, ChromaSamplePosition::Colocated),
     y4m::Colorspace::C422
     | y4m::Colorspace::C422p10
-    | y4m::Colorspace::C422p12 => ChromaSampling::Cs422,
+    | y4m::Colorspace::C422p12 => (ChromaSampling::Cs422, ChromaSamplePosition::Colocated),
     y4m::Colorspace::C444
     | y4m::Colorspace::C444p10
-    | y4m::Colorspace::C444p12 => ChromaSampling::Cs444,
-    _ => panic!("Chroma sampling unknown for the specified color space.")
+    | y4m::Colorspace::C444p12 => (ChromaSampling::Cs444, ChromaSamplePosition::Colocated),
+    _ => panic!("Chroma characteristics unknown for the specified color space.")
   };
 
   let bit_depth = color_space.get_bit_depth();
 
   let cfg = Config {
-    frame_info: FrameInfo { width, height, bit_depth, chroma_sampling },
+    frame_info: FrameInfo { width, height, bit_depth, chroma_sampling, chroma_sample_position },
     timebase: Rational::new(framerate.den as u64, framerate.num as u64),
     enc: cli.enc
   };

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -36,21 +36,7 @@ fn main() {
     None => None
   };
 
-  let (chroma_sampling, chroma_sample_position) = match color_space {
-    y4m::Colorspace::C420jpeg
-    | y4m::Colorspace::C420paldv => (ChromaSampling::Cs420, ChromaSamplePosition::Unknown),
-    y4m::Colorspace::C420mpeg2 => (ChromaSampling::Cs420, ChromaSamplePosition::Vertical),
-    y4m::Colorspace::C420
-    | y4m::Colorspace::C420p10
-    | y4m::Colorspace::C420p12 => (ChromaSampling::Cs420, ChromaSamplePosition::Colocated),
-    y4m::Colorspace::C422
-    | y4m::Colorspace::C422p10
-    | y4m::Colorspace::C422p12 => (ChromaSampling::Cs422, ChromaSamplePosition::Colocated),
-    y4m::Colorspace::C444
-    | y4m::Colorspace::C444p10
-    | y4m::Colorspace::C444p12 => (ChromaSampling::Cs444, ChromaSamplePosition::Colocated),
-    _ => panic!("Chroma characteristics unknown for the specified color space.")
-  };
+  let (chroma_sampling, chroma_sample_position) = map_y4m_color_space(color_space);
 
   let bit_depth = color_space.get_bit_depth();
 

--- a/src/bin/rav1repl.rs
+++ b/src/bin/rav1repl.rs
@@ -42,25 +42,11 @@ fn main() {
     framerate.den
   );
 
-  let chroma_sampling = match color_space {
-    y4m::Colorspace::C420
-    | y4m::Colorspace::C420jpeg
-    | y4m::Colorspace::C420paldv
-    | y4m::Colorspace::C420mpeg2
-    | y4m::Colorspace::C420p10
-    | y4m::Colorspace::C420p12 => ChromaSampling::Cs420,
-    y4m::Colorspace::C422
-    | y4m::Colorspace::C422p10
-    | y4m::Colorspace::C422p12 => ChromaSampling::Cs422,
-    y4m::Colorspace::C444
-    | y4m::Colorspace::C444p10
-    | y4m::Colorspace::C444p12 => ChromaSampling::Cs444,
-    _ => panic!("Chroma sampling unknown for the specified color space.")
-  };
+  let (chroma_sampling, chroma_sample_position) = map_y4m_color_space(color_space);
   let bit_depth = color_space.get_bit_depth();
 
   let cfg = Config {
-    frame_info: FrameInfo { width, height, bit_depth, chroma_sampling },
+    frame_info: FrameInfo { width, height, bit_depth, chroma_sampling, chroma_sample_position },
     timebase: Rational::new(framerate.den as u64, framerate.num as u64),
     enc
   };

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -200,6 +200,20 @@ impl Default for ChromaSampling {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(C)]
+pub enum ChromaSamplePosition {
+    Unknown,
+    Vertical,
+    Colocated
+}
+
+impl Default for ChromaSamplePosition {
+    fn default() -> Self {
+        ChromaSamplePosition::Unknown
+    }
+}
+
 #[derive(Copy, Clone)]
 pub struct Sequence {
   // OBU Sequence header of AV1
@@ -208,6 +222,7 @@ pub struct Sequence {
     pub num_bits_height: u32,
     pub bit_depth: usize,
     pub chroma_sampling: ChromaSampling,
+    pub chroma_sample_position: ChromaSamplePosition,
     pub max_frame_width: u32,
     pub max_frame_height: u32,
     pub frame_id_numbers_present_flag: bool,
@@ -290,6 +305,7 @@ impl Sequence {
             num_bits_height: height_bits,
             bit_depth: info.bit_depth,
             chroma_sampling: info.chroma_sampling,
+            chroma_sample_position: info.chroma_sample_position,
             max_frame_width: info.width as u32,
             max_frame_height: info.height as u32,
             frame_id_numbers_present_flag: false,
@@ -860,7 +876,7 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
             unimplemented!(); // 4:2:2 or 4:4:4 sampling
         }
 
-        self.write(2, 0)?; // chroma_sample_position == CSP_UNKNOWN
+        self.write(2, seq.chroma_sample_position as u32)?;
 
         self.write_bit(false)?; // separate uv delta q
 

--- a/src/test_encode_decode.rs
+++ b/src/test_encode_decode.rs
@@ -87,7 +87,14 @@ fn setup_encoder(
   enc.low_latency = low_latency;
 
   let cfg = Config {
-    frame_info: FrameInfo { width: w, height: h, bit_depth, chroma_sampling },
+    frame_info: FrameInfo { 
+      width: w, 
+      height: h, 
+      bit_depth, 
+      chroma_sampling, 
+      chroma_sample_position: 
+      Default::default() 
+    },
     timebase: Rational::new(1, 1000),
     enc
   };


### PR DESCRIPTION
No desync based on a run of the build script (using the default sequence, i.e. `CSP_VERTICAL`).