### PR TITLE
Simplify RestorationState (prepare for tiling)

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2747,7 +2747,7 @@ fn encode_tile(fi: &FrameInvariants, fs: &mut FrameState) -> Vec<u8> {
       }
       /* TODO: Don't apply if lossless */
       if fi.sequence.enable_restoration {
-        fs.restoration.lrf_filter_frame(&mut fs.rec, &pre_cdef_frame, fi.sequence.bit_depth);
+        fs.restoration.lrf_filter_frame(&mut fs.rec, &pre_cdef_frame, &fi);
       }
     }
 


### PR DESCRIPTION
## Objective

As I explained in #836, I want to create `TileState<'_>` views from a `FrameState`, so that we can encode tiles in parallel (several threads could work on different `TileState<'_>` simultaneously).

`FrameState` now contains (since #836) a `RestorationState`, so `TileState<'_>` will contain a `TileRestorationState<'_>`, a tiled-view of the restoration state.

However, `RestorationState` contains `RestorationPlane`s, which each in turn contain a `PlaneConfig` named `clipped_cfg`. As a preliminary step, I would like to **remove this field entirely**, to simplify the future `TileRestorationState<'_>`.

## Details

AFAIU, this _clipped_ `PlaneConfig` was used for two reasons.

### Non-padded frame

`Frame`s are created with [padded width and height](https://github.com/xiph/rav1e/blob/969549044933efcdc4e98d900f63fc4fa69b3f40/src/encoder.rs#L431) ([rounded up to the next multiple of 8](
https://github.com/xiph/rav1e/blob/969549044933efcdc4e98d900f63fc4fa69b3f40/src/encoder.rs#L594-L595)).

Contrary to the other loop filters, the restoration filter is applied on the "cropped" (i.e. non-padded) frame. The `width` and `height` fields in `PlaneConfig` contain the padded values, only `FrameInvariants` knows the original values. _(thanks @xiphmont!)_

Therefore, on construction,`RestorationState` created a [clipped version](https://github.com/xiph/rav1e/blob/969549044933efcdc4e98d900f63fc4fa69b3f40/src/lrf.rs#L447-L461) from the frame `PlaneConfig`. It then used it in `lrf_filter_frame()` to get non-padded dimensions.

But we can achieve the same result by simply passing `&FrameInvariants` to `lrf_filter_frame()`. **This is what the first commit changes.**

### Mapping superblock → restoration unit

`RestorationPlane` exposes methods to retrieve the `RestorationUnit` associated to a `SuperBlockOffset` (currently, it [only called from `write_lrf()`](https://github.com/xiph/rav1e/blob/969549044933efcdc4e98d900f63fc4fa69b3f40/src/context.rs#L3017)).

For that purpose, it converted the offset to [plane coordinates](https://github.com/xiph/rav1e/blob/969549044933efcdc4e98d900f63fc4fa69b3f40/src/lrf.rs#L416-L422). But then, this made the implementation dependant of chroma subsampling, while in theory the mapping [superblock → restoration unit] is independant of subsampling. To handle this, the `xdec` and `ydec` fields of the clipped `PlaneConfig` were used to convert properly.

But we can retrieve the restoration unit directly from the superblock offset, without passing by plane coordinates. That way, we don't need `clipped_cfg` anymore. **This is what the second commit changes.**