### PR TITLE
Fix undersized frame buffers with non-4:2:0 chroma

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -50,7 +50,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
   let mut w = ec::WriterEncoder::new();
   let fc = CDFContext::new(fi.base_q_idx);
   let bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
-  let mut fs = FrameState::new(&fi);
+  let mut fs = FrameState::new(&fi, Default::default());
   // For now, restoration unit size is locked to superblock size.
   let rc = RestorationContext::new(fi.sb_width, fi.sb_height);
   let mut cw = ContextWriter::new(fc, bc, rc);
@@ -114,7 +114,7 @@ fn cdef_frame_bench(b: &mut Bencher, w: usize, h: usize) {
     EncoderConfig { quantizer: 100, speed_settings: SpeedSettings::from_preset(10), ..Default::default() };
   let fi = FrameInvariants::new(w, h, config);
   let mut bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
-  let mut fs = FrameState::new(&fi);
+  let mut fs = FrameState::new(&fi, Default::default());
 
   b.iter(|| cdef_filter_frame(&fi, &mut fs.rec, &mut bc, 8));
 }
@@ -135,7 +135,7 @@ fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
   let config =
     EncoderConfig { quantizer: 100, speed_settings: SpeedSettings::from_preset(10), ..Default::default() };
   let fi = FrameInvariants::new(1024, 1024, config);
-  let mut fs = FrameState::new(&fi);
+  let mut fs = FrameState::new(&fi, Default::default());
   let offset = BlockOffset { x: 1, y: 1 };
   b.iter(|| rdo_cfl_alpha(&mut fs, &offset, bsize, 8, Default::default()))
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -355,7 +355,7 @@ impl fmt::Display for Packet {
 
 impl Context {
   pub fn new_frame(&self) -> Arc<Frame> {
-    Arc::new(Frame::new(self.fi.padded_w, self.fi.padded_h))
+    Arc::new(Frame::new(self.fi.padded_w, self.fi.padded_h, self.seq.chroma_sampling))
   }
 
   pub fn send_frame<F>(&mut self, frame: F) -> Result<(), EncoderStatus>
@@ -488,7 +488,7 @@ impl Context {
     if self.fi.show_existing_frame {
       self.idx += 1;
 
-      let mut fs = FrameState::new(&self.fi);
+      let mut fs = FrameState::new(&self.fi, self.seq.chroma_sampling);
 
       let data = encode_frame(&mut self.seq, &mut self.fi, &mut fs);
 
@@ -507,7 +507,8 @@ impl Context {
         self.idx += 1;
 
         if let Some(frame) = f {
-          let mut fs = FrameState::new_with_frame(&self.fi, frame.clone());
+          let mut fs = FrameState::new_with_frame(&self.fi, frame.clone(),
+            self.seq.chroma_sampling);
 
           let data = encode_frame(&mut self.seq, &mut self.fi, &mut fs);
           self.packet_data.extend(data);

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -310,11 +310,11 @@ pub fn process_frame(
         if let Some(y4m_enc_uw) = y4m_enc.as_mut() {
           if let Some(ref rec) = pkt.rec {
             let pitch_y = if bit_depth > 8 { width * 2 } else { width };
-            let (pitch_uv, height_uv) = match map_y4m_color_space(y4m_color_space).0 {
-              ChromaSampling::Cs420 => (pitch_y / 2, height / 2),
-              ChromaSampling::Cs422 => (pitch_y / 2, height),
-              ChromaSampling::Cs444 => (pitch_y, height)
-            };
+            let chroma_sampling_period = map_y4m_color_space(y4m_color_space).0.sampling_period();
+            let (pitch_uv, height_uv) = (
+              pitch_y / chroma_sampling_period.0,
+              height / chroma_sampling_period.1
+            );
 
             let (mut rec_y, mut rec_u, mut rec_v) = (
               vec![128u8; pitch_y * height],

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -44,9 +44,12 @@ const FRAME_MARGIN: usize = 16 + SUBPEL_FILTER_SIZE;
 impl Frame {
     pub fn new(width: usize, height: usize, chroma_sampling: ChromaSampling) -> Frame {
         let chroma_sampling_period = chroma_sampling.sampling_period();
-        let (chroma_width, chroma_height) = (
+        let (chroma_width, chroma_height, chroma_padding, chroma_xdec, chroma_ydec) = (
             width / chroma_sampling_period.0,
-            height / chroma_sampling_period.1
+            height / chroma_sampling_period.1,
+            MAX_SB_SIZE / chroma_sampling_period.0 + FRAME_MARGIN,
+            chroma_sampling_period.0 - 1,
+            chroma_sampling_period.1 - 1
         );
 
         Frame {
@@ -58,13 +61,13 @@ impl Frame {
                 ),
                 Plane::new(
                     chroma_width, chroma_height,
-                    1, 1,
-                    MAX_SB_SIZE/2 + FRAME_MARGIN, MAX_SB_SIZE/2 + FRAME_MARGIN
+                    chroma_xdec, chroma_ydec,
+                    chroma_padding, chroma_padding
                 ),
                 Plane::new(
                     chroma_width, chroma_height,
-                    1, 1,
-                    MAX_SB_SIZE/2 + FRAME_MARGIN, MAX_SB_SIZE/2 + FRAME_MARGIN
+                    chroma_xdec, chroma_ydec,
+                    chroma_padding, chroma_padding
                 )
             ]
         }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -43,11 +43,11 @@ const FRAME_MARGIN: usize = 16 + SUBPEL_FILTER_SIZE;
 
 impl Frame {
     pub fn new(width: usize, height: usize, chroma_sampling: ChromaSampling) -> Frame {
-        let (chroma_width, chroma_height) = match chroma_sampling {
-            ChromaSampling::Cs420 => (width / 2, height / 2),
-            ChromaSampling::Cs422 => (width / 2, height),
-            ChromaSampling::Cs444 => (width, height)
-        };
+        let chroma_sampling_period = chroma_sampling.sampling_period();
+        let (chroma_width, chroma_height) = (
+            width / chroma_sampling_period.0,
+            height / chroma_sampling_period.1
+        );
 
         Frame {
             planes: [
@@ -203,6 +203,17 @@ pub enum ChromaSampling {
 impl Default for ChromaSampling {
     fn default() -> Self {
         ChromaSampling::Cs420
+    }
+}
+
+impl ChromaSampling {
+    // Provides the sampling period in the horizontal and vertical axes.
+    pub fn sampling_period(self) -> (usize, usize) {
+        match self {
+            ChromaSampling::Cs420 => (2, 2),
+            ChromaSampling::Cs422 => (2, 1),
+            ChromaSampling::Cs444 => (1, 1)
+        }
     }
 }
 


### PR DESCRIPTION
More work for #72.

This set allows to output the reconstruction for 4:4:4 chroma without crashing (4:2:2 is untested). The output `IVF` file for the default sequence is still undecodable. There are still likely many things to fix for higher sampling support, but this should help with debugging.