### PR TITLE
Compute lambda from ac_q rather than dc_q

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -28,7 +28,7 @@ use motion_compensate;
 use partition::*;
 use plane::*;
 use predict::{RAV1E_INTRA_MODES, RAV1E_INTER_MODES_MINIMAL, RAV1E_INTER_COMPOUND_MODES};
-use quantize::dc_q;
+use quantize::ac_q;
 use Tune;
 use write_tx_blocks;
 use write_tx_tree;
@@ -138,7 +138,7 @@ pub fn sse_wxh(
 }
 
 pub fn get_lambda(fi: &FrameInvariants) -> f64 {
-  let q = dc_q(fi.base_q_idx, fi.dc_delta_q[0], fi.sequence.bit_depth) as f64;
+  let q = ac_q(fi.base_q_idx, fi.dc_delta_q[0], fi.sequence.bit_depth) as f64;
 
   // Convert q into Q0 precision, given that libaom quantizers are Q3
   let q0 = q / 8.0_f64;
@@ -149,7 +149,7 @@ pub fn get_lambda(fi: &FrameInvariants) -> f64 {
 }
 
 pub fn get_lambda_sqrt(fi: &FrameInvariants) -> f64 {
-  let q = dc_q(fi.base_q_idx, fi.dc_delta_q[0], fi.sequence.bit_depth) as f64;
+  let q = ac_q(fi.base_q_idx, fi.dc_delta_q[0], fi.sequence.bit_depth) as f64;
 
   // Convert q into Q0 precision, given that libaom quantizers are Q3
   let q0 = q / 8.0_f64;


### PR DESCRIPTION
The rationale is that RDO is dominated by AC coefficients in most sequences.

AWCY results at [default speed and tune=Psychovisual](https://beta.arewecompressedyet.com/?job=master-3d5389903a5c3166d6b3dbc5ec4b4b9a0e0a57fe&job=psy-lambda-ac-q%402019-02-07T14%3A35%3A10.099Z):

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.7150 | -5.1618 | -5.7443 |  -0.3831 | -1.1512 | -1.1489 |    -2.6864 |

AWCY results at [default speed and tune=Psnr](https://beta.arewecompressedyet.com/?job=psnr-3d5389903a5c3166d6b3dbc5ec4b4b9a0e0a57fe%402019-02-06T17%3A16%3A56.096Z&job=psnr-lambda-dc-q%402019-02-07T13%3A19%3A29.257Z):

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -2.6675 | -4.5719 | -5.0094 |  -2.0622 | -1.7526 | -1.4547 |    -3.2220 |