### PR TITLE
Fix miscalculation of PSNR with frame reordering

### DIFF
--- a/src/plane.rs
+++ b/src/plane.rs
@@ -245,7 +245,7 @@ impl<'a> Iterator for PlaneIter<'a> {
   type Item = u16;
 
   fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-    if self.y == self.height() - 1 && self.x == self.width() - 1 {
+    if self.y == self.height() {
       return None;
     }
     let pixel = self.plane.p(self.x, self.y);


### PR DESCRIPTION
With frame reordering enabled, every other frame would be compared to a
blank frame, generating a very low PSNR calculation. Also fixes an issue
where the PlaneIter ends one pixel too early, which currently is only
used by PSNR calculation.