### PR TITLE
Resolve an overflow on left-shift cdef_dist_wxh_8x8

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -101,7 +101,7 @@ fn cdef_dist_wxh_8x8<T: Pixel>(
   let sse = (sum_d2 + sum_s2 - 2 * sum_sd) as f64;
   //The two constants were tuned for CDEF, but can probably be better tuned for use in general RDO
   let ssim_boost = (4033_f64 / 16_384_f64) * (svar + dvar + (16_384 << 2 * coeff_shift) as f64)
-    / f64::sqrt((16_265_089 << 4 * coeff_shift) as f64 + svar * dvar);
+    / f64::sqrt((16_265_089u64 << 4 * coeff_shift) as f64 + svar * dvar);
   (sse * ssim_boost + 0.5_f64) as u64
 }
 


### PR DESCRIPTION
When `svar*dvar` is small or even zero and `bit_depth > 8`, the overflow results in taking the square-root of a negative number which yields `NaN`. This is cast to `u64` as `1 << 63`, causing overflow on unsaturated add later in `cdef_dist_wxh`.