### PR TITLE
Fix update_partition_context() to be not called for rect partition

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1486,6 +1486,8 @@ impl BlockContext {
     &mut self, bo: &BlockOffset, subsize: BlockSize, bsize: BlockSize
   ) {
     #[allow(dead_code)]
+    assert!(bsize.is_sqr());
+
     let bw = bsize.width_mi();
     let bh = bsize.height_mi();
 
@@ -1904,6 +1906,7 @@ impl ContextWriter {
   pub fn write_partition(
     &mut self, w: &mut dyn Writer, bo: &BlockOffset, p: PartitionType, bsize: BlockSize
   ) {
+    debug_assert!(bsize.is_sqr());
     assert!(bsize >= BlockSize::BLOCK_8X8 );
     let hbs = bsize.width_mi() / 2;
     let has_cols = (bo.x + hbs) < self.bc.cols;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2476,7 +2476,7 @@ fn encode_partition_bottomup(
 
     assert!(best_partition != PartitionType::PARTITION_INVALID);
 
-    if bsize.gte(BlockSize::BLOCK_8X8) &&
+    if is_square && bsize.gte(BlockSize::BLOCK_8X8) &&
         (bsize == BlockSize::BLOCK_8X8 || best_partition != PartitionType::PARTITION_SPLIT) {
         cw.bc.update_partition_context(bo, bsize.subsize(best_partition), bsize);
     }
@@ -2690,7 +2690,7 @@ fn encode_partition_topdown(fi: &FrameInvariants, fs: &mut FrameState,
         _ => { assert!(false); },
     }
 
-    if bsize.gte(BlockSize::BLOCK_8X8) &&
+    if is_square && bsize.gte(BlockSize::BLOCK_8X8) &&
         (bsize == BlockSize::BLOCK_8X8 || partition != PartitionType::PARTITION_SPLIT) {
             cw.bc.update_partition_context(bo, subsize, bsize);
     }


### PR DESCRIPTION
Fix the bug that update_partition_context() has been called for rectangular partition.
This bug has probably been introduced due to the design differences between rav1e and libaom.
The rav1e recursively calls the partitioning function until the final leaf block (and encode the block in the same function), while libaom calls dedicated encode block function once partitioning is finished.