### PR TITLE
Allow sub-8x8 partitions with --tune=Psychovisual

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -578,15 +578,8 @@ impl FrameInvariants {
         // Speed level decides the minimum partition size, i.e. higher speed --> larger min partition size,
         // with exception that SBs on right or bottom frame borders split down to BLOCK_4X4.
         // At speed = 0, RDO search is exhaustive.
-        let mut min_partition_size = config.speed_settings.min_block_size;
+        let min_partition_size = config.speed_settings.min_block_size;
 
-        if config.tune == Tune::Psychovisual {
-            if min_partition_size < BlockSize::BLOCK_8X8 {
-                // TODO: Display message that min partition size is enforced to 8x8
-                min_partition_size = BlockSize::BLOCK_8X8;
-                println!("If tune=Psychovisual is used, min partition size is enforced to 8x8");
-            }
-        }
         let use_reduced_tx_set = config.speed_settings.reduced_tx_set;
         let use_tx_domain_distortion = config.tune == Tune::Psnr && config.speed_settings.tx_domain_distortion;
 


### PR DESCRIPTION
First, tune cdef_dist_wxh_8x8 scaling:
- Ensure ssim_boost >= 1 where svar < 4096 and dvar < 8192.
- Fix the value of ssim_boost at (0, 4096) to 5/4.

Fall back to SSE for blocks where w < 8 or h < 8.

AWCY results at [speed 1 relative to --tune=Psnr](https://beta.arewecompressedyet.com/?job=rav1e-s1%402019-02-01T15%3A39%3A55.533Z&job=rav1e-s1-psy-9%402019-02-04T11%3A22%3A43.572Z):

|   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|   ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| 1.1413 | -6.4113 | -6.5019 |  -2.2832 | -6.5178 | -6.9733 |    -3.4859 |

AWCY results at [speed 2 relative to prior constants](https://beta.arewecompressedyet.com/?job=rav1e-s2-psy%402019-02-01T01%3A14%3A38.035Z&job=rav1e-s2-psy-9%402019-02-04T07%3A03%3A17.426Z):

|    PSNR |  PSNR Cb |  PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |     ---: |     ---: |     ---: |    ---: |    ---: |       ---: |
| -3.1037 | -14.2481 | -14.6910 |  -3.7521 | -3.5587 | -3.7257 |    -8.3253 |