### PR TITLE
Add estimated time and 3rd decimal to fps in CLI output

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -492,6 +492,13 @@ impl ProgressInfo {
       .map(|frames| self.encoded_size * frames / self.frames_encoded())
       .unwrap_or_default()
   }
+  
+  // Estimates the remaining encoding time in seconds, if the number of frames is known
+  pub fn estimated_time(&self) -> f64 {
+    self.total_frames
+      .map(|frames| (frames - self.frames_encoded()) as f64 / self.encoding_fps())
+      .unwrap_or_default()
+  }
 
   // Number of frames of given type which appear in the video
   pub fn get_frame_type_count(&self, frame_type: FrameType) -> usize {
@@ -558,17 +565,18 @@ impl fmt::Display for ProgressInfo {
     if let Some(total_frames) = self.total_frames {
       write!(
         f,
-        "encoded {}/{} frames, {:.2} fps, {:.2} Kb/s, est. size: {:.2} MB",
+        "encoded {}/{} frames, {:.3} fps, {:.2} Kb/s, est. size: {:.2} MB, est. time: {:.0} s",
         self.frames_encoded(),
         total_frames,
         self.encoding_fps(),
         self.bitrate() as f64 / 1024f64,
-        self.estimated_size() as f64 / (1024 * 1024) as f64
+        self.estimated_size() as f64 / (1024 * 1024) as f64,
+        self.estimated_time()
       )
     } else {
       write!(
         f,
-        "encoded {} frames, {:.2} fps, {:.2} Kb/s",
+        "encoded {} frames, {:.3} fps, {:.2} Kb/s",
         self.frames_encoded(),
         self.encoding_fps(),
         self.bitrate() as f64 / 1024f64


### PR DESCRIPTION
Replaces #888.

Some small changes to the CLI output
- Adds a estimated time
- Adds a 3rd decimal to fps

Previous CLI output: 
```encoded 60/120 frames, 0.25 fps, 1075.22 Kb/s, est. size: 0.26 MB```

New CLI output: 
```encoded 60/120 frames, 0.248 fps, 1075.22 Kb/s, est. size: 0.26 MB, est. time: 242 s```