### PR TITLE
Add basic 1-pass rate control

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -85,10 +85,16 @@ pub fn parse_cli() -> CliOptions {
     )
     .arg(
       Arg::with_name("QP")
-        .help("Quantizer (0-255)")
+        .help("Quantizer (0-255), smaller values are higher quality [default: 100]")
         .long("quantizer")
         .takes_value(true)
-        .default_value("100")
+    )
+    .arg(
+      Arg::with_name("BITRATE")
+        .help("Bitrate (kbps)")
+        .short("b")
+        .long("bitrate")
+        .takes_value(true)
     )
     .arg(
       Arg::with_name("SPEED")
@@ -247,7 +253,20 @@ pub fn parse_cli() -> CliOptions {
 }
 
 fn parse_config(matches: &ArgMatches<'_>) -> EncoderConfig {
-  let quantizer = matches.value_of("QP").unwrap().parse().unwrap();
+  let maybe_quantizer = matches.value_of("QP").map(|qp| qp.parse().unwrap());
+  let maybe_bitrate =
+    matches.value_of("BITRATE").map(|bitrate| bitrate.parse().unwrap());
+  let quantizer = maybe_quantizer.unwrap_or_else(|| {
+    if maybe_bitrate.is_some() {
+      // If a bitrate is specified, the quantizer is the maximum allowed (e.g.,
+      //  the minimum quality allowed), which by default should be
+      //  unconstrained.
+      255
+    } else {
+      100
+    }
+  });
+  let bitrate = maybe_bitrate.unwrap_or(0);
   if quantizer == 0 {
     unimplemented!("Lossless encoding not yet implemented");
   } else if quantizer > 255 {
@@ -344,6 +363,7 @@ fn parse_config(matches: &ArgMatches<'_>) -> EncoderConfig {
   };
 
   cfg.quantizer = quantizer;
+  cfg.bitrate = bitrate;
   cfg.show_psnr = matches.is_present("PSNR");
   cfg.pass = matches.value_of("PASS").map(|pass| pass.parse().unwrap());
   cfg.stats_file = if cfg.pass.is_some() {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -539,7 +539,7 @@ pub struct FrameInvariants {
   pub enable_early_exit: bool,
 }
 
-fn pos_to_lvl(pos: u64, pyramid_depth: u64) -> u64 {
+pub(crate) fn pos_to_lvl(pos: u64, pyramid_depth: u64) -> u64 {
   // Derive level within pyramid for a frame with a given coding order position
   // For example, with a pyramid of depth 2, the 2 least significant bits of the
   // position determine the level:

--- a/src/me.rs
+++ b/src/me.rs
@@ -163,7 +163,7 @@ pub fn motion_estimation(
       let y_lo = po.y + ((-range + (cmv.row / 8) as isize).max(mvy_min / 8).min(mvy_max / 8));
       let y_hi = po.y + ((range + (cmv.row / 8) as isize).max(mvy_min / 8).min(mvy_max / 8));
 
-      let mut lowest_cost = std::u32::MAX;
+      let mut lowest_cost = std::u64::MAX;
       let mut best_mv = MotionVector { row: 0, col: 0 };
 
       // 0.5 is a fudge factor
@@ -241,7 +241,7 @@ pub fn motion_estimation(
             let rate1 = get_mv_rate(cand_mv, pmv[0], fi.allow_high_precision_mv);
             let rate2 = get_mv_rate(cand_mv, pmv[1], fi.allow_high_precision_mv);
             let rate = rate1.min(rate2 + 1);
-            let cost = 256 * sad + rate * lambda;
+            let cost = 256 * sad as u64 + rate as u64 * lambda as u64;
 
             if cost < lowest_cost {
               lowest_cost = cost;
@@ -261,7 +261,7 @@ pub fn motion_estimation(
 fn full_search(
   x_lo: isize, x_hi: isize, y_lo: isize, y_hi: isize, blk_h: usize,
   blk_w: usize, p_org: &Plane, p_ref: &Plane, best_mv: &mut MotionVector,
-  lowest_cost: &mut u32, po: &PlaneOffset, step: usize, bit_depth: usize,
+  lowest_cost: &mut u64, po: &PlaneOffset, step: usize, bit_depth: usize,
   lambda: u32, pmv: &[MotionVector; 2], allow_high_precision_mv: bool
 ) {
     let search_range_y = (y_lo..=y_hi).step_by(step);
@@ -282,7 +282,7 @@ fn full_search(
       let rate1 = get_mv_rate(mv, pmv[0], allow_high_precision_mv);
       let rate2 = get_mv_rate(mv, pmv[1], allow_high_precision_mv);
       let rate = rate1.min(rate2 + 1);
-      let cost = 256 * sad + rate * lambda;
+      let cost = 256 * sad as u64 + rate as u64 * lambda as u64;
 
       (cost, mv)
   }).min_by_key(|(c, _)| *c).unwrap();
@@ -332,7 +332,7 @@ pub fn estimate_motion_ss4(
     let y_lo = po.y + (((-range_y).max(mvy_min / 8)) >> 2);
     let y_hi = po.y + (((range_y).min(mvy_max / 8)) >> 2);
 
-    let mut lowest_cost = std::u32::MAX;
+    let mut lowest_cost = std::u64::MAX;
     let mut best_mv = MotionVector { row: 0, col: 0 };
 
     // Divide by 16 to account for subsampling, 0.125 is a fudge factor
@@ -378,7 +378,7 @@ pub fn estimate_motion_ss2(
     let range = 16;
     let (mvx_min, mvx_max, mvy_min, mvy_max) = get_mv_range(fi, &bo_adj, blk_w, blk_h);
 
-    let mut lowest_cost = std::u32::MAX;
+    let mut lowest_cost = std::u64::MAX;
     let mut best_mv = MotionVector { row: 0, col: 0 };
 
     // Divide by 4 to account for subsampling, 0.125 is a fudge factor

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -7,11 +7,12 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use crate::encoder::FrameInvariants;
+use crate::api::Context;
 use crate::quantize::ac_q;
 use crate::quantize::dc_q;
 use crate::quantize::select_ac_qi;
 use crate::quantize::select_dc_qi;
+use crate::util::clamp;
 
 // The number of frame sub-types for which we track distinct parameters.
 pub const FRAME_NSUBTYPES: usize = 4;
@@ -23,6 +24,12 @@ pub const FRAME_SUBTYPE_B1: usize = 3;
 
 // The scale of AV1 quantizer tables (relative to the pixel domain), i.e., Q3.
 const QSCALE: i32 = 3;
+
+// We clamp the actual I and B frame delays to a minimum of 10 to work
+//  within the range of values where later incrementing the delay works as
+//  designed.
+// 10 is not an exact choice, but rather a good working trade-off.
+const INTER_DELAY_TARGET_MIN: i32 = 10;
 
 // The base quantizer for a frame is adjusted based on the frame type using the
 //  formula (log_qp*mqp + dqp), where log_qp is the base-2 logarithm of the
@@ -246,12 +253,171 @@ fn blog64(w: i64) -> i64 {
   q57(ipart) + z
 }
 
+// Converts a Q57 fixed-point fraction to Q24 by rounding.
+const fn q57_to_q24(v: i64) -> i32 {
+  (((v >> 32) + 1) >> 1) as i32
+}
+
+// Converts a Q24 fixed-point fraction to Q57.
+const fn q24_to_q57(v: i32) -> i64 {
+  (v as i64) << 33
+}
+
+#[rustfmt::skip]
+const ROUGH_TAN_LOOKUP: &[u16; 18] = &[
+     0,   358,   722,  1098,  1491,  1910,
+  2365,  2868,  3437,  4096,  4881,  5850,
+  7094,  8784, 11254, 15286, 23230, 46817
+];
+
+// A digital approximation of a 2nd-order low-pass Bessel follower.
+// We use this for rate control because it has fast reaction time, but is
+//  critically damped.
+pub struct IIRBessel2 {
+  c: [i32; 2],
+  g: i32,
+  x: [i32; 2],
+  y: [i32; 2]
+}
+
+// alpha is Q24 in the range [0,0.5).
+// The return value is 5.12.
+// TODO: Mark const once we can use local variables in a const function.
+fn warp_alpha(alpha: i32) -> i32 {
+  let i = (alpha*36 >> 24).min(16);
+  let t0 = ROUGH_TAN_LOOKUP[i as usize];
+  let t1 = ROUGH_TAN_LOOKUP[i as usize + 1];
+  let d = alpha*36 - (i << 24);
+  ((((t0 as i64) << 32) + (((t1 - t0) << 8) as i64)*(d as i64)) >> 32) as i32
+}
+
+// Compute Bessel filter coefficients with the specified delay.
+// Return: Filter parameters (c[0], c[1], g).
+fn iir_bessel2_get_parameters(delay: i32) -> (i32, i32, i32) {
+  // This borrows some code from an unreleased version of Postfish.
+  // See the recipe at http://unicorn.us.com/alex/2polefilters.html for details
+  //  on deriving the filter coefficients.
+  // alpha is Q24
+  let alpha = (1 << 24)/delay;
+  // warp is 7.12 (5.12? the max value is 70386 in Q12).
+  let warp = warp_alpha(alpha).max(1) as i64;
+  // k1 is 9.12 (6.12?)
+  let k1 = 3*warp;
+  // k2 is 16.24 (11.24?)
+  let k2 = k1*warp;
+  // d is 16.15 (10.15?)
+  let d = ((((1 << 12) + k1) << 12) + k2 + 256) >> 9;
+  // a is 0.32, since d is larger than both 1.0 and k2
+  let a = (k2 << 23)/d;
+  // ik2 is 25.24
+  let ik2 = (1i64 << 48)/k2;
+  // b1 is Q56; in practice, the integer ranges between -2 and 2.
+  let b1 = 2*a*(ik2 - (1i64 << 24));
+  // b2 is Q56; in practice, the integer ranges between -2 and 2.
+  let b2 = (1i64 << 56) - ((4*a) << 24) - b1;
+  // All of the filter parameters are Q24.
+  (
+    ((b1 + (1i64 << 31)) >> 32) as i32,
+    ((b2 + (1i64 << 31)) >> 32) as i32,
+    ((a + 128) >> 8) as i32
+  )
+}
+
+impl IIRBessel2 {
+  pub fn new(delay: i32, value: i32) -> IIRBessel2 {
+    let (c0, c1, g) = iir_bessel2_get_parameters(delay);
+    IIRBessel2 { c: [c0, c1], g, x: [value, value], y: [value, value] }
+  }
+
+  // Re-initialize Bessel filter coefficients with the specified delay.
+  // This does not alter the x/y state, but changes the reaction time of the
+  //  filter.
+  // Altering the time constant of a reactive filter without altering internal
+  //  state is something that has to be done carefuly, but our design operates
+  //  at high enough delays and with small enough time constant changes to make
+  //  it safe.
+  pub fn reinit(&mut self, delay: i32) {
+    let (c0, c1, g) = iir_bessel2_get_parameters(delay);
+    self.c[0] = c0;
+    self.c[1] = c1;
+    self.g = g;
+  }
+
+  pub fn update(&mut self, x: i32) -> i32 {
+    let c0 = self.c[0] as i64;
+    let c1 = self.c[1] as i64;
+    let g = self.g as i64;
+    let x0 = self.x[0] as i64;
+    let x1 = self.x[1] as i64;
+    let y0 = self.y[0] as i64;
+    let y1 = self.y[1] as i64;
+    let ya = ((((x as i64) + x0*2 + x1)*g + y0*c0 + y1*c1
+      + (1i64 << 23)) >> 24) as i32;
+    self.x[1] = self.x[0];
+    self.x[0] = x;
+    self.y[1] = self.y[0];
+    self.y[0] = ya;
+    ya
+  }
+}
+
 pub struct RCState {
-  // TODO: Add state needed for actual bitrate targeting.
+  // The target bit-rate in bits per second.
+  target_bitrate: i32,
+  // The number of frames over which to distribute the reservoir usage.
+  reservoir_frame_delay: i32,
+  // The maximum quantizer index to allow (for the luma AC coefficients, other
+  //  quantizers will still be adjusted to match).
+  maybe_ac_qi_max: Option<u8>,
+  // Will we drop frames to meet bitrate requirements?
+  drop_frames: bool,
+  // Do we respect the maximum reservoir fullness?
+  cap_overflow: bool,
+  // Can the reservoir go negative?
+  cap_underflow: bool,
+  // Two-pass mode state.
+  // 0 => 1-pass encoding.
+  // 1 => 1st pass of 2-pass encoding.
+  // 2 => 2nd pass of 2-pass encoding.
+  twopass_state: i32,
+  // The log of the number of pixels in a frame in Q57 format.
+  log_npixels: i64,
+  // The target average bits per frame.
+  bits_per_frame: i64,
+  // The current bit reservoir fullness (bits available to be used).
+  reservoir_fullness: i64,
+  // The target buffer fullness.
+  // This is where we'd like to be by the last keyframe that appears in the
+  //  next reservoir_frame_delay frames.
+  reservoir_target: i64,
+  // The maximum buffer fullness (total size of the buffer).
+  reservoir_max: i64,
+  // The log of estimated scale factor for the rate model in Q57 format.
+  log_scale: [i64; FRAME_NSUBTYPES],
+  // The exponent used in the rate model in Q6 format.
+  exp: [u8; FRAME_NSUBTYPES],
+  // The log of an estimated scale factor used to obtain the real framerate,
+  //  for VFR sources or, e.g., 12 fps content doubled to 24 fps, etc.
+  // TODO vfr: log_vfr_scale: i64,
+  // Second-order lowpass filters to track scale and VFR.
+  scalefilter: [IIRBessel2; FRAME_NSUBTYPES],
+  // TODO vfr: vfrfilter: IIRBessel2,
+  // The number of frames of each type we have seen, for filter adaptation
+  //  purposes.
+  nframes: [i32; FRAME_NSUBTYPES],
+  inter_delay: [i32; FRAME_NSUBTYPES - 1],
+  inter_delay_target: i32,
+  // The total accumulated estimation bias.
+  rate_bias: i64
 }
 
 // TODO: Separate qi values for each color plane.
 pub struct QuantizerParameters {
+  // The full-precision, unmodulated log quantizer upon which our modulated
+  //  quantizer indices are based.
+  // This is only used to limit sudden quality changes from frame to frame, and
+  //  as such is not adjusted when we encounter buffer overrun or underrun.
+  pub log_base_q: i64,
   // The full-precision log quantizer modulated by the current frame type upon
   //  which our quantizer indices are based (including any adjustments to
   //  prevent buffer overrun or underrun).
@@ -267,9 +433,12 @@ const Q57_SQUARE_EXP_SCALE: f64 =
   (2.0 * ::std::f64::consts::LN_2) / ((1i64 << 57) as f64);
 
 impl QuantizerParameters {
-  fn new_from_log_q(log_target_q: i64, bit_depth: i32) -> QuantizerParameters {
+  fn new_from_log_q(
+    log_base_q: i64, log_target_q: i64, bit_depth: i32
+  ) -> QuantizerParameters {
     let quantizer = bexp64(log_target_q + q57(QSCALE + bit_depth - 8));
     QuantizerParameters {
+      log_base_q,
       log_target_q,
       dc_qi: select_dc_qi(quantizer, bit_depth as usize),
       ac_qi: select_ac_qi(quantizer, bit_depth as usize),
@@ -280,36 +449,335 @@ impl QuantizerParameters {
 }
 
 impl RCState {
-  pub fn new() -> RCState {
-    RCState {}
+  pub fn new(
+    frame_width: i32, frame_height: i32, framerate_num: i64,
+    framerate_den: i64, target_bitrate: i32, maybe_ac_qi_max: Option<u8>,
+    max_key_frame_interval: i32
+  ) -> RCState {
+    // The buffer size is set equal to 1.5x the keyframe interval, clamped to
+    //  the range [12, 256] frames.
+    // The interval is short enough to allow reaction, but long enough to allow
+    //  looking into the next GOP (avoiding the case where the last frames
+    //  before an I-frame get starved).
+    // The 12 frame minimum gives us some chance to distribute bit estimation
+    //  errors in the worst case.
+    // The 256 frame maximum means we'll require 8-10 seconds of pre-buffering
+    // at 24-30 fps, which is not unreasonable.
+    let reservoir_frame_delay = clamp(max_key_frame_interval*3 >> 1, 12, 256);
+    // TODO: What are the limits on these?
+    let npixels = (frame_width as i64)*(frame_height as i64);
+    // Insane framerates or frame sizes mean insane bitrates.
+    // Let's not get carried away.
+    // TODO: Support constraints imposed by levels.
+    let bits_per_frame = clamp(
+      (target_bitrate as i64)*framerate_den/framerate_num, 32, 0x400000000000
+    );
+    let reservoir_max = bits_per_frame*(reservoir_frame_delay as i64);
+    // Start with a buffer fullness and fullness target of 50%.
+    let reservoir_target = (reservoir_max + 1) >> 1;
+    // Pick exponents and initial scales for quantizer selection.
+    let ibpp = npixels/bits_per_frame;
+    // All of these initial scale/exp values are from Theora, and have not yet
+    //  been adapted to AV1, so they're certainly wrong.
+    // The B-frame values especially are simply copies of the P-frame values.
+    let i_exp: u8;
+    let i_log_scale: i64;
+    if ibpp < 1 {
+      i_exp = 59;
+      i_log_scale = blog64(1997) - q57(QSCALE);
+    } else if ibpp < 2 {
+      i_exp = 55;
+      i_log_scale = blog64(1604) - q57(QSCALE);
+    } else {
+      i_exp = 48;
+      i_log_scale = blog64(834) - q57(QSCALE);
+    }
+    let p_exp: u8;
+    let p_log_scale: i64;
+    if ibpp < 4 {
+      p_exp = 100;
+      p_log_scale = blog64(2249) - q57(QSCALE);
+    } else if ibpp < 8 {
+      p_exp = 95;
+      p_log_scale = blog64(1751) - q57(QSCALE);
+    } else {
+      p_exp = 73;
+      p_log_scale = blog64(1260) - q57(QSCALE);
+    }
+    // TODO: Add support for "golden" P frames.
+    RCState {
+      target_bitrate,
+      reservoir_frame_delay,
+      maybe_ac_qi_max,
+      // By default, enforce hard buffer constraints.
+      drop_frames: true,
+      cap_overflow: true,
+      cap_underflow: false,
+      // TODO: Support multiple passes.
+      twopass_state: 0,
+      log_npixels: blog64(npixels),
+      bits_per_frame,
+      reservoir_fullness: reservoir_target,
+      reservoir_target,
+      reservoir_max,
+      log_scale: [i_log_scale, p_log_scale, p_log_scale, p_log_scale],
+      exp: [i_exp, p_exp, p_exp, p_exp],
+      scalefilter: [
+        IIRBessel2::new(4, q57_to_q24(i_log_scale)),
+        IIRBessel2::new(INTER_DELAY_TARGET_MIN, q57_to_q24(p_log_scale)),
+        IIRBessel2::new(INTER_DELAY_TARGET_MIN, q57_to_q24(p_log_scale)),
+        IIRBessel2::new(INTER_DELAY_TARGET_MIN, q57_to_q24(p_log_scale))
+      ],
+      // TODO VFR
+      nframes: [0; FRAME_NSUBTYPES],
+      inter_delay: [INTER_DELAY_TARGET_MIN; FRAME_NSUBTYPES - 1],
+      inter_delay_target: reservoir_frame_delay >> 1,
+      rate_bias: 0
+    }
   }
 
   // TODO: Separate quantizers for Cb and Cr.
   pub fn select_qi(
-    &self, fi: &FrameInvariants, fti: usize
+    &self, ctx: &Context, fti: usize, maybe_prev_log_base_q: Option<i64>
   ) -> QuantizerParameters {
-    // Rate control is not active.
-    // Derive quantizer directly from frame type.
-    // TODO: Rename "quantizer" something that indicates it is a quantizer
-    //  index, and move it somewhere more sensible (or choose a better way to
-    //  parameterize a "quality" configuration parameter).
-    let base_qi = fi.config.quantizer;
-    let bit_depth = fi.sequence.bit_depth as i32;
-    // We use the AC quantizer as the source quantizer since its quantizer
-    //  tables have unique entries, while the DC tables do not.
-    let ac_quantizer = ac_q(base_qi as u8, 0, bit_depth as usize) as i64;
-    // Pick the nearest DC entry since an exact match may be unavailable.
-    let dc_qi = select_dc_qi(ac_quantizer, bit_depth as usize);
-    let dc_quantizer = dc_q(dc_qi as u8, 0, bit_depth as usize) as i64;
-    // Get the log quantizers as Q57.
-    let log_ac_q = blog64(ac_quantizer) - q57(QSCALE + bit_depth - 8);
-    let log_dc_q = blog64(dc_quantizer) - q57(QSCALE + bit_depth - 8);
-    // Target the midpoint of the chosen entries.
-    let log_base_q = (log_ac_q + log_dc_q + 1) >> 1;
-    // Adjust the quantizer for the frame type, result is Q57:
-    let log_q = ((log_base_q + (1i64 << 11)) >> 12) * (MQP_Q12[fti] as i64)
-      + DQP_Q57[fti];
-    QuantizerParameters::new_from_log_q(log_q, bit_depth)
+    // Is rate control active?
+    if self.target_bitrate <= 0 {
+      // Rate control is not active.
+      // Derive quantizer directly from frame type.
+      // TODO: Rename "quantizer" something that indicates it is a quantizer
+      //  index, and move it somewhere more sensible (or choose a better way to
+      //  parameterize a "quality" configuration parameter).
+      let base_qi = ctx.config.enc.quantizer;
+      let bit_depth = ctx.config.enc.bit_depth as i32;
+      // We use the AC quantizer as the source quantizer since its quantizer
+      //  tables have unique entries, while the DC tables do not.
+      let ac_quantizer = ac_q(base_qi as u8, 0, bit_depth as usize) as i64;
+      // Pick the nearest DC entry since an exact match may be unavailable.
+      let dc_qi = select_dc_qi(ac_quantizer, bit_depth as usize);
+      let dc_quantizer = dc_q(dc_qi as u8, 0, bit_depth as usize) as i64;
+      // Get the log quantizers as Q57.
+      let log_ac_q = blog64(ac_quantizer) - q57(QSCALE + bit_depth - 8);
+      let log_dc_q = blog64(dc_quantizer) - q57(QSCALE + bit_depth - 8);
+      // Target the midpoint of the chosen entries.
+      let log_base_q = (log_ac_q + log_dc_q + 1) >> 1;
+      // Adjust the quantizer for the frame type, result is Q57:
+      let log_q = ((log_base_q + (1i64 << 11)) >> 12) * (MQP_Q12[fti] as i64)
+        + DQP_Q57[fti];
+      QuantizerParameters::new_from_log_q(log_base_q, log_q, bit_depth)
+    } else {
+      match self.twopass_state {
+        // Single pass only right now.
+        _ => {
+          // Figure out how to re-distribute bits so that we hit our fullness
+          //  target before the last keyframe in our current buffer window
+          //  (after the current frame), or the end of the buffer window,
+          //  whichever comes first.
+          // Count the various types and classes of frames.
+          let mut nframes: [i32; FRAME_NSUBTYPES] = [0; FRAME_NSUBTYPES];
+          let reservoir_frames = ctx.guess_frame_subtypes(&mut nframes,
+            self.reservoir_frame_delay);
+          // TODO: Scale for VFR.
+          // If we've been missing our target, add a penalty term.
+          let rate_bias =
+            (self.rate_bias/(ctx.idx as i64 + 100))*(reservoir_frames as i64);
+          // rate_total is the total bits available over the next
+          //  reservoir_frames frames.
+          let rate_total = self.reservoir_fullness - self.reservoir_target
+            + rate_bias + (reservoir_frames as i64)*self.bits_per_frame;
+          // Find a target quantizer that meets our rate target for the
+          //  specific mix of frame types we'll have over the next
+          //  reservoir_frame frames.
+          // We model the rate<->quantizer relationship as
+          //  rate = scale*(quantizer**-exp)
+          // In this case, we have our desired rate, an exponent selected in
+          //  setup, and a scale that's been measured over our frame history,
+          //  so we're solving for the quantizer.
+          // Exponentiation with arbitrary exponents is expensive, so we work
+          //  in the binary log domain (binary exp and log aren't too bad):
+          //  rate = exp2(log2(scale) - log2(quantizer)*exp)
+          // There's no easy closed form solution, so we bisection searh for it.
+          let bit_depth = ctx.config.enc.bit_depth as i32;
+          // TODO: Proper handling of lossless.
+          let mut log_qlo = blog64(dc_q(0, 0, bit_depth as usize) as i64)
+            - q57(QSCALE + bit_depth - 8);
+          // The AC quantizer tables map to values larger than the DC quantizer
+          //  tables, so we use that as the upper bound to make sure we can use
+          //  the full table if needed.
+          let mut log_qhi = blog64(ac_q(self.maybe_ac_qi_max.unwrap_or(255), 0,
+            bit_depth as usize) as i64) - q57(QSCALE + bit_depth - 8);
+          let mut log_base_q = (log_qlo + log_qhi) >> 1;
+          while log_qlo < log_qhi {
+            // Count bits contributed by each frame type using the model.
+            let mut bits = 0i64;
+            for ftj in 0..FRAME_NSUBTYPES {
+              // Modulate base quantizer by frame type.
+              let log_q =
+                ((log_base_q + (1i64 << 11)) >> 12)*(MQP_Q12[ftj] as i64)
+                + DQP_Q57[ftj];
+              // All the fields here are Q57 except for the exponent, which is
+              //  Q6.
+              bits += (nframes[ftj] as i64)*
+                bexp64(self.log_scale[ftj] + self.log_npixels
+                - ((log_q + 32) >> 6)*(self.exp[ftj] as i64));
+            }
+            let diff = bits - rate_total;
+            if diff > 0 {
+              log_qlo = log_base_q + 1;
+            } else if diff < 0 {
+              log_qhi = log_base_q - 1;
+            } else {
+              break;
+            }
+            log_base_q = (log_qlo + log_qhi) >> 1;
+          }
+          // If this was not one of the initial frames, limit the change in
+          //  base quantizer to within [0.8*Q, 1.2*Q] where Q is the previous
+          //  frame's base quantizer.
+          if let Some(prev_log_base_q) = maybe_prev_log_base_q {
+            log_base_q = clamp(
+              log_base_q,
+              prev_log_base_q - 0xA4D3C25E68DC58,
+              prev_log_base_q + 0xA4D3C25E68DC58
+            );
+          }
+          // Modulate base quantizer by frame type.
+          let mut log_q =
+            ((log_base_q + (1i64 << 11)) >> 12)*(MQP_Q12[fti] as i64)
+            + DQP_Q57[fti];
+          // The above allocation looks only at the total rate we'll accumulate
+          //  in the next reservoir_frame_delay frames.
+          // However, we could overflow the bit reservoir on the very next
+          //  frame.
+          // Check for that here if we're not using a soft target.
+          if self.cap_overflow {
+            // Allow 3% of the buffer for prediction error.
+            // This should be plenty, and we don't mind if we go a bit over.
+            // We only want to keep these bits from being completely wasted.
+            let margin = (self.reservoir_max + 31) >> 5;
+            // We want to use at least this many bits next frame.
+            let soft_limit = self.reservoir_fullness + self.bits_per_frame
+              - (self.reservoir_max - margin);
+            let log_soft_limit = blog64(soft_limit);
+            // If we're predicting we won't use that many bits...
+            let log_scale_pixels = self.log_scale[fti] + self.log_npixels;
+            let exp = self.exp[fti] as i64;
+            let mut log_q_exp = ((log_q + 32) >> 6)*exp;
+            if log_scale_pixels - log_q_exp < log_soft_limit {
+              // Scale the adjustment based on how far into the margin we are.
+              log_q_exp +=
+                ((log_scale_pixels - log_soft_limit - log_q_exp) >> 32)*
+                (margin.min(soft_limit) << 32)/margin;
+              log_q = ((log_q_exp + (exp >> 1))/exp) << 6;
+            }
+          }
+          // We just checked we don't overflow the reservoir next frame, now
+          //  check we don't underflow and bust the budget (when not using a
+          //  soft target).
+          if self.maybe_ac_qi_max.is_none() {
+            // Compute the maximum number of bits we can use in the next frame.
+            // Allow 50% of the rate for a single frame for prediction error.
+            // This may not be enough for keyframes or sudden changes in
+            //  complexity.
+            let log_hard_limit =
+              blog64(self.reservoir_fullness + (self.bits_per_frame >> 1));
+            // If we're predicting we'll use more than this...
+            let log_scale_pixels = self.log_scale[fti] + self.log_npixels;
+            let exp = self.exp[fti] as i64;
+            let mut log_q_exp = ((log_q + 32) >> 6)*exp;
+            if log_scale_pixels - log_q_exp > log_hard_limit {
+              // Force the target to hit our limit exactly.
+              log_q_exp = log_scale_pixels - log_hard_limit;
+              log_q = ((log_q_exp + (exp >> 1))/exp) << 6;
+              // If that target is unreasonable, oh well; we'll have to drop.
+            }
+          }
+          QuantizerParameters::new_from_log_q(log_base_q, log_q, bit_depth)
+        }
+      }
+    }
+  }
+
+  pub fn update_state(
+    &mut self, bits: i64, fti: usize, log_target_q: i64, droppable: bool
+  ) -> bool {
+    let mut dropped = false;
+    // Update rate control only if rate control is active.
+    if self.target_bitrate > 0 {
+      let log_q_exp = ((log_target_q + 32) >> 6)*(self.exp[fti] as i64);
+      let prev_log_scale = self.log_scale[fti];
+      let mut bits = bits;
+      if bits <= 0 {
+        // We didn't code any blocks in this frame.
+        bits = 0;
+        dropped = true;
+        // TODO: Adjust VFR rate based on drop count.
+      } else {
+        // Compute the estimated scale factor for this frame type.
+        let log_bits = blog64(bits);
+        let log_scale = (log_bits - self.log_npixels + log_q_exp).min(q57(16));
+        let log_scale_q24 = q57_to_q24(log_scale);
+        // If this is the first example of the given frame type we've seen, we
+        //  immediately replace the default scale factor guess with the
+        //  estimate we just computed using the first frame.
+        if self.nframes[fti] <= 0 {
+          let f = &mut self.scalefilter[fti];
+          let x = log_scale_q24;
+          f.x[0] = x;
+          f.x[1] = x;
+          f.y[0] = x;
+          f.y[1] = x;
+          // TODO: Duplicate regular P frame state for first golden P frame.
+        } else {
+          // Lengthen the time constant for the inter filters as we collect
+          //  more frame statistics, until we reach our target.
+          if fti > 0
+            && self.inter_delay[fti - 1] < self.inter_delay_target
+            && self.nframes[fti] >= self.inter_delay[fti - 1]
+          {
+            self.inter_delay[fti - 1] += 1;
+            self.scalefilter[fti].reinit(self.inter_delay[fti - 1]);
+          }
+          // Update the low-pass scale filter for this frame type regardless of
+          //  whether or not we will ultimately drop this frame.
+          self.log_scale[fti] =
+            q24_to_q57(self.scalefilter[fti].update(log_scale_q24));
+        }
+        // If this frame busts our budget, it must be dropped.
+        if droppable
+          && self.drop_frames
+          && self.reservoir_fullness + self.bits_per_frame < bits
+        {
+          // TODO: Adjust VFR rate based on drop count.
+          bits = 0;
+          dropped = true;
+        } else {
+          // TODO: Update a low-pass filter to estimate the "real" frame rate
+          //  taking timestamps and drops into account.
+          // This is only done if the frame is coded, as it needs the final
+          //  count of dropped frames.
+        }
+        // Increment the frame count for filter adaptation purposes.
+        if self.nframes[fti] < ::std::i32::MAX {
+          self.nframes[fti] += 1;
+        }
+      }
+      self.reservoir_fullness += self.bits_per_frame - bits;
+      // If we're too quick filling the buffer and overflow is capped, that
+      //  rate is lost forever.
+      if self.cap_overflow {
+        self.reservoir_fullness =
+          self.reservoir_fullness.min(self.reservoir_max);
+      }
+      // If we're too quick draining the buffer and underflow is capped, don't
+      //  try to make up that rate later.
+      if self.cap_underflow {
+        self.reservoir_fullness = self.reservoir_fullness.max(0);
+      }
+      // Adjust the bias for the real bits we've used.
+      self.rate_bias +=
+        bexp64(prev_log_scale + self.log_npixels - log_q_exp) - bits;
+    }
+    dropped
   }
 }
 

--- a/src/test_encode_decode_aom.rs
+++ b/src/test_encode_decode_aom.rs
@@ -85,7 +85,7 @@ impl Drop for AomDecoder {
 fn setup_encoder(
   w: usize, h: usize, speed: usize, quantizer: usize, bit_depth: usize,
   chroma_sampling: ChromaSampling, min_keyint: u64, max_keyint: u64,
-  low_latency: bool
+  low_latency: bool, bitrate: i32
 ) -> Context {
   unsafe {
     av1_rtcd();
@@ -101,6 +101,7 @@ fn setup_encoder(
   enc.height = h;
   enc.bit_depth = bit_depth;
   enc.chroma_sampling = chroma_sampling;
+  enc.bitrate = bitrate;
 
   let cfg = Config {
     enc
@@ -120,7 +121,7 @@ fn speed(s: usize) {
   let h = 80;
 
   for b in DIMENSION_OFFSETS.iter() {
-      encode_decode(w + b.0, h + b.1, s, quantizer, limit, 8, Default::default(), 15, 15, true);
+      encode_decode(w + b.0, h + b.1, s, quantizer, limit, 8, Default::default(), 15, 15, true, 0);
   }
 }
 
@@ -175,7 +176,7 @@ fn dimension(w: usize, h: usize) {
   let limit = 1;
   let speed = 4;
 
-  encode_decode(w, h, speed, quantizer, limit, 8, Default::default(), 15, 15, true);
+  encode_decode(w, h, speed, quantizer, limit, 8, Default::default(), 15, 15, true, 0);
 }
 
 #[test]
@@ -187,7 +188,21 @@ fn quantizer() {
 
   for b in DIMENSION_OFFSETS.iter() {
     for &q in [80, 100, 120].iter() {
-      encode_decode(w + b.0, h + b.1, speed, q, limit, 8, Default::default(), 15, 15, true);
+      encode_decode(w + b.0, h + b.1, speed, q, limit, 8, Default::default(), 15, 15, true, 0);
+    }
+  }
+}
+
+#[test]
+fn bitrate() {
+  let limit = 5;
+  let w = 64;
+  let h = 80;
+  let speed = 4;
+
+  for &q in [172, 220, 252, 255].iter() {
+    for &r in [100, 1000, 10_000].iter() {
+      encode_decode(w, h, speed, q, limit, 8, Default::default(), 15, 15, true, r);
     }
   }
 }
@@ -200,7 +215,7 @@ fn keyframes() {
   let speed = 10;
   let q = 100;
 
-  encode_decode(w, h, speed, q, limit, 8, Default::default(), 6, 6, true);
+  encode_decode(w, h, speed, q, limit, 8, Default::default(), 6, 6, true, 0);
 }
 
 #[test]
@@ -212,7 +227,7 @@ fn reordering() {
   let q = 100;
 
   for keyint in &[4, 5, 6] {
-    encode_decode(w, h, speed, q, limit, 8, Default::default(), *keyint, *keyint, false);
+    encode_decode(w, h, speed, q, limit, 8, Default::default(), *keyint, *keyint, false, 0);
   }
 }
 
@@ -226,7 +241,7 @@ fn reordering_short_video() {
   let q = 100;
   let keyint = 12;
 
-  encode_decode(w, h, speed, q, limit, 8, Default::default(), keyint, keyint, false);
+  encode_decode(w, h, speed, q, limit, 8, Default::default(), keyint, keyint, false, 0);
 }
 
 #[test]
@@ -238,7 +253,7 @@ fn odd_size_frame_with_full_rdo() {
   let speed = 0;
   let qindex = 100;
 
-  encode_decode(w, h, speed, qindex, limit, 8, Default::default(), 15, 15, true);
+  encode_decode(w, h, speed, qindex, limit, 8, Default::default(), 15, 15, true, 0);
 }
 
 #[test]
@@ -250,10 +265,10 @@ fn high_bd() {
   let h = 80;
 
   // 10-bit
-  encode_decode(w, h, speed, quantizer, limit, 10, Default::default(), 15, 15, true);
+  encode_decode(w, h, speed, quantizer, limit, 10, Default::default(), 15, 15, true, 0);
 
   // 12-bit
-  encode_decode(w, h, speed, quantizer, limit, 12, Default::default(), 15, 15, true);
+  encode_decode(w, h, speed, quantizer, limit, 12, Default::default(), 15, 15, true, 0);
 }
 
 #[test]
@@ -267,10 +282,10 @@ fn chroma_sampling() {
   // TODO: bump keyint when inter is supported
 
   // 4:2:2
-  encode_decode(w, h, speed, quantizer, limit, 8, ChromaSampling::Cs422, 1, 1, true);
+  encode_decode(w, h, speed, quantizer, limit, 8, ChromaSampling::Cs422, 1, 1, true, 0);
 
   // 4:4:4
-  encode_decode(w, h, speed, quantizer, limit, 8, ChromaSampling::Cs444, 1, 1, true);
+  encode_decode(w, h, speed, quantizer, limit, 8, ChromaSampling::Cs444, 1, 1, true, 0);
 }
 
 fn compare_plane<T: Ord + std::fmt::Debug>(
@@ -326,14 +341,14 @@ fn compare_img(img: *const aom_image_t, frame: &Frame, bit_depth: usize, width: 
 fn encode_decode(
   w: usize, h: usize, speed: usize, quantizer: usize, limit: usize,
   bit_depth: usize, chroma_sampling: ChromaSampling, min_keyint: u64,
-  max_keyint: u64, low_latency: bool
+  max_keyint: u64, low_latency: bool, bitrate: i32
 ) {
   let mut ra = ChaChaRng::from_seed([0; 32]);
 
   let mut dec = setup_decoder(w, h);
   let mut ctx =
     setup_encoder(w, h, speed, quantizer, bit_depth, chroma_sampling,
-                  min_keyint, max_keyint, low_latency);
+                  min_keyint, max_keyint, low_latency, bitrate);
   ctx.set_limit(limit as u64);
 
   println!("Encoding {}x{} speed {} quantizer {}", w, h, speed, quantizer);


### PR DESCRIPTION
This is an adaptation of [tterribe/rate_control8](https://git.xiph.org/?p=users/tterribe/rav1e.git;a=shortlog;h=refs/heads/rate_control8):

> This is just the minimal patch required to get something working. There are still plenty of TODOs left to do: two-pass support, VFR support, golden frame support, the ability to drop frames, trial encodes for the first frames, quantization matrices, separate quantizer choices for Cb and Cr, proper lossless handling, support for AV1's levels, and some general refactoring to improve maintainability.