### PR TITLE
Fix warnings caused by redundant field names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ jobs:
          - cargo doc --verbose
          - rustup component add clippy
          - cargo clippy --version
-         - cargo clippy -- -D warnings -A clippy::all --verbose
+         - cargo clippy -- -D warnings -A clippy::complexity -A clippy::correctness -A clippy::perf -A clippy::assign_op_pattern -A clippy::get_unwrap -A clippy::len_zero -A clippy::let_and_return -A clippy::needless_range_loop -A clippy::needless_return -A clippy::neg_multiply -A clippy::new_without_default -A clippy::new_without_default_derive -A clippy::ptr_arg -A clippy::single_match -A clippy::unreadable_literal -A clippy::useless_let_if_seq -A clippy::verbose_bit_mask --verbose

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -272,7 +272,7 @@ pub fn cdef_sb_padded_frame_copy(fi: &FrameInvariants, sbo: &SuperBlockOffset,
     let w = fi.padded_w as isize >> xdec;
     let offset = sbo.plane_offset(&f.planes[p].cfg);
     for y in 0..((sb_size>>ydec) + pad*2) as isize {
-      let mut out_slice = out.planes[p].mut_slice(&PlaneOffset {x:0, y:y});
+      let mut out_slice = out.planes[p].mut_slice(&PlaneOffset {x:0, y});
       let mut out_row = out_slice.as_mut_slice();
       if offset.y + y < ipad || offset.y+y >= h + ipad {
         // above or below the frame, fill with flag

--- a/src/context.rs
+++ b/src/context.rs
@@ -2089,7 +2089,7 @@ impl ContextWriter {
           let mv_cand = CandidateMV {
             this_mv: blk.mv[0],
             comp_mv: blk.mv[1],
-            weight: weight
+            weight
           };
 
           mv_stack.push(mv_cand);
@@ -2117,7 +2117,7 @@ impl ContextWriter {
             let mv_cand = CandidateMV {
               this_mv: blk.mv[i],
               comp_mv: MotionVector { row: 0, col: 0 },
-              weight: weight
+              weight
             };
 
             mv_stack.push(mv_cand);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -313,7 +313,7 @@ impl Sequence {
         }
 
         Sequence {
-            profile: profile,
+            profile,
             num_bits_width: width_bits,
             num_bits_height: height_bits,
             bit_depth: info.bit_depth,
@@ -344,11 +344,11 @@ impl Sequence {
             enable_cdef: true,
             enable_restoration: true,
             operating_points_cnt_minus_1: 0,
-            operating_point_idc: operating_point_idc,
+            operating_point_idc,
             display_model_info_present_flag: false,
             decoder_model_info_present_flag: false,
-            level: level,
-            tier: tier,
+            level,
+            tier,
             film_grain_params_present: false,
             separate_uv_delta_q: false,
         }
@@ -641,7 +641,7 @@ impl FrameInvariants {
             dc_delta_q: [0; 3],
             ac_delta_q: [0; 3],
             me_range_scale: 1,
-            use_tx_domain_distortion: use_tx_domain_distortion,
+            use_tx_domain_distortion,
             inter_cfg: None,
             enable_early_exit: true,
         }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -764,7 +764,7 @@ pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState,
 
   RDOPartitionOutput {
     bo: bo.clone(),
-    bsize: bsize,
+    bsize,
     pred_mode_luma: best.mode_luma,
     pred_mode_chroma: best.mode_chroma,
     pred_cfl_params: best.cfl_params,


### PR DESCRIPTION
This PR enables lints from the [clippy::style](https://rust-lang.github.io/rust-clippy/master/index.html) category, and fixes the [clippy::redundant_field_names](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names) warnings.

Other lints from the style category, that are causing warnings, were disabled, in order to keep the amount of noise and changes as minimal as possible.