### PR TITLE
Rebalance speed levels based on benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
          - cargo install cargo-kcov
          - kcov --version
          - cargo build --release --verbose
-         - cargo kcov --coveralls --features=decode_test -- --verify --exclude-pattern=$HOME/.cargo,aom_build,.h,test
+         - cargo kcov --coveralls --features=decode_test -- --nocapture --verify --exclude-pattern=$HOME/.cargo,aom_build,.h,test
       - name: "Tests"
         script: cargo test --verbose --release --features=decode_test -- --ignored
       - name: "Bench"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
          - cargo install cargo-kcov
          - kcov --version
          - cargo build --release --verbose
-         - cargo kcov --coveralls --features=decode_test -- --nocapture --verify --exclude-pattern=$HOME/.cargo,aom_build,.h,test
+         - cargo kcov --coveralls --features=decode_test -- --verify --exclude-pattern=$HOME/.cargo,aom_build,.h,test
       - name: "Tests"
         script: cargo test --verbose --release --features=decode_test -- --ignored
       - name: "Bench"

--- a/src/api.rs
+++ b/src/api.rs
@@ -203,9 +203,8 @@ impl SpeedSettings {
     speed == 0
   }
 
-  /// RDO TX decision, counter-intuitively, provides a speed up, with a very small quality cost
   fn rdo_tx_decision_preset(speed: usize) -> bool {
-    speed >= 6
+    speed <= 2
   }
 
   fn prediction_modes_preset(speed: usize) -> PredictionModesSetting {

--- a/src/api.rs
+++ b/src/api.rs
@@ -191,7 +191,7 @@ impl SpeedSettings {
   }
 
   fn reduced_tx_set_preset(speed: usize) -> bool {
-    speed >= 4
+    speed >= 5
   }
 
   /// TX domain distortion is always faster, with no significant quality change
@@ -204,13 +204,13 @@ impl SpeedSettings {
   }
 
   fn rdo_tx_decision_preset(speed: usize) -> bool {
-    speed <= 2
+    speed <= 3
   }
 
   fn prediction_modes_preset(speed: usize) -> PredictionModesSetting {
     if speed <= 1 {
       PredictionModesSetting::ComplexAll
-    } else if speed <= 4 {
+    } else if speed <= 5 {
       PredictionModesSetting::ComplexKeyframes
     } else {
       PredictionModesSetting::Simple

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -37,6 +37,9 @@ pub fn parse_cli() -> CliOptions {
     .about("AV1 video encoder")
     .setting(AppSettings::DeriveDisplayOrder)
     .setting(AppSettings::SubcommandsNegateReqs)
+    .arg(Arg::with_name("FULLHELP")
+      .help("Prints more detailed help information")
+      .long("fullhelp"))
     // THREADS
     .arg(
       Arg::with_name("THREADS")
@@ -49,7 +52,7 @@ pub fn parse_cli() -> CliOptions {
     .arg(
       Arg::with_name("INPUT")
         .help("Uncompressed YUV4MPEG2 video input")
-        .required(true)
+        .required_unless("FULLHELP")
         .index(1)
     )
     .arg(
@@ -57,7 +60,7 @@ pub fn parse_cli() -> CliOptions {
         .help("Compressed AV1 in IVF video output")
         .short("o")
         .long("output")
-        .required(true)
+        .required_unless("FULLHELP")
         .takes_value(true)
     )
     .arg(
@@ -100,6 +103,8 @@ pub fn parse_cli() -> CliOptions {
     .arg(
       Arg::with_name("SPEED")
         .help("Speed level (0 is best quality, 10 is fastest)\n\
+        Speeds 10 and 0 are extremes and are generally not recommended")
+        .long_help("Speed level (0 is best quality, 10 is fastest)\n\
         Speeds 10 and 0 are extremes and are generally not recommended\n\
         - 10 (fastest):\n\
         Min block size 64x64, TX domain distortion, RDO TX decision, fast deblock, no scenechange detection\n\
@@ -245,6 +250,11 @@ pub fn parse_cli() -> CliOptions {
     );
 
   let matches = app.clone().get_matches();
+
+  if matches.is_present("FULLHELP") {
+    app.print_long_help().unwrap();
+    std::process::exit(0);
+  }
 
   if let Some(threads) = matches.value_of("THREADS").map(|v| v.parse().expect("Threads must be an integer")) {
     rayon::ThreadPoolBuilder::new().num_threads(threads).build_global().unwrap();

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -107,15 +107,15 @@ pub fn parse_cli() -> CliOptions {
         .long_help("Speed level (0 is best quality, 10 is fastest)\n\
         Speeds 10 and 0 are extremes and are generally not recommended\n\
         - 10 (fastest):\n\
-        Min block size 64x64, TX domain distortion, RDO TX decision, fast deblock, no scenechange detection\n\
+        Min block size 64x64, TX domain distortion, fast deblock, no scenechange detection\n\
         - 9:\n\
-        Min block size 64x64, TX domain distortion, RDO TX decision, fast deblock\n\
+        Min block size 64x64, TX domain distortion, fast deblock\n\
         - 8:\n\
-        Min block size 8x8, reduced TX set, TX domain distortion, RDO TX decision, fast deblock\n\
+        Min block size 8x8, reduced TX set, TX domain distortion, fast deblock\n\
         - 7:\n\
-        Min block size 8x8, reduced TX set, TX domain distortion, RDO TX decision\n\
+        Min block size 8x8, reduced TX set, TX domain distortion\n\
         - 6:\n\
-        Min block size 8x8, reduced TX set, TX domain distortion, RDO TX decision\n\
+        Min block size 8x8, reduced TX set, TX domain distortion\n\
         - 5 (default):\n\
         Min block size 8x8, reduced TX set, TX domain distortion\n\
         - 4:\n\
@@ -123,11 +123,11 @@ pub fn parse_cli() -> CliOptions {
         - 3:\n\
         Min block size 8x8, TX domain distortion, complex pred modes for keyframes\n\
         - 2:\n\
-        Min block size 8x8, TX domain distortion, complex pred modes for keyframes, include near MVs\n\
+        Min block size 8x8, TX domain distortion, complex pred modes for keyframes, RDO TX decision, include near MVs\n\
         - 1:\n\
-        Min block size 8x8, TX domain distortion, complex pred modes, include near MVs\n\
+        Min block size 8x8, TX domain distortion, complex pred modes, RDO TX decision, include near MVs\n\
         - 0 (slowest):\n\
-        Min block size 4x4, TX domain distortion, complex pred modes, include near MVs, bottom-up encoding\n")
+        Min block size 4x4, TX domain distortion, complex pred modes, RDO TX decision, include near MVs, bottom-up encoding\n")
         .short("s")
         .long("speed")
         .takes_value(true)

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -117,11 +117,11 @@ pub fn parse_cli() -> CliOptions {
         - 6:\n\
         Min block size 8x8, reduced TX set, TX domain distortion\n\
         - 5 (default):\n\
-        Min block size 8x8, reduced TX set, TX domain distortion\n\
-        - 4:\n\
         Min block size 8x8, reduced TX set, TX domain distortion, complex pred modes for keyframes\n\
-        - 3:\n\
+        - 4:\n\
         Min block size 8x8, TX domain distortion, complex pred modes for keyframes\n\
+        - 3:\n\
+        Min block size 8x8, TX domain distortion, complex pred modes for keyframes, RDO TX decision\n\
         - 2:\n\
         Min block size 8x8, TX domain distortion, complex pred modes for keyframes, RDO TX decision, include near MVs\n\
         - 1:\n\

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -99,11 +99,34 @@ pub fn parse_cli() -> CliOptions {
     )
     .arg(
       Arg::with_name("SPEED")
-        .help("Speed level (0 is best quality, 10 is fastest)")
+        .help("Speed level (0 is best quality, 10 is fastest)\n\
+        Speeds 10 and 0 are extremes and are generally not recommended\n\
+        - 10 (fastest):\n\
+        Min block size 64x64, TX domain distortion, RDO TX decision, fast deblock, no scenechange detection\n\
+        - 9:\n\
+        Min block size 64x64, TX domain distortion, RDO TX decision, fast deblock\n\
+        - 8:\n\
+        Min block size 8x8, reduced TX set, TX domain distortion, RDO TX decision, fast deblock\n\
+        - 7:\n\
+        Min block size 8x8, reduced TX set, TX domain distortion, RDO TX decision\n\
+        - 6:\n\
+        Min block size 8x8, reduced TX set, TX domain distortion, RDO TX decision\n\
+        - 5 (default):\n\
+        Min block size 8x8, reduced TX set, TX domain distortion\n\
+        - 4:\n\
+        Min block size 8x8, reduced TX set, TX domain distortion, complex pred modes for keyframes\n\
+        - 3:\n\
+        Min block size 8x8, TX domain distortion, complex pred modes for keyframes\n\
+        - 2:\n\
+        Min block size 8x8, TX domain distortion, complex pred modes for keyframes, include near MVs\n\
+        - 1:\n\
+        Min block size 8x8, TX domain distortion, complex pred modes, include near MVs\n\
+        - 0 (slowest):\n\
+        Min block size 4x4, TX domain distortion, complex pred modes, include near MVs, bottom-up encoding\n")
         .short("s")
         .long("speed")
         .takes_value(true)
-        .default_value("3")
+        .default_value("5")
     )
     .arg(
       Arg::with_name("MIN_KEYFRAME_INTERVAL")
@@ -123,7 +146,8 @@ pub fn parse_cli() -> CliOptions {
     )
     .arg(
       Arg::with_name("LOW_LATENCY")
-        .help("Low latency mode; disables frame reordering")
+        .help("Low latency mode; disables frame reordering\n\
+            Has a significant speed-to-quality trade-off")
         .long("low_latency")
         .takes_value(true)
         .default_value("false")
@@ -207,23 +231,6 @@ pub fn parse_cli() -> CliOptions {
         .hidden(true)
         .long("speed-test")
         .takes_value(true)
-        .possible_values(&[
-          "baseline",
-          "min_block_size_4x4",
-          "min_block_size_8x8",
-          "min_block_size_32x32",
-          "min_block_size_64x64",
-          "multiref",
-          "fast_deblock",
-          "reduced_tx_set",
-          "tx_domain_distortion",
-          "encode_bottomup",
-          "rdo_tx_decision",
-          "prediction_modes_keyframes",
-          "prediction_modes_all",
-          "include_near_mvs",
-          "no_scene_detection",
-        ])
     )
     .subcommand(SubCommand::with_name("advanced")
                 .setting(AppSettings::Hidden)
@@ -447,6 +454,9 @@ fn apply_speed_test_cfg(cfg: &mut EncoderConfig, setting: &str) {
     "no_scene_detection" => {
       cfg.speed_settings.no_scene_detection = true;
     },
+    "diamond_me" => {
+      cfg.speed_settings.diamond_me = true;
+    }
     setting => {
       panic!("Unrecognized speed test setting {}", setting);
     }

--- a/src/test_encode_decode_aom.rs
+++ b/src/test_encode_decode_aom.rs
@@ -175,7 +175,7 @@ test_dimensions!{
 fn dimension(w: usize, h: usize) {
   let quantizer = 100;
   let limit = 1;
-  let speed = 4;
+  let speed = 8;
 
   encode_decode(w, h, speed, quantizer, limit, 8, Default::default(), 15, 15, true, 0);
 }
@@ -185,7 +185,7 @@ fn quantizer() {
   let limit = 5;
   let w = 64;
   let h = 80;
-  let speed = 4;
+  let speed = 8;
 
   for b in DIMENSION_OFFSETS.iter() {
     for &q in [80, 100, 120].iter() {
@@ -199,7 +199,7 @@ fn bitrate() {
   let limit = 5;
   let w = 64;
   let h = 80;
-  let speed = 4;
+  let speed = 8;
 
   for &q in [172, 220, 252, 255].iter() {
     for &r in [100, 1000, 10_000].iter() {
@@ -213,7 +213,7 @@ fn keyframes() {
   let limit = 12;
   let w = 64;
   let h = 80;
-  let speed = 10;
+  let speed = 9;
   let q = 100;
 
   encode_decode(w, h, speed, q, limit, 8, Default::default(), 6, 6, true, 0);

--- a/src/test_encode_decode_aom.rs
+++ b/src/test_encode_decode_aom.rs
@@ -175,7 +175,7 @@ test_dimensions!{
 fn dimension(w: usize, h: usize) {
   let quantizer = 100;
   let limit = 1;
-  let speed = 8;
+  let speed = 10;
 
   encode_decode(w, h, speed, quantizer, limit, 8, Default::default(), 15, 15, true, 0);
 }
@@ -185,7 +185,7 @@ fn quantizer() {
   let limit = 5;
   let w = 64;
   let h = 80;
-  let speed = 8;
+  let speed = 10;
 
   for b in DIMENSION_OFFSETS.iter() {
     for &q in [80, 100, 120].iter() {
@@ -199,7 +199,7 @@ fn bitrate() {
   let limit = 5;
   let w = 64;
   let h = 80;
-  let speed = 8;
+  let speed = 10;
 
   for &q in [172, 220, 252, 255].iter() {
     for &r in [100, 1000, 10_000].iter() {
@@ -258,12 +258,15 @@ fn odd_size_frame_with_full_rdo() {
 }
 
 #[test]
-fn high_bd() {
+fn all_bit_depths() {
   let quantizer = 100;
   let limit = 3; // Include inter frames
   let speed = 0; // Test as many tools as possible
   let w = 64;
   let h = 80;
+
+  // 8-bit
+  encode_decode(w, h, speed, quantizer, limit, 8, Default::default(), 15, 15, true, 0);
 
   // 10-bit
   encode_decode(w, h, speed, quantizer, limit, 10, Default::default(), 15, 15, true, 0);
@@ -281,6 +284,9 @@ fn chroma_sampling() {
   let h = 80;
 
   // TODO: bump keyint when inter is supported
+
+  // 4:2:0
+  encode_decode(w, h, speed, quantizer, limit, 8, ChromaSampling::Cs420, 1, 1, true, 0);
 
   // 4:2:2
   encode_decode(w, h, speed, quantizer, limit, 8, ChromaSampling::Cs422, 1, 1, true, 0);


### PR DESCRIPTION
Makes use of all 10 speed levels, and updates the CLI help text to
reflect which settings are enabled at specific speed levels.

This also changes the default speed level to 5.

Based on benchmarks which are viewable (at least for the time being) [here](https://condor3280.startdedicated.com/files/rav1espeed/). Closes #1015 