### PR TITLE
Miscellaneous clean-up

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -15,17 +15,16 @@ mod predict;
 mod transform;
 mod me;
 
-use std::time::Duration;
-use criterion::*;
+use rav1e::*;
 use rav1e::cdef::cdef_filter_frame;
 use rav1e::context::*;
-use rav1e::ec;
 use rav1e::partition::*;
 use rav1e::predict::*;
 use rav1e::rdo::rdo_cfl_alpha;
-use rav1e::*;
-
 use transform::transform;
+
+use criterion::*;
+use std::time::Duration;
 
 #[cfg(feature = "comparative_bench")]
 mod comparative;

--- a/benches/comparative/predict.rs
+++ b/benches/comparative/predict.rs
@@ -8,9 +8,10 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use comparative::libc;
-use criterion::*;
 use predict as predict_native;
 use predict::*;
+
+use criterion::*;
 use rand::{ChaChaRng, Rng, SeedableRng};
 
 extern {

--- a/benches/me.rs
+++ b/benches/me.rs
@@ -9,6 +9,7 @@
 
 use criterion::*;
 use partition::*;
+use partition::BlockSize::*;
 use plane::*;
 use rand::{ChaChaRng, Rng, SeedableRng};
 use rav1e::me;
@@ -52,7 +53,6 @@ fn bench_get_sad(b: &mut Bencher, bs: &BlockSize) {
 }
 
 pub fn get_sad(c: &mut Criterion) {
-  use partition::BlockSize::*;
   let blocks = vec![
     BLOCK_4X4,
     BLOCK_4X8,

--- a/src/api.rs
+++ b/src/api.rs
@@ -7,15 +7,16 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use bitstream_io::*;
 use encoder::*;
-use partition::*;
-
-use std::cmp;
-use std::collections::BTreeMap;
-use std::fmt;
-use std::sync::Arc;
-use scenechange::SceneChangeDetector;
 use metrics::calculate_frame_psnr;
+use partition::*;
+use scenechange::SceneChangeDetector;
+use self::EncoderStatus::*;
+
+use std::{cmp, fmt, io};
+use std::collections::BTreeMap;
+use std::sync::Arc;
 
 // TODO: use the num crate?
 #[derive(Clone, Copy, Debug)]
@@ -173,7 +174,6 @@ pub struct Config {
 
 impl Config {
   pub fn parse(&mut self, key: &str, value: &str) -> Result<(), EncoderStatus> {
-    use self::EncoderStatus::*;
     match key {
       "low_latency" => self.enc.low_latency = value.parse().map_err(|_e| ParseError)?,
       "min_key_frame_interval" => self.enc.min_key_frame_interval = value.parse().map_err(|_e| ParseError)?,

--- a/src/api.rs
+++ b/src/api.rs
@@ -294,29 +294,29 @@ impl Context {
   }
 
   pub fn container_sequence_header(&mut self) -> Vec<u8> {
-    use bitstream_io::*;
-    use std::io;
     fn sequence_header_inner(seq: &Sequence) -> io::Result<Vec<u8>> {
       let mut buf = Vec::new();
-      {
-      let mut bw = BitWriter::endian(&mut buf, BigEndian);
-      bw.write_bit(true)?; // marker
-      bw.write(7, 1)?; // version
-      bw.write(3, seq.profile)?;
-      bw.write(5, 32)?; // level
-      bw.write_bit(false)?; // tier
-      bw.write_bit(seq.bit_depth > 8)?; // high_bitdepth
-      bw.write_bit(seq.bit_depth == 12)?; // twelve_bit
-      bw.write_bit(seq.bit_depth == 1)?; // monochrome
-      bw.write_bit(seq.bit_depth == 12)?; // twelve_bit
-      bw.write_bit(seq.chroma_sampling != ChromaSampling::Cs444)?; // chroma_subsampling_x
-      bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs420)?; // chroma_subsampling_y
-      bw.write(2, 0)?; // sample_position
-      bw.write(3, 0)?; // reserved
-      bw.write_bit(false)?; // initial_presentation_delay_present
 
-      bw.write(4, 0)?; // reserved
+      {
+        let mut bw = BitWriter::endian(&mut buf, BigEndian);
+        bw.write_bit(true)?; // marker
+        bw.write(7, 1)?; // version
+        bw.write(3, seq.profile)?;
+        bw.write(5, 32)?; // level
+        bw.write_bit(false)?; // tier
+        bw.write_bit(seq.bit_depth > 8)?; // high_bitdepth
+        bw.write_bit(seq.bit_depth == 12)?; // twelve_bit
+        bw.write_bit(seq.bit_depth == 1)?; // monochrome
+        bw.write_bit(seq.bit_depth == 12)?; // twelve_bit
+        bw.write_bit(seq.chroma_sampling != ChromaSampling::Cs444)?; // chroma_subsampling_x
+        bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs420)?; // chroma_subsampling_y
+        bw.write(2, 0)?; // sample_position
+        bw.write(3, 0)?; // reserved
+        bw.write_bit(false)?; // initial_presentation_delay_present
+
+        bw.write(4, 0)?; // reserved
       }
+
       Ok(buf)
     }
 

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -9,11 +9,10 @@
 
 use clap::{App, Arg, ArgMatches};
 use rav1e::*;
-use std::fmt;
+
+use std::{fmt, io, slice};
 use std::fs::File;
-use std::io;
 use std::io::prelude::*;
-use std::slice;
 use std::sync::Arc;
 use std::time::Instant;
 use y4m;

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -13,10 +13,10 @@ extern crate y4m;
 
 mod common;
 use common::*;
+use rav1e::*;
 
 use std::io;
 use std::io::Write;
-use rav1e::*;
 
 fn main() {
   let mut cli = parse_cli();

--- a/src/bin/rav1repl.rs
+++ b/src/bin/rav1repl.rs
@@ -10,12 +10,11 @@
 extern crate clap;
 extern crate rustyline;
 extern crate y4m;
-
 extern crate rav1e;
 
 mod common;
-use common::*;
 
+use common::*;
 use rav1e::*;
 
 use rustyline::error::ReadlineError;

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -45,7 +45,7 @@ fn cdef_find_dir(img: &[u16], stride: usize, var: &mut i32, coeff_shift: i32) ->
     for i in 0..8 {
         for j in 0..8 {
             // We subtract 128 here to reduce the maximum range of the squared
-            // partial sums. 
+            // partial sums.
             debug_assert!((img[i * stride + j] >> coeff_shift) <= 255);
             let x = (img[i * stride + j] as i32 >> coeff_shift) - 128;
             partial[0][i + j] += x;
@@ -91,11 +91,11 @@ fn cdef_find_dir(img: &[u16], stride: usize, var: &mut i32, coeff_shift: i32) ->
         }
     }
     // Difference between the optimal variance and the variance along the
-    // orthogonal direction. Again, the sum(x^2) terms cancel out. 
+    // orthogonal direction. Again, the sum(x^2) terms cancel out.
     // We'd normally divide by 840, but dividing by 1024 is close enough
     // for what we're going to do with this. */
     *var = (best_cost - cost[(best_dir + 4) & 7]) >> 10;
-        
+
     best_dir as i32
 }
 
@@ -107,7 +107,7 @@ fn constrain(diff: i32, threshold: i32, damping: i32) -> i32 {
             -1 * magnitude
         } else {
             magnitude
-        }   
+        }
     } else {
         0
     }
@@ -285,12 +285,12 @@ pub fn cdef_filter_superblock(fi: &FrameInvariants,
                         let in_slice = &in_plane.mut_slice(&in_po);
                         let out_stride = out_plane.cfg.stride;
                         let mut out_slice = &mut out_plane.mut_slice(&out_po);
-                            
+
                         let mut local_pri_strength;
                         let mut local_sec_strength;
                         let mut local_damping: i32 = cdef_damping + coeff_shift;
                         let mut local_dir: usize;
-                            
+
                         if p==0 {
                             local_pri_strength = adjust_strength(cdef_pri_y_strength << coeff_shift, var);
                             local_sec_strength = cdef_sec_y_strength << coeff_shift;
@@ -301,7 +301,7 @@ pub fn cdef_filter_superblock(fi: &FrameInvariants,
                             local_damping -= 1;
                             local_dir = if cdef_pri_uv_strength != 0 {dir as usize} else {0};
                         }
-                            
+
                         unsafe {
                             cdef_filter_block(out_slice.offset_as_mutable(8*bx>>xdec,8*by>>ydec),
                                               out_stride as isize,

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -9,13 +9,13 @@
 
 #![allow(safe_extern_statics)]
 
-use std::cmp;
 use context::*;
-use plane::*;
-use util::clamp;
-use util::msb;
-use FrameInvariants;
 use Frame;
+use FrameInvariants;
+use plane::*;
+use util::{clamp, msb};
+
+use std::cmp;
 
 pub struct CdefDirections {
     dir: [[u8; 8]; 8],

--- a/src/context.rs
+++ b/src/context.rs
@@ -3664,7 +3664,7 @@ pub fn get_mv_class(z: u32, offset: &mut u32) -> usize {
   c
 }
 
-pub fn encode_mv_component(w: &mut Writer, comp: i32, 
+pub fn encode_mv_component(w: &mut Writer, comp: i32,
   mvcomp: &mut NMVComponent, precision: MvSubpelPrecision) {
   assert!(comp != 0);
   let mut offset: u32 = 0;
@@ -3701,7 +3701,7 @@ pub fn encode_mv_component(w: &mut Writer, comp: i32,
   // High precision bit
   if precision > MvSubpelPrecision::MV_SUBPEL_LOW_PRECISION {
     w.symbol_with_update(
-        hp, 
+        hp,
         if mv_class == MV_CLASS_0 { &mut mvcomp.class0_hp_cdf }
         else { &mut mvcomp.hp_cdf});
   }

--- a/src/context.rs
+++ b/src/context.rs
@@ -17,25 +17,20 @@
 #![cfg_attr(feature = "cargo-clippy", allow(collapsible_if))]
 
 use ec::Writer;
+use encoder::{FrameInvariants, ReferenceMode};
+use entropymode::*;
+use lrf::{WIENER_TAPS_MID, SGR_XQD_MID};
+use partition::*;
 use partition::BlockSize::*;
 use partition::PredictionMode::*;
 use partition::TxSize::*;
 use partition::TxType::*;
-use partition::*;
-use lrf::WIENER_TAPS_MID;
-use lrf::SGR_XQD_MID;
 use plane::*;
-use util::clamp;
-use util::msb;
-use std::*;
-use entropymode::*;
-use token_cdfs::*;
-use encoder::FrameInvariants;
 use scan_order::*;
-use encoder::ReferenceMode;
+use token_cdfs::*;
+use util::{clamp, msb};
 
-use self::REF_CONTEXTS;
-use self::SINGLE_REFS;
+use std::*;
 
 pub const PLANES: usize = 3;
 

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -10,17 +10,16 @@
 #![allow(safe_extern_statics)]
 
 use context::*;
-use partition::PredictionMode::*;
-use partition::*;
-use plane::*;
-use quantize::*;
-use std::cmp;
-use util::clamp;
-use util::ILog;
 use DeblockState;
 use FrameInvariants;
 use FrameState;
 use FrameType;
+use partition::*;
+use partition::PredictionMode::*;
+use plane::*;
+use quantize::*;
+use std::cmp;
+use util::{clamp, ILog};
 
 fn deblock_adjusted_level(
   deblock: &DeblockState, block: &Block, pli: usize, vertical: bool

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -274,6 +274,7 @@ impl<S> WriterBase<S> {
   fn new(storage: S) -> Self {
     WriterBase { rng: 0x8000, cnt: -9, debug: false, s: storage }
   }
+
   /// Compute low and range values from token cdf values and local state
   fn lr_compute(&mut self, fl: u16, fh: u16, nms: u16) -> (ec_window, u16) {
     let u: u32;
@@ -292,6 +293,7 @@ impl<S> WriterBase<S> {
       (0, r as u16)
     }
   }
+
   /// Given the current total integer number of bits used and the current value of
   /// rng, computes the fraction number of bits used to `OD_BITRES` precision.
   /// This is used by `od_ec_enc_tell_frac()` and `od_ec_dec_tell_frac()`.
@@ -326,7 +328,8 @@ impl<S> WriterBase<S> {
     }
     nbits - l
   }
-  /// Function to update the CDF for Writer calls that do so.
+
+  // Function to update the CDF for Writer calls that do so.
   fn update_cdf(cdf: &mut [u16], val: u32) {
     let nsymbs = cdf.len() - 1;
     let rate = 3 + (nsymbs >> 1).min(2) + (cdf[nsymbs] >> 4) as usize;

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -344,7 +344,6 @@ impl<S> WriterBase<S> {
 
   #[cfg(debug)]
   fn print_backtrace(&self, s: u32) {
-    use backtrace;
     let mut depth = 3;
     backtrace::trace(|frame| {
       let ip = frame.ip();
@@ -644,6 +643,7 @@ impl<W: io::Write> BCodeWriter for BitWriter<W, BigEndian> {
 #[cfg(test)]
 mod test {
   use super::*;
+
   const WINDOW_SIZE: i16 = 32;
   const LOTS_OF_BITS: i16 = 0x4000;
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -9,25 +9,25 @@
 
 use api::*;
 use cdef::*;
-use lrf::*;
 use context::*;
 use deblock::*;
-use segmentation::*;
 use ec::*;
+use lrf::*;
+use me::*;
 use partition::*;
 use plane::*;
 use quantize::*;
 use rdo::*;
-use std::fmt;
+use segmentation::*;
 use transform::*;
 use util::*;
-use me::*;
 
 use bitstream_io::{BitWriter, BigEndian, LittleEndian};
 use std;
-use std::io;
+use std::{fmt, io};
 use std::io::Write;
 use std::rc::Rc;
+use std::sync::Arc;
 
 extern {
     pub fn av1_rtcd();
@@ -400,8 +400,6 @@ impl Sequence {
       }
     }
 }
-
-use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct FrameState {
@@ -2760,9 +2758,10 @@ pub fn update_rec_buffer(fi: &mut FrameInvariants, fs: FrameState) {
 
 #[cfg(test)]
 mod test {
+  use super::*;
+
   #[test]
   fn frame_state_window() {
-    use super::*;
     let config = EncoderConfig { ..Default::default() };
     let fi = FrameInvariants::new(1024, 1024, config);
     let mut fs = FrameState::new(&fi);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2529,7 +2529,7 @@ fn encode_tile(sequence: &mut Sequence, fi: &FrameInvariants, fs: &mut FrameStat
     };
 
     let bc = BlockContext::new(fi.w_in_b, fi.h_in_b);
-    // For now, restoration unit size is locked to superblock size. 
+    // For now, restoration unit size is locked to superblock size.
     let rc = RestorationContext::new(fi.sb_width, fi.sb_height);
     let mut cw = ContextWriter::new(fc, bc, rc);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,5 @@ mod api;
 pub use api::*;
 pub use encoder::*;
 
-// #[cfg(test)]
 #[cfg(all(test, feature="decode_test"))]
 mod test_encode_decode;
-
-

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -14,7 +14,6 @@ pub const RESTORE_SWITCHABLE: u8 = 1;
 pub const RESTORE_WIENER: u8 = 2;
 pub const RESTORE_SGRPROJ: u8 = 3;
 
-
 pub const WIENER_TAPS_MIN: [i8; 3] = [ -5, -23, -17 ];
 pub const WIENER_TAPS_MID: [i8; 3] = [ 3, -7, 15 ];
 pub const WIENER_TAPS_MAX: [i8; 3] = [ 10, 8, 46 ];

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2018, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 use encoder::Frame;
 use plane::Plane;
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -12,7 +12,11 @@
 
 use self::BlockSize::*;
 use self::TxSize::*;
+use context::*;
 use encoder::{ChromaSampling, FrameInvariants};
+use plane::*;
+use predict::*;
+use util::*;
 
 pub const NONE_FRAME: usize = 8;
 pub const INTRA_FRAME: usize = 0;
@@ -855,11 +859,6 @@ pub enum MvJointType {
   MV_JOINT_HZVNZ = 2,  /* Hor zero, vert nonzero */
   MV_JOINT_HNZVNZ = 3  /* Both components nonzero */
 }
-
-use context::*;
-use plane::*;
-use predict::*;
-use util::*;
 
 impl PredictionMode {
   pub fn predict_intra<'a>(

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -9,6 +9,8 @@
 
 #![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
 
+use std::iter::FusedIterator;
+
 use util::*;
 
 /// Plane-specific configuration.
@@ -331,7 +333,6 @@ impl<'a> Iterator for IterWidth<'a> {
 
 impl<'a> ExactSizeIterator for IterWidth<'a> { }
 
-use std::iter::FusedIterator;
 impl<'a> FusedIterator for IterWidth<'a> { }
 
 impl<'a> PlaneSlice<'a> {

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -11,22 +11,20 @@
 #![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
 #![cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 
+use context::{INTRA_MODES, MAX_TX_SIZE};
+use partition::*;
+use util::*;
+
 #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
 use libc;
 use num_traits::*;
-
-use context::INTRA_MODES;
-use context::MAX_TX_SIZE;
-use partition::*;
-use util::*;
-use std::mem::*;
-#[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
-use std::ptr;
-
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+use std::mem::*;
+#[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
+use std::ptr;
 
 pub static RAV1E_INTRA_MODES: &'static [PredictionMode] = &[
   PredictionMode::DC_PRED,
@@ -767,6 +765,7 @@ pub trait Inter: Dim {}
 pub mod test {
   use super::*;
   use rand::{ChaChaRng, Rng, SeedableRng};
+  use util::*;
 
   const MAX_ITER: usize = 50000;
 
@@ -1010,7 +1009,6 @@ pub mod test {
 
   #[test]
   fn pred_matches_u8() {
-    use util::*;
     let mut edge_buf: AlignedArray<[u8; 2 * MAX_TX_SIZE + 1]> =
       UninitializedAlignedArray();
     for i in 0..edge_buf.array.len() {

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -11,6 +11,7 @@
 #![allow(non_upper_case_globals)]
 
 use partition::TxSize;
+
 use std::mem;
 
 pub fn get_log_tx_scale(tx_size: TxSize) -> i32 {
@@ -90,6 +91,7 @@ fn divu_pair(x: i32, d: (u32, u32, u32)) -> i32 {
 mod test {
   use super::*;
   use partition::TxSize::*;
+
   #[test]
   fn test_divu_pair() {
     for d in 1..1024 {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -11,34 +11,31 @@
 #![allow(non_camel_case_types)]
 #![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
 
+use api::PredictionModesSetting;
+use cdef::*;
 use context::*;
-use me::*;
-use ec::OD_BITRES;
-use ec::Writer;
-use ec::WriterCounter;
-use luma_ac;
+use ec::{OD_BITRES, Writer, WriterCounter};
+use encoder::{ChromaSampling, ReferenceMode};
 use encode_block_a;
 use encode_block_b;
-use motion_compensate;
-use partition::*;
-use plane::*;
-use cdef::*;
-use predict::{RAV1E_INTRA_MODES, RAV1E_INTRA_MODES_MINIMAL, RAV1E_INTER_MODES_MINIMAL, RAV1E_INTER_COMPOUND_MODES};
-use quantize::dc_q;
-use std;
-use std::f64;
-use std::vec::Vec;
-use write_tx_blocks;
-use write_tx_tree;
-use partition::BlockSize;
 use Frame;
 use FrameInvariants;
 use FrameState;
 use FrameType;
-use Tune;
+use luma_ac;
+use me::*;
+use motion_compensate;
+use partition::*;
+use plane::*;
+use predict::{RAV1E_INTRA_MODES, RAV1E_INTRA_MODES_MINIMAL, RAV1E_INTER_MODES_MINIMAL, RAV1E_INTER_COMPOUND_MODES};
+use quantize::dc_q;
 use Sequence;
-use encoder::{ChromaSampling, ReferenceMode};
-use api::PredictionModesSetting;
+use Tune;
+use write_tx_blocks;
+use write_tx_tree;
+
+use std;
+use std::vec::Vec;
 
 #[derive(Clone)]
 pub struct RDOOutput {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -651,7 +651,7 @@ pub fn rdo_mode_decision(
       let cost = wr.tell_frac() - tell;
 
       // For CFL, tx-domain distortion is not an option.
-      let rd = 
+      let rd =
         compute_rd_cost(
           fi,
           fs,
@@ -699,7 +699,7 @@ pub fn rdo_mode_decision(
 }
 
 pub fn rdo_cfl_alpha(
-  fs: &mut FrameState, bo: &BlockOffset, bsize: BlockSize, bit_depth: usize, 
+  fs: &mut FrameState, bo: &BlockOffset, bsize: BlockSize, bit_depth: usize,
   chroma_sampling: ChromaSampling) -> Option<CFLParams> {
   let uv_tx_size = bsize.largest_uv_tx_size(chroma_sampling);
 

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -1,5 +1,6 @@
-use encoder::Frame;
 use api::FrameInfo;
+use encoder::Frame;
+
 use std::sync::Arc;
 
 /// Detects fast cuts using changes in colour and intensity between frames.

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2018, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 use api::FrameInfo;
 use encoder::Frame;
 

--- a/src/test_encode_decode.rs
+++ b/src/test_encode_decode.rs
@@ -87,13 +87,13 @@ fn setup_encoder(
   enc.low_latency = low_latency;
 
   let cfg = Config {
-    frame_info: FrameInfo { 
-      width: w, 
-      height: h, 
-      bit_depth, 
-      chroma_sampling, 
-      chroma_sample_position: 
-      Default::default() 
+    frame_info: FrameInfo {
+      width: w,
+      height: h,
+      bit_depth,
+      chroma_sampling,
+      chroma_sample_position:
+      Default::default()
     },
     timebase: Rational::new(1, 1000),
     enc

--- a/src/test_encode_decode.rs
+++ b/src/test_encode_decode.rs
@@ -15,10 +15,10 @@
 include!(concat!(env!("OUT_DIR"), "/aom.rs"));
 
 use super::*;
-
 use rand::{ChaChaRng, Rng, SeedableRng};
+use std::{mem, ptr, slice};
 use std::collections::VecDeque;
-use std::mem;
+use std::ffi::CStr;
 use std::sync::Arc;
 
 fn fill_frame(ra: &mut ChaChaRng, frame: &mut Frame) {
@@ -225,7 +225,6 @@ fn compare_plane<T: Ord + std::fmt::Debug>(
 }
 
 fn compare_img(img: *const aom_image_t, frame: &Frame, bit_depth: usize, width: usize, height: usize) {
-  use std::slice;
   let img = unsafe { *img };
   let img_iter = img.planes.iter().zip(img.stride.iter());
 
@@ -270,7 +269,6 @@ fn encode_decode(
   w: usize, h: usize, speed: usize, quantizer: usize, limit: usize,
   bit_depth: usize, min_keyint: u64, max_keyint: u64, low_latency: bool
 ) {
-  use std::ptr;
   let mut ra = ChaChaRng::from_seed([0; 32]);
 
   let mut dec = setup_decoder(w, h);
@@ -313,7 +311,6 @@ fn encode_decode(
           );
           println!("Decoded. -> {}", ret);
           if ret != 0 {
-            use std::ffi::CStr;
             let error_msg = aom_codec_error(&mut dec.dec);
             println!(
               "  Decode codec_decode failed: {}",
@@ -345,7 +342,6 @@ fn encode_decode(
                 &mut corrupted
               );
               if ret != 0 {
-                use std::ffi::CStr;
                 let detail = aom_codec_error_detail(&mut dec.dec);
                 panic!(
                   "Decode codec_control failed {}",

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -8,11 +8,9 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use super::*;
+use partition::{TxSize, TxType};
 
 use std::cmp;
-
-use partition::TxSize;
-use partition::TxType;
 
 const MAX_TXFM_STAGE_NUM: usize = 12;
 const MAX_TXWH_IDX: usize = 5;

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -8,11 +8,11 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use super::*;
-
-use std::cmp;
-use util::clamp;
 use num_traits::*;
 use partition::TxType;
+use util::clamp;
+
+use std::cmp;
 
 static COSPI_INV: [i32; 64] = [
   4096, 4095, 4091, 4085, 4076, 4065, 4052, 4036, 4017, 3996, 3973, 3948,

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -7,17 +7,12 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use partition::TxSize;
-use partition::TxType;
-use partition::TX_TYPES;
-
-use util::*;
-
 pub use self::forward::*;
 pub use self::inverse::*;
 
-// Blocks
+use partition::{TxSize, TxType, TX_TYPES};
 use predict::*;
+use util::*;
 
 mod forward;
 mod inverse;

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,12 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use num_traits::*;
+use std::mem;
+use std::mem::size_of;
+#[allow(deprecated, unused_imports)]
+use ::std::ascii::AsciiExt;
+
 // Imported from clap, to avoid to depend directly to the crate
 macro_rules! _clap_count_exprs {
     () => { 0 };
@@ -23,8 +29,6 @@ macro_rules! arg_enum {
             type Err = String;
 
             fn from_str(s: &str) -> ::std::result::Result<Self,Self::Err> {
-                #[allow(deprecated, unused_imports)]
-                use ::std::ascii::AsciiExt;
                 match s {
                     $(stringify!($v) |
                     _ if s.eq_ignore_ascii_case(stringify!($v)) => Ok($e::$v)),+,
@@ -156,7 +160,6 @@ pub fn AlignedArray<ARRAY>(array: ARRAY) -> AlignedArray<ARRAY> {
 
 #[allow(non_snake_case)]
 pub fn UninitializedAlignedArray<ARRAY>() -> AlignedArray<ARRAY> {
-  use std::mem;
   AlignedArray(unsafe { mem::uninitialized() })
 }
 
@@ -206,9 +209,6 @@ pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
     input
   }
 }
-
-use num_traits::*;
-use std::mem::size_of;
 
 pub trait Pixel: PrimInt + Into<u32> + Into<i32> + AsPrimitive<i32> + 'static {}
 impl Pixel for u8 {}


### PR DESCRIPTION
More of it.

* Organize use statements
* Add missing license headers
* Trim trailing whitespace and redundant/outdated comments
* Fix some inconsistent indentation