### PR TITLE
Add limited (first cut) but true CDEF <-> LRF aware loop filter RDO to rav1e

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -257,11 +257,11 @@ pub fn cdef_sb_frame<T: Pixel>(fi: &FrameInvariants<T>, f: &Frame<T>) -> Frame<T
   Frame {
     planes: [
       Plane::new(sb_size >> f.planes[0].cfg.xdec, sb_size >> f.planes[0].cfg.ydec,
-                 f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
+                 f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 3, 3),
       Plane::new(sb_size >> f.planes[1].cfg.xdec, sb_size >> f.planes[1].cfg.ydec,
-                 f.planes[1].cfg.xdec, f.planes[1].cfg.ydec, 0, 0),
+                 f.planes[1].cfg.xdec, f.planes[1].cfg.ydec, 3, 3),
       Plane::new(sb_size >> f.planes[2].cfg.xdec, sb_size >> f.planes[2].cfg.ydec,
-                 f.planes[2].cfg.xdec, f.planes[2].cfg.ydec, 0, 0),
+                 f.planes[2].cfg.xdec, f.planes[2].cfg.ydec, 3, 3),
     ]
   }
 }
@@ -276,11 +276,11 @@ pub fn cdef_sb_padded_frame_copy<T: Pixel>(
   let mut out = Frame {
     planes: [
       Plane::new((sb_size >> f.planes[0].cfg.xdec) + pad*2, (sb_size >> f.planes[0].cfg.ydec) + pad*2,
-                 f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
+                 f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 3, 3),
       Plane::new((sb_size >> f.planes[1].cfg.xdec) + pad*2, (sb_size >> f.planes[1].cfg.ydec) + pad*2,
-                 f.planes[1].cfg.xdec, f.planes[1].cfg.ydec, 0, 0),
+                 f.planes[1].cfg.xdec, f.planes[1].cfg.ydec, 3, 3),
       Plane::new((sb_size >> f.planes[2].cfg.xdec) + pad*2, (sb_size >> f.planes[2].cfg.ydec) + pad*2,
-                 f.planes[2].cfg.xdec, f.planes[2].cfg.ydec, 0, 0),
+                 f.planes[2].cfg.xdec, f.planes[2].cfg.ydec, 3, 3),
     ]
   };
   // Copy data into padded frame
@@ -322,6 +322,18 @@ pub fn cdef_sb_padded_frame_copy<T: Pixel>(
       }
     }
   }
+  out
+}
+
+
+pub fn cdef_empty_frame<T: Pixel>(f: &Frame<T>) -> Frame<T> {
+  let out = Frame {
+    planes: [
+      Plane::new(0, 0, f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
+      Plane::new(0, 0, f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
+      Plane::new(0, 0, f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
+    ]
+  };
   out
 }
 

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -327,14 +327,13 @@ pub fn cdef_sb_padded_frame_copy<T: Pixel>(
 
 
 pub fn cdef_empty_frame<T: Pixel>(f: &Frame<T>) -> Frame<T> {
-  let out = Frame {
+  Frame {
     planes: [
       Plane::new(0, 0, f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
       Plane::new(0, 0, f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
       Plane::new(0, 0, f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
     ]
-  };
-  out
+  }
 }
 
 // We assume in is padded, and the area we'll write out is at least as

--- a/src/context.rs
+++ b/src/context.rs
@@ -3057,20 +3057,21 @@ impl ContextWriter {
               }
               w.literal(SGRPROJ_PARAMS_BITS, set as u32);
               for i in 0..2 {
-                let r = SGRPROJ_PARAMS_RADIUS[set as usize][i];
+                let s = SGRPROJ_PARAMS_S[set as usize][i];
                 let min = SGRPROJ_XQD_MIN[i] as i32;
                 let max = SGRPROJ_XQD_MAX[i] as i32;
-                if r>0 {
+                if s > 0 {
                   w.write_signed_subexp_with_ref(xqd[i] as i32, min, max+1, SGRPROJ_PRJ_SUBEXP_K,
                                                  rp.sgrproj_ref[i] as i32);
                   rp.sgrproj_ref[i] = xqd[i];
                 } else {
                   // Nothing written, just update the reference
                   if i==0 {
+                    assert!(xqd[i] == 0);
                     rp.sgrproj_ref[0] = 0;
                   } else {
-                    rp.sgrproj_ref[1] =
-                      clamp((1 << SGRPROJ_PRJ_BITS) - rp.sgrproj_ref[0], min as i8, max as i8);
+                    assert!(xqd[i] == 95);
+                    rp.sgrproj_ref[1] = 95; // LOL at spec.  The result is always 95.
                   }
                 }
               }
@@ -3087,7 +3088,13 @@ impl ContextWriter {
                 _ => unreachable!()
               }
               for pass in 0..2 {
-                let first_coeff = if pli==0 {0} else {1};
+                let first_coeff =
+                  if pli==0 {
+                    0
+                  } else {
+                    assert!(coeffs[pass][0] == 0);
+                    1
+                  };
                 for i in first_coeff..3 {
                   let min = WIENER_TAPS_MIN[i] as i32;
                   let max = WIENER_TAPS_MAX[i] as i32;

--- a/src/context.rs
+++ b/src/context.rs
@@ -13,6 +13,7 @@
 #![allow(non_camel_case_types)]
 
 use crate::ec::Writer;
+use crate::ec::OD_BITRES;
 use crate::encoder::FrameInvariants;
 use crate::entropymode::*;
 use crate::header::ReferenceMode;
@@ -1561,6 +1562,11 @@ impl BlockContext {
     }
   }
 
+  pub fn get_cdef(&mut self, sbo: &SuperBlockOffset) -> u8 {
+    let bo = sbo.block_offset(0, 0);
+    self.blocks[bo.y][bo.x].cdef_index
+  }
+
   // The mode info data structure has a one element border above and to the
   // left of the entries corresponding to real macroblocks.
   // The prediction flags in these dummy entries are initialized to 0.
@@ -3015,6 +3021,36 @@ impl ContextWriter {
     symbol_with_update!(self, w, coded_id as u32, &mut self.fc.spatial_segmentation_cdfs[cdf_index as usize]);
   }
 
+  // rather than test writing and rolling back the cdf, we just count Q8 bits using the current cdf
+  pub fn count_lrf_switchable(&mut self, w: &dyn Writer, rs: &RestorationState,
+                              filter: &RestorationFilter, pli: usize) -> u32 {
+    let nsym = &self.fc.lrf_switchable_cdf.len()-1;
+    match *filter {
+      RestorationFilter::None => {
+        w.symbol_bits(0, &self.fc.lrf_switchable_cdf[..nsym])
+      }
+      RestorationFilter::Wiener{coeffs: _} => {
+        unreachable!() // for now, not permanently
+      }
+      RestorationFilter::Sgrproj{set, xqd} => {
+        // Does *not* use 'RESTORE_SGRPROJ' but rather just '2'
+        let rp = &rs.plane[pli];
+        let mut bits = w.symbol_bits(2, &self.fc.lrf_switchable_cdf[..nsym]) +
+          ((SGRPROJ_PARAMS_BITS as u32) << OD_BITRES);
+        for i in 0..2 {
+          let s = SGRPROJ_PARAMS_S[set as usize][i];
+          let min = SGRPROJ_XQD_MIN[i] as i32;
+          let max = SGRPROJ_XQD_MAX[i] as i32;
+          if s > 0 {
+            bits += w.count_signed_subexp_with_ref(xqd[i] as i32, min, max+1, SGRPROJ_PRJ_SUBEXP_K,
+                                                   rp.sgrproj_ref[i] as i32);
+          }
+        }
+        bits
+      }
+    }
+  }
+
   pub fn write_lrf<T: Pixel>(
     &mut self, w: &mut dyn Writer, fi: &FrameInvariants<T>, rs: &mut RestorationState, sbo: &SuperBlockOffset
   ) {
@@ -3051,7 +3087,7 @@ impl ContextWriter {
                 }
                 RESTORE_SWITCHABLE => {
                   // Does *not* write 'RESTORE_SGRPROJ'
-                  symbol_with_update!(self, w, 2 as u32, &mut self.fc.lrf_switchable_cdf);
+                  symbol_with_update!(self, w, 2, &mut self.fc.lrf_switchable_cdf);
                 }
                 _ => unreachable!()
               }
@@ -3070,7 +3106,6 @@ impl ContextWriter {
                     assert!(xqd[i] == 0);
                     rp.sgrproj_ref[0] = 0;
                   } else {
-                    assert!(xqd[i] == 95);
                     rp.sgrproj_ref[1] = 95; // LOL at spec.  The result is always 95.
                   }
                 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -3029,7 +3029,7 @@ impl ContextWriter {
       RestorationFilter::None => {
         w.symbol_bits(0, &self.fc.lrf_switchable_cdf[..nsym])
       }
-      RestorationFilter::Wiener{coeffs: _} => {
+      RestorationFilter::Wiener{ .. } => {
         unreachable!() // for now, not permanently
       }
       RestorationFilter::Sgrproj{set, xqd} => {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2044,7 +2044,7 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
 
       // loop restoration must be decided last but coded before anything else
       if fi.sequence.enable_restoration {
-        fs.restoration.lrf_optimize_superblock(&sbo, fi, &mut cw);
+        // optimization would occur here
         cw.write_lrf(&mut w, fi, &mut fs.restoration, &sbo);
       }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1934,7 +1934,6 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
     for sbx in 0..fi.sb_width {
       let mut w_pre_cdef = WriterRecorder::new();
       let mut w_post_cdef = WriterRecorder::new();
-      let mut cdef_index = 0;
       let sbo = SuperBlockOffset { x: sbx, y: sby };
       let bo = sbo.block_offset(0, 0);
       cw.bc.cdef_coded = false;
@@ -2036,15 +2035,13 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
                                  BlockSize::BLOCK_64X64, &bo, &None, &pmvs);
       }
 
-      // CDEF has to be decided before loop restoration, but coded after
-      if cw.bc.cdef_coded {
-        cdef_index = rdo_cdef_decision(&sbo, fi, fs, &mut cw);
-        cw.bc.set_cdef(&sbo, cdef_index);
+      // CDEF has to be decided before loop restoration, but coded after.
+      // loop restoration must be decided last but coded before anything else.
+      if cw.bc.cdef_coded || fi.sequence.enable_restoration {
+        rdo_loop_decision(&sbo, fi, fs, &mut cw, &mut w);
       }
 
-      // loop restoration must be decided last but coded before anything else
       if fi.sequence.enable_restoration {
-        // optimization would occur here
         cw.write_lrf(&mut w, fi, &mut fs.restoration, &sbo);
       }
 
@@ -2053,6 +2050,7 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
 
       if cw.bc.cdef_coded {
         // CDEF index must be written in the middle, we can code it now
+        let cdef_index = cw.bc.get_cdef(&sbo);
         cw.write_cdef(&mut w, cdef_index, fi.cdef_bits);
         // ...and then finally code what comes after the CDEF index
         w_post_cdef.replay(&mut w);

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -15,6 +15,7 @@ use crate::context::SuperBlockOffset;
 use crate::context::PLANES;
 use crate::context::MAX_SB_SIZE;
 use crate::plane::Plane;
+use crate::plane::PlaneSlice;
 use crate::plane::PlaneOffset;
 use crate::plane::PlaneConfig;
 use std::cmp;
@@ -66,11 +67,9 @@ impl RestorationFilter {
   }
 }
 
-fn sgrproj_sum_finish(ssq: i32, sum: i32,
-                      n: i32, one_over_n: i32, s: i32,
-                      bit_depth: usize) -> (i32, i32) {
-  let scaled_ssq = ssq + (1 << 2*(bit_depth-8) >> 1) >> 2*(bit_depth-8);
-  let scaled_sum = sum + (1 << bit_depth - 8 >> 1) >> bit_depth - 8;
+fn sgrproj_sum_finish(ssq: i32, sum: i32, n: i32, one_over_n: i32, s: i32, bdm8: usize) -> (i32, i32) {
+  let scaled_ssq = ssq + (1 << 2*bdm8 >> 1) >> 2*bdm8;
+  let scaled_sum = sum + (1 << bdm8 >> 1) >> bdm8;
   let p = cmp::max(0, scaled_ssq*(n as i32) - scaled_sum*scaled_sum);
   let z = p*s + (1 << SGRPROJ_MTABLE_BITS >> 1) >> SGRPROJ_MTABLE_BITS;
   let a = if z >= 255 {
@@ -83,64 +82,129 @@ fn sgrproj_sum_finish(ssq: i32, sum: i32,
   let b = ((1 << SGRPROJ_SGR_BITS) - a ) * sum * one_over_n;
   (a, b + (1 << SGRPROJ_RECIP_BITS >> 1) >> SGRPROJ_RECIP_BITS)
 }
-fn sgrproj_box_sum_slow<T: Pixel>(a: &mut i32, b: &mut i32, row: isize, r: usize,
-                        crop_w: usize, crop_h: usize, stripe_h: usize,
-                        stripe_x: isize, stripe_y: isize,
-                        n: i32, one_over_n: i32, s: i32,
-                        cdeffed: &Plane<T>, deblocked: &Plane<T>, bit_depth: usize) {  
-  let xn = cmp::min(r as isize + 1, crop_w as isize - stripe_x);
+
+// The addressing below is a bit confusing, made worse by LRF's odd
+// clipping requirements, and our reusing code for partial frames.  So
+// I'm documenting the LRF conventions here in detail.
+
+// 'Relative to plane storage' means that a coordinate or bound is
+// being applied as if to the full Plane backing the PlaneSlice.  For
+// example, a PlaneSlice may represent a subset of a middle of a
+// plane, but when we say the top/left bounds are clipped 'relative to
+// plane storage', that means relative to 0,0 of the plane, not 0,0 of
+// the plane slice.
+
+// 'Relative to the slice view' means that a coordinate or bound is
+// counted from the 0,0 of the PlaneSlice, not the Plane from which it
+// was sliced.
+
+// Passed in plane slices may be the same size or different sizes;
+// filter access will be clipped to 0,0..w,h of the underlying plane
+// storage for both planes, depending which is accessed.  Note that
+// the passed in w/h that specifies the storage clipping is actually
+// relative to the the slice view, not the plane storage (it
+// simplifies the math internally).  Eg, if a PlaceSlice has a y
+// offset of -2 (meaning its origin is two rows above the top row of
+// the backing plane), and we pass in a height of 4, the rows
+// 0,1,2,3,4 of the slice address -2, -1, 0, 1, 2 of the backing plane
+// with access clipped to 0, 0, 0, 1, 1.
+
+// Active area cropping is done by specifying a w,h smaller
+// than the actual underlying plane storage.
+
+// stripe_y is the beginning of the current stripe (used for source
+// buffer choice/clipping) relative to the passed in plane view.  It
+// may (and regularly will) be negative.
+
+// stripe_h is the hright of the current stripe, again used for source
+// buffer choice/clipping).  It may specify a stripe boundary less
+// than, eqqal to, or larger than the buffers we're accessing.
+
+// x and y specify the center pixel of the current filter kernel
+// application.  They are relative to the passed in slice views.
+
+fn sgrproj_box_sum_slow<T: Pixel>(a: &mut i32, b: &mut i32,
+                                  stripe_y: isize, stripe_h: usize,
+                                  x: isize, y: isize,
+                                  r: usize, n: i32, one_over_n: i32, s: i32, bdm8: usize,
+                                  backing: &PlaneSlice<T>, backing_w: usize, backing_h: usize,
+                                  cdeffed: &PlaneSlice<T>, cdeffed_w: usize, cdeffed_h: usize) {  
   let mut ssq:i32 = 0;
   let mut sum:i32 = 0;
 
-  for yi in row-r as isize..=row+r as isize {
-    let src_plane = if yi >= 0 && yi < stripe_h as isize {cdeffed} else {deblocked};
-    let ly = clamp(clamp(yi+stripe_y, 0, crop_h as isize - 1),
-                   stripe_y - 2, stripe_y + stripe_h as isize + 1) as usize;
+  for yi in y-r as isize..=y+r as isize {
+    let src_plane;
+    let src_w;
+    let src_h;
+    
+    // decide if we're vertically inside or outside the stripe
+    if yi >= stripe_y && yi < stripe_y + stripe_h as isize {
+      src_plane = cdeffed;
+      src_w = (cdeffed_w as isize - x + r as isize) as usize;
+      src_h = cdeffed_h as isize;
+    } else {
+      src_plane = backing;
+      src_w = (backing_w as isize - x + r as isize) as usize;
+      src_h = backing_h as isize;
+    }
+    // clamp vertically to storage at top and passed-in height at bottom 
+    let cropped_y = clamp(yi, -src_plane.y, src_h - 1);
+    // clamp vertically to stripe limits
+    let ly = clamp(cropped_y, stripe_y - 2, stripe_y + stripe_h as isize + 1);
+    // Reslice to avoid a negative X index.
+    let p = src_plane.reslice(x - r as isize,ly).as_slice();
+    // left-hand addressing limit
+    let left = cmp::max(0, r as isize - x - src_plane.x) as usize;
+    // right-hand addressing limit
+    let right = cmp::min(2*r+1, src_w);
 
-    for _xi in -(r as isize)..-stripe_x {
-      let c:i32 = src_plane.p(0, ly).as_();
+    // run accumulation to left of frame storage (if any)
+    for _xi in 0..left {
+      let c = i32::cast_from(p[(r as isize - x) as usize]);
       ssq += c*c;
       sum += c;
     }
-    for xi in cmp::max(-(r as isize), -stripe_x)..xn {
-      let c:i32 = src_plane.p((xi + stripe_x) as usize, ly).as_();
+    // run accumulation in-frame
+    for xi in left..right {
+      let c = i32::cast_from(p[xi]);
       ssq += c*c;
       sum += c;
     }
-    for _xi in xn..r as isize + 1 {
-      let c:i32 = src_plane.p(crop_w - 1, ly).as_();
+    // run accumulation to right of frame (if any)
+    for _xi in right..2*r+1 {
+      let c = i32::cast_from(p[src_w - 1]);
       ssq += c*c;
       sum += c;
     }
   }
-  let (reta, retb) = sgrproj_sum_finish(ssq, sum, n, one_over_n, s, bit_depth);
+  let (reta, retb) = sgrproj_sum_finish(ssq, sum, n, one_over_n, s, bdm8);
   *a = reta;
   *b = retb;
 }
 
-// unrolled computation to be used when all bounds-checking has been pre-satisfied.
-fn sgrproj_box_sum_fastxy_r1<T: Pixel>(a: &mut i32, b: &mut i32, stripe_x: isize, stripe_y: isize,
-                                       s: i32, p: &Plane<T>, bit_depth: usize) {
+// unrolled computation to be used when all bounds-checking has been satisfied.
+fn sgrproj_box_sum_fastxy_r1<T: Pixel>(a: &mut i32, b: &mut i32, x: isize, y: isize,
+                                       s: i32, bdm8: usize, p: &PlaneSlice<T>) {
   let mut ssq:i32 = 0;
   let mut sum:i32 = 0;
   for yi in -1..=1 {
-    let x = p.slice(&PlaneOffset{x: stripe_x - 1, y: stripe_y + yi}).as_slice();
+    let x = p.reslice(x - 1, y + yi).as_slice();
     ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
       i32::cast_from(x[1]) * i32::cast_from(x[1]) +
       i32::cast_from(x[2]) * i32::cast_from(x[2]);
     sum += i32::cast_from(x[0]) + i32::cast_from(x[1]) + i32::cast_from(x[2]);
   }
-  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 9, 455, s, bit_depth);
+  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 9, 455, s, bdm8);
   *a = reta;
   *b = retb;
 }
 
-fn sgrproj_box_sum_fastxy_r2<T: Pixel>(a: &mut i32, b: &mut i32, stripe_x: isize, stripe_y: isize,
-                                       s: i32, p: &Plane<T>, bit_depth: usize) {
+fn sgrproj_box_sum_fastxy_r2<T: Pixel>(a: &mut i32, b: &mut i32, x: isize, y: isize,
+                                       s: i32, bdm8: usize, p: &PlaneSlice<T>) {
   let mut ssq:i32 = 0;
   let mut sum:i32 = 0;
   for yi in -2..=2 {
-    let x = p.slice(&PlaneOffset{x: stripe_x - 2, y: stripe_y + yi}).as_slice();
+    let x = p.reslice(x - 2, y + yi).as_slice();
     ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
       i32::cast_from(x[1]) * i32::cast_from(x[1]) +
       i32::cast_from(x[2]) * i32::cast_from(x[2]) +
@@ -149,46 +213,72 @@ fn sgrproj_box_sum_fastxy_r2<T: Pixel>(a: &mut i32, b: &mut i32, stripe_x: isize
     sum += i32::cast_from(x[0]) + i32::cast_from(x[1]) + i32::cast_from(x[2]) +
       i32::cast_from(x[3]) + i32::cast_from(x[4]);
   }
-  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 25, 164, s, bit_depth);
+  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 25, 164, s, bdm8);
   *a = reta;
   *b = retb;
 }
 
-// unrolled computation to be used when X bounds-checking has been pre-satisfied.
-fn sgrproj_box_sum_fastx_r1<T: Pixel>(a: &mut i32, b: &mut i32, row: isize,
-                                      crop_h: usize, stripe_h: usize,
-                                      stripe_x: isize, stripe_y: isize,
-                                      s: i32, cdeffed: &Plane<T>, deblocked: &Plane<T>,
-                                      bit_depth: usize) {  
+// unrolled computation to be used when only X bounds-checking has been satisfied.
+fn sgrproj_box_sum_fastx_r1<T: Pixel>(a: &mut i32, b: &mut i32,
+                                      stripe_y: isize, stripe_h: usize,
+                                      x: isize, y: isize,
+                                      s: i32, bdm8: usize,
+                                      backing: &PlaneSlice<T>, backing_h: usize,
+                                      cdeffed: &PlaneSlice<T>, cdeffed_h: usize) {  
   let mut ssq:i32 = 0;
   let mut sum:i32 = 0;
-  for yi in row-1 as isize..=row+1 as isize {
-    let p = if yi >= 0 && yi < stripe_h as isize {cdeffed} else {deblocked};
-    let ly = clamp(clamp(yi+stripe_y, 0, crop_h as isize - 1),
-                   stripe_y - 2, stripe_y + stripe_h as isize + 1);
-    let x = p.slice(&PlaneOffset{x: stripe_x - 1, y: ly}).as_slice();
+  for yi in y-1..=y+1 {
+    let src_plane;
+    let src_h;
+    
+    // decide if we're vertically inside or outside the stripe
+    if yi >= stripe_y && yi < stripe_y + stripe_h as isize {
+      src_plane = cdeffed;
+      src_h = cdeffed_h as isize;
+    } else {
+      src_plane = backing;
+      src_h = backing_h as isize;
+    }
+    // clamp vertically to storage addressing limit
+    let cropped_y = clamp(yi, -src_plane.y, src_h - 1);
+    // clamp vertically to stripe limits
+    let ly = clamp(cropped_y, stripe_y - 2, stripe_y + stripe_h as isize + 1);
+    let x = src_plane.reslice(x - 1, ly).as_slice();
     ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
       i32::cast_from(x[1]) * i32::cast_from(x[1]) +
       i32::cast_from(x[2]) * i32::cast_from(x[2]);
     sum += i32::cast_from(x[0]) + i32::cast_from(x[1]) + i32::cast_from(x[2]);
   }
-  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 9, 455, s, bit_depth);
+  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 9, 455, s, bdm8);
   *a = reta;
   *b = retb;
 }
 
-fn sgrproj_box_sum_fastx_r2<T: Pixel>(a: &mut i32, b: &mut i32, row: isize,
-                                      crop_h: usize, stripe_h: usize,
-                                      stripe_x: isize, stripe_y: isize,
-                                      s: i32, cdeffed: &Plane<T>, deblocked: &Plane<T>,
-                                      bit_depth: usize) {  
+fn sgrproj_box_sum_fastx_r2<T: Pixel>(a: &mut i32, b: &mut i32,
+                                      stripe_y: isize, stripe_h: usize,
+                                      x: isize, y: isize,
+                                      s: i32, bdm8: usize,
+                                      backing: &PlaneSlice<T>, backing_h: usize,
+                                      cdeffed: &PlaneSlice<T>, cdeffed_h: usize) {  
   let mut ssq:i32 = 0;
   let mut sum:i32 = 0;
-  for yi in row-2 as isize..=row+2 as isize {
-    let p = if yi >= 0 && yi < stripe_h as isize {cdeffed} else {deblocked};
-    let ly = clamp(clamp(yi+stripe_y, 0, crop_h as isize - 1),
-                   stripe_y - 2, stripe_y + stripe_h as isize + 1);
-    let x = p.slice(&PlaneOffset{x: stripe_x - 2, y: ly}).as_slice();
+  for yi in y - 2..=y + 2 {
+    let src_plane;
+    let src_h;
+    
+    // decide if we're vertically inside or outside the stripe
+    if yi >= stripe_y && yi < stripe_y + stripe_h as isize {
+      src_plane = cdeffed;
+      src_h = cdeffed_h as isize;
+    } else {
+      src_plane = backing;
+      src_h = backing_h as isize;
+    }
+    // clamp vertically to storage addressing limit
+    let cropped_y = clamp(yi, -src_plane.y, src_h as isize - 1);
+    // clamp vertically to stripe limits
+    let ly = clamp(cropped_y, stripe_y - 2, stripe_y + stripe_h as isize + 1);
+    let x = src_plane.reslice(x - 2, ly).as_slice();
     ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
       i32::cast_from(x[1]) * i32::cast_from(x[1]) +
       i32::cast_from(x[2]) * i32::cast_from(x[2]) +
@@ -197,46 +287,69 @@ fn sgrproj_box_sum_fastx_r2<T: Pixel>(a: &mut i32, b: &mut i32, row: isize,
     sum += i32::cast_from(x[0]) + i32::cast_from(x[1]) + i32::cast_from(x[2]) +
       i32::cast_from(x[3]) + i32::cast_from(x[4]);
   }
-  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 25, 164, s, bit_depth);
+  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 25, 164, s, bdm8);
   *a = reta;
   *b = retb;
 }
 
+// computes an intermediate (ab) column for rows stripe_y through
+// stripe_y+stripe_h (no inclusize) at column stripe_x.
 // r=1 case computes every row as every row is used (see r2 version below)
 fn sgrproj_box_ab_r1<T: Pixel>(af: &mut[i32; 64+2],
                                bf: &mut[i32; 64+2],
-                               s: i32,
-                               crop_w: usize, crop_h: usize, stripe_h: usize,
-                               stripe_x: isize, stripe_y: isize,
-                               cdeffed: &Plane<T>, deblocked: &Plane<T>, bit_depth: usize) {
-  let boundary0 = cmp::max(0, -stripe_y) as usize;
+                               stripe_x: isize, stripe_y: isize, stripe_h: usize,
+                               s: i32, bdm8: usize,
+                               backing: &PlaneSlice<T>, backing_w: usize, backing_h: usize,
+                               cdeffed: &PlaneSlice<T>, cdeffed_w: usize, cdeffed_h: usize) {
+  // we will fill the af and bf arrays from 0..stripe_h+1 (ni),
+  // representing stripe_y-1 to stripe_y+stripe_h+1 inclusive
+  let boundary0 = 0;
   let boundary3 = stripe_h + 2;
-  if stripe_x > 1 && stripe_x < crop_w as isize - 2 {
-    // Away from left and right edges; no X clipping to worry about,
-    // but top/bottom few rows still need to worry about Y
-    let boundary1 = cmp::max(3, 3-stripe_y) as usize;
-    let boundary2 = cmp::min(crop_h as isize - stripe_y - 1, stripe_h as isize - 1) as usize;
+  if backing.x + stripe_x > 0 && stripe_x < backing_w as isize - 1 &&
+    cdeffed.x + stripe_x > 0 && stripe_x < cdeffed_w as isize - 1 {
+    // Addressing is away from left and right edges of cdeffed storage;
+    // no X clipping to worry about, but the top/bottom few rows still
+    // need to worry about storage and stripe limits
+      
+    // boundary1 is the point where we're guaranteed all our y
+    // addressing will be both in the stripe and in cdeffed storage  
+    let boundary1 = cmp::max(2, 2 - cdeffed.y - stripe_y) as usize;
+    // boundary 2 is when we have to bounds check along the bottom of
+    // the stripe or bottom of storage
+    let boundary2 = cmp::min(cdeffed_h as isize - stripe_y - 1, stripe_h as isize - 1) as usize;
 
-    // top rows, away from left and right columns
+    // top rows (if any), away from left and right columns
     for i in boundary0..boundary1 {
-      sgrproj_box_sum_fastx_r1(&mut af[i], &mut bf[i], i as isize - 1, crop_h, stripe_h,
-                           stripe_x, stripe_y, s, cdeffed, deblocked, bit_depth);
+      sgrproj_box_sum_fastx_r1(&mut af[i], &mut bf[i],
+                               stripe_y, stripe_h, 
+                               stripe_x, stripe_y + i as isize - 1,
+                               s, bdm8,
+                               backing, backing_h,
+                               cdeffed, cdeffed_h);
     }
     // middle rows, away from left and right columns
     for i in boundary1..boundary2 {
       sgrproj_box_sum_fastxy_r1(&mut af[i], &mut bf[i],
-                            stripe_x, stripe_y + i as isize - 1, s, cdeffed, bit_depth);
+                                stripe_x, stripe_y + i as isize - 1, s, bdm8, cdeffed);
     }
-    // bottom rows, away from left and right columns
+    // bottom rows (if any), away from left and right columns
     for i in boundary2..boundary3 {
-      sgrproj_box_sum_fastx_r1(&mut af[i], &mut bf[i], i as isize - 1, crop_h, stripe_h,
-                           stripe_x, stripe_y, s, cdeffed, deblocked, bit_depth);
+      sgrproj_box_sum_fastx_r1(&mut af[i], &mut bf[i],
+                               stripe_y, stripe_h, 
+                               stripe_x, stripe_y + i as isize - 1,
+                               s, bdm8,
+                               backing, backing_h,
+                               cdeffed, cdeffed_h);
     }
   } else {
     // top/bottom rows and left/right columns, where we need to worry about frame and stripe clipping
     for i in boundary0..boundary3 {
-      sgrproj_box_sum_slow(&mut af[i], &mut bf[i], i as isize - 1, 1, crop_w, crop_h, stripe_h,
-                           stripe_x, stripe_y, 9, 455, s, cdeffed, deblocked, bit_depth);
+      sgrproj_box_sum_slow(&mut af[i], &mut bf[i],                           
+                           stripe_y, stripe_h,
+                           stripe_x, stripe_y + i as isize - 1,
+                           1, 9, 455, s, bdm8,
+                           backing, backing_w, backing_h,
+                           cdeffed, cdeffed_w, cdeffed_h);
     }
   }
 }
@@ -250,51 +363,74 @@ fn sgrproj_box_ab_r1<T: Pixel>(af: &mut[i32; 64+2],
 // (ie not as much as it may appear).
 fn sgrproj_box_ab_r2<T: Pixel>(af: &mut[i32; 64+2],
                                bf: &mut[i32; 64+2],
-                               s: i32,
-                               crop_w: usize, crop_h: usize, stripe_h: usize,
-                               stripe_x: isize, stripe_y: isize,
-                               cdeffed: &Plane<T>, deblocked: &Plane<T>,
-                               bit_depth: usize) {
-  let boundary0 = cmp::max(0, -stripe_y) as usize; // always even
+                               stripe_x: isize, stripe_y: isize, stripe_h: usize,
+                               s: i32, bdm8: usize,
+                               backing: &PlaneSlice<T>, backing_w: usize, backing_h: usize,
+                               cdeffed: &PlaneSlice<T>, cdeffed_w: usize, cdeffed_h: usize) {  
+  // we will fill the af and bf arrays from 0..stripe_h+1 (ni),
+  // representing stripe_y-1 to stripe_y+stripe_h+1 inclusive
+  let boundary0 = 0; // even
   let boundary3 = stripe_h + 2; // don't care if odd
-  if stripe_x > 1 && stripe_x < crop_w as isize - 2 {
-    // make even, round up
-    let boundary1 = cmp::max(3, 3-stripe_y) as usize + 1 >> 1 << 1;
+  if backing.x + stripe_x > 1 && stripe_x < backing_w as isize - 2 &&
+    cdeffed.x + stripe_x > 1 && stripe_x < cdeffed_w as isize - 2 {
+    // Addressing is away from left and right edges of cdeffed storage;
+    // no X clipping to worry about, but the top/bottom few rows still
+    // need to worry about storage and stripe limits
+      
+    // boundary1 is the point where we're guaranteed all our y
+    // addressing will be both in the stripe and in cdeffed storage
+    // make even and round up  
+    let boundary1 = (cmp::max(3, 3 - cdeffed.y - stripe_y) + 1 >> 1 << 1) as usize;
+    // boundary 2 is when we have to bounds check along the bottom of
+    // the stripe or bottom of storage
     // must be even, rounding of +1 cancels fencepost of -1
-    let boundary2 = cmp::min(crop_h as isize - stripe_y, stripe_h as isize) as usize >> 1 << 1;
+    let boundary2 = (cmp::min(cdeffed_h as isize - stripe_y, stripe_h as isize) >> 1 << 1) as usize;
 
     // top rows, away from left and right columns
     for i in (boundary0..boundary1).step_by(2) {
-      sgrproj_box_sum_fastx_r2(&mut af[i], &mut bf[i], i as isize - 1, crop_h, stripe_h,
-                           stripe_x, stripe_y, s, cdeffed, deblocked, bit_depth);
+      sgrproj_box_sum_fastx_r2(&mut af[i], &mut bf[i],
+                               stripe_y, stripe_h, 
+                               stripe_x, stripe_y + i as isize - 1,
+                               s, bdm8,
+                               backing, backing_h,
+                               cdeffed, cdeffed_h);
     }
     // middle rows, away from left and right columns
     for i in (boundary1..boundary2).step_by(2) {
       sgrproj_box_sum_fastxy_r2(&mut af[i], &mut bf[i],
-                            stripe_x, stripe_y + i as isize - 1, s, cdeffed, bit_depth);
+                                stripe_x, stripe_y + i as isize - 1,
+                                s, bdm8, cdeffed);
     }
     // bottom rows, away from left and right columns
     for i in (boundary2..boundary3).step_by(2) {
-      sgrproj_box_sum_fastx_r2(&mut af[i], &mut bf[i], i as isize - 1, crop_h, stripe_h,
-                           stripe_x, stripe_y, s, cdeffed, deblocked, bit_depth);
+      sgrproj_box_sum_fastx_r2(&mut af[i], &mut bf[i],
+                               stripe_y, stripe_h, 
+                               stripe_x, stripe_y + i as isize - 1,
+                               s, bdm8,
+                               backing, backing_h,
+                               cdeffed, cdeffed_h);
     }
   } else {
     // top/bottom rows and left/right columns, where we need to worry about frame and stripe clipping
     for i in (boundary0..boundary3).step_by(2) {
-      sgrproj_box_sum_slow(&mut af[i], &mut bf[i], i as isize - 1, 2, crop_w, crop_h, stripe_h,
-                           stripe_x, stripe_y, 25, 164, s, cdeffed, deblocked, bit_depth);
+      sgrproj_box_sum_slow(&mut af[i], &mut bf[i],
+                           stripe_y, stripe_h,
+                           stripe_x, stripe_y + i as isize - 1,
+                           2, 25, 164, s, bdm8,
+                           backing, backing_w, backing_h,
+                           cdeffed, cdeffed_w, cdeffed_h);
     }
   }
 }
 
-fn sgrproj_box_f_r0<T: Pixel>(f: &mut[i32; 64], x: usize, y: isize, h: usize, cdeffed: &Plane<T>) {
+fn sgrproj_box_f_r0<T: Pixel>(f: &mut[i32; 64], x: usize, y: isize, h: usize, cdeffed: &PlaneSlice<T>) {
   for i in cmp::max(0, -y) as usize..h {
     f[i as usize] = (i32::cast_from(cdeffed.p(x, (y + i as isize) as usize))) << SGRPROJ_RST_BITS;
   }
 }
 
 fn sgrproj_box_f_r1<T: Pixel>(af: &[&[i32; 64+2]; 3], bf: &[&[i32; 64+2]; 3], f: &mut[i32; 64],
-                              x: usize, y: isize, h: usize, cdeffed: &Plane<T>) {
+                              x: usize, y: isize, h: usize, cdeffed: &PlaneSlice<T>) {
   let shift = 5 + SGRPROJ_SGR_BITS - SGRPROJ_RST_BITS;
   for i in cmp::max(0, -y) as usize..h {
     let a =
@@ -309,7 +445,7 @@ fn sgrproj_box_f_r1<T: Pixel>(af: &[&[i32; 64+2]; 3], bf: &[&[i32; 64+2]; 3], f:
 }
 
 fn sgrproj_box_f_r2<T: Pixel>(af: &[&[i32; 64+2]; 3], bf: &[&[i32; 64+2]; 3], f: &mut[i32; 64],
-                              x: usize, y: isize, h: usize, cdeffed: &Plane<T>) {
+                              x: usize, y: isize, h: usize, cdeffed: &PlaneSlice<T>) {
   let shift = 5 + SGRPROJ_SGR_BITS - SGRPROJ_RST_BITS;
   let shifto = 4 + SGRPROJ_SGR_BITS - SGRPROJ_RST_BITS;
   for i in (cmp::max(0, -y) as usize..h).step_by(2) {
@@ -335,10 +471,11 @@ fn sgrproj_box_f_r2<T: Pixel>(af: &[&[i32; 64+2]; 3], bf: &[&[i32; 64+2]; 3], f:
 fn sgrproj_stripe_filter<T: Pixel>(set: u8, xqd: [i8; 2], fi: &FrameInvariants<T>,
                                    crop_w: usize, crop_h: usize,
                                    stripe_w: usize, stripe_h: usize,
-                                   stripe_x: usize, stripe_y: isize,
+                                   stripe_x: isize, stripe_y: isize,
                                    cdeffed: &Plane<T>, deblocked: &Plane<T>, out: &mut Plane<T>) {
 
   assert!(stripe_h <= 64);
+  let bdm8 = fi.sequence.bit_depth - 8;
   let mut a_r2: [[i32; 64+2]; 3] = [[0; 64+2]; 3];
   let mut b_r2: [[i32; 64+2]; 3] = [[0; 64+2]; 3];
   let mut f_r2: [i32; 64] = [0; 64];
@@ -349,58 +486,90 @@ fn sgrproj_stripe_filter<T: Pixel>(set: u8, xqd: [i8; 2], fi: &FrameInvariants<T
   let s_r2: i32 = SGRPROJ_PARAMS_S[set as usize][0];
   let s_r1: i32 = SGRPROJ_PARAMS_S[set as usize][1];
 
+  let deblocked_slice = deblocked.slice(&PlaneOffset{x: stripe_x, y: stripe_y});
+  let cdeffed_slice = cdeffed.slice(&PlaneOffset{x: stripe_x, y: stripe_y});
+  
   /* prime the intermediate arrays */
   if s_r2 > 0 {
-    sgrproj_box_ab_r2(&mut a_r2[0], &mut b_r2[0], s_r2,
-                   crop_w, crop_h, stripe_h,
-                   stripe_x as isize - 1, stripe_y,
-                   cdeffed, deblocked, fi.sequence.bit_depth);
-    sgrproj_box_ab_r2(&mut a_r2[1], &mut b_r2[1], s_r2,
-                   crop_w, crop_h, stripe_h,
-                   stripe_x as isize, stripe_y,
-                   cdeffed, deblocked, fi.sequence.bit_depth);
+    sgrproj_box_ab_r2(&mut a_r2[0], &mut b_r2[0],
+                      -1, 0, stripe_h,
+                      s_r2, bdm8,
+                      &deblocked_slice,
+                      (crop_w as isize - stripe_x) as usize,
+                      (crop_h as isize - stripe_y) as usize,
+                      &cdeffed_slice,
+                      (crop_w as isize - stripe_x) as usize,
+                      (crop_h as isize - stripe_y) as usize);
+    sgrproj_box_ab_r2(&mut a_r2[1], &mut b_r2[1],
+                      0, 0, stripe_h,
+                      s_r2, bdm8,
+                      &deblocked_slice,
+                      (crop_w as isize - stripe_x) as usize,
+                      (crop_h as isize - stripe_y) as usize,
+                      &cdeffed_slice,
+                      (crop_w as isize - stripe_x) as usize,
+                      (crop_h as isize - stripe_y) as usize);
   }
   if s_r1 > 0 {
-    sgrproj_box_ab_r1(&mut a_r1[0], &mut b_r1[0], s_r1,
-                      crop_w, crop_h, stripe_h,
-                      stripe_x as isize - 1, stripe_y,
-                      cdeffed, deblocked, fi.sequence.bit_depth);
-    sgrproj_box_ab_r1(&mut a_r1[1], &mut b_r1[1], s_r1,
-                      crop_w, crop_h, stripe_h,
-                      stripe_x as isize, stripe_y,
-                      cdeffed, deblocked, fi.sequence.bit_depth);
+    sgrproj_box_ab_r1(&mut a_r1[0], &mut b_r1[0],
+                      -1, 0, stripe_h,
+                      s_r1, bdm8,
+                      &deblocked_slice,
+                      (crop_w as isize - stripe_x) as usize,
+                      (crop_h as isize - stripe_y) as usize,
+                      &cdeffed_slice,
+                      (crop_w as isize - stripe_x) as usize,
+                      (crop_h as isize - stripe_y) as usize);
+    sgrproj_box_ab_r1(&mut a_r1[1], &mut b_r1[1],
+                      0, 0, stripe_h,
+                      s_r1, bdm8,
+                      &deblocked_slice,
+                      (crop_w as isize - stripe_x) as usize,
+                      (crop_h as isize - stripe_y) as usize,
+                      &cdeffed_slice,
+                      (crop_w as isize - stripe_x) as usize,
+                      (crop_h as isize - stripe_y) as usize);
   }
 
   /* iterate by column */
   let start = cmp::max(0, -stripe_y) as usize;
-  let cdeffed_slice = cdeffed.slice(&PlaneOffset{x: stripe_x as isize, y: stripe_y});
-  let outstride = out.cfg.stride;
-  let mut out_slice = out.mut_slice(&PlaneOffset{x: stripe_x as isize, y: stripe_y});
+  let outstride = out.cfg.stride; 
+  let mut out_slice = out.mut_slice(&PlaneOffset{x: stripe_x, y: stripe_y});
   let out_data = out_slice.as_mut_slice();
   for xi in 0..stripe_w {
     /* build intermediate array columns */
     if s_r2 > 0 {
-      sgrproj_box_ab_r2(&mut a_r2[(xi+2)%3], &mut b_r2[(xi+2)%3], s_r2,
-                     crop_w, crop_h, stripe_h,
-                     (stripe_x + xi + 1) as isize, stripe_y,
-                     cdeffed, deblocked, fi.sequence.bit_depth);
+      sgrproj_box_ab_r2(&mut a_r2[(xi+2)%3], &mut b_r2[(xi+2)%3],
+                        xi as isize + 1, 0, stripe_h,
+                        s_r2, bdm8,
+                        &deblocked_slice,
+                        (crop_w as isize - stripe_x) as usize,                        
+                        (crop_h as isize - stripe_y) as usize,
+                        &cdeffed_slice,
+                        (crop_w as isize - stripe_x) as usize,
+                        (crop_h as isize - stripe_y) as usize);
       let ap0: [&[i32; 64+2]; 3] = [&a_r2[xi%3], &a_r2[(xi+1)%3], &a_r2[(xi+2)%3]];
       let bp0: [&[i32; 64+2]; 3] = [&b_r2[xi%3], &b_r2[(xi+1)%3], &b_r2[(xi+2)%3]];
-      sgrproj_box_f_r2(&ap0, &bp0, &mut f_r2, stripe_x + xi, stripe_y, stripe_h as usize, cdeffed);
+      sgrproj_box_f_r2(&ap0, &bp0, &mut f_r2, xi, 0, stripe_h as usize, &cdeffed_slice);
     } else {
-      sgrproj_box_f_r0(&mut f_r2, stripe_x + xi, stripe_y, stripe_h as usize, cdeffed);
+      sgrproj_box_f_r0(&mut f_r2, xi, 0, stripe_h as usize, &cdeffed_slice);
     }
     if s_r1 > 0 {
-      sgrproj_box_ab_r1(&mut a_r1[(xi+2)%3], &mut b_r1[(xi+2)%3], s_r1,
-                        crop_w, crop_h, stripe_h,
-                        (stripe_x + xi + 1) as isize, stripe_y,
-                        cdeffed, deblocked, fi.sequence.bit_depth);
+      sgrproj_box_ab_r1(&mut a_r1[(xi+2)%3], &mut b_r1[(xi+2)%3],
+                        xi as isize + 1, 0, stripe_h,
+                        s_r1, bdm8,
+                        &deblocked_slice,
+                        (crop_w as isize - stripe_x) as usize,
+                        (crop_h as isize - stripe_y) as usize,
+                        &cdeffed_slice,
+                        (crop_w as isize - stripe_x) as usize,
+                        (crop_h as isize - stripe_y) as usize);
       let ap1: [&[i32; 64+2]; 3] = [&a_r1[xi%3], &a_r1[(xi+1)%3], &a_r1[(xi+2)%3]];
       let bp1: [&[i32; 64+2]; 3] = [&b_r1[xi%3], &b_r1[(xi+1)%3], &b_r1[(xi+2)%3]];
 
-      sgrproj_box_f_r1(&ap1, &bp1, &mut f_r1, stripe_x + xi, stripe_y, stripe_h as usize, cdeffed);
+      sgrproj_box_f_r1(&ap1, &bp1, &mut f_r1, xi, 0, stripe_h as usize, &cdeffed_slice);
     } else {
-      sgrproj_box_f_r0(&mut f_r1, stripe_x + xi, stripe_y, stripe_h as usize, cdeffed);
+      sgrproj_box_f_r0(&mut f_r1, xi, 0, stripe_h as usize, &cdeffed_slice);
     }
 
     /* apply filter */
@@ -683,7 +852,7 @@ impl RestorationState {
               sgrproj_stripe_filter(set, xqd, fi,
                                     crop_w, crop_h,
                                     ru_size, stripe_size,
-                                    ru_start_x, stripe_start_y,
+                                    ru_start_x as isize, stripe_start_y,
                                     &cdeffed.planes[pli], &pre_cdef.planes[pli],
                                     &mut out.planes[pli]);
             },

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -11,7 +11,6 @@
 
 use crate::encoder::Frame;
 use crate::encoder::FrameInvariants;
-use crate::context::ContextWriter;
 use crate::context::SuperBlockOffset;
 use crate::context::PLANES;
 use crate::context::MAX_SB_SIZE;
@@ -46,17 +45,11 @@ pub const SGRPROJ_MTABLE_BITS: u8 = 20;
 pub const SGRPROJ_SGR_BITS: u8 = 8;
 pub const SGRPROJ_RECIP_BITS: u8 = 12;
 pub const SGRPROJ_RST_BITS: u8 = 4;
-pub const SGRPROJ_PARAMS_RADIUS: [[u8; 2]; 1 << SGRPROJ_PARAMS_BITS] = [
-  [2, 1], [2, 1], [2, 1], [2, 1],
-  [2, 1], [2, 1], [2, 1], [2, 1],
-  [2, 1], [2, 1], [0, 1], [0, 1],
-  [0, 1], [0, 1], [2, 0], [2, 0],
-];
-pub const SGRPROJ_PARAMS_EPS: [[u8; 2]; 1 << SGRPROJ_PARAMS_BITS] = [
-  [12,  4], [15,  6], [18,  8], [21,  9],
-  [24, 10], [29, 11], [36, 12], [45, 13],
-  [56, 14], [68, 15], [ 0,  5], [ 0,  8],
-  [ 0, 11], [ 0, 14], [30,  0], [75,  0],
+pub const SGRPROJ_PARAMS_S: [[i32; 2]; 1 << SGRPROJ_PARAMS_BITS] = [
+  [140, 3236], [112, 2158], [ 93, 1618], [ 80, 1438],
+  [ 70, 1295], [ 58, 1177], [ 47, 1079], [ 37,  996],
+  [ 30,  925], [ 25,  863], [  0, 2589], [  0, 1618],
+  [  0, 1177], [  0,  925], [ 56,    0], [ 22,    0]
 ];
 
 #[derive(Copy, Clone, Debug)]
@@ -69,169 +62,313 @@ pub enum RestorationFilter {
 
 impl RestorationFilter {
   pub fn default() -> RestorationFilter {
-    RestorationFilter::None
+    RestorationFilter::Sgrproj {set:4, xqd: SGRPROJ_XQD_MID}
   }
 }
 
-fn sgrproj_box_ab<T: Pixel>(
-  af: &mut[i32; 64+2],
-  bf: &mut[i32; 64+2],
-  r: isize,
-  eps: isize,
-  crop_w: usize,
-  crop_h: usize,
-  stripe_h: isize,
-  stripe_x: isize,
-  stripe_y: isize,
-  cdeffed: &Plane<T>,
-  deblocked: &Plane<T>,
-  bit_depth: usize,
-) {
-  let n = ((2*r + 1) * (2*r + 1)) as i32;
-  let one_over_n = ((1 << SGRPROJ_RECIP_BITS) + n/2 ) / n;
-  let n2e = n*n*eps as i32;
-  let s = ((1 << SGRPROJ_MTABLE_BITS) + n2e/2) / n2e;
-  let xn = cmp::min(r+1, crop_w as isize - stripe_x);
-  for row in -1..=stripe_h {
-    let mut a:i32 = 0;
-    let mut b:i32 = 0;
+fn sgrproj_sum_finish(ssq: i32, sum: i32,
+                      n: i32, one_over_n: i32, s: i32,
+                      bit_depth: usize) -> (i32, i32) {
+  let scaled_ssq = ssq + (1 << 2*(bit_depth-8) >> 1) >> 2*(bit_depth-8);
+  let scaled_sum = sum + (1 << bit_depth - 8 >> 1) >> bit_depth - 8;
+  let p = cmp::max(0, scaled_ssq*(n as i32) - scaled_sum*scaled_sum);
+  let z = p*s + (1 << SGRPROJ_MTABLE_BITS >> 1) >> SGRPROJ_MTABLE_BITS;
+  let a = if z >= 255 {
+    256
+  } else if z == 0 {
+    1
+  } else {
+    ((z << SGRPROJ_SGR_BITS) + z/2) / (z+1)
+  };
+  let b = ((1 << SGRPROJ_SGR_BITS) - a ) * sum * one_over_n;
+  (a, b + (1 << SGRPROJ_RECIP_BITS >> 1) >> SGRPROJ_RECIP_BITS)
+}
+fn sgrproj_box_sum_slow<T: Pixel>(a: &mut i32, b: &mut i32, row: isize, r: usize,
+                        crop_w: usize, crop_h: usize, stripe_h: usize,
+                        stripe_x: isize, stripe_y: isize,
+                        n: i32, one_over_n: i32, s: i32,
+                        cdeffed: &Plane<T>, deblocked: &Plane<T>, bit_depth: usize) {  
+  let xn = cmp::min(r as isize + 1, crop_w as isize - stripe_x);
+  let mut ssq:i32 = 0;
+  let mut sum:i32 = 0;
 
-    for yi in stripe_y+row-r..=stripe_y+row+r {
-      let src_plane: &Plane<T>;
-      let ly;
-      if yi < stripe_y {
-        ly = cmp::max(cmp::max(yi, 0), stripe_y - 2) as usize;
-        src_plane = deblocked;
-      } else if yi < stripe_y + stripe_h {
-        ly = clamp(yi, 0, crop_h as isize - 1) as usize;
-        src_plane = cdeffed;
-      } else {
-        ly = cmp::min(clamp(yi, 0, crop_h as isize - 1), stripe_y+stripe_h+1) as usize;
-        src_plane = deblocked;
-      }
+  for yi in row-r as isize..=row+r as isize {
+    let src_plane = if yi >= 0 && yi < stripe_h as isize {cdeffed} else {deblocked};
+    let ly = clamp(clamp(yi+stripe_y, 0, crop_h as isize - 1),
+                   stripe_y - 2, stripe_y + stripe_h as isize + 1) as usize;
 
-      for _xi in -r..-stripe_x {
-        let c: i32 = src_plane.p(0, ly).as_();
-        a += c*c;
-        b += c;
-      }
-      for xi in cmp::max(-r, -stripe_x)..xn {
-        let c: i32 = src_plane.p((xi + stripe_x) as usize, ly).as_();
-        a += c*c;
-        b += c;
-      }
-      for _xi in xn..=r {
-        let c: i32 = src_plane.p(crop_w - 1, ly).as_();
-        a += c*c;
-        b += c;
-      }
+    for _xi in -(r as isize)..-stripe_x {
+      let c:i32 = src_plane.p(0, ly).as_();
+      ssq += c*c;
+      sum += c;
     }
-    a = a + (1 << 2*(bit_depth-8) >> 1) >> 2*(bit_depth-8);
-    let d = b + (1 << bit_depth - 8 >> 1) >> bit_depth - 8;
-    let p = cmp::max(0, a*(n as i32) - d*d);
-    let z = p*s + (1 << SGRPROJ_MTABLE_BITS >> 1) >> SGRPROJ_MTABLE_BITS;
-    let a2 = if z >= 255 {
-      256
-    } else if z == 0 {
-      1
-    } else {
-      ((z << SGRPROJ_SGR_BITS) + z/2) / (z+1)
-    };
-    let b2 = ((1 << SGRPROJ_SGR_BITS) - a2 ) * b * one_over_n;
-    af[(row+1) as usize] = a2;
-    bf[(row+1) as usize] = b2 + (1 << SGRPROJ_RECIP_BITS >> 1) >> SGRPROJ_RECIP_BITS;
+    for xi in cmp::max(-(r as isize), -stripe_x)..xn {
+      let c:i32 = src_plane.p((xi + stripe_x) as usize, ly).as_();
+      ssq += c*c;
+      sum += c;
+    }
+    for _xi in xn..r as isize + 1 {
+      let c:i32 = src_plane.p(crop_w - 1, ly).as_();
+      ssq += c*c;
+      sum += c;
+    }
+  }
+  let (reta, retb) = sgrproj_sum_finish(ssq, sum, n, one_over_n, s, bit_depth);
+  *a = reta;
+  *b = retb;
+}
+
+// unrolled computation to be used when all bounds-checking has been pre-satisfied.
+fn sgrproj_box_sum_fastxy_r1<T: Pixel>(a: &mut i32, b: &mut i32, stripe_x: isize, stripe_y: isize,
+                                       s: i32, p: &Plane<T>, bit_depth: usize) {
+  let mut ssq:i32 = 0;
+  let mut sum:i32 = 0;
+  for yi in -1..=1 {
+    let x = p.slice(&PlaneOffset{x: stripe_x - 1, y: stripe_y + yi}).as_slice();
+    ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
+      i32::cast_from(x[1]) * i32::cast_from(x[1]) +
+      i32::cast_from(x[2]) * i32::cast_from(x[2]);
+    sum += i32::cast_from(x[0]) + i32::cast_from(x[1]) + i32::cast_from(x[2]);
+  }
+  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 9, 455, s, bit_depth);
+  *a = reta;
+  *b = retb;
+}
+
+fn sgrproj_box_sum_fastxy_r2<T: Pixel>(a: &mut i32, b: &mut i32, stripe_x: isize, stripe_y: isize,
+                                       s: i32, p: &Plane<T>, bit_depth: usize) {
+  let mut ssq:i32 = 0;
+  let mut sum:i32 = 0;
+  for yi in -2..=2 {
+    let x = p.slice(&PlaneOffset{x: stripe_x - 2, y: stripe_y + yi}).as_slice();
+    ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
+      i32::cast_from(x[1]) * i32::cast_from(x[1]) +
+      i32::cast_from(x[2]) * i32::cast_from(x[2]) +
+      i32::cast_from(x[3]) * i32::cast_from(x[3]) +
+      i32::cast_from(x[4]) * i32::cast_from(x[4]);
+    sum += i32::cast_from(x[0]) + i32::cast_from(x[1]) + i32::cast_from(x[2]) +
+      i32::cast_from(x[3]) + i32::cast_from(x[4]);
+  }
+  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 25, 164, s, bit_depth);
+  *a = reta;
+  *b = retb;
+}
+
+// unrolled computation to be used when X bounds-checking has been pre-satisfied.
+fn sgrproj_box_sum_fastx_r1<T: Pixel>(a: &mut i32, b: &mut i32, row: isize,
+                                      crop_h: usize, stripe_h: usize,
+                                      stripe_x: isize, stripe_y: isize,
+                                      s: i32, cdeffed: &Plane<T>, deblocked: &Plane<T>,
+                                      bit_depth: usize) {  
+  let mut ssq:i32 = 0;
+  let mut sum:i32 = 0;
+  for yi in row-1 as isize..=row+1 as isize {
+    let p = if yi >= 0 && yi < stripe_h as isize {cdeffed} else {deblocked};
+    let ly = clamp(clamp(yi+stripe_y, 0, crop_h as isize - 1),
+                   stripe_y - 2, stripe_y + stripe_h as isize + 1);
+    let x = p.slice(&PlaneOffset{x: stripe_x - 1, y: ly}).as_slice();
+    ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
+      i32::cast_from(x[1]) * i32::cast_from(x[1]) +
+      i32::cast_from(x[2]) * i32::cast_from(x[2]);
+    sum += i32::cast_from(x[0]) + i32::cast_from(x[1]) + i32::cast_from(x[2]);
+  }
+  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 9, 455, s, bit_depth);
+  *a = reta;
+  *b = retb;
+}
+
+fn sgrproj_box_sum_fastx_r2<T: Pixel>(a: &mut i32, b: &mut i32, row: isize,
+                                      crop_h: usize, stripe_h: usize,
+                                      stripe_x: isize, stripe_y: isize,
+                                      s: i32, cdeffed: &Plane<T>, deblocked: &Plane<T>,
+                                      bit_depth: usize) {  
+  let mut ssq:i32 = 0;
+  let mut sum:i32 = 0;
+  for yi in row-2 as isize..=row+2 as isize {
+    let p = if yi >= 0 && yi < stripe_h as isize {cdeffed} else {deblocked};
+    let ly = clamp(clamp(yi+stripe_y, 0, crop_h as isize - 1),
+                   stripe_y - 2, stripe_y + stripe_h as isize + 1);
+    let x = p.slice(&PlaneOffset{x: stripe_x - 2, y: ly}).as_slice();
+    ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
+      i32::cast_from(x[1]) * i32::cast_from(x[1]) +
+      i32::cast_from(x[2]) * i32::cast_from(x[2]) +
+      i32::cast_from(x[3]) * i32::cast_from(x[3]) +
+      i32::cast_from(x[4]) * i32::cast_from(x[4]);
+    sum += i32::cast_from(x[0]) + i32::cast_from(x[1]) + i32::cast_from(x[2]) +
+      i32::cast_from(x[3]) + i32::cast_from(x[4]);
+  }
+  let (reta, retb) = sgrproj_sum_finish(ssq, sum, 25, 164, s, bit_depth);
+  *a = reta;
+  *b = retb;
+}
+
+// r=1 case computes every row as every row is used (see r2 version below)
+fn sgrproj_box_ab_r1<T: Pixel>(af: &mut[i32; 64+2],
+                               bf: &mut[i32; 64+2],
+                               s: i32,
+                               crop_w: usize, crop_h: usize, stripe_h: usize,
+                               stripe_x: isize, stripe_y: isize,
+                               cdeffed: &Plane<T>, deblocked: &Plane<T>, bit_depth: usize) {
+  let boundary0 = cmp::max(0, -stripe_y) as usize;
+  let boundary3 = stripe_h + 2;
+  if stripe_x > 1 && stripe_x < crop_w as isize - 2 {
+    // Away from left and right edges; no X clipping to worry about,
+    // but top/bottom few rows still need to worry about Y
+    let boundary1 = cmp::max(3, 3-stripe_y) as usize;
+    let boundary2 = cmp::min(crop_h as isize - stripe_y - 1, stripe_h as isize - 1) as usize;
+
+    // top rows, away from left and right columns
+    for i in boundary0..boundary1 {
+      sgrproj_box_sum_fastx_r1(&mut af[i], &mut bf[i], i as isize - 1, crop_h, stripe_h,
+                           stripe_x, stripe_y, s, cdeffed, deblocked, bit_depth);
+    }
+    // middle rows, away from left and right columns
+    for i in boundary1..boundary2 {
+      sgrproj_box_sum_fastxy_r1(&mut af[i], &mut bf[i],
+                            stripe_x, stripe_y + i as isize - 1, s, cdeffed, bit_depth);
+    }
+    // bottom rows, away from left and right columns
+    for i in boundary2..boundary3 {
+      sgrproj_box_sum_fastx_r1(&mut af[i], &mut bf[i], i as isize - 1, crop_h, stripe_h,
+                           stripe_x, stripe_y, s, cdeffed, deblocked, bit_depth);
+    }
+  } else {
+    // top/bottom rows and left/right columns, where we need to worry about frame and stripe clipping
+    for i in boundary0..boundary3 {
+      sgrproj_box_sum_slow(&mut af[i], &mut bf[i], i as isize - 1, 1, crop_w, crop_h, stripe_h,
+                           stripe_x, stripe_y, 9, 455, s, cdeffed, deblocked, bit_depth);
+    }
   }
 }
 
-fn sgrproj_box_f<T: Pixel>(
-  af: &[&[i32; 64+2]; 3],
-  bf: &[&[i32; 64+2]; 3],
-  f: &mut[i32; 64],
-  x: usize,
-  y: isize,
-  h: isize,
-  cdeffed: &Plane<T>,
-  pass: usize,
-) {
-  for i in 0..h as usize {
-    let shift = if pass == 0 && (i&1) == 1 {4} else {5} + SGRPROJ_SGR_BITS - SGRPROJ_RST_BITS;
-    let mut a = 0;
-    let mut b = 0;
-    for dy in 0..=2 {
-      for dx in 0..=2 {
-        let weight = if pass == 0 {
-          if ((i+dy) & 1) == 0 {
-            if dx == 1 {
-              6
-            } else {
-              5
-            }
-          } else {
-            0
-          }
-        } else {
-          if dx == 1 || dy == 1 {
-            4
-          } else {
-            3
-          }
-        };
-        a += weight * af[dx][i+dy];
-        b += weight * bf[dx][i+dy];
-      }
+// One oddness about the radius=2 intermediate array computations that
+// the spec doesn't make clear: Although the spec defines computation
+// of every row (of a, b and f), only half of the rows (every-other
+// row) are actually used.  We use the full-size array here but only
+// compute the even rows.  This is not so much optimization as trying
+// to illustrate what this convoluted filter is actually doing
+// (ie not as much as it may appear).
+fn sgrproj_box_ab_r2<T: Pixel>(af: &mut[i32; 64+2],
+                               bf: &mut[i32; 64+2],
+                               s: i32,
+                               crop_w: usize, crop_h: usize, stripe_h: usize,
+                               stripe_x: isize, stripe_y: isize,
+                               cdeffed: &Plane<T>, deblocked: &Plane<T>,
+                               bit_depth: usize) {
+  let boundary0 = cmp::max(0, -stripe_y) as usize; // always even
+  let boundary3 = stripe_h + 2; // don't care if odd
+  if stripe_x > 1 && stripe_x < crop_w as isize - 2 {
+    // make even, round up
+    let boundary1 = cmp::max(3, 3-stripe_y) as usize + 1 >> 1 << 1;
+    // must be even, rounding of +1 cancels fencepost of -1
+    let boundary2 = cmp::min(crop_h as isize - stripe_y, stripe_h as isize) as usize >> 1 << 1;
+
+    // top rows, away from left and right columns
+    for i in (boundary0..boundary1).step_by(2) {
+      sgrproj_box_sum_fastx_r2(&mut af[i], &mut bf[i], i as isize - 1, crop_h, stripe_h,
+                           stripe_x, stripe_y, s, cdeffed, deblocked, bit_depth);
     }
-    let v = a * i32::cast_from(cdeffed.p(x, (y+i as isize) as usize)) + b;
+    // middle rows, away from left and right columns
+    for i in (boundary1..boundary2).step_by(2) {
+      sgrproj_box_sum_fastxy_r2(&mut af[i], &mut bf[i],
+                            stripe_x, stripe_y + i as isize - 1, s, cdeffed, bit_depth);
+    }
+    // bottom rows, away from left and right columns
+    for i in (boundary2..boundary3).step_by(2) {
+      sgrproj_box_sum_fastx_r2(&mut af[i], &mut bf[i], i as isize - 1, crop_h, stripe_h,
+                           stripe_x, stripe_y, s, cdeffed, deblocked, bit_depth);
+    }
+  } else {
+    // top/bottom rows and left/right columns, where we need to worry about frame and stripe clipping
+    for i in (boundary0..boundary3).step_by(2) {
+      sgrproj_box_sum_slow(&mut af[i], &mut bf[i], i as isize - 1, 2, crop_w, crop_h, stripe_h,
+                           stripe_x, stripe_y, 25, 164, s, cdeffed, deblocked, bit_depth);
+    }
+  }
+}
+
+fn sgrproj_box_f_r0<T: Pixel>(f: &mut[i32; 64], x: usize, y: isize, h: usize, cdeffed: &Plane<T>) {
+  for i in cmp::max(0, -y) as usize..h {
+    f[i as usize] = (i32::cast_from(cdeffed.p(x, (y + i as isize) as usize))) << SGRPROJ_RST_BITS;
+  }
+}
+
+fn sgrproj_box_f_r1<T: Pixel>(af: &[&[i32; 64+2]; 3], bf: &[&[i32; 64+2]; 3], f: &mut[i32; 64],
+                              x: usize, y: isize, h: usize, cdeffed: &Plane<T>) {
+  let shift = 5 + SGRPROJ_SGR_BITS - SGRPROJ_RST_BITS;
+  for i in cmp::max(0, -y) as usize..h {
+    let a =
+      3 * (af[0][i+0] + af[2][i+0] + af[0][i+2] + af[2][i+2]) +
+      4 * (af[1][i+0] + af[0][i+1] + af[1][i+1] + af[2][i+1] + af[1][i+2]);
+    let b =
+      3 * (bf[0][i+0] + bf[2][i+0] + bf[0][i+2] + bf[2][i+2]) +
+      4 * (bf[1][i+0] + bf[0][i+1] + bf[1][i+1] + bf[2][i+1] + bf[1][i+2]);
+    let v = a * i32::cast_from(cdeffed.p(x, (y + i as isize) as usize)) + b;
     f[i as usize] = v + (1 << shift >> 1) >> shift;
   }
 }
 
-fn sgrproj_stripe_rdu<T: Pixel>(
-  set: u8,
-  xqd: [i8; 2],
-  fi: &FrameInvariants<T>,
-  crop_w: usize,
-  crop_h: usize,
-  stripe_w: usize,
-  stripe_h: isize,
-  stripe_x: usize,
-  stripe_y: isize,
-  cdeffed: &Plane<T>,
-  deblocked: &Plane<T>,
-  out: &mut Plane<T>,
-) {
-  assert!(stripe_h <= 64);
-  let mut a0: [[i32; 64+2]; 3] = [[0; 64+2]; 3];
-  let mut a1: [[i32; 64+2]; 3] = [[0; 64+2]; 3];
-  let mut b0: [[i32; 64+2]; 3] = [[0; 64+2]; 3];
-  let mut b1: [[i32; 64+2]; 3] = [[0; 64+2]; 3];
-  let mut f0: [i32; 64] = [0; 64];
-  let mut f1: [i32; 64] = [0; 64];
+fn sgrproj_box_f_r2<T: Pixel>(af: &[&[i32; 64+2]; 3], bf: &[&[i32; 64+2]; 3], f: &mut[i32; 64],
+                              x: usize, y: isize, h: usize, cdeffed: &Plane<T>) {
+  let shift = 5 + SGRPROJ_SGR_BITS - SGRPROJ_RST_BITS;
+  let shifto = 4 + SGRPROJ_SGR_BITS - SGRPROJ_RST_BITS;
+  for i in (cmp::max(0, -y) as usize..h).step_by(2) {
+    let a =
+      5 * (af[0][i+0] + af[2][i+0]) + 
+      6 * (af[1][i+0]);
+    let b =
+      5 * (bf[0][i+0] + bf[2][i+0]) + 
+      6 * (bf[1][i+0]);
+    let ao =
+      5 * (af[0][i+2] + af[2][i+2]) + 
+      6 * (af[1][i+2]);
+    let bo =
+      5 * (bf[0][i+2] + bf[2][i+2]) + 
+      6 * (bf[1][i+2]);
+    let v = (a + ao) * i32::cast_from(cdeffed.p(x, (y+i as isize) as usize)) + b + bo;
+    f[i as usize] = v + (1 << shift >> 1) >> shift;
+    let vo = ao * i32::cast_from(cdeffed.p(x, (y + i as isize) as usize + 1)) + bo;
+    f[i as usize + 1] = vo + (1 << shifto >> 1) >> shifto;
+  }
+}
 
-  let r0: u8 = SGRPROJ_PARAMS_RADIUS[set as usize][0];
-  let r1: u8 = SGRPROJ_PARAMS_RADIUS[set as usize][1];
-  let eps0: u8 = SGRPROJ_PARAMS_EPS[set as usize][0];
-  let eps1: u8 = SGRPROJ_PARAMS_EPS[set as usize][1];
+fn sgrproj_stripe_filter<T: Pixel>(set: u8, xqd: [i8; 2], fi: &FrameInvariants<T>,
+                                   crop_w: usize, crop_h: usize,
+                                   stripe_w: usize, stripe_h: usize,
+                                   stripe_x: usize, stripe_y: isize,
+                                   cdeffed: &Plane<T>, deblocked: &Plane<T>, out: &mut Plane<T>) {
+
+  assert!(stripe_h <= 64);
+  let mut a_r2: [[i32; 64+2]; 3] = [[0; 64+2]; 3];
+  let mut b_r2: [[i32; 64+2]; 3] = [[0; 64+2]; 3];
+  let mut f_r2: [i32; 64] = [0; 64];
+  let mut a_r1: [[i32; 64+2]; 3] = [[0; 64+2]; 3];
+  let mut b_r1: [[i32; 64+2]; 3] = [[0; 64+2]; 3];
+  let mut f_r1: [i32; 64] = [0; 64];
+
+  let s_r2: i32 = SGRPROJ_PARAMS_S[set as usize][0];
+  let s_r1: i32 = SGRPROJ_PARAMS_S[set as usize][1];
 
   /* prime the intermediate arrays */
-  if r0 > 0 {
-    sgrproj_box_ab(&mut a0[0], &mut b0[0], r0 as isize, eps0 as isize,
+  if s_r2 > 0 {
+    sgrproj_box_ab_r2(&mut a_r2[0], &mut b_r2[0], s_r2,
                    crop_w, crop_h, stripe_h,
                    stripe_x as isize - 1, stripe_y,
                    cdeffed, deblocked, fi.sequence.bit_depth);
-    sgrproj_box_ab(&mut a0[1], &mut b0[1], r0 as isize, eps0 as isize,
+    sgrproj_box_ab_r2(&mut a_r2[1], &mut b_r2[1], s_r2,
                    crop_w, crop_h, stripe_h,
                    stripe_x as isize, stripe_y,
                    cdeffed, deblocked, fi.sequence.bit_depth);
   }
-  if r1 > 0 {
-    sgrproj_box_ab(&mut a1[0], &mut b1[0], r1 as isize, eps1 as isize,
-                   crop_w, crop_h, stripe_h,
-                   stripe_x as isize - 1, stripe_y,
-                   cdeffed, deblocked, fi.sequence.bit_depth);
-    sgrproj_box_ab(&mut a1[1], &mut b1[1], r1 as isize, eps1 as isize,
-                   crop_w, crop_h, stripe_h,
-                   stripe_x as isize, stripe_y,
-                   cdeffed, deblocked, fi.sequence.bit_depth);
+  if s_r1 > 0 {
+    sgrproj_box_ab_r1(&mut a_r1[0], &mut b_r1[0], s_r1,
+                      crop_w, crop_h, stripe_h,
+                      stripe_x as isize - 1, stripe_y,
+                      cdeffed, deblocked, fi.sequence.bit_depth);
+    sgrproj_box_ab_r1(&mut a_r1[1], &mut b_r1[1], s_r1,
+                      crop_w, crop_h, stripe_h,
+                      stripe_x as isize, stripe_y,
+                      cdeffed, deblocked, fi.sequence.bit_depth);
   }
 
   /* iterate by column */
@@ -242,74 +379,49 @@ fn sgrproj_stripe_rdu<T: Pixel>(
   let out_data = out_slice.as_mut_slice();
   for xi in 0..stripe_w {
     /* build intermediate array columns */
-    if r0 > 0 {
-      sgrproj_box_ab(&mut a0[(xi+2)%3], &mut b0[(xi+2)%3], r0 as isize, eps0 as isize,
+    if s_r2 > 0 {
+      sgrproj_box_ab_r2(&mut a_r2[(xi+2)%3], &mut b_r2[(xi+2)%3], s_r2,
                      crop_w, crop_h, stripe_h,
                      (stripe_x + xi + 1) as isize, stripe_y,
                      cdeffed, deblocked, fi.sequence.bit_depth);
-      let ap0: [&[i32; 64+2]; 3] = [&a0[xi%3], &a0[(xi+1)%3], &a0[(xi+2)%3]];
-      let bp0: [&[i32; 64+2]; 3] = [&b0[xi%3], &b0[(xi+1)%3], &b0[(xi+2)%3]];
-      sgrproj_box_f(&ap0, &bp0, &mut f0, stripe_x + xi, stripe_y, stripe_h, cdeffed, 0);
-    }
-    if r1 > 0 {
-      sgrproj_box_ab(&mut a1[(xi+2)%3], &mut b1[(xi+2)%3], r1 as isize, eps1 as isize,
-                     crop_w, crop_h, stripe_h,
-                     (stripe_x + xi + 1) as isize, stripe_y,
-                     cdeffed, deblocked, fi.sequence.bit_depth);
-      let ap1: [&[i32; 64+2]; 3] = [&a1[xi%3], &a1[(xi+1)%3], &a1[(xi+2)%3]];
-      let bp1: [&[i32; 64+2]; 3] = [&b1[xi%3], &b1[(xi+1)%3], &b1[(xi+2)%3]];
-
-      sgrproj_box_f(&ap1, &bp1, &mut f1, stripe_x + xi, stripe_y, stripe_h, cdeffed, 1);
-    }
-    let bit_depth = fi.sequence.bit_depth;
-    if r0 > 0 {
-      if r1 > 0 {
-        let w0 = xqd[0] as i32;
-        let w1 = xqd[1] as i32;
-        let w2 = (1 << SGRPROJ_PRJ_BITS) - w0 - w1;
-        for yi in start..stripe_h as usize {
-          let u = i32::cast_from(cdeffed_slice.p(xi, yi)) << SGRPROJ_RST_BITS;
-          let v = w0*f0[yi] + w1*u + w2*f1[yi];
-          let s = v + (1 << SGRPROJ_RST_BITS + SGRPROJ_PRJ_BITS >> 1) >> SGRPROJ_RST_BITS + SGRPROJ_PRJ_BITS;
-          out_data[xi + yi*outstride] = T::cast_from(clamp(u16::cast_from(s), 0, (1 << bit_depth) - 1));
-        }
-      } else {
-        let w0 = xqd[0] as i32;
-        let w = (1 << SGRPROJ_PRJ_BITS) - w0;
-        for yi in start..stripe_h as usize {
-          let u = i32::cast_from(cdeffed_slice.p(xi, yi)) << SGRPROJ_RST_BITS;
-          let v = w0*f0[yi] + w*u;
-          let s = v + (1 << SGRPROJ_RST_BITS + SGRPROJ_PRJ_BITS >> 1) >> SGRPROJ_RST_BITS + SGRPROJ_PRJ_BITS;
-          out_data[xi + yi*outstride] = T::cast_from(clamp(u16::cast_from(s), 0, (1 << bit_depth) - 1));
-        }
-      }
+      let ap0: [&[i32; 64+2]; 3] = [&a_r2[xi%3], &a_r2[(xi+1)%3], &a_r2[(xi+2)%3]];
+      let bp0: [&[i32; 64+2]; 3] = [&b_r2[xi%3], &b_r2[(xi+1)%3], &b_r2[(xi+2)%3]];
+      sgrproj_box_f_r2(&ap0, &bp0, &mut f_r2, stripe_x + xi, stripe_y, stripe_h as usize, cdeffed);
     } else {
-      /* if r0 is 0, the r1 must be nonzero */
-      let w = xqd[0] as i32 + xqd[1] as i32;
-      let w2 = (1 << SGRPROJ_PRJ_BITS) - w;
-      for yi in start..stripe_h as usize {
-        let u = i32::cast_from(cdeffed_slice.p(xi, yi)) << SGRPROJ_RST_BITS;
-        let v = w*u + w2*f1[yi];
-        let s = v + (1 << SGRPROJ_RST_BITS + SGRPROJ_PRJ_BITS >> 1) >> SGRPROJ_RST_BITS + SGRPROJ_PRJ_BITS;
-        out_data[xi + yi*outstride] = T::cast_from(clamp(u16::cast_from(s), 0, (1 << bit_depth) - 1));
-      }
+      sgrproj_box_f_r0(&mut f_r2, stripe_x + xi, stripe_y, stripe_h as usize, cdeffed);
+    }
+    if s_r1 > 0 {
+      sgrproj_box_ab_r1(&mut a_r1[(xi+2)%3], &mut b_r1[(xi+2)%3], s_r1,
+                        crop_w, crop_h, stripe_h,
+                        (stripe_x + xi + 1) as isize, stripe_y,
+                        cdeffed, deblocked, fi.sequence.bit_depth);
+      let ap1: [&[i32; 64+2]; 3] = [&a_r1[xi%3], &a_r1[(xi+1)%3], &a_r1[(xi+2)%3]];
+      let bp1: [&[i32; 64+2]; 3] = [&b_r1[xi%3], &b_r1[(xi+1)%3], &b_r1[(xi+2)%3]];
+
+      sgrproj_box_f_r1(&ap1, &bp1, &mut f_r1, stripe_x + xi, stripe_y, stripe_h as usize, cdeffed);
+    } else {
+      sgrproj_box_f_r0(&mut f_r1, stripe_x + xi, stripe_y, stripe_h as usize, cdeffed);
+    }
+
+    /* apply filter */
+    let bit_depth = fi.sequence.bit_depth;
+    let w0 = xqd[0] as i32;
+    let w1 = xqd[1] as i32;
+    let w2 = (1 << SGRPROJ_PRJ_BITS) - w0 - w1;
+    for yi in start..stripe_h as usize {
+      let u = i32::cast_from(cdeffed_slice.p(xi, yi)) << SGRPROJ_RST_BITS;
+      let v = w0*f_r2[yi] + w1*u + w2*f_r1[yi];
+      let s = v + (1 << SGRPROJ_RST_BITS + SGRPROJ_PRJ_BITS >> 1) >> SGRPROJ_RST_BITS + SGRPROJ_PRJ_BITS;
+      out_data[xi + yi*outstride] = T::cast_from(clamp(s, 0, (1 << bit_depth) - 1));
     }
   }
 }
 
-fn wiener_stripe_rdu<T: Pixel>(
-  coeffs: [[i8; 3]; 2],
-  fi: &FrameInvariants<T>,
-  crop_w: usize,
-  crop_h: usize,
-  stripe_w: usize,
-  stripe_h: isize,
-  stripe_x: usize,
-  stripe_y: isize,
-  cdeffed: &Plane<T>,
-  deblocked: &Plane<T>,
-  out: &mut Plane<T>
-) {
+fn wiener_stripe_filter<T: Pixel>(coeffs: [[i8; 3]; 2], fi: &FrameInvariants<T>,
+                      crop_w: usize, crop_h: usize,
+                      stripe_w: usize, stripe_h: usize,
+                      stripe_x: usize, stripe_y: isize,
+                      cdeffed: &Plane<T>, deblocked: &Plane<T>, out: &mut Plane<T>) {
   let bit_depth = fi.sequence.bit_depth;
   let round_h = if bit_depth == 12 {5} else {3};
   let round_v = if bit_depth == 12 {9} else {11};
@@ -340,10 +452,10 @@ fn wiener_stripe_rdu<T: Pixel>(
   // starts off the top of the frame by 8 pixels, and can also run off the end of the frame
   let start_wi = if stripe_y < 0 {-stripe_y} else {0} as usize;
   let start_yi = if stripe_y < 0 {0} else {stripe_y} as usize;
-  let end_i = cmp::max(0, if stripe_y + stripe_h > crop_h as isize {
+  let end_i = cmp::max(0, if stripe_h as isize + stripe_y > crop_h as isize {
     crop_h as isize - stripe_y - start_wi as isize
   } else {
-    stripe_h - start_wi as isize
+    stripe_h as isize - start_wi as isize
   }) as usize;
 
   let stride = out.cfg.stride;
@@ -352,18 +464,18 @@ fn wiener_stripe_rdu<T: Pixel>(
 
   for xi in stripe_x..stripe_x+stripe_w {
     let n = cmp::min(7, crop_w as isize + 3 - xi as isize);
-    for yi in stripe_y-3..stripe_y+stripe_h+4 {
+    for yi in stripe_y - 3..stripe_y + stripe_h as isize + 4 {
       let src_plane: &Plane<T>;
       let mut acc = 0;
       let ly;
       if yi < stripe_y {
         ly = cmp::max(clamp(yi, 0, crop_h as isize - 1), stripe_y - 2) as usize;
         src_plane = deblocked;
-      } else if yi < stripe_y+stripe_h {
+      } else if yi < stripe_y+stripe_h as isize {
         ly = clamp(yi, 0, crop_h as isize - 1) as usize;
         src_plane = cdeffed;
       } else {
-        ly = cmp::min(clamp(yi, 0, crop_h as isize - 1), stripe_y + stripe_h + 1) as usize;
+        ly = cmp::min(clamp(yi, 0, crop_h as isize - 1), stripe_y + stripe_h as isize + 1) as usize;
         src_plane = deblocked;
       }
 
@@ -524,10 +636,6 @@ impl RestorationState {
     self.plane[pli].restoration_unit_as_mut(sbo)
   }
 
-  pub fn lrf_optimize_superblock<T: Pixel>(&mut self, _sbo: &SuperBlockOffset, _fi: &FrameInvariants<T>,
-                                           _cw: &mut ContextWriter) {
-  }
-
   pub fn lrf_filter_frame<T: Pixel>(&mut self, out: &mut Frame<T>, pre_cdef: &Frame<T>,
                                     fi: &FrameInvariants<T>) {
     let cdeffed = out.clone();
@@ -563,21 +671,21 @@ impl RestorationState {
           };
           let ru = rp.restoration_unit_by_stripe(si, rux);
           match ru.filter {
-            RestorationFilter::Wiener{coeffs} => {
-              wiener_stripe_rdu(coeffs, fi,
-                                crop_w, crop_h,
-                                ru_size, stripe_size,
-                                ru_start_x, stripe_start_y,
-                                &cdeffed.planes[pli], &pre_cdef.planes[pli],
-                                &mut out.planes[pli]);
+            RestorationFilter::Wiener{coeffs} => {          
+              wiener_stripe_filter(coeffs, fi,
+                                   crop_w, crop_h,
+                                   ru_size, stripe_size,
+                                   ru_start_x, stripe_start_y,
+                                   &cdeffed.planes[pli], &pre_cdef.planes[pli],
+                                   &mut out.planes[pli]);
             },
             RestorationFilter::Sgrproj{set, xqd} => {
-              sgrproj_stripe_rdu(set, xqd, fi,
-                                 crop_w, crop_h,
-                                 ru_size, stripe_size,
-                                 ru_start_x, stripe_start_y,
-                                 &cdeffed.planes[pli], &pre_cdef.planes[pli],
-                                 &mut out.planes[pli]);
+              sgrproj_stripe_filter(set, xqd, fi,
+                                    crop_w, crop_h,
+                                    ru_size, stripe_size,
+                                    ru_start_x, stripe_start_y,
+                                    &cdeffed.planes[pli], &pre_cdef.planes[pli],
+                                    &mut out.planes[pli]);
             },
             RestorationFilter::None => {
               // do nothing

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -134,20 +134,16 @@ fn sgrproj_box_sum_slow<T: Pixel>(a: &mut i32, b: &mut i32,
   let mut sum:i32 = 0;
 
   for yi in y-r as isize..=y+r as isize {
-    let src_plane;
-    let src_w;
-    let src_h;
-    
     // decide if we're vertically inside or outside the stripe
-    if yi >= stripe_y && yi < stripe_y + stripe_h as isize {
-      src_plane = cdeffed;
-      src_w = (cdeffed_w as isize - x + r as isize) as usize;
-      src_h = cdeffed_h as isize;
+    let (src_plane, src_w, src_h) = if yi >= stripe_y && yi < stripe_y + stripe_h as isize {
+      (cdeffed, 
+       (cdeffed_w as isize - x + r as isize) as usize,
+       cdeffed_h as isize)
     } else {
-      src_plane = backing;
-      src_w = (backing_w as isize - x + r as isize) as usize;
-      src_h = backing_h as isize;
-    }
+      (backing,
+       (backing_w as isize - x + r as isize) as usize,
+       backing_h as isize)
+    };
     // clamp vertically to storage at top and passed-in height at bottom 
     let cropped_y = clamp(yi, -src_plane.y, src_h - 1);
     // clamp vertically to stripe limits
@@ -172,7 +168,7 @@ fn sgrproj_box_sum_slow<T: Pixel>(a: &mut i32, b: &mut i32,
       sum += c;
     }
     // run accumulation to right of frame (if any)
-    for _xi in right..2*r+1 {
+    for _xi in right..=2*r {
       let c = i32::cast_from(p[src_w - 1]);
       ssq += c*c;
       sum += c;
@@ -229,17 +225,14 @@ fn sgrproj_box_sum_fastx_r1<T: Pixel>(a: &mut i32, b: &mut i32,
   let mut ssq:i32 = 0;
   let mut sum:i32 = 0;
   for yi in y-1..=y+1 {
-    let src_plane;
-    let src_h;
-    
     // decide if we're vertically inside or outside the stripe
-    if yi >= stripe_y && yi < stripe_y + stripe_h as isize {
-      src_plane = cdeffed;
-      src_h = cdeffed_h as isize;
+    let (src_plane, src_h) = if yi >= stripe_y && yi < stripe_y + stripe_h as isize {
+      (cdeffed,
+       cdeffed_h as isize)
     } else {
-      src_plane = backing;
-      src_h = backing_h as isize;
-    }
+      (backing,
+       backing_h as isize)
+    };
     // clamp vertically to storage addressing limit
     let cropped_y = clamp(yi, -src_plane.y, src_h - 1);
     // clamp vertically to stripe limits
@@ -264,17 +257,14 @@ fn sgrproj_box_sum_fastx_r2<T: Pixel>(a: &mut i32, b: &mut i32,
   let mut ssq:i32 = 0;
   let mut sum:i32 = 0;
   for yi in y - 2..=y + 2 {
-    let src_plane;
-    let src_h;
-    
     // decide if we're vertically inside or outside the stripe
-    if yi >= stripe_y && yi < stripe_y + stripe_h as isize {
-      src_plane = cdeffed;
-      src_h = cdeffed_h as isize;
+    let (src_plane, src_h) = if yi >= stripe_y && yi < stripe_y + stripe_h as isize {
+      (cdeffed,
+       cdeffed_h as isize)
     } else {
-      src_plane = backing;
-      src_h = backing_h as isize;
-    }
+      (backing,
+       backing_h as isize)
+    };
     // clamp vertically to storage addressing limit
     let cropped_y = clamp(yi, -src_plane.y, src_h as isize - 1);
     // clamp vertically to stripe limits

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -71,14 +71,14 @@ impl RestorationFilter {
 fn sgrproj_sum_finish(ssq: i32, sum: i32, n: i32, one_over_n: i32, s: i32, bdm8: usize) -> (i32, i32) {
   let scaled_ssq = ssq + (1 << 2*bdm8 >> 1) >> 2*bdm8;
   let scaled_sum = sum + (1 << bdm8 >> 1) >> bdm8;
-  let p = cmp::max(0, scaled_ssq*(n as i32) - scaled_sum*scaled_sum);
-  let z = p*s + (1 << SGRPROJ_MTABLE_BITS >> 1) >> SGRPROJ_MTABLE_BITS;
-  let a = if z >= 255 {
+  let p = cmp::max(0, scaled_ssq*(n as i32) - scaled_sum*scaled_sum) as u32;
+  let z = p*s as u32 + (1 << SGRPROJ_MTABLE_BITS >> 1) >> SGRPROJ_MTABLE_BITS;
+  let a:i32 = if z >= 255 {
     256
   } else if z == 0 {
     1
   } else {
-    ((z << SGRPROJ_SGR_BITS) + z/2) / (z+1)
+    (((z << SGRPROJ_SGR_BITS) + z/2) / (z+1)) as i32
   };
   let b = ((1 << SGRPROJ_SGR_BITS) - a ) * sum * one_over_n;
   (a, b + (1 << SGRPROJ_RECIP_BITS >> 1) >> SGRPROJ_RECIP_BITS)

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -358,6 +358,14 @@ impl<'a, T: Pixel> PlaneSlice<'a, T> {
     }
   }
 
+  pub fn reslice(&self, xo: isize, yo: isize) -> PlaneSlice<'a, T> {
+    PlaneSlice {
+      plane: self.plane,
+      x: self.x + xo,
+      y: self.y + yo
+    }
+  }
+
   /// A slice starting i pixels above the current one.
   pub fn go_up(&self, i: usize) -> PlaneSlice<'a, T> {
     PlaneSlice { plane: self.plane, x: self.x, y: self.y - i as isize }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1189,6 +1189,17 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
     lrf_output = cdef_sb_frame(fi, &fs.rec);
   }
 
+  let mut lrf_any_uncoded = false;
+  if fi.sequence.enable_restoration {
+    for pli in 0..PLANES {
+      let ru = fs.restoration.plane[pli].restoration_unit(sbo);
+      if !ru.coded {
+        lrf_any_uncoded = true;
+        break;
+      }
+    }
+  }
+
   // CDEF/LRF decision iteration
   // Start with a default of CDEF 0 and RestorationFilter::None
   // Try all CDEF options with current LRF; if new CDEF+LRF choice is better, select it.
@@ -1254,7 +1265,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
     
     // check for new best restoration filter if enabled
     let mut lrf_change = false;
-    if fi.sequence.enable_restoration {
+    if fi.sequence.enable_restoration && lrf_any_uncoded {
       // need cdef output from best index, not just last iteration
       if fi.sequence.enable_cdef {
         cdef_filter_superblock(fi, &mut cdef_input, &mut lrf_input,
@@ -1265,32 +1276,35 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
 
       // SgrProj LRF decision
       for pli in 0..3 {
-        for set in 0..16 {
-          let in_plane = &fs.input.planes[pli];  // reference
-          let ipo = &sbo.plane_offset(&in_plane.cfg);
-          let cdef_plane = &lrf_input.planes[pli];
-          let (xqd0, xqd1) = sgrproj_solve(set, fi,
-                                           &in_plane.slice(ipo),
-                                           &cdef_plane.slice(&PlaneOffset{x: 0, y: 0}),
-                                           cmp::min(cdef_plane.cfg.width, fi.width - ipo.x as usize),
-                                           cmp::min(cdef_plane.cfg.height, fi.height - ipo.y as usize));
-          let current_lrf = RestorationFilter::Sgrproj{set: set, xqd: [xqd0, xqd1]};
-          if let RestorationFilter::Sgrproj{set, xqd} = current_lrf {
-            // At present, this is a gross simplification
-            sgrproj_stripe_filter(set, xqd, fi,
-                                  lrf_input.planes[pli].cfg.width, lrf_input.planes[pli].cfg.height,
-                                  lrf_input.planes[pli].cfg.width, lrf_input.planes[pli].cfg.height,
-                                  &lrf_input.planes[pli].slice(&PlaneOffset{x:0, y:0}),
-                                  &lrf_input.planes[pli].slice(&PlaneOffset{x:0, y:0}),
-                                  &mut lrf_output.planes[pli].mut_slice(&PlaneOffset{x:0, y:0}));
-          }
-          let err = rdo_loop_plane_error(sbo, fi, fs, &cw.bc, &lrf_output, pli);
-          let rate = cw.count_lrf_switchable(w, &fs.restoration, &current_lrf, pli);
-          let cost = err as f64 + fi.lambda * rate as f64 / ((1<<OD_BITRES) as f64);
-          if best_cost[pli] < 0. || cost < best_cost[pli] {
-            best_cost[pli] = cost;
-            best_lrf[pli] = current_lrf;
-            lrf_change = true;
+        let ru = fs.restoration.plane[pli].restoration_unit(sbo);
+        if !ru.coded {
+          for set in 0..16 {
+            let in_plane = &fs.input.planes[pli];  // reference
+            let ipo = &sbo.plane_offset(&in_plane.cfg);
+            let cdef_plane = &lrf_input.planes[pli];
+            let (xqd0, xqd1) = sgrproj_solve(set, fi,
+                                             &in_plane.slice(ipo),
+                                             &cdef_plane.slice(&PlaneOffset{x: 0, y: 0}),
+                                             cmp::min(cdef_plane.cfg.width, fi.width - ipo.x as usize),
+                                             cmp::min(cdef_plane.cfg.height, fi.height - ipo.y as usize));
+            let current_lrf = RestorationFilter::Sgrproj{set: set, xqd: [xqd0, xqd1]};
+            if let RestorationFilter::Sgrproj{set, xqd} = current_lrf {
+              // At present, this is a gross simplification
+              sgrproj_stripe_filter(set, xqd, fi,
+                                    lrf_input.planes[pli].cfg.width, lrf_input.planes[pli].cfg.height,
+                                    lrf_input.planes[pli].cfg.width, lrf_input.planes[pli].cfg.height,
+                                    &lrf_input.planes[pli].slice(&PlaneOffset{x:0, y:0}),
+                                    &lrf_input.planes[pli].slice(&PlaneOffset{x:0, y:0}),
+                                    &mut lrf_output.planes[pli].mut_slice(&PlaneOffset{x:0, y:0}));
+            }
+            let err = rdo_loop_plane_error(sbo, fi, fs, &cw.bc, &lrf_output, pli);
+            let rate = cw.count_lrf_switchable(w, &fs.restoration, &current_lrf, pli);
+            let cost = err as f64 + fi.lambda * rate as f64 / ((1<<OD_BITRES) as f64);
+            if best_cost[pli] < 0. || cost < best_cost[pli] {
+              best_cost[pli] = cost;
+              best_lrf[pli] = current_lrf;
+              lrf_change = true;
+            }
           }
         }
       }
@@ -1316,7 +1330,10 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
 
   if fi.sequence.enable_restoration {
     for pli in 0..PLANES {
-      fs.restoration.plane[pli].restoration_unit_as_mut(sbo).filter = best_lrf[pli];
+      let ru = fs.restoration.plane[pli].restoration_unit_as_mut(sbo);
+      if !ru.coded {
+        ru.filter = best_lrf[pli];
+      }
     }
   }
 }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -12,6 +12,7 @@
 
 use crate::api::*;
 use crate::cdef::*;
+use crate::lrf::*;
 use crate::context::*;
 use crate::ec::{OD_BITRES, Writer, WriterCounter};
 use crate::header::ReferenceMode;
@@ -20,6 +21,7 @@ use crate::encode_block_b;
 use crate::encode_block_with_modes;
 use crate::FrameInvariants;
 use crate::FrameState;
+use crate::Frame;
 use crate::luma_ac;
 use crate::me::*;
 use crate::motion_compensate;
@@ -32,6 +34,7 @@ use crate::write_tx_tree;
 use crate::util::{CastFromPrimitive, Pixel};
 
 use std;
+use std::cmp;
 use std::vec::Vec;
 use crate::partition::PartitionType::*;
 
@@ -1120,69 +1123,200 @@ pub fn rdo_partition_decision<T: Pixel>(
   }
 }
 
-pub fn rdo_cdef_decision<T: Pixel>(
-  sbo: &SuperBlockOffset, fi: &FrameInvariants<T>,
-  fs: &FrameState<T>, cw: &mut ContextWriter
-) -> u8 {
-  // Construct a single-superblock-sized frame to test-filter into
+fn rdo_loop_plane_error<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<T>,
+                                  fs: &FrameState<T>, bc: &BlockContext,
+                                  test: &Frame<T>, pli: usize) -> u64 {
   let sbo_0 = SuperBlockOffset { x: 0, y: 0 };
-  let bc = &mut cw.bc;
-  let mut cdef_output = cdef_sb_frame(fi, &fs.rec);
-  let mut rec_input = cdef_sb_padded_frame_copy(fi, sbo, &fs.rec, 2);
+  let sb_blocks = if fi.sequence.use_128x128_superblock {16} else {8};  
+  // Each direction block is 8x8 in y, potentially smaller if subsampled in chroma
+  // accumulating in-frame and unpadded
+  let mut err:u64 = 0;
+  for by in 0..sb_blocks {
+    for bx in 0..sb_blocks {
+      let bo = sbo.block_offset(bx<<1, by<<1);
+      if bo.x < bc.cols && bo.y < bc.rows {
+        let skip = bc.at(&bo).skip;
+        if !skip {
+          let in_plane = &fs.input.planes[pli];
+          let in_po = sbo.block_offset(bx<<1, by<<1).plane_offset(&in_plane.cfg);
+          let in_slice = in_plane.slice(&in_po);
 
-  // RDO comparisons
-  let sb_blocks = if fi.sequence.use_128x128_superblock {16} else {8};
-  let mut best_index: u8 = 0;
-  let mut best_err: u64 = 0;
-  let cdef_dirs = cdef_analyze_superblock(&mut rec_input, bc, &sbo_0, &sbo, fi.sequence.bit_depth);
-  for cdef_index in 0..(1<<fi.cdef_bits) {
-    //for p in 0..3 {
-    //    for i in 0..cdef_output.planes[p].data.len() { cdef_output.planes[p].data[i] = CDEF_VERY_LARGE; }
-    //}
-    // TODO: Don't repeat find_direction over and over; split filter_superblock to run it separately
-    cdef_filter_superblock(fi, &mut rec_input, &mut cdef_output,
-                           bc, &sbo_0, &sbo, cdef_index, &cdef_dirs);
+          let test_plane = &test.planes[pli];
+          let test_po = sbo_0.block_offset(bx<<1, by<<1).plane_offset(&test_plane.cfg);
+          let test_slice = &test_plane.slice(&test_po);
 
-    // Rate is constant, compute just distortion
-    // Computation is block by block, paying attention to skip flag
+          let xdec = in_plane.cfg.xdec;
+          let ydec = in_plane.cfg.ydec;
 
-    // Each direction block is 8x8 in y, potentially smaller if subsampled in chroma
-    // We're dealing only with in-frmae and unpadded planes now
-    let mut err:u64 = 0;
-    for by in 0..sb_blocks {
-      for bx in 0..sb_blocks {
-        let bo = sbo.block_offset(bx<<1, by<<1);
-        if bo.x < bc.cols && bo.y < bc.rows {
-          let skip = bc.at(&bo).skip;
-          if !skip {
-            for p in 0..3 {
-              let in_plane = &fs.input.planes[p];
-              let in_po = sbo.block_offset(bx<<1, by<<1).plane_offset(&in_plane.cfg);
-              let in_slice = in_plane.slice(&in_po);
+          if pli==0 {
+            err += cdef_dist_wxh_8x8(&in_slice, &test_slice, fi.sequence.bit_depth);
+          } else {
+            err += sse_wxh(&in_slice, &test_slice, 8>>xdec, 8>>ydec);
+          }
+        }
+      }
+    }
+  }
+  err
+}
 
-              let out_plane = &mut cdef_output.planes[p];
-              let out_po = sbo_0.block_offset(bx<<1, by<<1).plane_offset(&out_plane.cfg);
-              let out_slice = &out_plane.slice(&out_po);
+pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<T>,
+                                   fs: &mut FrameState<T>,
+                                   cw: &mut ContextWriter, w: &mut dyn Writer) {
+  assert!(fi.sequence.enable_cdef || fi.sequence.enable_restoration);
+  // Construct a single-superblock-sized padded frame to filter from,
+  // and a single-superblock-sized padded frame to test-filter into
+  let mut best_index = -1;
+  let mut best_lrf = [RestorationFilter::None{}; PLANES];
+  let mut best_cost_acc = -1.;
+  let mut best_cost = [-1.; PLANES];
+  let sbo_0 = SuperBlockOffset { x: 0, y: 0 };
+  let mut lrf_input;
+  let mut lrf_output;
+  let mut cdef_input;
 
-              let xdec = in_plane.cfg.xdec;
-              let ydec = in_plane.cfg.ydec;
+  if fi.sequence.enable_cdef {
+    // all stages; reconstruction goes to cdef so it must be additionally padded
+    // TODO: use the new plane padding mechanism rather than this old kludge.  Will require
+    // altering CDEF code a little.
+    cdef_input = cdef_sb_padded_frame_copy(fi, sbo, &fs.rec, 2);
+    lrf_input = cdef_sb_frame(fi, &fs.rec);
+    lrf_output = cdef_sb_frame(fi, &fs.rec);
+  } else {
+    // no cdef; unpadded reconstruction offered directly to LRF optimization
+    cdef_input = cdef_empty_frame(&fs.rec);
+    lrf_input = cdef_sb_padded_frame_copy(fi, sbo, &fs.rec, 0);
+    lrf_output = cdef_sb_frame(fi, &fs.rec);
+  }
 
-              if p==0 && fi.config.tune == Tune::Psychovisual {
-                err += cdef_dist_wxh_8x8(&in_slice, &out_slice, fi.sequence.bit_depth);
-              } else {
-                err += sse_wxh(&in_slice, &out_slice, 8>>xdec, 8>>ydec);
+  // CDEF/LRF decision iteration
+  // Start with a default of CDEF 0 and RestorationFilter::None
+  // Try all CDEF options with current LRF; if new CDEF+LRF choice is better, select it.
+  // Try all LRF options with current CDEF; if new CDEF+LRF choice is better, select it.
+  // If LRF choice changed for any plane, repeat last two steps.
+  let cdef_dirs = cdef_analyze_superblock(&mut cdef_input, &mut cw.bc,
+                                          &sbo_0, &sbo, fi.sequence.bit_depth);
+  let mut first_loop = true;
+  loop {
+    // check for [new] cdef index if cdef is enabled.
+    let mut cdef_change = false;
+    let prev_best_index = best_index;
+    if fi.sequence.enable_cdef {
+      for cdef_index in 0..(1<<fi.cdef_bits) {
+        if cdef_index != prev_best_index {
+          let mut cost = [0.; PLANES];
+          let mut cost_acc = 0.;
+          cdef_filter_superblock(fi, &mut cdef_input, &mut lrf_input,
+                                 &mut cw.bc, &sbo_0, &sbo, cdef_index as u8, &cdef_dirs);
+          for pli in 0..3 {
+            match best_lrf[pli] {
+              RestorationFilter::None{} => {
+                let err = rdo_loop_plane_error(sbo, fi, fs, &cw.bc, &lrf_input, pli);
+                let rate = if fi.sequence.enable_restoration {
+                  cw.count_lrf_switchable(w, &fs.restoration, &best_lrf[pli], pli)
+                } else {
+                  0 // no relative cost differeneces to different CDEF params.  If cdef is on, it's a wash.
+                };
+                cost[pli] = err as f64 + fi.lambda * rate as f64 / ((1<<OD_BITRES) as f64);
+                cost_acc += cost[pli];
               }
+              RestorationFilter::Sgrproj{set, xqd} => {
+                sgrproj_stripe_filter(set, xqd, fi,
+                                      lrf_input.planes[pli].cfg.width,
+                                      lrf_input.planes[pli].cfg.height,
+                                      lrf_input.planes[pli].cfg.width,
+                                      lrf_input.planes[pli].cfg.height,
+                                      &lrf_input.planes[pli].slice(&PlaneOffset{x:0, y:0}),
+                                      &lrf_input.planes[pli].slice(&PlaneOffset{x:0, y:0}),
+                                      &mut lrf_output.planes[pli].mut_slice(&PlaneOffset{x:0, y:0}));
+                let err = rdo_loop_plane_error(sbo, fi, fs, &cw.bc, &lrf_output, pli);
+                let rate = cw.count_lrf_switchable(w, &fs.restoration, &best_lrf[pli], pli);
+                cost[pli] = err as f64 + fi.lambda * rate as f64 / ((1<<OD_BITRES) as f64);
+                cost_acc += cost[pli];
+              }
+              RestorationFilter::Wiener{..} => unreachable!() // coming soon
+            }
+          }
+          if best_cost_acc < 0. || cost_acc < best_cost_acc {
+            cdef_change = true;
+            best_cost_acc = cost_acc;
+            best_index = cdef_index;
+            for pli in 0..3 {
+              best_cost[pli] = cost[pli];
             }
           }
         }
       }
     }
 
-    if cdef_index == 0 || err < best_err {
-      best_err = err;
-      best_index = cdef_index;
-    }
+    if !cdef_change && !first_loop { break; }
+    first_loop = false;
+    
+    // check for new best restoration filter if enabled
+    let mut lrf_change = false;
+    if fi.sequence.enable_restoration {
+      // need cdef output from best index, not just last iteration
+      if fi.sequence.enable_cdef {
+        cdef_filter_superblock(fi, &mut cdef_input, &mut lrf_input,
+                               &mut cw.bc, &sbo_0, &sbo, best_index as u8, &cdef_dirs);
+      }
 
+      // Wiener LRF decision coming soon
+
+      // SgrProj LRF decision
+      for pli in 0..3 {
+        for set in 0..16 {
+          let in_plane = &fs.input.planes[pli];  // reference
+          let ipo = &sbo.plane_offset(&in_plane.cfg);
+          let cdef_plane = &lrf_input.planes[pli];
+          let (xqd0, xqd1) = sgrproj_solve(set, fi,
+                                           &in_plane.slice(ipo),
+                                           &cdef_plane.slice(&PlaneOffset{x: 0, y: 0}),
+                                           cmp::min(cdef_plane.cfg.width, fi.width - ipo.x as usize),
+                                           cmp::min(cdef_plane.cfg.height, fi.height - ipo.y as usize));
+          let current_lrf = RestorationFilter::Sgrproj{set: set, xqd: [xqd0, xqd1]};
+          if let RestorationFilter::Sgrproj{set, xqd} = current_lrf {
+            // At present, this is a gross simplification
+            sgrproj_stripe_filter(set, xqd, fi,
+                                  lrf_input.planes[pli].cfg.width, lrf_input.planes[pli].cfg.height,
+                                  lrf_input.planes[pli].cfg.width, lrf_input.planes[pli].cfg.height,
+                                  &lrf_input.planes[pli].slice(&PlaneOffset{x:0, y:0}),
+                                  &lrf_input.planes[pli].slice(&PlaneOffset{x:0, y:0}),
+                                  &mut lrf_output.planes[pli].mut_slice(&PlaneOffset{x:0, y:0}));
+          }
+          let err = rdo_loop_plane_error(sbo, fi, fs, &cw.bc, &lrf_output, pli);
+          let rate = cw.count_lrf_switchable(w, &fs.restoration, &current_lrf, pli);
+          let cost = err as f64 + fi.lambda * rate as f64 / ((1<<OD_BITRES) as f64);
+          if best_cost[pli] < 0. || cost < best_cost[pli] {
+            best_cost[pli] = cost;
+            best_lrf[pli] = current_lrf;
+            lrf_change = true;
+          }
+        }
+      }
+
+      // we tried all LRF possibilities for this cdef index; is the local result for this
+      // cdef index better than the best previous result?
+      if lrf_change {
+        let mut cost_acc = 0.;
+        for pli in 0..3 {
+          cost_acc += best_cost[pli];
+        }
+        best_cost_acc = cost_acc;
+      }
+    }
+    if !lrf_change || !cdef_change{
+      break;
+    }
   }
-  best_index
+
+  if cw.bc.cdef_coded {
+    cw.bc.set_cdef(&sbo, best_index as u8);
+  }
+
+  if fi.sequence.enable_restoration {
+    for pli in 0..PLANES {
+      fs.restoration.plane[pli].restoration_unit_as_mut(sbo).filter = best_lrf[pli];
+    }
+  }
 }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1287,7 +1287,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
                                              &cdef_plane.slice(&PlaneOffset{x: 0, y: 0}),
                                              cmp::min(cdef_plane.cfg.width, fi.width - ipo.x as usize),
                                              cmp::min(cdef_plane.cfg.height, fi.height - ipo.y as usize));
-            let current_lrf = RestorationFilter::Sgrproj{set: set, xqd: [xqd0, xqd1]};
+            let current_lrf = RestorationFilter::Sgrproj{set, xqd: [xqd0, xqd1]};
             if let RestorationFilter::Sgrproj{set, xqd} = current_lrf {
               // At present, this is a gross simplification
               sgrproj_stripe_filter(set, xqd, fi,


### PR DESCRIPTION
he impact of LRF is currently quite muted, as we're locked to the smallest possible loop restoration unit size right now (LRU == SB) and the coding overhead is very high.