### PR TITLE
Disable low_latency by default

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -87,7 +87,7 @@ impl EncoderConfig {
     EncoderConfig {
       min_key_frame_interval: 12,
       max_key_frame_interval: 240,
-      low_latency: true,
+      low_latency: false,
       quantizer: 100,
       tune: Tune::Psnr,
       color_description: None,

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -88,10 +88,10 @@ pub fn parse_cli() -> CliOptions {
         .default_value("240")
     ).arg(
       Arg::with_name("LOW_LATENCY")
-        .help("low latency mode. true or false")
+        .help("low latency mode. true or [false]")
         .long("low_latency")
         .takes_value(true)
-        .default_value("true")
+        .default_value("false")
     ).arg(
       Arg::with_name("TUNE")
         .help("Quality tuning (Will enforce partition sizes >= 8x8)")


### PR DESCRIPTION
Note in the help text which is the default.
Fix #905.