### PR TITLE
Bump the dav1d and bindgen versions again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ syn = "^0.15.20"
 quote = "^0.6.10" # hack for proc-macro-hack
 num-traits = "0.2"
 paste = "0.1"
-dav1d-sys = { version = "0.1.1", optional = true }
+dav1d-sys = { version = "0.1.2", optional = true }
 
 [build-dependencies]
 cmake = { version = "0.1", optional = true }
@@ -39,7 +39,7 @@ nasm-rs = { version = "0.1.4", optional = true }
 
 [target.'cfg(unix)'.build-dependencies]
 pkg-config = "0.3.12"
-bindgen = { version = "0.37", optional = true }
+bindgen = { version = "0.47.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.2"


### PR DESCRIPTION
I tested it with fedora 29 and seems working fine, could you please try and confirm?