### PR TITLE
Fix chroma transform sizes with 4:4:4 sampling

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -193,13 +193,7 @@ impl BlockSize {
 
   pub fn largest_uv_tx_size(self, chroma_sampling: ChromaSampling) -> TxSize {
     match chroma_sampling {
-      ChromaSampling::Cs444 => match self {
-        BLOCK_64X64 | BLOCK_64X32 | BLOCK_32X64 |
-        BLOCK_128X128 | BLOCK_128X64 | BLOCK_64X128 => TX_32X32,
-        BLOCK_64X16 => TX_32X16,
-        BLOCK_16X64 => TX_16X32,
-        _ => self.tx_size()
-      },
+      ChromaSampling::Cs444 => self.tx_size(),
       ChromaSampling::Cs422 => match self {
         BLOCK_4X4 | BLOCK_8X4 => TX_4X4,
         BLOCK_8X8 => TX_4X8,


### PR DESCRIPTION
I misread the specification in #784, this fixes reconstruction output for 4:4:4 encoding.