### PR TITLE
Revert "Early termination for bottomup partition search (i.e. speed 0…

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2292,8 +2292,7 @@ pub fn encode_block_with_modes(fi: &FrameInvariants, fs: &mut FrameState,
 fn encode_partition_bottomup(
   fi: &FrameInvariants, fs: &mut FrameState, cw: &mut ContextWriter,
   w_pre_cdef: &mut dyn Writer, w_post_cdef: &mut dyn Writer, bsize: BlockSize,
-  bo: &BlockOffset, pmvs: &[[Option<MotionVector>; REF_FRAMES]; 5],
-  ref_rd_cost: f64
+  bo: &BlockOffset, pmvs: &[[Option<MotionVector>; REF_FRAMES]; 5]
 ) -> (f64, Option<RDOPartitionOutput>) {
     let mut rd_cost = std::f64::MAX;
     let mut best_rd = std::f64::MAX;
@@ -2337,12 +2336,14 @@ fn encode_partition_bottomup(
     // Code the whole block
     // TODO(yushin): Try move PARTITION_NONE to below partition loop
     if !must_split {
+        best_partition = PartitionType::PARTITION_NONE;
+
         let mut cost: f64 = 0.0;
 
         if bsize.gte(BlockSize::BLOCK_8X8) && is_square {
             let w: &mut dyn Writer = if cw.bc.cdef_coded {w_post_cdef} else {w_pre_cdef};
             let tell = w.tell_frac();
-            cw.write_partition(w, bo, PartitionType::PARTITION_NONE, bsize);
+            cw.write_partition(w, bo, best_partition, bsize);
             cost = (w.tell_frac() - tell) as f64 * get_lambda(fi)/ ((1 << OD_BITRES) as f64);
         }
 
@@ -2356,16 +2357,13 @@ fn encode_partition_bottomup(
         let mode_decision = rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs, false).part_modes[0].clone();
 
         rd_cost = mode_decision.rd_cost + cost;
+        best_rd = rd_cost;
 
-        if rd_cost < ref_rd_cost {
-            best_partition = PartitionType::PARTITION_NONE;
-            best_rd = rd_cost;
-            best_decision = mode_decision.clone();
-            best_pred_modes.push(best_decision.clone());
+        encode_block_with_modes(fi, fs, cw, w_pre_cdef, w_post_cdef, bsize, bo,
+                            &mode_decision);
 
-            encode_block_with_modes(fi, fs, cw, w_pre_cdef, w_post_cdef, bsize, bo,
-                                &mode_decision);
-        }
+        best_decision = mode_decision;
+        best_pred_modes.push(best_decision.clone());
     }
 
     // Test all partition types other than PARTITION_NONE by comparing their RD costs
@@ -2413,7 +2411,7 @@ fn encode_partition_bottomup(
             // If either of horz or vert partition types is being tested,
             // two partitioned rectangles, defined in 'partitions', of the current block
             // is passed to encode_partition_bottomup()
-            for offset in partitions {
+            partitions.iter().for_each(|&offset| {
                 if let (cost, Some(mode_decision)) = encode_partition_bottomup(
                     fi,
                     fs,
@@ -2422,25 +2420,22 @@ fn encode_partition_bottomup(
                     w_post_cdef,
                     subsize,
                     offset,
-                    pmvs,//&best_decision.mvs[0]
-                    best_rd
+                    pmvs//&best_decision.mvs[0]
                 ) {
                     rd_cost += cost;
-                    if rd_cost > best_rd || rd_cost > ref_rd_cost { break; }
-                    else { child_modes.push(mode_decision); }
+                    child_modes.push(mode_decision);
                 }
-            };
+            });
 
-            if rd_cost < best_rd && rd_cost < ref_rd_cost {
+            if rd_cost < best_rd {
                 best_rd = rd_cost;
                 best_partition = partition;
                 best_pred_modes = child_modes.clone();
             }
         }
 
-        // If the best partition is not PARTITION_SPLIT or PARTITION_INVALID, recode it
-        if best_partition != PartitionType::PARTITION_SPLIT &&
-            best_partition != PartitionType::PARTITION_INVALID {
+        // If the best partition is not PARTITION_SPLIT, recode it
+        if best_partition != PartitionType::PARTITION_SPLIT {
             cw.rollback(&cw_checkpoint);
             w_pre_cdef.rollback(&w_pre_checkpoint);
             w_post_cdef.rollback(&w_post_checkpoint);
@@ -2462,14 +2457,13 @@ fn encode_partition_bottomup(
         }
     }
 
-    if best_partition != PartitionType::PARTITION_INVALID {
-        let subsize = bsize.subsize(best_partition);
+    let subsize = bsize.subsize(best_partition);
 
-        if bsize.gte(BlockSize::BLOCK_8X8) &&
-            (bsize == BlockSize::BLOCK_8X8 || best_partition != PartitionType::PARTITION_SPLIT) {
-            cw.bc.update_partition_context(bo, subsize, bsize);
-        }
+    if bsize.gte(BlockSize::BLOCK_8X8) &&
+        (bsize == BlockSize::BLOCK_8X8 || best_partition != PartitionType::PARTITION_SPLIT) {
+        cw.bc.update_partition_context(bo, subsize, bsize);
     }
+
     (best_rd, Some(best_decision))
 }
 
@@ -2776,7 +2770,7 @@ fn encode_tile(fi: &FrameInvariants, fs: &mut FrameState) -> Vec<u8> {
             if fi.config.speed_settings.encode_bottomup {
                 encode_partition_bottomup(fi, fs, &mut cw,
                                           &mut w_pre_cdef, &mut w_post_cdef,
-                                          BlockSize::BLOCK_64X64, &bo, &pmvs, std::f64::MAX);
+                                          BlockSize::BLOCK_64X64, &bo, &pmvs);
             }
             else {
                 encode_partition_topdown(fi, fs, &mut cw,


### PR DESCRIPTION
… only) (#858)"

This reverts commit 3a261f320befe0df2a6b89128dff708962402adb.

Because of bd-rate change,

|   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000 |
|   ---: |    ---: |    ---: |     ---: |   ---: |    ---: |       ---: |
| 0.0046 |  0.0263 |  0.0246 |   0.0055 | 0.0032 |  0.0059 |     0.0151 |

[AWCY results](https://beta.arewecompressedyet.com/?job=master_de68ab_s0_lowlatency%402019-01-16T01%3A27%3A21.601Z&job=early_exit_bottom_s0_low_latent%402019-01-16T01%3A27%3A37.303Z)

Hence I'd want to consider reverting this commit until we found the clear reason of bdrate change.

Otherwise, I'd like a workaround fix, https://github.com/xiph/rav1e/pull/876, 
which gives no change in bdrate.
