### PR TITLE
Refactor decoder to be codec agnostic

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1,0 +1,51 @@
+use encoder::Frame;
+use y4m::Colorspace;
+use std::io;
+use encoder::ChromaSampling;
+use encoder::ChromaSamplePosition;
+use api::Rational;
+
+pub mod y4m;
+
+pub trait Decoder {
+  fn get_video_details(&self) -> VideoDetails;
+  fn read_frame(&mut self, cfg: &VideoDetails) -> Result<Frame, DecodeError>;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct VideoDetails {
+  pub width: usize,
+  pub height: usize,
+  pub bits: usize,
+  pub bytes: usize,
+  pub color_space: Colorspace,
+  pub bit_depth: usize,
+  pub chroma_sampling: ChromaSampling,
+  pub chroma_sample_position: ChromaSamplePosition,
+  pub framerate: Rational,
+}
+
+impl Default for VideoDetails {
+  fn default() -> Self {
+    VideoDetails {
+      width: 640,
+      height: 480,
+      bits: 8,
+      bytes: 1,
+      color_space: Colorspace::Cmono,
+      bit_depth: 8,
+      chroma_sampling: ChromaSampling::Cs420,
+      chroma_sample_position: ChromaSamplePosition::Unknown,
+      framerate: Rational { num: 1, den: 1 }
+    }
+  }
+}
+
+#[derive(Debug)]
+pub enum DecodeError {
+  EOF,
+  BadInput,
+  UnknownColorspace,
+  ParseError,
+  IoError(io::Error),
+}

--- a/src/decoder/y4m.rs
+++ b/src/decoder/y4m.rs
@@ -1,0 +1,88 @@
+use std::io::Read;
+
+use api::Rational;
+use decoder::DecodeError;
+use decoder::Decoder;
+use decoder::VideoDetails;
+use encoder::ChromaSamplePosition;
+use encoder::ChromaSampling;
+use encoder::Frame;
+use util::Fixed;
+
+impl Decoder for y4m::Decoder<'_, Box<dyn Read>> {
+  fn get_video_details(&self) -> VideoDetails {
+    let width = self.get_width();
+    let height = self.get_height();
+    let bits = self.get_bit_depth();
+    let bytes = self.get_bytes_per_sample();
+    let color_space = self.get_colorspace();
+    let bit_depth = color_space.get_bit_depth();
+    let (chroma_sampling, chroma_sample_position) = map_y4m_color_space(color_space);
+    let framerate = self.get_framerate();
+    let framerate =  Rational::new(framerate.num as u64, framerate.den as u64);
+    VideoDetails {
+      width,
+      height,
+      bits,
+      bytes,
+      color_space,
+      bit_depth,
+      chroma_sampling,
+      chroma_sample_position,
+      framerate,
+    }
+  }
+
+  fn read_frame(&mut self, cfg: &VideoDetails) -> Result<Frame, DecodeError> {
+    self.read_frame()
+      .map(|frame| {
+        let mut f = Frame::new(
+          cfg.width.align_power_of_two(3),
+          cfg.height.align_power_of_two(3),
+          cfg.chroma_sampling
+        );
+        f.planes[0].copy_from_raw_u8(frame.get_y_plane(), cfg.width * cfg.bytes, cfg.bytes);
+        f.planes[1].copy_from_raw_u8(
+          frame.get_u_plane(),
+          cfg.width * cfg.bytes / 2,
+          cfg.bytes
+        );
+        f.planes[2].copy_from_raw_u8(
+          frame.get_v_plane(),
+          cfg.width * cfg.bytes / 2,
+          cfg.bytes
+        );
+        f
+      })
+      .map_err(|e| e.into())
+  }
+}
+
+impl From<y4m::Error> for DecodeError {
+  fn from(e: y4m::Error) -> DecodeError {
+    match e {
+      y4m::Error::EOF => DecodeError::EOF,
+      y4m::Error::BadInput => DecodeError::BadInput,
+      y4m::Error::UnknownColorspace => DecodeError::UnknownColorspace,
+      y4m::Error::ParseError => DecodeError::ParseError,
+      y4m::Error::IoError(e) => DecodeError::IoError(e),
+    }
+  }
+}
+
+pub fn map_y4m_color_space(
+  color_space: y4m::Colorspace
+) -> (ChromaSampling, ChromaSamplePosition) {
+  use y4m::Colorspace::*;
+  use ChromaSampling::*;
+  use ChromaSamplePosition::*;
+  match color_space {
+    C420jpeg | C420paldv => (Cs420, Unknown),
+    C420mpeg2 => (Cs420, Vertical),
+    C420 | C420p10 | C420p12 => (Cs420, Colocated),
+    C422 | C422p10 | C422p12 => (Cs422, Colocated),
+    C444 | C444p10 | C444p12 => (Cs444, Colocated),
+    _ =>
+      panic!("Chroma characteristics unknown for the specified color space.")
+  }
+}

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -30,6 +30,7 @@ use std::{fmt, io};
 use std::io::Write;
 use std::rc::Rc;
 use std::sync::Arc;
+use decoder::VideoDetails;
 
 extern {
     pub fn av1_rtcd();
@@ -287,7 +288,7 @@ pub struct Sequence {
 }
 
 impl Sequence {
-    pub fn new(info: &FrameInfo) -> Sequence {
+    pub fn new(info: &VideoDetails) -> Sequence {
         let width_bits = 32 - (info.width as u32).leading_zeros();
         let height_bits = 32 - (info.height as u32).leading_zeros();
         assert!(width_bits <= 16);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ extern crate dav1d_sys;
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
+extern crate y4m;
 
 pub mod ec;
 pub mod partition;
@@ -41,6 +42,7 @@ pub mod deblock;
 pub mod segmentation;
 pub mod cdef;
 pub mod lrf;
+pub mod decoder;
 pub mod encoder;
 pub mod mc;
 pub mod me;

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -7,10 +7,10 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use api::FrameInfo;
 use encoder::Frame;
 
 use std::sync::Arc;
+use decoder::VideoDetails;
 
 /// Detects fast cuts using changes in colour and intensity between frames.
 /// Since the difference between frames is used, only fast cuts are detected
@@ -41,9 +41,9 @@ impl Default for SceneChangeDetector {
 }
 
 impl SceneChangeDetector {
-  pub fn new(frame_info: &FrameInfo) -> Self {
+  pub fn new(video_info: &VideoDetails) -> Self {
     let mut detector = Self::default();
-    detector.threshold = detector.threshold * frame_info.bit_depth as u8 / 8;
+    detector.threshold = detector.threshold * video_info.bit_depth as u8 / 8;
     detector
   }
 

--- a/src/test_encode_decode_aom.rs
+++ b/src/test_encode_decode_aom.rs
@@ -20,6 +20,11 @@ use std::{mem, ptr, slice};
 use std::collections::VecDeque;
 use std::ffi::CStr;
 use std::sync::Arc;
+use decoder::Decoder;
+use decoder::VideoDetails;
+use decoder::DecodeError;
+use util::Fixed;
+use y4m::Colorspace;
 
 fn fill_frame(ra: &mut ChaChaRng, frame: &mut Frame) {
   for plane in frame.planes.iter_mut() {
@@ -34,7 +39,7 @@ fn fill_frame(ra: &mut ChaChaRng, frame: &mut Frame) {
 }
 
 struct AomDecoder {
-  dec: aom_codec_ctx
+  dec: aom_codec_ctx,
 }
 
 fn setup_decoder(w: usize, h: usize) -> AomDecoder {
@@ -70,6 +75,23 @@ impl Drop for AomDecoder {
   }
 }
 
+impl Decoder for AomDecoder {
+  fn get_video_details(&self) -> VideoDetails {
+    unimplemented!()
+  }
+
+  fn read_frame(&mut self, cfg: &VideoDetails) -> Result<Frame, DecodeError> {
+    let mut f = Frame::new(
+      cfg.width.align_power_of_two(3),
+      cfg.height.align_power_of_two(3),
+      cfg.chroma_sampling
+    );
+    let mut ra = ChaChaRng::from_seed([0; 32]);
+    fill_frame(&mut ra, &mut f);
+    Ok(f)
+  }
+}
+
 fn setup_encoder(
   w: usize, h: usize, speed: usize, quantizer: usize, bit_depth: usize,
   chroma_sampling: ChromaSampling, min_keyint: u64, max_keyint: u64,
@@ -87,14 +109,17 @@ fn setup_encoder(
   enc.low_latency = low_latency;
 
   let cfg = Config {
-    frame_info: FrameInfo {
+    video_info: VideoDetails {
       width: w,
       height: h,
+      bits: bit_depth,
+      bytes: 1,
+      color_space: Colorspace::C420,
       bit_depth,
       chroma_sampling,
-      ..Default::default()
+      chroma_sample_position: ChromaSamplePosition::Unknown,
+      framerate: Rational::new(1000, 1),
     },
-    timebase: Rational::new(1, 1000),
     enc
   };
 
@@ -289,8 +314,6 @@ fn encode_decode(
   w: usize, h: usize, speed: usize, quantizer: usize, limit: usize,
   bit_depth: usize, min_keyint: u64, max_keyint: u64, low_latency: bool
 ) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
-
   let mut dec = setup_decoder(w, h);
   let mut ctx =
     setup_encoder(w, h, speed, quantizer, bit_depth, ChromaSampling::Cs420,
@@ -303,10 +326,8 @@ fn encode_decode(
   let mut rec_fifo = VecDeque::new();
 
   for _ in 0..limit {
-    let mut input = ctx.new_frame();
-    fill_frame(&mut ra, Arc::get_mut(&mut input).unwrap());
-
-    let _ = ctx.send_frame(Some(input));
+    let mut input = dec.read_frame(&ctx.config.video_info).unwrap();
+    let _ = ctx.send_frame(Some(Arc::new(input)));
 
     let mut done = false;
     let mut corrupted_count = 0;


### PR DESCRIPTION
This allows implementing other decoders in the future, and isolates the
decoding logic into one section of the codebase, making it easier to
refactor the encode/decode tests to handle lookahead and frame
reordering the same way as rav1e.