### PR TITLE
Fully use tx-domain distortion (when chosen) with topdown partition search

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2433,7 +2433,7 @@ fn encode_partition_bottomup(
     };
     let spmvs = &pmvs[pmv_idx];
 
-    let mode_decision = rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs, false);
+    let mode_decision = rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs);
 
     rd_cost = mode_decision.rd_cost + cost;
 
@@ -2657,7 +2657,7 @@ fn encode_partition_topdown(fi: &FrameInvariants, fs: &mut FrameState,
         let spmvs = &pmvs[pmv_idx];
 
         // Make a prediction mode decision for blocks encoded with no rdo_partition_decision call (e.g. edges)
-        rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs, false)
+        rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs)
       };
 
       let mut mode_luma = part_decision.pred_mode_luma;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -372,7 +372,7 @@ impl Default for EncodingSettings {
 // RDO-based mode decision
 pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState,
                          cw: &mut ContextWriter, bsize: BlockSize, bo: &BlockOffset,
-                         pmvs: &[Option<MotionVector>], needs_rec: bool
+                         pmvs: &[Option<MotionVector>]
 ) -> RDOPartitionOutput {
   let mut best = EncodingSettings::default();
 
@@ -501,6 +501,8 @@ pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState,
         if bsize >= BlockSize::BLOCK_8X8 && bsize.is_sqr() {
           cw.write_partition(wr, bo, PartitionType::PARTITION_NONE, bsize);
         }
+
+        let needs_rec = luma_mode_is_intra && tx_size < bsize.tx_size();
 
         encode_block_a(&fi.sequence, fs, cw, wr, bsize, bo, skip);
         let tx_dist =
@@ -1003,7 +1005,7 @@ pub fn rdo_partition_decision(
 
         let spmvs = &pmvs[pmv_idx];
 
-        let mode_decision = rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs, false);
+        let mode_decision = rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs);
         child_modes.push(mode_decision);
       }
       PARTITION_SPLIT |
@@ -1048,7 +1050,7 @@ pub fn rdo_partition_decision(
         for (offset, pmv_idx) in partitions.iter().zip(pmv_idxs) {
           let mode_decision =
             rdo_mode_decision(fi, fs, cw, subsize, &offset,
-                              &pmvs[pmv_idx], true);
+                              &pmvs[pmv_idx]);
 
           rd_cost_sum += mode_decision.rd_cost;
 


### PR DESCRIPTION
    Fully use tx-domain distortion with topdown partition search
    
    The 'needs_rec' parameter for one of the two rdo_mode_decision() calls by
    topdown parition search has been passed with wrong value.
    It should be false, since re-encoding step follows once rdo_mode_decision()
    decided the mode.
    In fact, we don't need 'needs_rec' parameter in rdo_mode_decision(), so remove it.
    
    This patch will cause loss of coding efficiency (0.1250% at speed 1)
    with a small speedup.
    
    However, if there is more than one intra prediction blocks in a
    partition, i.e. tx_size < partition size, rdo_mode_decision() will need
    generate reconstrtucted pixels for intra prediction modes. Sine tx
    partition is not provided by rav1e yet, this condition can be
    implemented in the future.