### PR TITLE
Enable full early-exit for bottomup partition search

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2568,7 +2568,7 @@ fn encode_partition_bottomup(
           if fi.enable_early_exit && (rd_cost >= best_rd || rd_cost >= ref_rd_cost) {
             assert!(cost != std::f64::MAX);
             early_exit = true;
-            if partition == PartitionType::PARTITION_SPLIT { break; }
+            break;
           }
           else {
             if partition != PartitionType::PARTITION_SPLIT {


### PR DESCRIPTION
https://github.com/xiph/rav1e/issues/877

In addition to PARTITION_SPLIT, fully enable early-exit for HORZ
and VERT partition types. This gives further reduction of encoding time
at speed 0, now x3 and x2 for Qindex 252 and 220, resp.

It turns out that the broken directional intra prediction has been
the curprit of bdrate change when enabling full early-exit with bottomup
partition search.