### PR TITLE
Use SSE for CDEF RDO with --tune=Psnr

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1139,7 +1139,7 @@ pub fn rdo_cdef_decision(sbo: &SuperBlockOffset, fi: &FrameInvariants,
               let xdec = in_plane.cfg.xdec;
               let ydec = in_plane.cfg.ydec;
 
-              if p==0 {
+              if p==0 && fi.config.tune == Tune::Psychovisual {
                 err += cdef_dist_wxh_8x8(&in_slice, &out_slice, fi.sequence.bit_depth);
               } else {
                 err += sse_wxh(&in_slice, &out_slice, 8>>xdec, 8>>ydec);


### PR DESCRIPTION
Use sum-of-squared error as the distortion metric for picking CDEF parameters with --tune=Psnr.

AWCY results [relative to metric from libaom](https://beta.arewecompressedyet.com/?job=rav1e-s2%402019-02-01T01%3A14%3A08.420Z&job=rav1e-s2-cdef-sse%402019-02-04T16%3A59%3A28.508Z):

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |   ---: |    ---: |       ---: |
| -0.1880 |  0.0690 |  0.2093 |   0.0097 | 0.4081 |  0.3468 |    -0.2152 |