### PR TITLE
Remove the public Context::new_frame() API call.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -17,7 +17,6 @@ use self::EncoderStatus::*;
 use std::{cmp, fmt, io};
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use util::Fixed;
 use std::collections::BTreeSet;
 
 const LOOKAHEAD_FRAMES: u64 = 10;
@@ -411,13 +410,6 @@ impl fmt::Display for Packet {
 }
 
 impl Context {
-  pub fn new_frame(&self) -> Arc<Frame> {
-    Arc::new(Frame::new(
-      self.config.enc.width.align_power_of_two(3),
-      self.config.enc.height.align_power_of_two(3),
-      self.config.enc.chroma_sampling
-    ))
-  }
 
   pub fn send_frame<F>(&mut self, frame: F) -> Result<(), EncoderStatus>
   where

--- a/src/test_encode_decode_dav1d.rs
+++ b/src/test_encode_decode_dav1d.rs
@@ -12,6 +12,7 @@ use rand::{ChaChaRng, Rng, SeedableRng};
 use std::{mem, ptr, slice};
 use std::collections::VecDeque;
 use std::sync::Arc;
+use util::Fixed;
 
 use dav1d_sys::*;
 
@@ -27,9 +28,11 @@ fn fill_frame(ra: &mut ChaChaRng, frame: &mut Frame) {
   }
 }
 
-fn read_frame_batch(ctx: &mut Context, ra: &mut ChaChaRng) {
+fn read_frame_batch(ctx: &mut Context, ra: &mut ChaChaRng, w: usize, h: usize,
+ chroma_sampling: ChromaSampling) {
   while ctx.needs_more_lookahead() {
-    let mut input = ctx.new_frame();
+    let mut input = Arc::new(Frame::new(
+      w.align_power_of_two(3), h.align_power_of_two(3), chroma_sampling));
     fill_frame(ra, Arc::get_mut(&mut input).unwrap());
 
     let _ = ctx.send_frame(Some(input));
@@ -316,7 +319,7 @@ fn encode_decode(
   let mut rec_fifo = VecDeque::new();
 
   for _ in 0..limit {
-    read_frame_batch(&mut ctx, &mut ra);
+    read_frame_batch(&mut ctx, &mut ra, w, h, chroma_sampling);
 
     let mut done = false;
     let mut corrupted_count = 0;


### PR DESCRIPTION
The only place this is used is by the test_encode_decode_aom and
 test_encode_decode_dav1d client implementations using the public API.
Instead of passing the frame width and height to the client side
 implementation of read_frame_batch() through the public API, it simply
 passes the information as a parameter.