### PR TITLE
The rdo_mode_decision() only  returns RDOPartitionOutput struct

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2348,7 +2348,7 @@ fn encode_partition_bottomup(
         };
         let spmvs = &pmvs[pmv_idx];
 
-        let mode_decision = rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs, false).part_modes[0].clone();
+        let mode_decision = rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs, false);
 
         rd_cost = mode_decision.rd_cost + cost;
 
@@ -2572,7 +2572,7 @@ fn encode_partition_topdown(fi: &FrameInvariants, fs: &mut FrameState,
                     let spmvs = &pmvs[pmv_idx];
 
                     // Make a prediction mode decision for blocks encoded with no rdo_partition_decision call (e.g. edges)
-                    rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs, false).part_modes[0].clone()
+                    rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs, false)
                 };
 
             let mut mode_luma = part_decision.pred_mode_luma;


### PR DESCRIPTION
This also makes it possiblt to remove all .clone() calls to
the return value of rdo_mode_decision().