### PR TITLE
Add estimated time and 3rd decimal to fps in CLI output

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -16,7 +16,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::sync::Arc;
 use std::time::Instant;
-use std::ops::Sub
+use std::ops::Sub;
 use y4m;
 
 pub struct EncoderIO {

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -457,6 +457,11 @@ impl ProgressInfo {
       .map(|frames| self.encoded_size * frames / self.frames_encoded())
       .unwrap_or_default()
   }
+  
+  // Estimates the remaining encoding time in seconds, if the number of frames is known
+  pub fn estimated_time(&self) -> f64 {
+    self.total_frames() - self.frames_encoded() / self.encoding_fps()
+  }
 
   // Number of frames of given type which appear in the video
   pub fn get_frame_type_count(&self, frame_type: FrameType) -> usize {
@@ -505,12 +510,13 @@ impl fmt::Display for ProgressInfo {
     if let Some(total_frames) = self.total_frames {
       write!(
         f,
-        "encoded {}/{} frames, {:.3} fps, {:.2} Kb/s, est. size: {:.2} MB",
+        "encoded {}/{} frames, {:.3} fps, {:.2} Kb/s, est. size: {:.2} MB, est. time: {} s",
         self.frames_encoded(),
         total_frames,
         self.encoding_fps(),
         self.bitrate() as f64 / 1024f64,
         self.estimated_size() as f64 / (1024 * 1024) as f64
+        self.estimated_time(),
       )
     } else {
       write!(

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -460,7 +460,7 @@ impl ProgressInfo {
   
   // Estimates the remaining encoding time in seconds
   pub fn estimated_time(&self) -> f64 {
-    (self.total_frames() - self.frames_encoded()) as f64 / self.encoding_fps()
+    (self.total_frames - self.frames_encoded()) as f64 / self.encoding_fps()
   }
 
   // Number of frames of given type which appear in the video

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -458,9 +458,11 @@ impl ProgressInfo {
       .unwrap_or_default()
   }
   
-  // Estimates the remaining encoding time in seconds
+  // Estimates the remaining encoding time in seconds, if the number of frames is known
   pub fn estimated_time(&self) -> f64 {
-    (total_frames as f64 - self.frames_encoded() as f64) / self.encoding_fps()
+    self.total_frames
+      .map(|frames| frames - self.frames_encoded() / self.encoding_fps())
+      .unwrap_or_default()
   }
 
   // Number of frames of given type which appear in the video

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -505,7 +505,7 @@ impl fmt::Display for ProgressInfo {
     if let Some(total_frames) = self.total_frames {
       write!(
         f,
-        "encoded {}/{} frames, {:.2} fps, {:.2} Kb/s, est. size: {:.2} MB",
+        "encoded {}/{} frames, {:.3} fps, {:.2} Kb/s, est. size: {:.2} MB",
         self.frames_encoded(),
         total_frames,
         self.encoding_fps(),
@@ -515,7 +515,7 @@ impl fmt::Display for ProgressInfo {
     } else {
       write!(
         f,
-        "encoded {} frames, {:.2} fps, {:.2} Kb/s",
+        "encoded {} frames, {:.3} fps, {:.2} Kb/s",
         self.frames_encoded(),
         self.encoding_fps(),
         self.bitrate() as f64 / 1024f64

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -16,7 +16,6 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::sync::Arc;
 use std::time::Instant;
-use std::ops::Sub;
 use y4m;
 
 pub struct EncoderIO {
@@ -461,7 +460,7 @@ impl ProgressInfo {
   
   // Estimates the remaining encoding time in seconds
   pub fn estimated_time(&self) -> f64 {
-    (self.total_frames - self.frames_encoded()) as f64 / self.encoding_fps()
+    (self.total_frames as f64 - self.frames_encoded() as f64) / self.encoding_fps()
   }
 
   // Number of frames of given type which appear in the video

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -16,6 +16,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::sync::Arc;
 use std::time::Instant;
+use std::ops::Sub
 use y4m;
 
 pub struct EncoderIO {

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -458,9 +458,9 @@ impl ProgressInfo {
       .unwrap_or_default()
   }
   
-  // Estimates the remaining encoding time in seconds, if the number of frames is known
+  // Estimates the remaining encoding time in seconds
   pub fn estimated_time(&self) -> f64 {
-    self.total_frames() - self.frames_encoded() / self.encoding_fps()
+    (self.total_frames() - self.frames_encoded()) as f64 / self.encoding_fps()
   }
 
   // Number of frames of given type which appear in the video

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -461,7 +461,7 @@ impl ProgressInfo {
   // Estimates the remaining encoding time in seconds, if the number of frames is known
   pub fn estimated_time(&self) -> f64 {
     self.total_frames
-      .map(|frames| frames - self.frames_encoded() / self.encoding_fps())
+      .map(|frames| (frames - self.frames_encoded()) as f64 / self.encoding_fps())
       .unwrap_or_default()
   }
 

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -515,8 +515,8 @@ impl fmt::Display for ProgressInfo {
         total_frames,
         self.encoding_fps(),
         self.bitrate() as f64 / 1024f64,
-        self.estimated_size() as f64 / (1024 * 1024) as f64
-        self.estimated_time(),
+        self.estimated_size() as f64 / (1024 * 1024) as f64,
+        self.estimated_time()
       )
     } else {
       write!(

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -512,7 +512,7 @@ impl fmt::Display for ProgressInfo {
     if let Some(total_frames) = self.total_frames {
       write!(
         f,
-        "encoded {}/{} frames, {:.3} fps, {:.2} Kb/s, est. size: {:.2} MB, est. time: {} s",
+        "encoded {}/{} frames, {:.3} fps, {:.2} Kb/s, est. size: {:.2} MB, est. time: {:.0} s",
         self.frames_encoded(),
         total_frames,
         self.encoding_fps(),

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -460,7 +460,7 @@ impl ProgressInfo {
   
   // Estimates the remaining encoding time in seconds
   pub fn estimated_time(&self) -> f64 {
-    (self.total_frames as f64 - self.frames_encoded() as f64) / self.encoding_fps()
+    (total_frames as f64 - self.frames_encoded() as f64) / self.encoding_fps()
   }
 
   // Number of frames of given type which appear in the video


### PR DESCRIPTION
Some small changes to the CLI output
- Adds a estimated time
- Adds a 3rd decimal to fps

Previous CLI output: 
```encoded 60/120 frames, 0.25 fps, 1075.22 Kb/s, est. size: 0.26 MB```

New CLI output: 
```encoded 60/120 frames, 0.248 fps, 1075.22 Kb/s, est. size: 0.26 MB, est. time: 242 s```