### PR TITLE
Revert "cdef: simplify best_cost/dir search"

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -40,6 +40,8 @@ const CDEF_DIV_TABLE: [i32; 9] = [ 0, 840, 420, 280, 210, 168, 140, 120, 105 ];
 fn cdef_find_dir(img: &[u16], stride: usize, var: &mut i32, coeff_shift: i32) -> i32 {
     let mut cost: [i32; 8] = [0; 8];
     let mut partial: [[i32; 15]; 8] = [[0; 15]; 8];
+    let mut best_cost: i32 = 0;
+    let mut best_dir = 0;
     for i in 0..8 {
         for j in 0..8 {
             // We subtract 128 here to reduce the maximum range of the squared
@@ -82,8 +84,13 @@ fn cdef_find_dir(img: &[u16], stride: usize, var: &mut i32, coeff_shift: i32) ->
         }
         i+=2;
     }
-
-    let (best_dir, best_cost) = cost.iter().enumerate().max_by_key(|(_i, &v)| v).unwrap();
+    // In case of a tie, the first direction must be selected.
+    for i in 0..8 {
+        if cost[i] > best_cost {
+            best_cost = cost[i];
+            best_dir = i;
+        }
+    }
     // Difference between the optimal variance and the variance along the
     // orthogonal direction. Again, the sum(x^2) terms cancel out.
     // We'd normally divide by 840, but dividing by 1024 is close enough


### PR DESCRIPTION
This reverts commit c8bd47245744006710386557e54d35f92034656b.

Causes a desync in nyan.y4m. Caused when multiple dir costs
are equal.