### PR TITLE
Do not build aom examples and tools

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -85,6 +85,8 @@ fn main() {
         .define("ENABLE_DOCS", "0")
         .define("ENABLE_NASM", "1")
         .define("ENABLE_TESTS", "0")
+        .define("ENABLE_TOOLS", "0")
+        .define("ENABLE_EXAMPLES", "0")
         .no_build_target(cfg!(windows))
         .build();
 


### PR DESCRIPTION
While debugging some strange issue with @xiphmont I noticed we spend time building something we not use.