### PR TITLE
Add Clippy to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: rust
+rust:
+  - stable
 addons:
   apt:
     packages: binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev
@@ -33,5 +35,10 @@ jobs:
         script: cargo test --verbose --release --features=decode_test -- --ignored
       - name: "Bench"
         script: cargo bench --verbose
+      - name: "Clippy (linter): verifying code quality"
+        script:
+          rustup component add clippy &&
+          cargo clippy --version &&
+          cargo clippy -- -D warnings -A clippy::all --verbose
       - name: "Doc"
         script: cargo doc --verbose

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,10 +11,10 @@
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
-#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
-#![cfg_attr(feature = "cargo-clippy", allow(unnecessary_mut_passed))]
-#![cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
-#![cfg_attr(feature = "cargo-clippy", allow(collapsible_if))]
+#![allow(clippy::cast_lossless)]
+#![allow(clippy::unnecessary_mut_passed)]
+#![allow(clippy::needless_range_loop)]
+#![allow(clippy::collapsible_if)]
 
 use ec::Writer;
 use encoder::{FrameInvariants, ReferenceMode};

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -9,9 +9,9 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 #![allow(non_camel_case_types)]
-#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
-#![cfg_attr(feature = "cargo-clippy", allow(identity_op))]
-#![cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
+#![allow(clippy::cast_lossless)]
+#![allow(clippy::identity_op)]
+#![allow(clippy::needless_range_loop)]
 
 use bitstream_io::{BitWriter, BigEndian};
 use std;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 #![allow(safe_extern_statics)]
-#![cfg_attr(feature = "cargo-clippy", allow(collapsible_if))]
+#![allow(clippy::collapsible_if)]
 
 extern crate bitstream_io;
 extern crate backtrace;

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -7,7 +7,7 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
+#![allow(clippy::cast_lossless)]
 
 use std::iter::FusedIterator;
 

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -8,8 +8,8 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 #![allow(non_upper_case_globals)]
-#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
-#![cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
+#![allow(clippy::cast_lossless)]
+#![allow(clippy::needless_range_loop)]
 
 use context::{INTRA_MODES, MAX_TX_SIZE};
 use partition::*;

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -7,7 +7,7 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
+#![allow(clippy::cast_lossless)]
 #![allow(non_upper_case_globals)]
 
 use partition::TxSize;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -9,7 +9,7 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 #![allow(non_camel_case_types)]
-#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
+#![allow(clippy::cast_lossless)]
 
 use api::PredictionModesSetting;
 use cdef::*;


### PR DESCRIPTION
This PR adds Clippy (a linter for code quality verification) to the CI pipeline.

Currently, in order to prevent build failures and minimize the amount of noise in the build output, all errors and warnings are disabled. The idea is to start enabling different lints and lint categories slowly, one by one, fixing all found warnings and errors, so that such changes would be minimal and wouldn't affect anyone else.

Some files with `cfg_attr` attributes for Clippy had to be modified, because otherwise Clippy would treat them as warnings, since they're deprecated. Clippy is configured to treat warnings as errors, so this would cause build failures. I didn't find a way to ignore such issues, so I decided to simply fix them, because changes that they cause are quite small.