### PR TITLE
[WIP] Add a diamond motion estimation pattern

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -79,6 +79,7 @@ pub struct SpeedSettings {
   pub rdo_tx_decision: bool,
   pub prediction_modes: PredictionModesSetting,
   pub include_near_mvs: bool,
+  pub diamond_motion_estimation: bool,
 }
 
 impl SpeedSettings {
@@ -93,6 +94,7 @@ impl SpeedSettings {
       rdo_tx_decision: Self::rdo_tx_decision_preset(speed),
       prediction_modes: Self::prediction_modes_preset(speed),
       include_near_mvs: Self::include_near_mvs_preset(speed),
+      diamond_motion_estimation: Self::diamond_motion_estimation_preset(speed),
     }
   }
 
@@ -146,6 +148,10 @@ impl SpeedSettings {
 
   fn include_near_mvs_preset(speed: usize) -> bool {
     speed <= 2
+  }
+
+  fn diamond_motion_estimation_preset(speed: usize) -> bool {
+    speed > 9
   }
 }
 


### PR DESCRIPTION
It performs 4 tests instead of 8 for the previous full search. On the *objective-1-fast* dataset, on average, it speeds up the encoding by **12.5%** with a size increase of **1.8%** and a quasi-constant distortion (PSNR decrease of 0.03%). In the current version of the patch, it is activated for the speed 10.

Here are some graph containing the size and compression time impacts of this pattern on the *objective-1-fast* samples:

![size_impact](http://people.videolan.org/~magsoft/rav1e/diamond_me_size_impact.png)
![time_impact](http://people.videolan.org/~magsoft/rav1e/diamond_me_time_impact.png)

Please let me know what you think about this.

