### PR TITLE
Move Sequence into FrameInvariants

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -246,13 +246,25 @@ pub struct ColorDescription {
 }
 
 /// Frame-specific information
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub struct FrameInfo {
   pub width: usize,
   pub height: usize,
   pub bit_depth: usize,
   pub chroma_sampling: ChromaSampling,
   pub chroma_sample_position: ChromaSamplePosition
+}
+
+impl Default for FrameInfo {
+    fn default() -> FrameInfo {
+        FrameInfo {
+            width: 640,
+            height: 480,
+            bit_depth: 8,
+            chroma_sampling: Default::default(),
+            chroma_sample_position: Default::default()
+        }
+    }
 }
 
 /// Contain all the encoder configuration

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -243,10 +243,9 @@ pub fn cdef_filter_superblock(fi: &FrameInvariants,
                               bc_global: &mut BlockContext,
                               sbo: &SuperBlockOffset,
                               sbo_global: &SuperBlockOffset,
-                              bit_depth: usize,
                               cdef_index: u8,
                               cdef_dirs: &CdefDirections) {
-    let coeff_shift = bit_depth as i32 - 8;
+    let coeff_shift = fi.sequence.bit_depth as i32 - 8;
     let cdef_damping = fi.cdef_damping as i32;
     let cdef_y_strength = fi.cdef_y_strengths[cdef_index as usize];
     let cdef_uv_strength = fi.cdef_uv_strengths[cdef_index as usize];
@@ -324,7 +323,7 @@ pub fn cdef_filter_superblock(fi: &FrameInvariants,
 // CDEF parameters are stored for each 64 by 64 block of pixels.
 // The CDEF filter is applied on each 8 by 8 block of pixels.
 // Reference: http://av1-spec.argondesign.com/av1-spec/av1-spec.html#cdef-process
-pub fn cdef_filter_frame(fi: &FrameInvariants, rec: &mut Frame, bc: &mut BlockContext, bit_depth: usize) {
+pub fn cdef_filter_frame(fi: &FrameInvariants, rec: &mut Frame, bc: &mut BlockContext) {
 
     // Each filter block is 64x64, except right and/or bottom for non-multiple-of-64 sizes.
     // FIXME: 128x128 SB support will break this, we need FilterBlockOffset etc.
@@ -384,8 +383,8 @@ pub fn cdef_filter_frame(fi: &FrameInvariants, rec: &mut Frame, bc: &mut BlockCo
         for fbx in 0..fb_width {
             let sbo = SuperBlockOffset { x: fbx, y: fby };
             let cdef_index = bc.at(&sbo.block_offset(0, 0)).cdef_index;
-            let cdef_dirs = cdef_analyze_superblock(&mut cdef_frame, bc, &sbo, &sbo, bit_depth);
-            cdef_filter_superblock(fi, &mut cdef_frame, rec, bc, &sbo, &sbo, bit_depth, cdef_index, &cdef_dirs);
+            let cdef_dirs = cdef_analyze_superblock(&mut cdef_frame, bc, &sbo, &sbo, fi.sequence.bit_depth);
+            cdef_filter_superblock(fi, &mut cdef_frame, rec, bc, &sbo, &sbo, cdef_index, &cdef_dirs);
         }
     }
 }

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -1339,13 +1339,11 @@ fn sse_optimize(fs: &mut FrameState, bc: &mut BlockContext, bit_depth: usize) {
 }
 
 pub fn deblock_filter_optimize(
-  fi: &FrameInvariants, fs: &mut FrameState, bc: &mut BlockContext,
-  bit_depth: usize
-) {
+  fi: &FrameInvariants, fs: &mut FrameState, bc: &mut BlockContext) {
   if fi.config.speed_settings.fast_deblock {
-    let q = ac_q(fi.base_q_idx, 0, bit_depth) as i32;
+    let q = ac_q(fi.base_q_idx, 0, fi.sequence.bit_depth) as i32;
     let level = clamp(
-      match bit_depth {
+      match fi.sequence.bit_depth {
         8 =>
           if fi.frame_type == FrameType::KEY {
             q * 17563 - 421574 + (1 << 18 >> 1) >> 18
@@ -1378,6 +1376,6 @@ pub fn deblock_filter_optimize(
     fs.deblock.levels[2] = level;
     fs.deblock.levels[3] = level;
   } else {
-    sse_optimize(fs, bc, bit_depth);
+    sse_optimize(fs, bc, fi.sequence.bit_depth);
   }
 }

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -16,7 +16,6 @@ use context::ContextWriter;
 use context::SuperBlockOffset;
 use context::PLANES;
 use context::MAX_SB_SIZE;
-use encoder::Sequence;
 use plane::Plane;
 use plane::PlaneConfig;
 use plane::PlaneOffset;
@@ -403,7 +402,7 @@ pub struct RestorationState {
 }
 
 impl RestorationState {
-  pub fn new(seq: &Sequence, fi: &FrameInvariants, input: &Frame) -> Self {
+  pub fn new(fi: &FrameInvariants, input: &Frame) -> Self {
     // unlike the other loop filters that operate over the padded
     // frame dimensions, restoration filtering and source pixel
     // accesses are clipped to the original frame dimensions
@@ -421,7 +420,7 @@ impl RestorationState {
     clipped_cfg[2].height = fi.height + (1 << ydec >> 1) >> ydec;
 
     // Currrently opt for smallest possible restoration unit size
-    let lrf_y_shift = if seq.use_128x128_superblock {1} else {2};
+    let lrf_y_shift = if fi.sequence.use_128x128_superblock {1} else {2};
     let lrf_uv_shift = lrf_y_shift + if xdec>0 && ydec>0 {1} else {0};
     let lrf_type: [u8; PLANES] = [RESTORE_SWITCHABLE, RESTORE_SWITCHABLE, RESTORE_SWITCHABLE];
     let unit_size: [usize; PLANES] = [RESTORATION_TILESIZE_MAX >> lrf_y_shift,
@@ -448,9 +447,7 @@ impl RestorationState {
   }  
 
   pub fn lrf_optimize_superblock(&mut self, _sbo: &SuperBlockOffset, _fi: &FrameInvariants,
-                                 _fs: &FrameState, _cw: &mut ContextWriter,
-                                 _bit_depth: usize) {
-    
+                                 _fs: &FrameState, _cw: &mut ContextWriter) {
   }
 
   pub fn lrf_filter_frame(&mut self, fs: &mut FrameState, pre_cdef: &Frame,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -1166,7 +1166,7 @@ impl PredictionMode {
   pub fn predict_inter<'a>(
     self, fi: &FrameInvariants, p: usize, po: &PlaneOffset,
     dst: &'a mut PlaneMutSlice<'a>, width: usize, height: usize,
-    ref_frames: [usize; 2], mvs: [MotionVector; 2], bit_depth: usize
+    ref_frames: [usize; 2], mvs: [MotionVector; 2]
   ) {
     assert!(!self.is_intra());
 
@@ -1189,11 +1189,11 @@ impl PredictionMode {
             (mvs[i].col as i32 - (col_offset << shift_col)) << (4 - shift_col);
           let ref_stride = rec_cfg.stride;
 
-          let max_sample_val = ((1 << bit_depth) - 1) as i32;
+          let max_sample_val = ((1 << fi.sequence.bit_depth) - 1) as i32;
           let y_filter_idx = if height <= 4 { 4 } else { 0 };
           let x_filter_idx = if width <= 4 { 4 } else { 0 };
           let shifts = {
-            let shift_offset = if bit_depth == 12 { 2 } else { 0 };
+            let shift_offset = if fi.sequence.bit_depth == 12 { 2 } else { 0 };
             let inter_round0 = 3 + shift_offset;
             let inter_round1 = if is_compound { 7 } else { 11 } - shift_offset;
             (inter_round0, inter_round1, 14 - inter_round0 - inter_round1)

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -13,7 +13,7 @@
 
 use context::{INTRA_MODES, MAX_TX_SIZE};
 use partition::*;
-use util::*;
+use util::Pixel;
 
 #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
 use libc;


### PR DESCRIPTION
This simplifies several function signatures.

I think that a reference to a `Sequence` would be better, but currently the header writing functions require a mutable `Sequence` and `FrameInvariants`, so there are some complications with mutable borrows. It is relatively simple to transition to a reference from there.

Will probably require changes to [crav1e](https://github.com/lu-zero/crav1e/).