### PR TITLE
Simple config

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -45,12 +45,14 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
     aom_dsp_rtcd();
   }
   let config = EncoderConfig {
+    width: 1024,
+    height: 1024,
     quantizer: qindex,
     speed_settings: SpeedSettings::from_preset(10),
     ..Default::default()
   };
   let sequence = Sequence::new(&Default::default());
-  let mut fi = FrameInvariants::new(1024, 1024, config, sequence);
+  let mut fi = FrameInvariants::new(config, sequence);
   let mut w = ec::WriterEncoder::new();
   let fc = CDFContext::new(fi.base_q_idx);
   let bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
@@ -111,11 +113,16 @@ fn cdef_frame(c: &mut Criterion) {
   c.bench_function(&n, move |b| cdef_frame_bench(b, w, h));
 }
 
-fn cdef_frame_bench(b: &mut Bencher, w: usize, h: usize) {
-  let config =
-    EncoderConfig { quantizer: 100, speed_settings: SpeedSettings::from_preset(10), ..Default::default() };
+fn cdef_frame_bench(b: &mut Bencher, width: usize, height: usize) {
+  let config = EncoderConfig {
+    width,
+    height,
+    quantizer: 100,
+    speed_settings: SpeedSettings::from_preset(10),
+    ..Default::default()
+  };
   let sequence = Sequence::new(&Default::default());
-  let fi = FrameInvariants::new(w, h, config, sequence);
+  let fi = FrameInvariants::new(config, sequence);
   let mut bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
   let mut fs = FrameState::new(&fi);
 
@@ -135,10 +142,15 @@ fn cfl_rdo(c: &mut Criterion) {
 }
 
 fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
-  let config =
-    EncoderConfig { quantizer: 100, speed_settings: SpeedSettings::from_preset(10), ..Default::default() };
+  let config = EncoderConfig {
+    width: 1024,
+    height: 1024,
+    quantizer: 100,
+    speed_settings: SpeedSettings::from_preset(10),
+    ..Default::default()
+  };
   let sequence = Sequence::new(&Default::default());
-  let fi = FrameInvariants::new(1024, 1024, config, sequence );
+  let fi = FrameInvariants::new(config, sequence );
   let mut fs = FrameState::new(&fi);
   let offset = BlockOffset { x: 1, y: 1 };
   b.iter(|| rdo_cfl_alpha(&mut fs, &offset, bsize, fi.sequence.bit_depth, fi.sequence.chroma_sampling))

--- a/src/api.rs
+++ b/src/api.rs
@@ -355,7 +355,7 @@ impl Config {
       packet_data: Vec::new(),
       segment_start_idx: 0,
       segment_start_frame: 0,
-      keyframe_detector: SceneChangeDetector::new(&self.video_info),
+      keyframe_detector: SceneChangeDetector::new(self.video_info.bit_depth),
       config: *self,
     }
   }

--- a/src/api.rs
+++ b/src/api.rs
@@ -22,29 +22,6 @@ use std::collections::BTreeSet;
 
 const LOOKAHEAD_FRAMES: u64 = 10;
 
-#[derive(Debug, Clone, Copy)]
-pub struct VideoDetails {
-  pub width: usize,
-  pub height: usize,
-  pub bit_depth: usize,
-  pub chroma_sampling: ChromaSampling,
-  pub chroma_sample_position: ChromaSamplePosition,
-  pub time_base: Rational,
-}
-
-impl Default for VideoDetails {
-  fn default() -> Self {
-    VideoDetails {
-      width: 640,
-      height: 480,
-      bit_depth: 8,
-      chroma_sampling: ChromaSampling::Cs420,
-      chroma_sample_position: ChromaSamplePosition::Unknown,
-      time_base: Rational { num: 30, den: 1 }
-    }
-  }
-}
-
 // TODO: use the num crate?
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -26,7 +26,6 @@ const LOOKAHEAD_FRAMES: u64 = 10;
 pub struct VideoDetails {
   pub width: usize,
   pub height: usize,
-  pub mono: bool,
   pub bit_depth: usize,
   pub chroma_sampling: ChromaSampling,
   pub chroma_sample_position: ChromaSamplePosition,
@@ -38,7 +37,6 @@ impl Default for VideoDetails {
     VideoDetails {
       width: 640,
       height: 480,
-      mono: false,
       bit_depth: 8,
       chroma_sampling: ChromaSampling::Cs420,
       chroma_sample_position: ChromaSamplePosition::Unknown,

--- a/src/api.rs
+++ b/src/api.rs
@@ -45,11 +45,20 @@ pub struct Point {
 
 #[derive(Copy, Clone, Debug)]
 pub struct EncoderConfig {
+  // output size
   pub width: usize,
   pub height: usize,
+
+  // data format and ancillary color information
   pub bit_depth: usize,
   pub chroma_sampling: ChromaSampling,
   pub chroma_sample_position: ChromaSamplePosition,
+  pub pixel_range: PixelRange,
+  pub color_description: Option<ColorDescription>,
+  pub mastering_display: Option<MasteringDisplay>,
+  pub content_light: Option<ContentLight>,
+
+  // encoder configuration
   pub time_base: Rational,
   /// The *minimum* interval between two keyframes
   pub min_key_frame_interval: u64,
@@ -58,10 +67,6 @@ pub struct EncoderConfig {
   pub low_latency: bool,
   pub quantizer: usize,
   pub tune: Tune,
-  pub pixel_range: PixelRange,
-  pub color_description: Option<ColorDescription>,
-  pub mastering_display: Option<MasteringDisplay>,
-  pub content_light: Option<ContentLight>,
   pub speed_settings: SpeedSettings,
   pub show_psnr: bool,
 }
@@ -78,19 +83,21 @@ impl EncoderConfig {
     EncoderConfig {
       width: 640,
       height: 480,
+
       bit_depth: 8,
       chroma_sampling: ChromaSampling::Cs420,
       chroma_sample_position: ChromaSamplePosition::Unknown,
+      pixel_range: PixelRange::Unspecified,
+      color_description: None,
+      mastering_display: None,
+      content_light: None,
+
       time_base: Rational { num: 30, den: 1 },
       min_key_frame_interval: 12,
       max_key_frame_interval: 240,
       low_latency: false,
       quantizer: 100,
       tune: Tune::Psnr,
-      pixel_range: PixelRange::Unspecified,
-      color_description: None,
-      mastering_display: None,
-      content_light: None,
       speed_settings: SpeedSettings::from_preset(speed),
       show_psnr: false,
     }

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use y4m;
 use decoder::Decoder;
+use decoder::VideoDetails;
 
 pub struct EncoderIO {
   pub input: Box<dyn Read>,

--- a/src/bin/decoder/mod.rs
+++ b/src/bin/decoder/mod.rs
@@ -17,3 +17,26 @@ pub enum DecodeError {
   ParseError,
   IoError(io::Error),
 }
+
+#[derive(Debug, Clone, Copy)]
+pub struct VideoDetails {
+  pub width: usize,
+  pub height: usize,
+  pub bit_depth: usize,
+  pub chroma_sampling: ChromaSampling,
+  pub chroma_sample_position: ChromaSamplePosition,
+  pub time_base: Rational,
+}
+
+impl Default for VideoDetails {
+  fn default() -> Self {
+    VideoDetails {
+      width: 640,
+      height: 480,
+      bit_depth: 8,
+      chroma_sampling: ChromaSampling::Cs420,
+      chroma_sample_position: ChromaSamplePosition::Unknown,
+      time_base: Rational { num: 30, den: 1 }
+    }
+  }
+}

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -15,18 +15,14 @@ impl Decoder for y4m::Decoder<'_, Box<dyn Read>> {
     let height = self.get_height();
     let color_space = self.get_colorspace();
     let bit_depth = color_space.get_bit_depth();
-    let mono = match color_space {
-        y4m::Colorspace::Cmono => true,
-        _ => false
-    };
     let (chroma_sampling, chroma_sample_position) = map_y4m_color_space(color_space);
     let framerate = self.get_framerate();
     let time_base =  Rational::new(framerate.den as u64, framerate.num as u64);
+
     VideoDetails {
       width,
       height,
       bit_depth,
-      mono,
       chroma_sampling,
       chroma_sample_position,
       time_base,
@@ -81,12 +77,11 @@ pub fn map_y4m_color_space(
   use ChromaSampling::*;
   use ChromaSamplePosition::*;
   match color_space {
+    Cmono => (Cs400, Unknown),
     C420jpeg | C420paldv => (Cs420, Unknown),
     C420mpeg2 => (Cs420, Vertical),
     C420 | C420p10 | C420p12 => (Cs420, Colocated),
     C422 | C422p10 | C422p12 => (Cs422, Colocated),
     C444 | C444p10 | C444p12 => (Cs444, Colocated),
-    _ =>
-      panic!("Chroma characteristics unknown for the specified color space.")
   }
 }

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -39,8 +39,13 @@ fn main() {
     None => None
   };
 
+  cli.enc.width = video_info.width;
+  cli.enc.height = video_info.height;
+  cli.enc.bit_depth = video_info.bit_depth;
+  cli.enc.chroma_sampling = video_info.chroma_sampling;
+  cli.enc.chroma_sample_position = video_info.chroma_sample_position;
+  cli.enc.time_base = video_info.time_base;
   let cfg = Config {
-    video_info,
     enc: cli.enc
   };
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -192,7 +192,8 @@ impl Default for Tune {
 pub enum ChromaSampling {
   Cs420,
   Cs422,
-  Cs444
+  Cs444,
+  Cs400,
 }
 
 impl Default for ChromaSampling {
@@ -208,7 +209,8 @@ impl ChromaSampling {
     match self {
       Cs420 => (2, 2),
       Cs422 => (2, 1),
-      Cs444 => (1, 1)
+      Cs444 => (1, 1),
+      Cs400 => (1, 1),
     }
   }
 }
@@ -255,7 +257,6 @@ pub struct Sequence {
   // 2 - adaptive
   pub still_picture: bool,               // Video is a single frame still picture
   pub reduced_still_picture_hdr: bool,   // Use reduced header for still picture
-  pub monochrome: bool,                  // Monochrome video
   pub enable_intra_edge_filter: bool,    // enables/disables corner/edge/upsampling
   pub enable_interintra_compound: bool,  // enables/disables interintra_compound
   pub enable_masked_compound: bool,      // enables/disables masked compound
@@ -337,7 +338,6 @@ impl Sequence {
       force_integer_mv: 2,
       still_picture: false,
       reduced_still_picture_hdr: false,
-      monochrome: false,
       enable_intra_edge_filter: false,
       enable_interintra_compound: false,
       enable_masked_compound: false,
@@ -1116,11 +1116,12 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
       self.write_bit(seq.bit_depth == 12)?;
     }
 
+    let monochrome = seq.chroma_sampling == ChromaSampling::Cs400;
     if seq.profile != 1 {
-      self.write_bit(seq.monochrome)?;
+      self.write_bit(monochrome)?;
     }
 
-    if seq.monochrome {
+    if monochrome {
       unimplemented!();
     }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -291,15 +291,15 @@ pub struct Sequence {
 }
 
 impl Sequence {
-  pub fn new(info: &VideoDetails) -> Sequence {
-    let width_bits = 32 - (info.width as u32).leading_zeros();
-    let height_bits = 32 - (info.height as u32).leading_zeros();
+  pub fn new(config: &EncoderConfig) -> Sequence {
+    let width_bits = 32 - (config.width as u32).leading_zeros();
+    let height_bits = 32 - (config.height as u32).leading_zeros();
     assert!(width_bits <= 16);
     assert!(height_bits <= 16);
 
-    let profile = if info.bit_depth == 12 {
+    let profile = if config.bit_depth == 12 {
       2
-    } else if info.chroma_sampling == ChromaSampling::Cs444 {
+    } else if config.chroma_sampling == ChromaSampling::Cs444 {
       1
     } else {
       0
@@ -320,15 +320,15 @@ impl Sequence {
       profile,
       num_bits_width: width_bits,
       num_bits_height: height_bits,
-      bit_depth: info.bit_depth,
-      chroma_sampling: info.chroma_sampling,
-      chroma_sample_position: info.chroma_sample_position,
-      pixel_range: PixelRange::Unspecified,
-      color_description: None,
-      mastering_display: None,
-      content_light: None,
-      max_frame_width: info.width as u32,
-      max_frame_height: info.height as u32,
+      bit_depth: config.bit_depth,
+      chroma_sampling: config.chroma_sampling,
+      chroma_sample_position: config.chroma_sample_position,
+      pixel_range: config.pixel_range,
+      color_description: config.color_description,
+      mastering_display: config.mastering_display,
+      content_light: config.content_light,
+      max_frame_width: config.width as u32,
+      max_frame_height: config.height as u32,
       frame_id_numbers_present_flag: false,
       frame_id_length: 0,
       delta_frame_id_length: 0,
@@ -579,8 +579,7 @@ pub struct FrameInvariants {
 }
 
 impl FrameInvariants {
-  pub fn new(width: usize, height: usize,
-             config: EncoderConfig, sequence: Sequence) -> FrameInvariants {
+  pub fn new(config: EncoderConfig, sequence: Sequence) -> FrameInvariants {
     // Speed level decides the minimum partition size, i.e. higher speed --> larger min partition size,
     // with exception that SBs on right or bottom frame borders split down to BLOCK_4X4.
     // At speed = 0, RDO search is exhaustive.
@@ -591,14 +590,14 @@ impl FrameInvariants {
 
     FrameInvariants {
       sequence,
-      width,
-      height,
-      padded_w: width.align_power_of_two(3),
-      padded_h: height.align_power_of_two(3),
-      sb_width: width.align_power_of_two_and_shift(6),
-      sb_height: height.align_power_of_two_and_shift(6),
-      w_in_b: 2 * width.align_power_of_two_and_shift(3), // MiCols, ((width+7)/8)<<3 >> MI_SIZE_LOG2
-      h_in_b: 2 * height.align_power_of_two_and_shift(3), // MiRows, ((height+7)/8)<<3 >> MI_SIZE_LOG2
+      width: config.width,
+      height: config.height,
+      padded_w: config.width.align_power_of_two(3),
+      padded_h: config.height.align_power_of_two(3),
+      sb_width: config.width.align_power_of_two_and_shift(6),
+      sb_height: config.height.align_power_of_two_and_shift(6),
+      w_in_b: 2 * config.width.align_power_of_two_and_shift(3), // MiCols, ((width+7)/8)<<3 >> MI_SIZE_LOG2
+      h_in_b: 2 * config.height.align_power_of_two_and_shift(3), // MiRows, ((height+7)/8)<<3 >> MI_SIZE_LOG2
       number: 0,
       order_hint: 0,
       show_frame: true,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -230,6 +230,7 @@ impl BlockSize {
         BLOCK_64X16 => TX_32X8,
         _ => TX_32X32
       }
+      ChromaSampling::Cs400 => unimplemented!()
     }
   }
 

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -911,7 +911,6 @@ pub trait Inter: Dim {}
 pub mod test {
   use super::*;
   use rand::{ChaChaRng, Rng, SeedableRng};
-  use util::*;
 
   const MAX_ITER: usize = 50000;
 

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -10,7 +10,6 @@
 use encoder::Frame;
 
 use std::sync::Arc;
-use api::VideoDetails;
 
 /// Detects fast cuts using changes in colour and intensity between frames.
 /// Since the difference between frames is used, only fast cuts are detected
@@ -41,9 +40,9 @@ impl Default for SceneChangeDetector {
 }
 
 impl SceneChangeDetector {
-  pub fn new(video_info: &VideoDetails) -> Self {
+  pub fn new(bit_depth: usize) -> Self {
     let mut detector = Self::default();
-    detector.threshold = detector.threshold * video_info.bit_depth as u8 / 8;
+    detector.threshold = detector.threshold * bit_depth as u8 / 8;
     detector
   }
 

--- a/src/test_encode_decode_aom.rs
+++ b/src/test_encode_decode_aom.rs
@@ -97,15 +97,12 @@ fn setup_encoder(
   enc.min_key_frame_interval = min_keyint;
   enc.max_key_frame_interval = max_keyint;
   enc.low_latency = low_latency;
+  enc.width = w;
+  enc.height = h;
+  enc.bit_depth = bit_depth;
+  enc.chroma_sampling = chroma_sampling;
 
   let cfg = Config {
-    video_info: VideoDetails {
-      width: w,
-      height: h,
-      bit_depth,
-      chroma_sampling,
-      ..Default::default()
-    },
     enc
   };
 

--- a/src/test_encode_decode_dav1d.rs
+++ b/src/test_encode_decode_dav1d.rs
@@ -77,15 +77,12 @@ fn setup_encoder(
   enc.min_key_frame_interval = min_keyint;
   enc.max_key_frame_interval = max_keyint;
   enc.low_latency = low_latency;
+  enc.width = w;
+  enc.height = h;
+  enc.bit_depth = bit_depth;
+  enc.chroma_sampling = chroma_sampling;
 
   let cfg = Config {
-    video_info: VideoDetails {
-      width: w,
-      height: h,
-      bit_depth,
-      chroma_sampling,
-      ..Default::default()
-    },
     enc
   };
 


### PR DESCRIPTION
as mentioned in #910 this should simplify the api a bit and other portions of the codebase

relevant commit message:
>    VideoDetails is mainly used while decoding y4m, but it is carried
>    around in the configuration, initializing various internal structures.
>
>   Having all encoding-related fields in a single structure simplifies
>  setting up and configuring the encoder, as well as offering
> an easier-to-use and more expandable API.