### PR TITLE
Remove leftover unnecessary "mut"s

### DIFF
--- a/benches/me.rs
+++ b/benches/me.rs
@@ -17,7 +17,7 @@ use rav1e::me;
 fn fill_plane(ra: &mut ChaChaRng, plane: &mut Plane) {
   let stride = plane.cfg.stride;
   for row in plane.data.chunks_mut(stride) {
-    for mut pixel in row {
+    for pixel in row {
       let v: u8 = ra.gen();
       *pixel = v as u16;
     }

--- a/src/me.rs
+++ b/src/me.rs
@@ -230,7 +230,7 @@ pub fn motion_estimation(
                 blk_w,
                 blk_h,
                 [ref_frame, NONE_FRAME],
-                [cand_mv, MotionVector { row: 0, col: 0 }]                
+                [cand_mv, MotionVector { row: 0, col: 0 }]
               );
             }
 
@@ -429,7 +429,7 @@ pub mod test {
     let mut rec_plane = input_plane.clone();
 
     for (i, row) in input_plane.data.chunks_mut(input_plane.cfg.stride).enumerate() {
-      for (j, mut pixel) in row.into_iter().enumerate() {
+      for (j, pixel) in row.into_iter().enumerate() {
         let val = ((j + i) as i32 & 255i32) as u16;
         assert!(val >= u8::min_value().into() &&
             val <= u8::max_value().into());
@@ -438,7 +438,7 @@ pub mod test {
     }
 
     for (i, row) in rec_plane.data.chunks_mut(rec_plane.cfg.stride).enumerate() {
-      for (j, mut pixel) in row.into_iter().enumerate() {
+      for (j, pixel) in row.into_iter().enumerate() {
         let val = (j as i32 - i as i32 & 255i32) as u16;
         assert!(val >= u8::min_value().into() &&
             val <= u8::max_value().into());

--- a/src/test_encode_decode_aom.rs
+++ b/src/test_encode_decode_aom.rs
@@ -25,7 +25,7 @@ fn fill_frame(ra: &mut ChaChaRng, frame: &mut Frame) {
   for plane in frame.planes.iter_mut() {
     let stride = plane.cfg.stride;
     for row in plane.data.chunks_mut(stride) {
-      for mut pixel in row {
+      for pixel in row {
         let v: u8 = ra.gen();
         *pixel = v as u16;
       }

--- a/src/test_encode_decode_dav1d.rs
+++ b/src/test_encode_decode_dav1d.rs
@@ -19,7 +19,7 @@ fn fill_frame(ra: &mut ChaChaRng, frame: &mut Frame) {
   for plane in frame.planes.iter_mut() {
     let stride = plane.cfg.stride;
     for row in plane.data.chunks_mut(stride) {
-      for mut pixel in row {
+      for pixel in row {
         let v: u8 = ra.gen();
         *pixel = v as u16;
       }


### PR DESCRIPTION
More warnings showed up following the previous pass. This should clear the remaining warnings in the benchmarks and the main codebase.