### PR TITLE
Support degraded 4:2:2/4:4:4 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ rav1e is an experimental AV1 video encoder. It is designed to eventually cover a
 * DC, H, V, Paeth, and smooth prediction modes
 * DCT, ADST and identity transforms (up to 64x64, 16x16 and 32x32 respectively)
 * 8-, 10- and 12-bit depth color
+* 4:2:0 (full support), 4:2:2 and 4:4:4 (limited) chroma sampling
 * Variable speed settings
 * Near real-time encoding at high speed levels
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Automated AppVeyor builds can be found [here](https://ci.appveyor.com/project/td
 
 # Building
 
-**rav1e** can optionally use a local copy of `libaom` to run some extended tests and some `x86_64`-specific optimizations require a recent version of NASM.
+**rav1e** can optionally use either a local copy of `libaom` (default) or a `dav1d` installation to run some extended tests.
+Some `x86_64`-specific optimizations require a recent version of NASM.
 
 ## Internal libaom setup
 
@@ -148,6 +149,11 @@ cargo test
 Run encode-decode integration tests with:
 ```
 cargo test --release --features=decode_test
+```
+
+Run the encode-decode tests against `dav1d` with:
+```
+cargo test --release --features=decode_test_dav1d
 ```
 
 Run regular benchmarks with:

--- a/src/api.rs
+++ b/src/api.rs
@@ -510,13 +510,18 @@ impl Context {
 
     let mut fi = self.frame_data[&(idx - 1)].clone();
 
+    // FIXME: inter unsupported with 4:2:2 and 4:4:4 chroma sampling
+    let chroma_sampling = self.config.enc.chroma_sampling;
+    let keyframe_only = chroma_sampling == ChromaSampling::Cs444 ||
+      chroma_sampling == ChromaSampling::Cs422;
+
     // Initially set up the frame as an inter frame.
     // We need to determine what the frame number is before we can
     // look up the frame type. If reordering is enabled, the idx
     // may not match the frame number.
     let idx_in_segment = idx - self.segment_start_idx;
     if idx_in_segment > 0 {
-      let next_keyframe = self.next_keyframe();
+      let next_keyframe = if keyframe_only { self.segment_start_frame + 1 } else { self.next_keyframe() };
       let (fi_temp, end_of_subgop) = FrameInvariants::new_inter_frame(
         &fi,
         self.segment_start_frame,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -585,7 +585,12 @@ impl FrameInvariants {
     // Speed level decides the minimum partition size, i.e. higher speed --> larger min partition size,
     // with exception that SBs on right or bottom frame borders split down to BLOCK_4X4.
     // At speed = 0, RDO search is exhaustive.
-    let min_partition_size = config.speed_settings.min_block_size;
+    let min_partition_size = if config.chroma_sampling == ChromaSampling::Cs444 ||
+      config.chroma_sampling == ChromaSampling::Cs422 {
+        config.speed_settings.min_block_size.max(BlockSize::BLOCK_8X8)
+      } else {
+        config.speed_settings.min_block_size
+      };
 
     let use_reduced_tx_set = config.speed_settings.reduced_tx_set;
     let use_tx_domain_distortion = config.tune == Tune::Psnr && config.speed_settings.tx_domain_distortion;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -349,7 +349,8 @@ impl Sequence {
       enable_warped_motion: false,
       enable_superres: false,
       enable_cdef: true,
-      enable_restoration: true,
+      enable_restoration: config.chroma_sampling != ChromaSampling::Cs422 &&
+        config.chroma_sampling != ChromaSampling::Cs444, // FIXME: not working yet
       operating_points_cnt_minus_1: 0,
       operating_point_idc,
       display_model_info_present_flag: false,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2477,6 +2477,8 @@ fn encode_partition_bottomup(
   if can_split {
     for &partition in RAV1E_PARTITION_TYPES {
       if partition == PartitionType::PARTITION_NONE { continue; }
+      if fi.sequence.chroma_sampling == ChromaSampling::Cs422 &&
+        partition == PartitionType::PARTITION_VERT { continue; }
 
       assert!(is_square);
       if must_split {
@@ -2631,7 +2633,8 @@ fn encode_partition_topdown(fi: &FrameInvariants, fs: &mut FrameState,
     let cbw = (fi.w_in_b - bo.x).min(bsw); // clipped block width, i.e. having effective pixels
     let cbh = (fi.h_in_b - bo.y).min(bsh);
 
-    if cbw == bsw/2 && cbh == bsh { split_vert = true; }
+    if cbw == bsw/2 && cbh == bsh &&
+      fi.sequence.chroma_sampling != ChromaSampling::Cs422 { split_vert = true; }
     if cbh == bsh/2 && cbw == bsw { split_horz = true; }
   }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -585,13 +585,7 @@ impl FrameInvariants {
     // Speed level decides the minimum partition size, i.e. higher speed --> larger min partition size,
     // with exception that SBs on right or bottom frame borders split down to BLOCK_4X4.
     // At speed = 0, RDO search is exhaustive.
-    let min_partition_size = if config.chroma_sampling == ChromaSampling::Cs444 ||
-      config.chroma_sampling == ChromaSampling::Cs422 {
-        config.speed_settings.min_block_size.max(BlockSize::BLOCK_8X8)
-      } else {
-        config.speed_settings.min_block_size
-      };
-
+    let min_partition_size = config.speed_settings.min_block_size;
     let use_reduced_tx_set = config.speed_settings.reduced_tx_set;
     let use_tx_domain_distortion = config.tune == Tune::Psnr && config.speed_settings.tx_domain_distortion;
 
@@ -2311,9 +2305,9 @@ pub fn write_tx_blocks(fi: &FrameInvariants, fs: &mut FrameState,
           let tx_bo =
             BlockOffset {
               x: bo.x + ((bx * uv_tx_size.width_mi()) << xdec) -
-                ((bw * tx_size.width_mi() == 1) as usize),
+                ((bw * tx_size.width_mi() == 1) as usize) * xdec,
               y: bo.y + ((by * uv_tx_size.height_mi()) << ydec) -
-                ((bh * tx_size.height_mi() == 1) as usize)
+                ((bh * tx_size.height_mi() == 1) as usize) * ydec
             };
 
           let mut po = bo.plane_offset(&fs.input.planes[p].cfg);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1117,7 +1117,9 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     }
 
     let monochrome = seq.chroma_sampling == ChromaSampling::Cs400;
-    if seq.profile != 1 {
+    if seq.profile == 1 {
+      assert!(monochrome == false);
+    } else {
       self.write_bit(monochrome)?;
     }
 
@@ -1146,19 +1148,27 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     if write_color_range {
       self.write_bit(seq.pixel_range == PixelRange::Full)?; // full color range
 
+      if monochrome {
+        return Ok(());
+      }
+
       let subsampling_x = seq.chroma_sampling != ChromaSampling::Cs444;
       let subsampling_y = seq.chroma_sampling == ChromaSampling::Cs420;
 
-      if seq.bit_depth == 12 {
-        self.write_bit(subsampling_x)?;
+      if seq.profile == 0 {
+        assert!(seq.chroma_sampling == ChromaSampling::Cs420);
+      } else if seq.profile == 1 {
+        assert!(seq.chroma_sampling == ChromaSampling::Cs444);
+      } else {
+        if seq.bit_depth == 12 {
+          self.write_bit(subsampling_x)?;
 
-        if subsampling_x {
-          self.write_bit(subsampling_y)?;
+          if subsampling_x {
+            self.write_bit(subsampling_y)?;
+          }
+        } else {
+          assert!(seq.chroma_sampling == ChromaSampling::Cs422);
         }
-      }
-
-      if subsampling_x && !subsampling_y {
-        unimplemented!(); // 4:2:2 sampling
       }
 
       if seq.chroma_sampling == ChromaSampling::Cs420 {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -297,7 +297,8 @@ impl Sequence {
     assert!(width_bits <= 16);
     assert!(height_bits <= 16);
 
-    let profile = if config.bit_depth == 12 {
+    let profile = if config.bit_depth == 12 ||
+      config.chroma_sampling == ChromaSampling::Cs422 {
       2
     } else if config.chroma_sampling == ChromaSampling::Cs444 {
       1

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -892,7 +892,7 @@ pub fn get_intra_edges<'a>(
 
       let num_avail = if y != 0 && has_tr(&bo, bsize) {
         tx_size.height().min(
-          (MI_SIZE >> plane_cfg.xdec) * frame_w_in_b
+          (MI_SIZE >> plane_cfg.ydec) * frame_w_in_b
             - x as usize
             - tx_size.width()
         )
@@ -927,7 +927,7 @@ pub fn get_intra_edges<'a>(
 
       let num_avail = if x != 0 && has_bl(&bo, bsize) {
         tx_size.width().min(
-          (MI_SIZE >> plane_cfg.xdec) * frame_h_in_b
+          (MI_SIZE >> plane_cfg.ydec) * frame_h_in_b
             - y as usize
             - tx_size.height()
         )

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -892,7 +892,7 @@ pub fn get_intra_edges<'a>(
 
       let num_avail = if y != 0 && has_tr(&bo, bsize) {
         tx_size.height().min(
-          (MI_SIZE >> plane_cfg.xdec) * frame_w_in_b // TODO: validate for 4:2:2
+          (MI_SIZE >> plane_cfg.xdec) * frame_w_in_b
             - x as usize
             - tx_size.width()
         )
@@ -927,7 +927,7 @@ pub fn get_intra_edges<'a>(
 
       let num_avail = if x != 0 && has_bl(&bo, bsize) {
         tx_size.width().min(
-          (MI_SIZE >> plane_cfg.xdec) * frame_h_in_b // TODO: validate for 4:2:2
+          (MI_SIZE >> plane_cfg.xdec) * frame_h_in_b
             - y as usize
             - tx_size.height()
         )

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -193,7 +193,13 @@ impl BlockSize {
 
   pub fn largest_uv_tx_size(self, chroma_sampling: ChromaSampling) -> TxSize {
     match chroma_sampling {
-      ChromaSampling::Cs444 => self.tx_size(),
+      ChromaSampling::Cs444 => match self {
+        BLOCK_64X64 | BLOCK_64X32 | BLOCK_32X64 |
+        BLOCK_128X128 | BLOCK_128X64 | BLOCK_64X128 => TX_32X32,
+        BLOCK_64X16 => TX_32X16,
+        BLOCK_16X64 => TX_16X32,
+        _ => self.tx_size()
+      },
       ChromaSampling::Cs422 => match self {
         BLOCK_4X4 | BLOCK_8X4 => TX_4X4,
         BLOCK_8X8 => TX_4X8,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -694,7 +694,8 @@ pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState,
     });
   }
 
-  if best.mode_luma.is_intra() && is_chroma_block && bsize.cfl_allowed() {
+  if best.mode_luma.is_intra() && is_chroma_block && bsize.cfl_allowed() &&
+    fi.config.chroma_sampling == ChromaSampling::Cs420 { // FIXME: 4:2:2/4:4:4 unimplemented
     let chroma_mode = PredictionMode::UV_CFL_PRED;
     let cw_checkpoint = cw.checkpoint();
     let wr: &mut dyn Writer = &mut WriterCounter::new();


### PR DESCRIPTION
This reverts an erroneous commit that caused intra frames in 4:4:4 to no longer be decodable, and fixes some additional issues. 4:4:4 and 4:2:2 encoding now work down to `-s 0` with keyframes only (enforced on the API end) and restoration disabled. CfL prediction is also disabled based on a comment from @barrbrain.