### PR TITLE
Make plane generic over pixel component type

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -49,7 +49,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
     ..Default::default()
   };
   let sequence = Sequence::new(&Default::default());
-  let mut fi = FrameInvariants::new(config, sequence);
+  let mut fi = FrameInvariants::<u16>::new(config, sequence);
   let mut w = ec::WriterEncoder::new();
   let fc = CDFContext::new(fi.base_q_idx);
   let bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
@@ -120,7 +120,7 @@ fn cdef_frame_bench(b: &mut Bencher, width: usize, height: usize) {
     ..Default::default()
   };
   let sequence = Sequence::new(&Default::default());
-  let fi = FrameInvariants::new(config, sequence);
+  let fi = FrameInvariants::<u16>::new(config, sequence);
   let mut bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
   let mut fs = FrameState::new(&fi);
 
@@ -148,7 +148,7 @@ fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
     ..Default::default()
   };
   let sequence = Sequence::new(&Default::default());
-  let fi = FrameInvariants::new(config, sequence );
+  let fi = FrameInvariants::<u16>::new(config, sequence);
   let mut fs = FrameState::new(&fi);
   let offset = BlockOffset { x: 1, y: 1 };
   b.iter(|| rdo_cfl_alpha(&mut fs, &offset, bsize, fi.sequence.bit_depth, fi.sequence.chroma_sampling))

--- a/benches/me.rs
+++ b/benches/me.rs
@@ -13,18 +13,19 @@ use crate::partition::BlockSize::*;
 use crate::plane::*;
 use rand::{ChaChaRng, Rng, SeedableRng};
 use rav1e::me;
+use rav1e::Pixel;
 
-fn fill_plane(ra: &mut ChaChaRng, plane: &mut Plane) {
+fn fill_plane<T: Pixel>(ra: &mut ChaChaRng, plane: &mut Plane<T>) {
   let stride = plane.cfg.stride;
   for row in plane.data.chunks_mut(stride) {
     for pixel in row {
       let v: u8 = ra.gen();
-      *pixel = v as u16;
+      *pixel = T::cast_from(v);
     }
   }
 }
 
-fn new_plane(ra: &mut ChaChaRng, width: usize, height: usize) -> Plane {
+fn new_plane<T: Pixel>(ra: &mut ChaChaRng, width: usize, height: usize) -> Plane<T> {
   let mut p = Plane::new(width, height, 0, 0, 128 + 8, 128 + 8);
 
   fill_plane(ra, &mut p);
@@ -39,8 +40,8 @@ fn bench_get_sad(b: &mut Bencher, bs: &BlockSize) {
   let w = 640;
   let h = 480;
   let bit_depth = 10;
-  let input_plane = new_plane(&mut ra, w, h);
-  let rec_plane = new_plane(&mut ra, w, h);
+  let input_plane = new_plane::<u16>(&mut ra, w, h);
+  let rec_plane = new_plane::<u16>(&mut ra, w, h);
   let po = PlaneOffset { x: 0, y: 0 };
 
   let plane_org = input_plane.slice(&po);

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,6 +16,7 @@ use crate::rate::FRAME_NSUBTYPES;
 use crate::rate::FRAME_SUBTYPE_I;
 use crate::rate::FRAME_SUBTYPE_P;
 use crate::scenechange::SceneChangeDetector;
+use crate::util::Pixel;
 use self::EncoderStatus::*;
 
 use std::{cmp, fmt, io};
@@ -437,7 +438,7 @@ impl Config {
     Ok(())
   }
 
-  pub fn new_context(&self) -> Context {
+  pub fn new_context<T: Pixel>(&self) -> Context<T> {
     #[cfg(feature = "aom")]
     unsafe {
       av1_rtcd();
@@ -483,16 +484,16 @@ impl Config {
   }
 }
 
-pub struct Context {
+pub struct Context<T: Pixel> {
   //    timebase: Rational,
   frame_count: u64,
   limit: u64,
   pub(crate) idx: u64,
   frames_processed: u64,
   /// Maps frame *number* to frames
-  frame_q: BTreeMap<u64, Option<Arc<Frame>>>, //    packet_q: VecDeque<Packet>
+  frame_q: BTreeMap<u64, Option<Arc<Frame<T>>>>, //    packet_q: VecDeque<Packet>
   /// Maps frame *idx* to frame data
-  frame_data: BTreeMap<u64, FrameInvariants>,
+  frame_data: BTreeMap<u64, FrameInvariants<T>>,
   /// A list of keyframe *numbers* in this encode. Needed so that we don't
   /// need to keep all of the frame_data in memory for the whole life of the encode.
   keyframes: BTreeSet<u64>,
@@ -500,7 +501,7 @@ pub struct Context {
   packet_data: Vec<u8>,
   segment_start_idx: u64,
   segment_start_frame: u64,
-  keyframe_detector: SceneChangeDetector,
+  keyframe_detector: SceneChangeDetector<T>,
   pub config: Config,
   rc_state: RCState,
   maybe_prev_log_base_q: Option<i64>,
@@ -519,16 +520,16 @@ pub enum EncoderStatus {
   ParseError
 }
 
-pub struct Packet {
+pub struct Packet<T: Pixel> {
   pub data: Vec<u8>,
-  pub rec: Option<Frame>,
+  pub rec: Option<Frame<T>>,
   pub number: u64,
   pub frame_type: FrameType,
   /// PSNR for Y, U, and V planes
   pub psnr: Option<(f64, f64, f64)>,
 }
 
-impl fmt::Display for Packet {
+impl<T: Pixel> fmt::Display for Packet<T> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(
       f,
@@ -540,8 +541,8 @@ impl fmt::Display for Packet {
   }
 }
 
-impl Context {
-  pub fn new_frame(&self) -> Arc<Frame> {
+impl<T: Pixel> Context<T> {
+  pub fn new_frame(&self) -> Arc<Frame<T>> {
     Arc::new(Frame::new(
       self.config.enc.width,
       self.config.enc.height,
@@ -551,7 +552,8 @@ impl Context {
 
   pub fn send_frame<F>(&mut self, frame: F) -> Result<(), EncoderStatus>
   where
-    F: Into<Option<Arc<Frame>>>
+    F: Into<Option<Arc<Frame<T>>>>,
+    T: Pixel,
   {
     let idx = self.frame_count;
     self.frame_q.insert(idx, frame.into());
@@ -559,7 +561,7 @@ impl Context {
     Ok(())
   }
 
-  pub fn get_frame(&self, frame_number: u64) -> Arc<Frame> {
+  pub fn get_frame(&self, frame_number: u64) -> Arc<Frame<T>> {
     // Clones only the arc, so low cost overhead
     self.frame_q.get(&frame_number).as_ref().unwrap().as_ref().unwrap().clone()
   }
@@ -628,7 +630,7 @@ impl Context {
     end_of_subgop
   }
 
-  fn build_frame_properties(&mut self, idx: u64) -> (FrameInvariants, bool) {
+  fn build_frame_properties(&mut self, idx: u64) -> (FrameInvariants<T>, bool) {
     if idx == 0 {
       let seq = Sequence::new(&self.config.enc);
 
@@ -711,7 +713,7 @@ impl Context {
     (fi, true)
   }
 
-  pub fn receive_packet(&mut self) -> Result<Packet, EncoderStatus> {
+  pub fn receive_packet(&mut self) -> Result<Packet<T>, EncoderStatus> {
     let idx = {
       let mut idx = self.idx;
       while !self.set_frame_properties(idx) {
@@ -794,7 +796,7 @@ impl Context {
     ret
   }
 
-  fn finalize_packet(&mut self, rec: Option<Frame>, fi: &FrameInvariants) -> Result<Packet, EncoderStatus> {
+  fn finalize_packet(&mut self, rec: Option<Frame<T>>, fi: &FrameInvariants<T>) -> Result<Packet<T>, EncoderStatus> {
     let data = self.packet_data.clone();
     self.packet_data.clear();
     if write_temporal_delimiter(&mut self.packet_data).is_err() {
@@ -972,8 +974,8 @@ pub struct FirstPassFrame {
   frame_type: FrameType,
 }
 
-impl From<&FrameInvariants> for FirstPassFrame {
-  fn from(fi: &FrameInvariants) -> FirstPassFrame {
+impl<T: Pixel> From<&FrameInvariants<T>> for FirstPassFrame {
+  fn from(fi: &FrameInvariants<T>) -> FirstPassFrame {
     FirstPassFrame {
       number: fi.number,
       frame_type: fi.frame_type,

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -443,8 +443,8 @@ pub struct FrameSummary {
   pub psnr: Option<(f64, f64, f64)>,
 }
 
-impl From<Packet> for FrameSummary {
-  fn from(packet: Packet) -> Self {
+impl<T: Pixel> From<Packet<T>> for FrameSummary {
+  fn from(packet: Packet<T>) -> Self {
     Self {
       size: packet.data.len(),
       number: packet.number,

--- a/src/bin/decoder/mod.rs
+++ b/src/bin/decoder/mod.rs
@@ -6,7 +6,7 @@ pub mod y4m;
 
 pub trait Decoder {
   fn get_video_details(&self) -> VideoDetails;
-  fn read_frame(&mut self, cfg: &VideoDetails) -> Result<Frame, DecodeError>;
+  fn read_frame<T: Pixel>(&mut self, cfg: &VideoDetails) -> Result<Frame<T>, DecodeError>;
 }
 
 #[derive(Debug)]

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -7,6 +7,7 @@ use crate::decoder::VideoDetails;
 use crate::ChromaSamplePosition;
 use crate::ChromaSampling;
 use crate::encoder::Frame;
+use rav1e::*;
 
 impl Decoder for y4m::Decoder<'_, Box<dyn Read>> {
   fn get_video_details(&self) -> VideoDetails {
@@ -28,11 +29,11 @@ impl Decoder for y4m::Decoder<'_, Box<dyn Read>> {
     }
   }
 
-  fn read_frame(&mut self, cfg: &VideoDetails) -> Result<Frame, DecodeError> {
+  fn read_frame<T: Pixel>(&mut self, cfg: &VideoDetails) -> Result<Frame<T>, DecodeError> {
     let bytes = self.get_bytes_per_sample();
     self.read_frame()
       .map(|frame| {
-        let mut f = Frame::new(cfg.width, cfg.height, cfg.chroma_sampling);
+        let mut f: Frame<T> = Frame::new(cfg.width, cfg.height, cfg.chroma_sampling);
 
         let (chroma_period, _) = cfg.chroma_sampling.sampling_period();
 

--- a/src/bin/muxer.rs
+++ b/src/bin/muxer.rs
@@ -10,10 +10,11 @@
 use crate::decoder::VideoDetails;
 use std::io::Write;
 use std::slice;
+use rav1e::*;
 
 pub use ivf::*;
 
-pub fn write_y4m_frame(y4m_enc: &mut y4m::Encoder<'_, Box<dyn Write>>, rec: &rav1e::Frame, y4m_details: VideoDetails) {
+pub fn write_y4m_frame<T: Pixel>(y4m_enc: &mut y4m::Encoder<'_, Box<dyn Write>>, rec: &rav1e::Frame<T>, y4m_details: VideoDetails) {
   let pitch_y = if y4m_details.bit_depth > 8 { y4m_details.width * 2 } else { y4m_details.width };
   let chroma_sampling_period = y4m_details.chroma_sampling.sampling_period();
   let (pitch_uv, height_uv) = (
@@ -47,7 +48,7 @@ pub fn write_y4m_frame(y4m_enc: &mut y4m::Encoder<'_, Box<dyn Write>>, rec: &rav
       }
     } else {
       line_out.copy_from_slice(
-        &line.iter().map(|&v| v as u8).collect::<Vec<u8>>()[..pitch_y]
+        &line.iter().map(|&v| u8::cast_from(v)).collect::<Vec<u8>>()[..pitch_y]
       );
     }
   }
@@ -65,7 +66,7 @@ pub fn write_y4m_frame(y4m_enc: &mut y4m::Encoder<'_, Box<dyn Write>>, rec: &rav
       }
     } else {
       line_out.copy_from_slice(
-        &line.iter().map(|&v| v as u8).collect::<Vec<u8>>()[..pitch_uv]
+        &line.iter().map(|&v| u8::cast_from(v)).collect::<Vec<u8>>()[..pitch_uv]
       );
     }
   }
@@ -83,7 +84,7 @@ pub fn write_y4m_frame(y4m_enc: &mut y4m::Encoder<'_, Box<dyn Write>>, rec: &rav
       }
     } else {
       line_out.copy_from_slice(
-        &line.iter().map(|&v| v as u8).collect::<Vec<u8>>()[..pitch_uv]
+        &line.iter().map(|&v| u8::cast_from(v)).collect::<Vec<u8>>()[..pitch_uv]
       );
     }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod header;
 pub use crate::api::*;
 pub use crate::encoder::*;
 pub use crate::header::*;
+pub use crate::util::{CastFromPrimitive, Pixel};
 
 #[cfg(all(test, feature="decode_test"))]
 mod test_encode_decode_aom;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -9,13 +9,14 @@
 
 use crate::encoder::Frame;
 use crate::plane::Plane;
+use crate::util::{CastFromPrimitive, Pixel};
 
 /// Calculates the PSNR for a `Frame` by comparing the original (uncompressed) to the compressed
 /// version of the frame. Higher PSNR is better--PSNR is capped at 100 in order to avoid skewed
 /// statistics from e.g. all black frames, which would otherwise show a PSNR of infinity.
 ///
 /// See https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio for more details.
-pub fn calculate_frame_psnr(original: &Frame, compressed: &Frame, bit_depth: usize) -> (f64, f64, f64) {
+pub fn calculate_frame_psnr<T: Pixel>(original: &Frame<T>, compressed: &Frame<T>, bit_depth: usize) -> (f64, f64, f64) {
   (calculate_plane_psnr(&original.planes[0], &compressed.planes[0], bit_depth),
     calculate_plane_psnr(&original.planes[1], &compressed.planes[1], bit_depth),
     calculate_plane_psnr(&original.planes[2], &compressed.planes[2], bit_depth))
@@ -23,7 +24,7 @@ pub fn calculate_frame_psnr(original: &Frame, compressed: &Frame, bit_depth: usi
 
 /// Calculate the PSNR for a `Plane` by comparing the original (uncompressed) to the compressed
 /// version.
-fn calculate_plane_psnr(original: &Plane, compressed: &Plane, bit_depth: usize) -> f64 {
+fn calculate_plane_psnr<T: Pixel>(original: &Plane<T>, compressed: &Plane<T>, bit_depth: usize) -> f64 {
   let mse = calculate_plane_mse(original, compressed);
   if mse <= 0.000_000_000_1 {
     return 100.0;
@@ -34,9 +35,9 @@ fn calculate_plane_psnr(original: &Plane, compressed: &Plane, bit_depth: usize) 
 
 /// Calculate the mean squared error for a `Plane` by comparing the original (uncompressed)
 /// to the compressed version.
-fn calculate_plane_mse(original: &Plane, compressed: &Plane) -> f64 {
+fn calculate_plane_mse<T: Pixel>(original: &Plane<T>, compressed: &Plane<T>) -> f64 {
   original.iter().zip(compressed.iter())
-    .map(|(a, b)| (a as i32 - b as i32).abs() as u64)
+    .map(|(a, b)| (i32::cast_from(a) - i32::cast_from(b)).abs() as u64)
     .map(|err| err * err)
     .sum::<u64>() as f64 / (original.cfg.width * original.cfg.height) as f64
 }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -814,17 +814,16 @@ pub enum MvJointType {
   MV_JOINT_HNZVNZ = 3  /* Both components nonzero */
 }
 
-pub fn get_intra_edges<'a>(
-  dst: &'a PlaneSlice<'a>,
+pub fn get_intra_edges<'a, T: Pixel>(
+  dst: &'a PlaneSlice<'a, T>,
   tx_size: TxSize,
   bit_depth: usize,
   plane_cfg: &'a PlaneConfig,
   frame_w_in_b: usize,
   frame_h_in_b: usize,
   opt_mode: Option<PredictionMode>
-) -> AlignedArray<[u16; 4 * MAX_TX_SIZE + 1]> {
-
-  let mut edge_buf: AlignedArray<[u16; 4 * MAX_TX_SIZE + 1]> =
+) -> AlignedArray<[T; 4 * MAX_TX_SIZE + 1]> {
+  let mut edge_buf: AlignedArray<[T; 4 * MAX_TX_SIZE + 1]> =
     UninitializedAlignedArray();
   let base = 128u16 << (bit_depth - 8);
 
@@ -872,7 +871,7 @@ pub fn get_intra_edges<'a>(
           left[2*MAX_TX_SIZE - tx_size.height() + i] = left_slice.p(0, tx_size.height() - 1 - i);
         }
       } else {
-        let val = if y != 0 { dst.go_up(1).p(0, 0) } else { base + 1 };
+        let val = if y != 0 { dst.go_up(1).p(0, 0) } else { T::cast_from(base + 1) };
         for v in left[2*MAX_TX_SIZE - tx_size.height()..].iter_mut() {
           *v = val
         }
@@ -882,7 +881,7 @@ pub fn get_intra_edges<'a>(
     // Needs top-left
     if needs_topleft {
       top_left[0] = match (x, y) {
-        (0, 0) => base,
+        (0, 0) => T::cast_from(base),
         (_, 0) => dst.go_left(1).p(0, 0),
         (0, _) => dst.go_up(1).p(0, 0),
         _ => dst.go_up(1).go_left(1).p(0, 0)
@@ -894,7 +893,7 @@ pub fn get_intra_edges<'a>(
       if y != 0 {
         above[..tx_size.width()].copy_from_slice(&dst.go_up(1).as_slice()[..tx_size.width()]);
       } else {
-        let val = if x != 0 { dst.go_left(1).p(0, 0) } else { base - 1 };
+        let val = if x != 0 { dst.go_left(1).p(0, 0) } else { T::cast_from(base - 1) };
         for v in above[..tx_size.width()].iter_mut() {
           *v = val;
         }
@@ -981,60 +980,60 @@ pub fn get_intra_edges<'a>(
 }
 
 impl PredictionMode {
-  pub fn predict_intra<'a>(
-    self, dst: &'a mut PlaneMutSlice<'a>, tx_size: TxSize, bit_depth: usize,
-    ac: &[i16], alpha: i16, edge_buf: &AlignedArray<[u16; 4 * MAX_TX_SIZE + 1]>
+  pub fn predict_intra<'a, T: Pixel>(
+    self, dst: &'a mut PlaneMutSlice<'a, T>, tx_size: TxSize, bit_depth: usize,
+    ac: &[i16], alpha: i16, edge_buf: &AlignedArray<[T; 4 * MAX_TX_SIZE + 1]>
   ) {
     assert!(self.is_intra());
 
     match tx_size {
       TxSize::TX_4X4 =>
-        self.predict_intra_inner::<Block4x4>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block4x4, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_8X8 =>
-        self.predict_intra_inner::<Block8x8>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block8x8, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_16X16 =>
-        self.predict_intra_inner::<Block16x16>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block16x16, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_32X32 =>
-        self.predict_intra_inner::<Block32x32>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block32x32, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_64X64 =>
-        self.predict_intra_inner::<Block64x64>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block64x64, _>(dst, bit_depth, ac, alpha, edge_buf),
 
       TxSize::TX_4X8 =>
-        self.predict_intra_inner::<Block4x8>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block4x8, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_8X4 =>
-        self.predict_intra_inner::<Block8x4>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block8x4, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_8X16 =>
-        self.predict_intra_inner::<Block8x16>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block8x16, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_16X8 =>
-        self.predict_intra_inner::<Block16x8>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block16x8, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_16X32 =>
-        self.predict_intra_inner::<Block16x32>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block16x32, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_32X16 =>
-        self.predict_intra_inner::<Block32x16>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block32x16, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_32X64 =>
-        self.predict_intra_inner::<Block32x64>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block32x64, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_64X32 =>
-        self.predict_intra_inner::<Block64x32>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block64x32, _>(dst, bit_depth, ac, alpha, edge_buf),
 
       TxSize::TX_4X16 =>
-        self.predict_intra_inner::<Block4x16>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block4x16, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_16X4 =>
-        self.predict_intra_inner::<Block16x4>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block16x4, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_8X32 =>
-        self.predict_intra_inner::<Block8x32>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block8x32, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_32X8 =>
-        self.predict_intra_inner::<Block32x8>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block32x8, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_16X64 =>
-        self.predict_intra_inner::<Block16x64>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block16x64, _>(dst, bit_depth, ac, alpha, edge_buf),
       TxSize::TX_64X16 =>
-        self.predict_intra_inner::<Block64x16>(dst, bit_depth, ac, alpha, edge_buf),
+        self.predict_intra_inner::<Block64x16, _>(dst, bit_depth, ac, alpha, edge_buf),
     }
   }
 
   #[inline(always)]
-  fn predict_intra_inner<'a, B: Intra<u16>>(
-    self, dst: &'a mut PlaneMutSlice<'a>, bit_depth: usize, ac: &[i16],
-    alpha: i16, edge_buf: &AlignedArray<[u16; 4 * MAX_TX_SIZE + 1]>
+  fn predict_intra_inner<'a, B: Intra<T>, T: Pixel>(
+    self, dst: &'a mut PlaneMutSlice<'a, T>, bit_depth: usize, ac: &[i16],
+    alpha: i16, edge_buf: &AlignedArray<[T; 4 * MAX_TX_SIZE + 1]>
   ) {
     // left pixels are order from bottom to top and right-aligned
     let (left, not_left) = edge_buf.array.split_at(2*MAX_TX_SIZE);
@@ -1140,9 +1139,9 @@ impl PredictionMode {
     self >= PredictionMode::V_PRED && self <= PredictionMode::D63_PRED
   }
 
-  pub fn predict_inter<'a>(
-    self, fi: &FrameInvariants, p: usize, po: &PlaneOffset,
-    dst: &'a mut PlaneMutSlice<'a>, width: usize, height: usize,
+  pub fn predict_inter<'a, T: Pixel>(
+    self, fi: &FrameInvariants<T>, p: usize, po: &PlaneOffset,
+    dst: &'a mut PlaneMutSlice<'a, T>, width: usize, height: usize,
     ref_frames: [usize; 2], mvs: [MotionVector; 2]
   ) {
     assert!(!self.is_intra());
@@ -1151,9 +1150,9 @@ impl PredictionMode {
     let is_compound =
       ref_frames[1] > INTRA_FRAME && ref_frames[1] != NONE_FRAME;
 
-    fn get_params<'a>(
-      rec_plane: &'a Plane, po: &PlaneOffset, mv: MotionVector
-    ) -> (i32, i32, PlaneSlice<'a>) {
+    fn get_params<'a, T: Pixel>(
+      rec_plane: &'a Plane<T>, po: &PlaneOffset, mv: MotionVector
+    ) -> (i32, i32, PlaneSlice<'a, T>) {
       let rec_cfg = &rec_plane.cfg;
       let shift_row = 3 + rec_cfg.ydec;
       let shift_col = 3 + rec_cfg.xdec;

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -127,8 +127,7 @@ macro_rules! block_dimension {
         const H: usize = $H;
       }
 
-      impl Intra<u8> for [<Block $W x $H>] {}
-      impl Intra<u16> for [<Block $W x $H>] {}
+      impl<T: Pixel> Intra<T> for [<Block $W x $H>] {}
     }
   };
 }

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -13,6 +13,7 @@ use crate::quantize::dc_q;
 use crate::quantize::select_ac_qi;
 use crate::quantize::select_dc_qi;
 use crate::util::clamp;
+use crate::util::Pixel;
 
 // The number of frame sub-types for which we track distinct parameters.
 pub const FRAME_NSUBTYPES: usize = 4;
@@ -537,8 +538,8 @@ impl RCState {
   }
 
   // TODO: Separate quantizers for Cb and Cr.
-  pub fn select_qi(
-    &self, ctx: &Context, fti: usize, maybe_prev_log_base_q: Option<i64>
+  pub fn select_qi<T: Pixel>(
+    &self, ctx: &Context<T>, fti: usize, maybe_prev_log_base_q: Option<i64>
   ) -> QuantizerParameters {
     // Is rate control active?
     if self.target_bitrate <= 0 {

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -12,8 +12,9 @@
 use crate::context::*;
 use crate::FrameInvariants;
 use crate::FrameState;
+use crate::util::Pixel;
 
-pub fn segmentation_optimize(_fi: &FrameInvariants, fs: &mut FrameState) {
+pub fn segmentation_optimize<T: Pixel>(_fi: &FrameInvariants<T>, fs: &mut FrameState<T>) {
     fs.segmentation.enabled = false;
     fs.segmentation.update_data = false;
     fs.segmentation.update_map = false;

--- a/src/test_encode_decode_dav1d.rs
+++ b/src/test_encode_decode_dav1d.rs
@@ -12,10 +12,11 @@ use rand::{ChaChaRng, Rng, SeedableRng};
 use std::{mem, ptr, slice};
 use std::collections::VecDeque;
 use std::sync::Arc;
+use crate::util::Pixel;
 
 use dav1d_sys::*;
 
-fn fill_frame(ra: &mut ChaChaRng, frame: &mut Frame) {
+fn fill_frame<T: Pixel>(ra: &mut ChaChaRng, frame: &mut Frame<T>) {
   for plane in frame.planes.iter_mut() {
     let stride = plane.cfg.stride;
     for row in plane.data.chunks_mut(stride) {
@@ -27,7 +28,7 @@ fn fill_frame(ra: &mut ChaChaRng, frame: &mut Frame) {
   }
 }
 
-fn read_frame_batch(ctx: &mut Context, ra: &mut ChaChaRng) {
+fn read_frame_batch<T: Pixel>(ctx: &mut Context<T>, ra: &mut ChaChaRng) {
   while ctx.needs_more_lookahead() {
     let mut input = ctx.new_frame();
     fill_frame(ra, Arc::get_mut(&mut input).unwrap());

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -14,6 +14,8 @@ use crate::partition::{TxSize, TxType, TX_TYPES};
 use crate::predict::*;
 use crate::util::*;
 
+use std::mem;
+
 mod forward;
 mod inverse;
 
@@ -172,10 +174,11 @@ pub fn forward_transform(
   }
 }
 
-pub fn inverse_transform_add(
-  input: &[i32], output: &mut [u16], stride: usize, tx_size: TxSize,
+pub fn inverse_transform_add<T: Pixel>(
+  input: &[i32], output: &mut [T], stride: usize, tx_size: TxSize,
   tx_type: TxType, bit_depth: usize
 ) {
+  assert!(mem::size_of::<T>() == 2, "only implemented for u16 for now");
   use self::TxSize::*;
   match tx_size {
     TX_4X4 => iht4x4_add(input, output, stride, tx_type, bit_depth),

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,6 +10,7 @@
 use num_traits::*;
 use std::mem;
 use std::mem::size_of;
+use std::fmt::{Debug, Display};
 #[allow(deprecated, unused_imports)]
 use ::std::ascii::AsciiExt;
 
@@ -250,6 +251,10 @@ pub trait Pixel:
   + CastFromPrimitive<i32>
   + CastFromPrimitive<u32>
   + CastFromPrimitive<usize>
+  + Debug
+  + Display
+  + Send
+  + Sync
   + 'static
 {}
 


### PR DESCRIPTION
In order to support both `u8` and `u16` for plane components, make the `Plane` structure generic over the component type. As a consequence, many other structures and functions also become generic.

Some functions are not `u8`-compatible yet, although they have been make generic over the component type to make the compilation work. They assert that the size of the generic parameter is 16 bits wide.

For this reason, the root context structure is unconditionally created as `Context<u16>` for now.