### PR TITLE
Override min-keyint in CLI if keyint is smaller

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -175,8 +175,12 @@ pub fn parse_cli() -> CliOptions {
 fn parse_config(matches: &ArgMatches) -> EncoderConfig {
   let speed = matches.value_of("SPEED").unwrap().parse().unwrap();
   let quantizer = matches.value_of("QP").unwrap().parse().unwrap();
-  let min_interval = matches.value_of("MIN_KEYFRAME_INTERVAL").unwrap().parse().unwrap();
-  let max_interval = matches.value_of("KEYFRAME_INTERVAL").unwrap().parse().unwrap();
+  let max_interval: u64 = matches.value_of("KEYFRAME_INTERVAL").unwrap().parse().unwrap();
+  let mut min_interval: u64 = matches.value_of("MIN_KEYFRAME_INTERVAL").unwrap().parse().unwrap();
+
+  if matches.occurrences_of("MIN_KEYFRAME_INTERVAL") == 0 {
+    min_interval = min_interval.min(max_interval);
+  }
 
   // Validate arguments
   if quantizer == 0 {


### PR DESCRIPTION
Right now if someone specifies `--keyint 10` for instance the interface will complain that it is lower than the minimum interval. For CLI usage it seems more practical to just set the minimum keyframe interval to match rather than force the user to add an additional option.

If `--min-keyint` is also specified, it will not be overridden.