### PR TITLE
Remove duplicate fields

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3036,7 +3036,7 @@ impl ContextWriter {
               }
             }
             RestorationFilter::Sgrproj{set, xqd} => {
-              match rs.lrf_type[pli] {
+              match rs.plane[pli].lrf_type {
                 RESTORE_SGRPROJ => {
                   symbol_with_update!(self, w, 1, &mut self.fc.lrf_sgrproj_cdf);
                 }
@@ -3067,7 +3067,7 @@ impl ContextWriter {
               }
             }
             RestorationFilter::Wiener{coeffs} => {
-              match rs.lrf_type[pli] {
+              match rs.plane[pli].lrf_type {
                 RESTORE_WIENER => {
                   symbol_with_update!(self, w, 1, &mut self.fc.lrf_wiener_cdf);
                 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1510,8 +1510,8 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
         let mut use_lrf = false;
         let mut use_chroma_lrf = false;
         for i in 0..PLANES {
-          self.write(2,rs.lrf_type[i])?; // filter type by plane
-          if rs.lrf_type[i] != RESTORE_NONE {
+          self.write(2, rs.plane[i].lrf_type)?; // filter type by plane
+          if rs.plane[i].lrf_type != RESTORE_NONE {
             use_lrf = true;
             if i > 0 { use_chroma_lrf = true; }
           }
@@ -1519,15 +1519,15 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
         if use_lrf {
           // The Y shift value written here indicates shift up from superblock size
           if !fi.sequence.use_128x128_superblock {
-            self.write(1, if rs.unit_size[0] > 64 {1} else {0})?;
+            self.write(1, if rs.plane[0].unit_size > 64 {1} else {0})?;
           }
-          if rs.unit_size[0] > 64 {
-            self.write(1, if rs.unit_size[0] > 128 {1} else {0})?;
+          if rs.plane[0].unit_size > 64 {
+            self.write(1, if rs.plane[0].unit_size > 128 {1} else {0})?;
           }
 
           if use_chroma_lrf {
             if fi.sequence.chroma_sampling == ChromaSampling::Cs420 {
-              self.write(1, if rs.unit_size[0] > rs.unit_size[1] {1} else {0})?;
+              self.write(1, if rs.plane[0].unit_size > rs.plane[1].unit_size {1} else {0})?;
             }
           }
         }

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -396,8 +396,6 @@ impl RestorationPlane {
 
 #[derive(Clone)]
 pub struct RestorationState {
-  pub lrf_type: [u8; PLANES],
-  pub unit_size: [usize; PLANES],
   pub plane: [RestorationPlane; PLANES]
 }
 
@@ -428,8 +426,6 @@ impl RestorationState {
                                       RESTORATION_TILESIZE_MAX >> lrf_uv_shift];
 
     RestorationState {
-      lrf_type,
-      unit_size,
       plane: [RestorationPlane::new(&clipped_cfg[0], lrf_type[0], unit_size[0]),
               RestorationPlane::new(&clipped_cfg[1], lrf_type[1], unit_size[1]),
               RestorationPlane::new(&clipped_cfg[2], lrf_type[2], unit_size[2])]


### PR DESCRIPTION
`lrf_type` and `unit_size` are per-plane values, there is no need to duplicate them as arrays in `RestorationState`.

(we could also rename `plane` to `planes`)