### PR TITLE
Fix misc. chroma sampling handling issues

### DIFF
--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -42,15 +42,18 @@ impl Decoder for y4m::Decoder<'_, Box<dyn Read>> {
           cfg.height.align_power_of_two(3),
           cfg.chroma_sampling
         );
+
+        let (chroma_period, _) = cfg.chroma_sampling.sampling_period();
+
         f.planes[0].copy_from_raw_u8(frame.get_y_plane(), cfg.width * bytes, bytes);
         f.planes[1].copy_from_raw_u8(
           frame.get_u_plane(),
-          cfg.width * bytes / 2,
+          cfg.width * bytes / chroma_period,
           bytes
         );
         f.planes[2].copy_from_raw_u8(
           frame.get_v_plane(),
-          cfg.width * bytes / 2,
+          cfg.width * bytes / chroma_period,
           bytes
         );
         f

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -128,8 +128,8 @@ impl<'a> Iterator for PixelIter<'a> {
     }
     let pixel = (
       self.planes[0].p(self.x, self.y),
-      self.planes[1].p(self.x / 2, self.y / 2),
-      self.planes[2].p(self.x / 2, self.y / 2),
+      self.planes[1].p(self.x >> self.planes[1].cfg.xdec, self.y >> self.planes[1].cfg.ydec),
+      self.planes[2].p(self.x >> self.planes[2].cfg.xdec, self.y >> self.planes[2].cfg.ydec),
     );
     if self.x == self.width() - 1 {
       self.x = 0;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -49,7 +49,7 @@ impl Frame {
         let (chroma_width, chroma_height, chroma_padding, chroma_xdec, chroma_ydec) = (
             width / chroma_sampling_period.0,
             height / chroma_sampling_period.1,
-            MAX_SB_SIZE / chroma_sampling_period.0 + FRAME_MARGIN,
+            (MAX_SB_SIZE + FRAME_MARGIN) / chroma_sampling_period.0,
             chroma_sampling_period.0 - 1,
             chroma_sampling_period.1 - 1
         );


### PR DESCRIPTION
A few additional fixes for chroma sampling, which brings 4:4:4 reconstruction output closer to correct, though there are still outstanding issues. I am not entirely sure if the first commit is correct, but based on the way the frame margin is handled elsewhere (downsampled luma) it seemed like it should be subsampled along with chroma, and I did not have issues decoding during my tests.