### PR TITLE
Fix infinite loop for very short clips with frame reordering

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -506,6 +506,11 @@ impl Context {
       }
     }
 
+    match self.frame_q.get(&fi.number) {
+      Some(Some(_)) => {},
+      _ => { return Err(fi); }
+    }
+
     // Now that we know the frame number, look up the correct frame type
     let frame_type = self.determine_frame_type(fi.number);
     if frame_type == FrameType::KEY {


### PR DESCRIPTION
Fixes #890. Also fixes the tests to test frame reordering and lookahead correctly.