### PR TITLE
Output JSON stats file with frame types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ autobins = false
 comparative_bench = ["aom"]
 decode_test = ["bindgen", "aom"]
 decode_test_dav1d = ["dav1d-sys"]
-binaries = ["ivf", "y4m", "clap", "scan_fmt"]
+binaries = ["ivf", "y4m", "clap", "scan_fmt", "serde_json"]
 default = ["binaries", "nasm"]
 aom = ["cmake"]
 nasm = ["nasm-rs"]
@@ -29,6 +29,9 @@ syn = "^0.15.20"
 quote = "^0.6.10" # hack for proc-macro-hack
 num-traits = "0.2"
 paste = "0.1"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = { version = "1.0", optional = true }
 dav1d-sys = { version = "0.1.2", optional = true }
 scan_fmt = { version = "0.1.3", optional = true }
 ivf = { path = "ivf/", optional = true }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -648,7 +648,6 @@ impl FrameInvariants {
       cdef_y_strengths: [0*4+0, 1*4+0, 2*4+1, 3*4+1, 5*4+2, 7*4+3, 10*4+3, 13*4+3],
       cdef_uv_strengths: [0*4+0, 1*4+0, 2*4+1, 3*4+1, 5*4+2, 7*4+3, 10*4+3, 13*4+3],
       delta_q_present: false,
-      config,
       ref_frames: [0; INTER_REFS_PER_FRAME],
       ref_frame_sign_bias: [false; INTER_REFS_PER_FRAME],
       rec_buffer: ReferenceFramesSet::new(),
@@ -661,6 +660,7 @@ impl FrameInvariants {
       use_tx_domain_distortion,
       inter_cfg: None,
       enable_early_exit: true,
+      config,
     }
   }
 
@@ -875,8 +875,8 @@ pub struct InterPropsConfig {
   pub group_idx: u64,
 }
 
-#[allow(dead_code,non_camel_case_types)]
-#[derive(Debug,PartialEq,Clone,Copy)]
+#[allow(dead_code, non_camel_case_types)]
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 #[repr(C)]
 pub enum FrameType {
   KEY,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@
 
 #![allow(safe_extern_statics)]
 
+#[macro_use]
+extern crate serde_derive;
+
 #[cfg(all(test, feature="decode_test_dav1d"))]
 extern crate dav1d_sys;
 


### PR DESCRIPTION
More data will likely be added to this stats file in the future.

Adds in `--pass 1` or `--pass 2` CLI options to prepare for two-pass encoding.
Currently the only difference between these, or omitting the option (which assumes
one-pass encoding) is that using `--pass 1` outputs the stats file. This will be added to
and optimized later.

Closes #898