### PR TITLE
Migrate to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rav1e"
 version = "0.1.0"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
+edition = "2018"
 build = "build.rs"
 include = ["/src/**", "/aom_build/**", "/Cargo.toml", "/build.rs"]
 autobenches = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -21,7 +21,7 @@ use rav1e::context::*;
 use rav1e::partition::*;
 use rav1e::predict::*;
 use rav1e::rdo::rdo_cfl_alpha;
-use transform::transform;
+use crate::transform::transform;
 
 use criterion::*;
 use std::time::Duration;

--- a/benches/me.rs
+++ b/benches/me.rs
@@ -8,9 +8,9 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use criterion::*;
-use partition::*;
-use partition::BlockSize::*;
-use plane::*;
+use crate::partition::*;
+use crate::partition::BlockSize::*;
+use crate::plane::*;
 use rand::{ChaChaRng, Rng, SeedableRng};
 use rav1e::me;
 

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -11,7 +11,7 @@ use criterion::*;
 use rand::{ChaChaRng, Rng, RngCore, SeedableRng};
 use rav1e::partition::BlockSize;
 use rav1e::predict::{Block4x4, Intra};
-use util::*;
+use crate::util::*;
 
 pub const BLOCK_SIZE: BlockSize = BlockSize::BLOCK_32X32;
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,16 +8,16 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use bitstream_io::*;
-use encoder::*;
-use metrics::calculate_frame_psnr;
-use partition::*;
-use scenechange::SceneChangeDetector;
+use crate::encoder::*;
+use crate::metrics::calculate_frame_psnr;
+use crate::partition::*;
+use crate::scenechange::SceneChangeDetector;
 use self::EncoderStatus::*;
 
 use std::{cmp, fmt, io};
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use util::Fixed;
+use crate::util::Fixed;
 use std::collections::BTreeSet;
 
 const LOOKAHEAD_FRAMES: u64 = 10;

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -8,7 +8,7 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use clap::{App, Arg, ArgMatches};
-use {ColorPrimaries, TransferCharacteristics, MatrixCoefficients};
+use crate::{ColorPrimaries, TransferCharacteristics, MatrixCoefficients};
 use rav1e::*;
 
 use std::{fmt, io};

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -1,13 +1,13 @@
 use std::io::Read;
 
 use rav1e::Rational;
-use decoder::DecodeError;
-use decoder::Decoder;
-use decoder::VideoDetails;
-use encoder::ChromaSamplePosition;
-use encoder::ChromaSampling;
-use encoder::Frame;
-use util::Fixed;
+use crate::decoder::DecodeError;
+use crate::decoder::Decoder;
+use crate::decoder::VideoDetails;
+use crate::encoder::ChromaSamplePosition;
+use crate::encoder::ChromaSampling;
+use crate::encoder::Frame;
+use crate::util::Fixed;
 
 impl Decoder for y4m::Decoder<'_, Box<dyn Read>> {
   fn get_video_details(&self) -> VideoDetails {
@@ -74,8 +74,8 @@ pub fn map_y4m_color_space(
   color_space: y4m::Colorspace
 ) -> (ChromaSampling, ChromaSamplePosition) {
   use y4m::Colorspace::*;
-  use ChromaSampling::*;
-  use ChromaSamplePosition::*;
+  use crate::ChromaSampling::*;
+  use crate::ChromaSamplePosition::*;
   match color_space {
     Cmono => (Cs400, Unknown),
     C420jpeg | C420paldv => (Cs420, Unknown),

--- a/src/bin/muxer.rs
+++ b/src/bin/muxer.rs
@@ -8,7 +8,7 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use bitstream_io::{BitWriter, LittleEndian};
-use decoder::VideoDetails;
+use crate::decoder::VideoDetails;
 use std::io;
 use std::io::Write;
 use std::slice;

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -17,16 +17,16 @@ extern crate bitstream_io;
 mod common;
 mod decoder;
 mod muxer;
-use common::*;
-use muxer::*;
+use crate::common::*;
+use crate::muxer::*;
 use rav1e::*;
 
 use std::io;
 use std::io::Write;
 use std::io::Read;
 use std::sync::Arc;
-use decoder::Decoder;
-use decoder::VideoDetails;
+use crate::decoder::Decoder;
+use crate::decoder::VideoDetails;
 
 fn read_frame_batch<D: Decoder>(ctx: &mut Context, decoder: &mut D, video_info: VideoDetails) {
   loop {

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -229,7 +229,7 @@ pub fn cdef_analyze_superblock(in_frame: &mut Frame,
 
         if !skip {
           let mut var: i32 = 0;
-          let mut in_plane = &mut in_frame.planes[0];
+          let in_plane = &mut in_frame.planes[0];
           let in_po = sbo.plane_offset(&in_plane.cfg);
           let in_stride = in_plane.cfg.stride;
           let in_slice = &in_plane.mut_slice(&in_po);
@@ -282,13 +282,13 @@ pub fn cdef_sb_padded_frame_copy(fi: &FrameInvariants, sbo: &SuperBlockOffset,
     let offset = sbo.plane_offset(&f.planes[p].cfg);
     for y in 0..((sb_size>>ydec) + pad*2) as isize {
       let mut out_slice = out.planes[p].mut_slice(&PlaneOffset {x:0, y});
-      let mut out_row = out_slice.as_mut_slice();
+      let out_row = out_slice.as_mut_slice();
       if offset.y + y < ipad || offset.y+y >= h + ipad {
         // above or below the frame, fill with flag
         for x in 0..(sb_size>>xdec) + pad*2 { out_row[x] = CDEF_VERY_LARGE; }
       } else {
-        let mut in_slice = f.planes[p].slice(&PlaneOffset {x:0, y:offset.y + y - ipad});
-        let mut in_row = in_slice.as_slice();
+        let in_slice = f.planes[p].slice(&PlaneOffset {x:0, y:offset.y + y - ipad});
+        let in_row = in_slice.as_slice();
         // are we guaranteed to be all in frame this row?
         if offset.x < ipad || offset.x + (sb_size as isize >>xdec) + ipad >= w {
           // No; do it the hard way.  off left or right edge, fill with flag.
@@ -350,9 +350,9 @@ pub fn cdef_filter_superblock(fi: &FrameInvariants,
           let dir = cdef_dirs.dir[bx][by];
           let var = cdef_dirs.var[bx][by];
           for p in 0..3 {
-            let mut out_plane = &mut out_frame.planes[p];
+            let out_plane = &mut out_frame.planes[p];
             let out_po = sbo.plane_offset(&out_plane.cfg);
-            let mut in_plane = &mut in_frame.planes[p];
+            let in_plane = &mut in_frame.planes[p];
             let in_po = sbo.plane_offset(&in_plane.cfg);
             let xdec = in_plane.cfg.xdec;
             let ydec = in_plane.cfg.ydec;
@@ -360,12 +360,12 @@ pub fn cdef_filter_superblock(fi: &FrameInvariants,
             let in_stride = in_plane.cfg.stride;
             let in_slice = &in_plane.mut_slice(&in_po);
             let out_stride = out_plane.cfg.stride;
-            let mut out_slice = &mut out_plane.mut_slice(&out_po);
+            let out_slice = &mut out_plane.mut_slice(&out_po);
 
-            let mut local_pri_strength;
-            let mut local_sec_strength;
+            let local_pri_strength;
+            let local_sec_strength;
             let mut local_damping: i32 = cdef_damping + coeff_shift;
-            let mut local_dir: usize;
+            let local_dir: usize;
 
             if p==0 {
               local_pri_strength = adjust_strength(cdef_pri_y_strength << coeff_shift, var);
@@ -427,14 +427,14 @@ pub fn cdef_filter_frame(fi: &FrameInvariants, rec: &mut Frame, bc: &mut BlockCo
       // pad first two elements of current row
       {
         let mut cdef_slice = cdef_frame.planes[p].mut_slice(&PlaneOffset { x: 0, y: row as isize });
-        let mut cdef_row = &mut cdef_slice.as_mut_slice()[..2];
+        let cdef_row = &mut cdef_slice.as_mut_slice()[..2];
         cdef_row[0] = CDEF_VERY_LARGE;
         cdef_row[1] = CDEF_VERY_LARGE;
       }
       // pad out end of current row
       {
         let mut cdef_slice = cdef_frame.planes[p].mut_slice(&PlaneOffset { x: rec_w as isize + 2, y: row as isize });
-        let mut cdef_row = &mut cdef_slice.as_mut_slice()[..padded_px[p][0]-rec_w-2];
+        let cdef_row = &mut cdef_slice.as_mut_slice()[..padded_px[p][0]-rec_w-2];
         for x in cdef_row {
           *x = CDEF_VERY_LARGE;
         }
@@ -442,7 +442,7 @@ pub fn cdef_filter_frame(fi: &FrameInvariants, rec: &mut Frame, bc: &mut BlockCo
       // copy current row from rec if we're in data, or pad if we're in first two rows/last N rows
       {
         let mut cdef_slice = cdef_frame.planes[p].mut_slice(&PlaneOffset { x: 2, y: row as isize });
-        let mut cdef_row = &mut cdef_slice.as_mut_slice()[..rec_w];
+        let cdef_row = &mut cdef_slice.as_mut_slice()[..rec_w];
         if row < 2 || row >= rec_h+2 {
           for x in cdef_row {
             *x = CDEF_VERY_LARGE;

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -9,11 +9,11 @@
 
 #![allow(safe_extern_statics)]
 
-use context::*;
-use Frame;
-use FrameInvariants;
-use plane::*;
-use util::{clamp, msb};
+use crate::context::*;
+use crate::Frame;
+use crate::FrameInvariants;
+use crate::plane::*;
+use crate::util::{clamp, msb};
 
 use std::cmp;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -3040,7 +3040,7 @@ impl ContextWriter {
               }
             }
             RestorationFilter::Sgrproj{set, xqd} => {
-              match rs.plane[pli].lrf_type {
+              match rp.lrf_type {
                 RESTORE_SGRPROJ => {
                   symbol_with_update!(self, w, 1, &mut self.fc.lrf_sgrproj_cdf);
                 }
@@ -3071,7 +3071,7 @@ impl ContextWriter {
               }
             }
             RestorationFilter::Wiener{coeffs} => {
-              match rs.plane[pli].lrf_type {
+              match rp.lrf_type {
                 RESTORE_WIENER => {
                   symbol_with_update!(self, w, 1, &mut self.fc.lrf_wiener_cdf);
                 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -806,13 +806,13 @@ impl CDFContext {
       ($field:expr) => (let r = $field.last_mut().unwrap(); *r = 0;)
     }
     macro_rules! reset_2d {
-      ($field:expr) => (for mut x in $field.iter_mut() { reset_1d!(x); })
+      ($field:expr) => (for x in $field.iter_mut() { reset_1d!(x); })
     }
     macro_rules! reset_3d {
-      ($field:expr) => (for mut x in $field.iter_mut() { reset_2d!(x); })
+      ($field:expr) => (for x in $field.iter_mut() { reset_2d!(x); })
     }
     macro_rules! reset_4d {
-      ($field:expr) => (for mut x in $field.iter_mut() { reset_3d!(x); })
+      ($field:expr) => (for x in $field.iter_mut() { reset_3d!(x); })
     }
 
     for i in 0..4 { self.partition_cdf[i][4] = 0; }

--- a/src/context.rs
+++ b/src/context.rs
@@ -16,19 +16,19 @@
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::collapsible_if)]
 
-use ec::Writer;
-use encoder::{FrameInvariants, ReferenceMode};
-use entropymode::*;
-use partition::BlockSize::*;
-use partition::PredictionMode::*;
-use partition::TxSize::*;
-use partition::TxType::*;
-use partition::*;
-use lrf::*;
-use plane::*;
-use scan_order::*;
-use token_cdfs::*;
-use util::{clamp, msb};
+use crate::ec::Writer;
+use crate::encoder::{FrameInvariants, ReferenceMode};
+use crate::entropymode::*;
+use crate::partition::BlockSize::*;
+use crate::partition::PredictionMode::*;
+use crate::partition::TxSize::*;
+use crate::partition::TxType::*;
+use crate::partition::*;
+use crate::lrf::*;
+use crate::plane::*;
+use crate::scan_order::*;
+use crate::token_cdfs::*;
+use crate::util::{clamp, msb};
 
 use std::*;
 
@@ -276,7 +276,7 @@ pub const seg_feature_bits: [u32; SegLvl::SEG_LVL_MAX as usize] =
 pub const seg_feature_is_signed: [bool; SegLvl::SEG_LVL_MAX as usize] =
     [ true, true, true, true, true, false, false, false, ];
 
-use context::TxClass::*;
+use crate::context::TxClass::*;
 
 static tx_type_to_class: [TxClass; TX_TYPES] = [
   TX_CLASS_2D,    // DCT_DCT
@@ -1711,7 +1711,7 @@ impl CFLSign {
   }
 }
 
-use context::CFLSign::*;
+use crate::context::CFLSign::*;
 const CFL_SIGNS: usize = 3;
 static cfl_sign_value: [i16; CFL_SIGNS] = [ 0, -1, 1 ];
 

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -9,17 +9,17 @@
 
 #![allow(safe_extern_statics)]
 
-use context::*;
-use DeblockState;
-use FrameInvariants;
-use FrameState;
-use FrameType;
-use partition::*;
-use partition::PredictionMode::*;
-use plane::*;
-use quantize::*;
+use crate::context::*;
+use crate::DeblockState;
+use crate::FrameInvariants;
+use crate::FrameState;
+use crate::FrameType;
+use crate::partition::*;
+use crate::partition::PredictionMode::*;
+use crate::plane::*;
+use crate::quantize::*;
 use std::cmp;
-use util::{clamp, ILog};
+use crate::util::{clamp, ILog};
 
 fn deblock_adjusted_level(
   deblock: &DeblockState, block: &Block, pli: usize, vertical: bool

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -16,8 +16,8 @@
 use bitstream_io::{BitWriter, BigEndian};
 use std;
 use std::io;
-use util::ILog;
-use util::msb;
+use crate::util::ILog;
+use crate::util::msb;
 
 pub const OD_BITRES: u8 = 3;
 const EC_PROB_SHIFT: u32 = 6;
@@ -62,7 +62,7 @@ pub trait Writer {
   /// Save current point in coding/recording to a checkpoint
   fn checkpoint(&mut self) -> WriterCheckpoint;
   /// Restore saved position in coding/recording from a checkpoint
-  fn rollback(&mut self, &WriterCheckpoint);
+  fn rollback(&mut self, _: &WriterCheckpoint);
 }
 
 /// StorageBackend is an internal trait used to tie a specific Writer
@@ -77,7 +77,7 @@ pub trait StorageBackend {
   /// Backend implementation of checkpoint to pass through Writer interface
   fn checkpoint(&mut self) -> WriterCheckpoint;
   /// Backend implementation of rollback to pass through Writer interface
-  fn rollback(&mut self, &WriterCheckpoint);
+  fn rollback(&mut self, _: &WriterCheckpoint);
 }
 
 #[derive(Debug, Clone)]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -7,22 +7,22 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use api::*;
-use cdef::*;
-use context::*;
-use deblock::*;
-use ec::*;
-use lrf::*;
-use mc::*;
-use me::*;
-use partition::*;
-use plane::*;
-use quantize::*;
-use rdo::*;
-use segmentation::*;
-use transform::*;
-use util::*;
-use partition::PartitionType::*;
+use crate::api::*;
+use crate::cdef::*;
+use crate::context::*;
+use crate::deblock::*;
+use crate::ec::*;
+use crate::lrf::*;
+use crate::mc::*;
+use crate::me::*;
+use crate::partition::*;
+use crate::plane::*;
+use crate::quantize::*;
+use crate::rdo::*;
+use crate::segmentation::*;
+use crate::transform::*;
+use crate::util::*;
+use crate::partition::PartitionType::*;
 
 use bitstream_io::{BitWriter, BigEndian};
 use std;

--- a/src/entropymode.rs
+++ b/src/entropymode.rs
@@ -9,8 +9,8 @@
 
 #![allow(non_upper_case_globals)]
 
-use context::*;
-use partition::*;
+use crate::context::*;
+use crate::partition::*;
 
 const PALATTE_BSIZE_CTXS: usize = 7;
 const PALETTE_Y_MODE_CONTEXTS: usize = 3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,8 @@ pub mod scenechange;
 
 mod api;
 
-pub use api::*;
-pub use encoder::*;
+pub use crate::api::*;
+pub use crate::encoder::*;
 
 #[cfg(all(test, feature="decode_test"))]
 mod test_encode_decode_aom;

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -9,17 +9,17 @@
 
 #![allow(safe_extern_statics)]
 
-use encoder::Frame;
-use encoder::FrameInvariants;
-use context::ContextWriter;
-use context::SuperBlockOffset;
-use context::PLANES;
-use context::MAX_SB_SIZE;
-use plane::Plane;
-use plane::PlaneOffset;
-use plane::PlaneConfig;
+use crate::encoder::Frame;
+use crate::encoder::FrameInvariants;
+use crate::context::ContextWriter;
+use crate::context::SuperBlockOffset;
+use crate::context::PLANES;
+use crate::context::MAX_SB_SIZE;
+use crate::plane::Plane;
+use crate::plane::PlaneOffset;
+use crate::plane::PlaneConfig;
 use std::cmp;
-use util::clamp;
+use crate::util::clamp;
 
 pub const RESTORATION_TILESIZE_MAX_LOG2: usize = 8;
 

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -136,8 +136,8 @@ const SUBPEL_FILTERS: [[[i32; SUBPEL_FILTER_SIZE]; 16]; 6] = [
 #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
 mod nasm {
   use super::*;
-  use plane::*;
-  use util::*;
+  use crate::plane::*;
+  use crate::util::*;
 
   use std::mem;
 
@@ -370,8 +370,8 @@ mod nasm {
 mod native {
   use super::*;
   use num_traits::*;
-  use plane::*;
-  use util::*;
+  use crate::plane::*;
+  use crate::util::*;
 
   fn run_filter<T: AsPrimitive<i32>>(
     src: &[T], stride: usize, filter: [i32; 8]

--- a/src/me.rs
+++ b/src/me.rs
@@ -11,17 +11,17 @@
 pub use self::nasm::get_sad;
 #[cfg(any(not(target_arch = "x86_64"), windows, not(feature = "nasm")))]
 pub use self::native::get_sad;
-use context::{BlockOffset, BLOCK_TO_PLANE_SHIFT, MI_SIZE};
-use FrameInvariants;
-use FrameState;
-use partition::*;
-use plane::*;
-use rdo::get_lambda_sqrt;
+use crate::context::{BlockOffset, BLOCK_TO_PLANE_SHIFT, MI_SIZE};
+use crate::FrameInvariants;
+use crate::FrameState;
+use crate::partition::*;
+use crate::plane::*;
+use crate::rdo::get_lambda_sqrt;
 
 #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
 mod nasm {
-  use plane::*;
-  use util::*;
+  use crate::plane::*;
+  use crate::util::*;
 
   use libc;
 
@@ -108,7 +108,7 @@ mod nasm {
 }
 
 mod native {
-  use plane::*;
+  use crate::plane::*;
 
   #[inline(always)]
   pub fn get_sad(
@@ -420,8 +420,8 @@ pub fn estimate_motion_ss2(
 #[cfg(test)]
 pub mod test {
   use super::*;
-  use partition::BlockSize;
-  use partition::BlockSize::*;
+  use crate::partition::BlockSize;
+  use crate::partition::BlockSize::*;
 
   // Generate plane data for get_sad_same()
   fn setup_sad() -> (Plane, Plane) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -7,8 +7,8 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use encoder::Frame;
-use plane::Plane;
+use crate::encoder::Frame;
+use crate::plane::Plane;
 
 /// Calculates the PSNR for a `Frame` by comparing the original (uncompressed) to the compressed
 /// version of the frame. Higher PSNR is better--PSNR is capped at 100 in order to avoid skewed

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -12,12 +12,12 @@
 
 use self::BlockSize::*;
 use self::TxSize::*;
-use context::*;
-use encoder::{ChromaSampling, FrameInvariants};
-use mc::*;
-use plane::*;
-use predict::*;
-use util::*;
+use crate::context::*;
+use crate::encoder::{ChromaSampling, FrameInvariants};
+use crate::mc::*;
+use crate::plane::*;
+use crate::predict::*;
+use crate::util::*;
 
 pub const NONE_FRAME: usize = 8;
 pub const INTRA_FRAME: usize = 0;

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -12,7 +12,7 @@
 use std::iter::FusedIterator;
 use std::fmt::{Debug, Formatter};
 
-use util::*;
+use crate::util::*;
 
 /// Plane-specific configuration.
 #[derive(Debug, Clone)]

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -194,7 +194,7 @@ impl Plane {
 
     for row in 0..height {
       let mut dst_slice = self.mut_slice(&PlaneOffset{ x: 0, y: row as isize });
-      let mut dst = dst_slice.as_mut_slice();
+      let dst = dst_slice.as_mut_slice();
 
       for col in 0..width {
         let mut sum = 0;

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -11,9 +11,9 @@
 #![allow(clippy::cast_lossless)]
 #![allow(clippy::needless_range_loop)]
 
-use context::{INTRA_MODES, MAX_TX_SIZE};
-use partition::*;
-use util::*;
+use crate::context::{INTRA_MODES, MAX_TX_SIZE};
+use crate::partition::*;
+use crate::util::*;
 
 #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
 use libc;

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::cast_lossless)]
 #![allow(non_upper_case_globals)]
 
-use partition::TxSize;
+use crate::partition::TxSize;
 
 use num_traits::*;
 use std::convert::Into;
@@ -98,7 +98,7 @@ fn divu_pair(x: i32, d: (u32, u32, u32)) -> i32 {
 #[cfg(test)]
 mod test {
   use super::*;
-  use partition::TxSize::*;
+  use crate::partition::TxSize::*;
 
   #[test]
   fn test_divu_pair() {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -717,7 +717,7 @@ pub fn rdo_mode_decision(fi: &FrameInvariants, fs: &mut FrameState,
     );
     cw.rollback(&cw_checkpoint);
     if let Some(cfl) = rdo_cfl_alpha(fs, bo, bsize, fi.sequence.bit_depth, fi.sequence.chroma_sampling) {
-      let mut wr: &mut dyn Writer = &mut WriterCounter::new();
+      let wr: &mut dyn Writer = &mut WriterCounter::new();
       let tell = wr.tell_frac();
 
       encode_block_a(&fi.sequence, fs, cw, wr, bsize, bo, best.skip);
@@ -864,7 +864,7 @@ pub fn rdo_tx_type_decision(
       motion_compensate(fi, fs, cw, mode, ref_frames, mvs, bsize, bo, true);
     }
 
-    let mut wr: &mut dyn Writer = &mut WriterCounter::new();
+    let wr: &mut dyn Writer = &mut WriterCounter::new();
     let tell = wr.tell_frac();
     let tx_dist = if is_inter {
       write_tx_tree(
@@ -1129,11 +1129,11 @@ pub fn rdo_cdef_decision(sbo: &SuperBlockOffset, fi: &FrameInvariants,
           let skip = bc.at(&bo).skip;
           if !skip {
             for p in 0..3 {
-              let mut in_plane = &fs.input.planes[p];
+              let in_plane = &fs.input.planes[p];
               let in_po = sbo.block_offset(bx<<1, by<<1).plane_offset(&in_plane.cfg);
               let in_slice = in_plane.slice(&in_po);
 
-              let mut out_plane = &mut cdef_output.planes[p];
+              let out_plane = &mut cdef_output.planes[p];
               let out_po = sbo_0.block_offset(bx<<1, by<<1).plane_offset(&out_plane.cfg);
               let out_slice = &out_plane.slice(&out_po);
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -11,31 +11,31 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::cast_lossless)]
 
-use api::PredictionModesSetting;
-use cdef::*;
-use context::*;
-use ec::{OD_BITRES, Writer, WriterCounter};
-use encoder::{ChromaSampling, ReferenceMode};
-use encode_block_a;
-use encode_block_b;
-use encode_block_with_modes;
-use FrameInvariants;
-use FrameState;
-use FrameType;
-use luma_ac;
-use me::*;
-use motion_compensate;
-use partition::*;
-use plane::*;
-use predict::{RAV1E_INTRA_MODES, RAV1E_INTER_MODES_MINIMAL, RAV1E_INTER_COMPOUND_MODES};
-use quantize::dc_q;
-use Tune;
-use write_tx_blocks;
-use write_tx_tree;
+use crate::api::PredictionModesSetting;
+use crate::cdef::*;
+use crate::context::*;
+use crate::ec::{OD_BITRES, Writer, WriterCounter};
+use crate::encoder::{ChromaSampling, ReferenceMode};
+use crate::encode_block_a;
+use crate::encode_block_b;
+use crate::encode_block_with_modes;
+use crate::FrameInvariants;
+use crate::FrameState;
+use crate::FrameType;
+use crate::luma_ac;
+use crate::me::*;
+use crate::motion_compensate;
+use crate::partition::*;
+use crate::plane::*;
+use crate::predict::{RAV1E_INTRA_MODES, RAV1E_INTER_MODES_MINIMAL, RAV1E_INTER_COMPOUND_MODES};
+use crate::quantize::dc_q;
+use crate::Tune;
+use crate::write_tx_blocks;
+use crate::write_tx_tree;
 
 use std;
 use std::vec::Vec;
-use partition::PartitionType::*;
+use crate::partition::PartitionType::*;
 
 #[derive(Clone)]
 pub struct RDOOutput {

--- a/src/scan_order.rs
+++ b/src/scan_order.rs
@@ -14,7 +14,7 @@
 
 const MAX_NEIGHBORS: usize = 2;
 
-use partition::*;
+use crate::partition::*;
 
 #[repr(C)]
 pub struct SCAN_ORDER {

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -7,7 +7,7 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use encoder::Frame;
+use crate::encoder::Frame;
 
 use std::sync::Arc;
 

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -9,9 +9,9 @@
 
 #![allow(safe_extern_statics)]
 
-use context::*;
-use FrameInvariants;
-use FrameState;
+use crate::context::*;
+use crate::FrameInvariants;
+use crate::FrameState;
 
 pub fn segmentation_optimize(_fi: &FrameInvariants, fs: &mut FrameState) {
     fs.segmentation.enabled = false;

--- a/src/token_cdfs.rs
+++ b/src/token_cdfs.rs
@@ -9,8 +9,8 @@
 
 #![allow(non_upper_case_globals)]
 
-use context::*;
-use partition::*;
+use crate::context::*;
+use crate::partition::*;
 
 const TOKEN_CDF_Q_CTXS: usize = 4;
 

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -8,7 +8,7 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use super::*;
-use partition::{TxSize, TxType};
+use crate::partition::{TxSize, TxType};
 
 type TxfmShift = [i8; 3];
 type TxfmShifts = [TxfmShift; 3];
@@ -65,7 +65,7 @@ use std::ops::*;
 trait TxOperations:
   Copy + Default + Add<Output = Self> + Sub<Output = Self>
 {
-  fn tx_mul(self, (i32, i32)) -> Self;
+  fn tx_mul(self, _: (i32, i32)) -> Self;
   fn add_avg(self, b: Self) -> Self;
   fn sub_avg(self, b: Self) -> Self;
   fn rshift1(self) -> Self;

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -16,7 +16,7 @@ pub use self::native::*;
 
 use super::*;
 use num_traits::*;
-use partition::TxType;
+use crate::partition::TxType;
 
 static COSPI_INV: [i32; 64] = [
   4096, 4095, 4091, 4085, 4076, 4065, 4052, 4036, 4017, 3996, 3973, 3948,
@@ -1509,7 +1509,7 @@ static INV_TXFM_FNS: [[fn(&[i32], &mut [i32], usize); 5]; 4] = [
 #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
 mod nasm {
   use super::*;
-  use partition::TxType;
+  use crate::partition::TxType;
 
   type InvTxfmFunc =
     unsafe extern fn(*mut u8, libc::ptrdiff_t, *const i16, i32);
@@ -1675,8 +1675,8 @@ mod nasm {
 
 mod native {
   use super::*;
-  use partition::TxType;
-  use util::clamp;
+  use crate::partition::TxType;
+  use crate::util::clamp;
 
   use std::cmp;
 

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -10,9 +10,9 @@
 pub use self::forward::*;
 pub use self::inverse::*;
 
-use partition::{TxSize, TxType, TX_TYPES};
-use predict::*;
-use util::*;
+use crate::partition::{TxSize, TxType, TX_TYPES};
+use crate::predict::*;
+use crate::util::*;
 
 mod forward;
 mod inverse;
@@ -263,8 +263,8 @@ mod test {
 
   #[test]
   fn roundtrips() {
-    use partition::TxSize::*;
-    use partition::TxType::*;
+    use crate::partition::TxSize::*;
+    use crate::partition::TxType::*;
     let combinations = [
       (TX_4X4, DCT_DCT, 0),
       (TX_4X4, ADST_DCT, 0),


### PR DESCRIPTION
Closes #957.

The original Rust 2018 migration page was advising to run `cargo fix`, which did not perform migration correctly, but `cargo fix --edition` did the trick.