### PR TITLE
Include `build.rs` in the set of files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rav1e"
 version = "0.1.0"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
 build = "build.rs"
-include = ["/src/**", "/aom_build/**", "/Cargo.toml"]
+include = ["/src/**", "/aom_build/**", "/Cargo.toml", "/build.rs"]
 autobenches = false
 autobins = false
 


### PR DESCRIPTION
Without it, a vendored version of the crate won't build.