### PR TITLE
Fix warnings caused by non-idiomatic returns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ jobs:
          - cargo doc --verbose
          - rustup component add clippy
          - cargo clippy --version
-         - cargo clippy -- -D warnings -A clippy::complexity -A clippy::correctness -A clippy::perf -A clippy::get_unwrap -A clippy::len_zero -A clippy::let_and_return -A clippy::needless_range_loop -A clippy::needless_return -A clippy::neg_multiply -A clippy::new_without_default -A clippy::new_without_default_derive -A clippy::ptr_arg -A clippy::single_match -A clippy::unreadable_literal -A clippy::useless_let_if_seq -A clippy::verbose_bit_mask --verbose
+         - cargo clippy -- -D warnings -A clippy::complexity -A clippy::correctness -A clippy::perf -A clippy::get_unwrap -A clippy::len_zero -A clippy::needless_range_loop -A clippy::neg_multiply -A clippy::new_without_default -A clippy::new_without_default_derive -A clippy::ptr_arg -A clippy::single_match -A clippy::unreadable_literal -A clippy::useless_let_if_seq -A clippy::verbose_bit_mask --verbose

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -231,7 +231,8 @@ pub fn cdef_analyze_superblock(in_frame: &mut Frame,
 
 pub fn cdef_sb_frame(fi: &FrameInvariants, f: &Frame) -> Frame {
   let sb_size = if fi.sequence.use_128x128_superblock {128} else {64};
-  let out = Frame {
+
+  Frame {
     planes: [
       Plane::new(sb_size >> f.planes[0].cfg.xdec, sb_size >> f.planes[0].cfg.ydec,
                  f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
@@ -240,8 +241,7 @@ pub fn cdef_sb_frame(fi: &FrameInvariants, f: &Frame) -> Frame {
       Plane::new(sb_size >> f.planes[2].cfg.xdec, sb_size >> f.planes[2].cfg.ydec,
                  f.planes[2].cfg.xdec, f.planes[2].cfg.ydec, 0, 0),
     ]
-  };
-  out
+  }
 }
 
 pub fn cdef_sb_padded_frame_copy(fi: &FrameInvariants, sbo: &SuperBlockOffset,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1812,6 +1812,7 @@ pub struct ContextWriter {
 }
 
 impl ContextWriter {
+  #[allow(clippy::let_and_return)]
   pub fn new(fc: CDFContext, bc: BlockContext) -> Self {
     #[allow(unused_mut)]
     let mut cw = ContextWriter {

--- a/src/me.rs
+++ b/src/me.rs
@@ -87,7 +87,7 @@ mod nasm {
         sum += func(org_ptr, org_stride, ref_ptr, ref_stride);
       }
     }
-    return sum;
+    sum
   }
 
   #[inline(always)]

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -1703,15 +1703,15 @@ impl Txfm2DFlipCfg {
     assert_ne!(txfm_type_col, TxfmType::Invalid);
     assert_ne!(txfm_type_row, TxfmType::Invalid);
     let (ud_flip, lr_flip) = Self::get_flip_cfg(tx_type);
-    let cfg = Txfm2DFlipCfg {
+
+    Txfm2DFlipCfg {
       tx_size,
       ud_flip,
       lr_flip,
       shift: FWD_TXFM_SHIFT_LS[tx_size as usize][(bd - 8) / 2],
       txfm_type_col,
       txfm_type_row
-    };
-    cfg
+    }
   }
 
   /// Determine the flip config, returning (ud_flip, lr_flip)


### PR DESCRIPTION
This PR enables Clippy's [let_and_return](https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return) and [needless_return](https://rust-lang.github.io/rust-clippy/master/index.html#needless_return) lints, and fixes related warnings.

P.S. I also noticed something strange, which is not related to this PR, but I think it's worth mentioning. Some blocks of code are marked with `#[cfg(debug)]` attributes ([for example](https://github.com/xiph/rav1e/blob/31bf6a6c91d323402ba81aa3a75862ca2a3c49cc/src/context.rs#L1810)). The intent is clear - to have additional functionality in debug builds, which must not present in the release ones. The problem is that there's no such configuration in Rust. So, currently, all code that is marked with such attribute is completely ignored. The closest value of this attribute with the desired behavior is [debug_assertions](https://doc.rust-lang.org/reference/conditional-compilation.html#debug_assertions). Is there really something wrong, or there's a way to make `#[cfg(debug)]` working?