### PR TITLE
Improve generic usage of Pixel trait 

### DIFF
--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -15,7 +15,6 @@ pub use self::native::*;
 // TODO: move 1d txfm code to native module.
 
 use super::*;
-use num_traits::*;
 use crate::partition::TxType;
 
 static COSPI_INV: [i32; 64] = [
@@ -1522,9 +1521,6 @@ mod nasm {
       bd: usize
     ) where
       T: Pixel,
-      i32: AsPrimitive<T>,
-      u8: AsPrimitive<T>,
-      T: AsPrimitive<u8>
     {
       if is_x86_feature_detected!("avx2") && bd == 8 {
         // 64x only uses 32 coeffs
@@ -1782,9 +1778,6 @@ macro_rules! impl_iht_fns {
           bit_depth: usize
         ) where
           T: Pixel,
-          i32: AsPrimitive<T>,
-          u8: AsPrimitive<T>,
-          T: AsPrimitive<u8>
         {
           [<Block $W x $H>]::inv_txfm2d_add(
             input, output, stride, tx_type, bit_depth

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1688,7 +1688,6 @@ mod native {
       bd: usize
     ) where
       T: Pixel,
-      i32: AsPrimitive<T>
     {
       // For 64 point transforms, rely on the last 32 columns being initialized
       //   to zero for filling out missing input coeffs.
@@ -1736,8 +1735,9 @@ mod native {
           .iter()
           .zip(output[c..].iter_mut().step_by(stride).take(Self::H))
         {
-          *out = clamp((*out).as_() + round_shift(*temp, 4), 0, (1 << bd) - 1)
-            .as_();
+          let v: i32 = (*out).as_();
+          let v = clamp(v + round_shift(*temp, 4), 0, (1 << bd) - 1);
+          *out = T::cast_from(v);
         }
       }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -208,7 +208,49 @@ pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
   }
 }
 
-pub trait Pixel: PrimInt + Into<u32> + Into<i32> + AsPrimitive<i32> + 'static {}
+pub trait CastFromPrimitive<T> : Copy + 'static {
+  fn cast_from(v: T) -> Self;
+}
+
+macro_rules! impl_cast_from_primitive {
+  ( $T:ty => $U:ty ) => {
+    impl CastFromPrimitive<$U> for $T {
+      fn cast_from(v: $U) -> Self { v as Self }
+    }
+  };
+  ( $T:ty => { $( $U:ty ),* } ) => {
+    $( impl_cast_from_primitive!($T => $U); )*
+  };
+}
+
+impl_cast_from_primitive!(u8 => { u8, u16, u32, u64, usize });
+impl_cast_from_primitive!(u8 => { i8, i16, i32, i64, isize });
+impl_cast_from_primitive!(u16 => { u8, u16, u32, u64, usize });
+impl_cast_from_primitive!(u16 => { i8, i16, i32, i64, isize });
+impl_cast_from_primitive!(i16 => { u8, u16, u32, u64, usize });
+impl_cast_from_primitive!(i16 => { i8, i16, i32, i64, isize });
+impl_cast_from_primitive!(i32 => { u8, u16, u32, u64, usize });
+impl_cast_from_primitive!(i32 => { i8, i16, i32, i64, isize });
+
+pub trait Pixel:
+  PrimInt
+  + Into<u32>
+  + Into<i32>
+  + AsPrimitive<u8>
+  + AsPrimitive<i16>
+  + AsPrimitive<u16>
+  + AsPrimitive<i32>
+  + AsPrimitive<u32>
+  + AsPrimitive<usize>
+  + CastFromPrimitive<u8>
+  + CastFromPrimitive<i16>
+  + CastFromPrimitive<u16>
+  + CastFromPrimitive<i32>
+  + CastFromPrimitive<u32>
+  + CastFromPrimitive<usize>
+  + 'static
+{}
+
 impl Pixel for u8 {}
 impl Pixel for u16 {}
 


### PR DESCRIPTION
In order to use either `u8` or `u16` for plane components, a `Pixel` trait regroups several "capabilities" that a generic pixel type must support, through trait inheritance.

That way, a generic function can just use the Pixel type, without listing them all:

```rust
fn f<T: Pixel>(...) { ... }
```

However, trait inheritance cannot express constraints about `T` for other types (like `i32: AsPrimitive<T>`). As a consequence, callers had to specify these additional constraints manually:

```rust
where
    T: Pixel,
    i32: AsPrimitive<T>,
    u32: AsPrimitive<T>,
```

This is redundant, because if `T` is a `Pixel`, then `i32` and `u32` necessarily implement `AsPrimitive<T>` (since Pixel is only implemented for `u8` and `u16`).

To express these relationships, create a new trait, `CastFromPrimitive<T>`, representing the inverse of `AsPrimitive<T>`.

This paves the way to make `Plane` (and many other structures) generic over the pixel type conveniently.

---
Since Pixel is only implemented for `u8` and `u16` types, it is always possible to cast a `Pixel` to an integral primitive type. However, the compiler could not know this, because in theory any other type could also implement the `Pixel` trait.

To enforce this restriction, make the (main) integral primitive types implement `CastForPrimitive<T>` for any `T` which implements `Pixel`. That way, the compiler knows that a `Pixel` (whatever its concrete type) can always be cast to an integer.

Then, rewrite the constraints on `convert_slice_2d()` to use `CastFromPrimitive`, so that callers need not to add redundant constraints if `T` implements `Pixel`.