### PR TITLE
Enable tx domain distortion at speed >= 4 instead of >= 1

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -159,7 +159,7 @@ impl SpeedSettings {
   }
 
   fn tx_domain_distortion_preset(speed: usize) -> bool {
-    speed >= 1
+    speed >= 4
   }
 
   fn encode_bottomup_preset(speed: usize) -> bool {


### PR DESCRIPTION
This way, the default speed (3) always uses pixel domain distortion
which is easier to understand while we figure out what our quantizers
should look like, how to set lambda, what distortion metrics to use,
etc.

Note that this only affects --tune Psnr since --tune Psychovisual always
uses (weighted) pixel domain distortion.