### PR TITLE
Store RestorationState into FrameState

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2714,7 +2714,7 @@ fn encode_tile(fi: &FrameInvariants, fs: &mut FrameState,
 
             // loop restoration must be decided last but coded before anything else
             if fi.sequence.enable_restoration {
-                rs.lrf_optimize_superblock(&sbo, fi, fs, &mut cw);
+                rs.lrf_optimize_superblock(&sbo, fi, &mut cw);
                 cw.write_lrf(&mut w, fi, rs, &sbo);
             }
 
@@ -2745,7 +2745,7 @@ fn encode_tile(fi: &FrameInvariants, fs: &mut FrameState,
       }
       /* TODO: Don't apply if lossless */
       if fi.sequence.enable_restoration {
-        rs.lrf_filter_frame(fs, &pre_cdef_frame, fi.sequence.bit_depth);
+        rs.lrf_filter_frame(&mut fs.rec, &pre_cdef_frame, fi.sequence.bit_depth);
       }
     }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -80,16 +80,6 @@ impl Frame {
         }
     }
 
-    pub fn window(&self, sbo: &SuperBlockOffset) -> Frame {
-        Frame {
-            planes: [
-                self.planes[0].window(&sbo.plane_offset(&self.planes[0].cfg)),
-                self.planes[1].window(&sbo.plane_offset(&self.planes[1].cfg)),
-                self.planes[2].window(&sbo.plane_offset(&self.planes[2].cfg))
-            ]
-        }
-    }
-
     /// Returns a `PixelIter` containing the data of this frame's planes in YUV format.
     /// Each point in the `PixelIter` is a triple consisting of a Y, U, and V component.
     /// The `PixelIter` is laid out as contiguous rows, e.g. to get a given 0-indexed row
@@ -458,19 +448,6 @@ impl FrameState {
             cdfs: CDFContext::new(0),
             deblock: Default::default(),
             segmentation: Default::default(),
-        }
-    }
-
-    pub fn window(&self, sbo: &SuperBlockOffset) -> FrameState {
-        FrameState {
-            input: Arc::new(self.input.window(sbo)),
-            input_hres: self.input_hres.window(&sbo.plane_offset(&self.input_hres.cfg)),
-            input_qres: self.input_qres.window(&sbo.plane_offset(&self.input_qres.cfg)),
-            rec: self.rec.window(sbo),
-            qc: self.qc,
-            cdfs: self.cdfs,
-            deblock: self.deblock,
-            segmentation: self.segmentation,
         }
     }
 }
@@ -2875,36 +2852,6 @@ pub fn update_rec_buffer(fi: &mut FrameInvariants, fs: FrameState) {
 #[cfg(test)]
 mod test {
   use super::*;
-
-  #[test]
-  fn frame_state_window() {
-    let config = EncoderConfig { ..Default::default() };
-    let seq = Sequence::new(&Default::default());
-    let fi = FrameInvariants::new(1024, 1024, config, seq);
-    let mut fs = FrameState::new(&fi);
-    for p in fs.rec.planes.iter_mut() {
-      for (i, v) in p
-        .mut_slice(&PlaneOffset { x: 0, y: 0 })
-        .as_mut_slice()
-        .iter_mut()
-        .enumerate()
-      {
-        *v = i as u16;
-      }
-    }
-    let offset = BlockOffset { x: 56, y: 56 };
-    let sbo = offset.sb_offset();
-    let fs_ = fs.window(&sbo);
-    for p in 0..3 {
-      assert!(fs_.rec.planes[p].cfg.xorigin < 0);
-      assert!(fs_.rec.planes[p].cfg.yorigin < 0);
-      let po = offset.plane_offset(&fs.rec.planes[p].cfg);
-      assert_eq!(
-        &fs.rec.planes[p].slice(&po).as_slice()[..32],
-        &fs_.rec.planes[p].slice(&po).as_slice()[..32]
-      );
-    }
-  }
 
   #[test]
   fn check_partition_types_order() {

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -10,7 +10,6 @@
 #![allow(safe_extern_statics)]
 
 use encoder::Frame;
-use encoder::FrameState;
 use encoder::FrameInvariants;
 use context::ContextWriter;
 use context::SuperBlockOffset;
@@ -443,13 +442,12 @@ impl RestorationState {
   }  
 
   pub fn lrf_optimize_superblock(&mut self, _sbo: &SuperBlockOffset, _fi: &FrameInvariants,
-                                 _fs: &FrameState, _cw: &mut ContextWriter) {
+                                 _cw: &mut ContextWriter) {
   }
 
-  pub fn lrf_filter_frame(&mut self, fs: &mut FrameState, pre_cdef: &Frame,
+  pub fn lrf_filter_frame(&mut self, out: &mut Frame, pre_cdef: &Frame,
                           bit_depth: usize) {
-    let cdeffed = &fs.rec.clone();
-    let out = &mut fs.rec;
+    let cdeffed = out.clone();
     
     // number of stripes (counted according to colocated Y luma position)
     let stripe_n = (self.plane[0].clipped_cfg.height + 7) / 64 + 1;

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -57,7 +57,7 @@ pub const SGRPROJ_PARAMS_EPS: [[u8; 2]; 1 << SGRPROJ_PARAMS_BITS] = [
   [ 0, 11], [ 0, 14], [30,  0], [75,  0],
 ];
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum RestorationFilter {
   None,
   Wiener  { coeffs: [[i8; 3]; 2] },
@@ -315,7 +315,7 @@ fn wiener_stripe_rdu(coeffs: [[i8; 3]; 2], y: isize, h: isize, x: usize, w: usiz
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct RestorationUnit {
   pub filter: RestorationFilter,
   pub coded: bool,
@@ -330,7 +330,7 @@ impl RestorationUnit {
   }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RestorationPlane {
   // all size units are subsampled if the plane is subsampled
   pub clipped_cfg: PlaneConfig,
@@ -393,7 +393,7 @@ impl RestorationPlane {
   }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RestorationState {
   pub plane: [RestorationPlane; PLANES]
 }

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -73,44 +73,6 @@ impl Plane {
     }
   }
 
-  pub fn window(&self, po: &PlaneOffset) -> Plane {
-    assert!(self.cfg.xorigin >= 0 && self.cfg.yorigin >= 0);
-    let x = po.x as usize;
-    let y = po.y as usize;
-    let xpad = self.cfg.xorigin as usize;
-    let ypad = self.cfg.yorigin as usize;
-    let xdec = self.cfg.xdec;
-    let ydec = self.cfg.ydec;
-    let xorigin = self.cfg.xorigin - po.x;
-    let yorigin = self.cfg.yorigin - po.y;
-    let width = 1 << (6 - xdec);
-    let height = 1 << (6 - ydec);
-    let stride = (xpad + width + xpad)
-      .align_power_of_two(Plane::STRIDE_ALIGNMENT_LOG2 - 1);
-    let alloc_height = ypad + height + ypad;
-    let mut data = vec![128u16; stride * alloc_height];
-    for (d, s) in data
-      .chunks_mut(stride)
-      .zip(self.data[(y * self.cfg.stride)..].chunks(self.cfg.stride))
-    {
-      let w = d.len().min(s.len() - x);
-      d[..w].copy_from_slice(&s[x..(x + w)]);
-    }
-    Plane {
-      data,
-      cfg: PlaneConfig {
-        stride,
-        alloc_height,
-        width,
-        height,
-        xdec,
-        ydec,
-        xorigin,
-        yorigin
-      }
-    }
-  }
-
   pub fn pad(&mut self, w: usize, h: usize) {
     assert!(self.cfg.xorigin >= 0 && self.cfg.yorigin >= 0);
     let xorigin = self.cfg.xorigin as usize;


### PR DESCRIPTION
## Context

In order to prepare for the possibility to encode tiles in parallel, I implemented an iterator providing non-overlapping tiles (`TileMut<'_>`), which are a "view" on the underlying frame (see https://github.com/xiph/rav1e/pull/821).

But _frames_ are only part of the data to be split.

To encode a tile, we will also need one `TileState` (similar to `FrameState`) per tile, each providing access to the tile (`TileMut<'_>`).

In addition, currently, the `RestorationState` is used both at "tile level" (accessing only data for a specific tile, independently of other tiles) and at "frame level" (crossing tile borders). To allow tile parallelization, the same way we created `TileMut<'_>` view from a `Frame`, we can create a `TileRestorationStateMut<'_>` (or whatever the name) view from a `RestorationState`. Concretely, such a view would expose only the `RestorationUnit`s (stored in the `RestorationPlane`s) belonging to the tile.

## Objective

Instead of managing several views (`TileMut<'_>`, `TileStateMut<'_>`, `TileRestorationStateMut<'_>`), the idea is to only use one (top-level) `TileStateMut<'_>` containing all tile-specific data and views.

Concretely, `FrameState` would expose an iterator providing `TileStateMut<'_>` instances, each one used to encode a tile (possibly in its own thread).

In `TileStateMut<'_>`:
 - `tile_state.tile` will expose the `TileMut<'_>`;
 - `tile_state.restoration` will expose the `TileRestorationStateMut<'_>`.

Once all the tiles for a frame have been encoded, we can then access the full `FrameState` (which has been written through the tile views) to execute "frame level" stuff (deblocking, restoration, …).

## PR

The first step to get a "unified" view for a tile, containing all necessary states, is to move `RestorationState` into `FrameState`.

Here is a summary of the commits (see commit messages for more details):
 - commit 1 removes `FrameState::window()`, which is unused and add unnecessary restrictions.
 - commit 2 avoids to borrow `FrameState` from a non-const `RestorationState` method (this would break borrowing rules once we move it).
 - commit 3 make `RestorationState` derive `Debug`.
 - commit 4 actually moves `RestorationState` into `FrameState`.
 - optional commits 5 and 6 narrow the borrowing to `FrameState` fields only (for consistency with what we do with `RestorationState`).

This PR is independent of tile encoding support (it just paves the way).

## Impact

This will conflicts with https://github.com/xiph/rav1e/pull/833, but should be easy to resolve.