### PR TITLE
Fix warnings caused by the Clippy's assign_op_pattern rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ jobs:
          - cargo doc --verbose
          - rustup component add clippy
          - cargo clippy --version
-         - cargo clippy -- -D warnings -A clippy::complexity -A clippy::correctness -A clippy::perf -A clippy::assign_op_pattern -A clippy::get_unwrap -A clippy::len_zero -A clippy::let_and_return -A clippy::needless_range_loop -A clippy::needless_return -A clippy::neg_multiply -A clippy::new_without_default -A clippy::new_without_default_derive -A clippy::ptr_arg -A clippy::single_match -A clippy::unreadable_literal -A clippy::useless_let_if_seq -A clippy::verbose_bit_mask --verbose
+         - cargo clippy -- -D warnings -A clippy::complexity -A clippy::correctness -A clippy::perf -A clippy::get_unwrap -A clippy::len_zero -A clippy::let_and_return -A clippy::needless_range_loop -A clippy::needless_return -A clippy::neg_multiply -A clippy::new_without_default -A clippy::new_without_default_derive -A clippy::ptr_arg -A clippy::single_match -A clippy::unreadable_literal -A clippy::useless_let_if_seq -A clippy::verbose_bit_mask --verbose

--- a/src/api.rs
+++ b/src/api.rs
@@ -386,7 +386,7 @@ impl Context {
   {
     let idx = self.frame_count;
     self.frame_q.insert(idx, frame.into());
-    self.frame_count = self.frame_count + 1;
+    self.frame_count += 1;
     Ok(())
   }
 
@@ -620,7 +620,7 @@ impl Context {
 
   pub fn flush(&mut self) {
     self.frame_q.insert(self.frame_count, None);
-    self.frame_count = self.frame_count + 1;
+    self.frame_count += 1;
   }
 
   fn determine_frame_type(&mut self, frame_number: u64) -> FrameType {

--- a/src/context.rs
+++ b/src/context.rs
@@ -2159,7 +2159,7 @@ impl ContextWriter {
             let mut cand_mv = blk.mv[cand_list];
             if cand_ref == ref_frames[list] && ref_id_count[list] < 2 {
               ref_id_mvs[list][ref_id_count[list]] = cand_mv;
-              ref_id_count[list] = ref_id_count[list] + 1;
+              ref_id_count[list] += 1;
             } else if ref_diff_count[list] < 2 {
               if fi.ref_frame_sign_bias[cand_ref - LAST_FRAME] !=
                 fi.ref_frame_sign_bias[ref_frames[list] - LAST_FRAME] {
@@ -2167,7 +2167,7 @@ impl ContextWriter {
                 cand_mv.col = -cand_mv.col;
               }
               ref_diff_mvs[list][ref_diff_count[list]] = cand_mv;
-              ref_diff_count[list] = ref_diff_count[list] + 1;
+              ref_diff_count[list] += 1;
             }
           }
         }
@@ -2474,12 +2474,12 @@ impl ContextWriter {
           let mut comp_count = 0;
           for idx in 0..ref_id_count[list] {
             combined_mvs[comp_count][list] = ref_id_mvs[list][idx];
-            comp_count = comp_count + 1;
+            comp_count += 1;
           }
           for idx in 0..ref_diff_count[list] {
             if comp_count < 2 {
               combined_mvs[comp_count][list] = ref_diff_mvs[list][idx];
-              comp_count = comp_count + 1;
+              comp_count += 1;
             }
           }
         }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1647,7 +1647,7 @@ fn aom_uleb_size_in_bytes(mut value: u64) -> usize {
   let mut size = 0;
   loop {
     size += 1;
-    value = value >> 7;
+    value >>= 7;
     if value == 0 { break; }
   }
   size

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -191,10 +191,10 @@ impl Plane {
 
       for col in 0..width {
         let mut sum = 0;
-        sum = sum + src.p(2*col, 2*row);
-        sum = sum + src.p(2*col+1, 2*row);
-        sum = sum + src.p(2*col, 2*row+1);
-        sum = sum + src.p(2*col+1, 2*row+1);
+        sum += src.p(2 * col, 2 * row);
+        sum += src.p(2 * col + 1, 2 * row);
+        sum += src.p(2 * col, 2 * row + 1);
+        sum += src.p(2 * col + 1, 2 * row + 1);
         let avg = (sum + 2) >> 2;
         dst[col] = avg;
       }


### PR DESCRIPTION
This PR enables the [assign_op_pattern](https://rust-lang.github.io/rust-clippy/current/index.html#assign_op_pattern) rule, and fixes all warnings caused by it.