### PR TITLE
Remove color description from FrameInfo

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -249,10 +249,7 @@ pub struct FrameInfo {
   pub height: usize,
   pub bit_depth: usize,
   pub chroma_sampling: ChromaSampling,
-  pub chroma_sample_position: ChromaSamplePosition,
-  pub primaries: ColorPrimaries,
-  pub transfer: TransferCharacteristics,
-  pub matrix: MatrixCoefficients
+  pub chroma_sample_position: ChromaSamplePosition
 }
 
 /// Contain all the encoder configuration


### PR DESCRIPTION
It is unused there, because parameters are passed to `EncoderConfig` instead.