### PR TITLE
Add Shell auto-completion support

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -226,6 +226,7 @@ pub fn parse_cli() -> CliOptions {
         ])
     )
     .subcommand(SubCommand::with_name("advanced")
+                .setting(AppSettings::Hidden)
                 .about("Advanced features")
                 .arg(Arg::with_name("SHELL")
                      .help("Output to stdout the completion definition for the shell")


### PR DESCRIPTION
It is implemented as an advanced command line option.

Run `rav1e advanced --help` for the list of supported shells.