### PR TITLE
Expose separate rows from PlaneSlice

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -300,8 +300,8 @@ pub fn cdef_sb_padded_frame_copy<T: Pixel>(
           out_row[x] = T::cast_from(CDEF_VERY_LARGE);
         }
       } else {
-        let in_slice = f.planes[p].slice(&PlaneOffset {x:0, y:offset.y + y - ipad});
-        let in_row = in_slice.as_slice();
+        let in_slice = f.planes[p].slice(&PlaneOffset {x:0, y:offset.y - ipad});
+        let in_row = &in_slice[y as usize];
         // are we guaranteed to be all in frame this row?
         if offset.x < ipad || offset.x + (sb_size as isize >>xdec) + ipad >= w {
           // No; do it the hard way.  off left or right edge, fill with flag.

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -411,16 +411,17 @@ fn deblock_h_size4<T: Pixel>(
 
 // Assumes rec[0] and src[0] are set 2 taps back from the edge.
 // Accesses four taps, accumulates four pixels into the tally
-fn sse_size4<T: Pixel>(
-  rec: &[T], src: &[T], tally: &mut [i64; MAX_LOOP_FILTER + 2],
-  rec_pitch: usize, src_pitch: usize, rec_stride: usize, src_stride: usize,
+fn sse_size4<'a, T: Pixel>(
+  rec: &PlaneSlice<'a, T>,
+  src: &PlaneSlice<'a, T>,
+  tally: &mut [i64; MAX_LOOP_FILTER + 2],
+  rec_pitch: usize,
+  src_pitch: usize,
   bd: usize
 ) {
-  let mut rec_s = 0;
-  let mut src_s = 0;
-  for _i in 0..4 {
-    let p = &rec[rec_s..]; // four taps
-    let a = &src[src_s..]; // four pixels to compare
+  for y in 0..4 {
+    let p = &rec[y]; // four taps
+    let a = &src[y]; // four pixels to compare
     let p1: i32 = p[0].as_();
     let p0: i32 = p[rec_pitch].as_();
     let q0: i32 = p[rec_pitch * 2].as_();
@@ -456,9 +457,6 @@ fn sse_size4<T: Pixel>(
     tally[mask] += sse_narrow2;
     tally[nhev] -= sse_narrow2;
     tally[nhev] += sse_narrow4;
-
-    rec_s += rec_stride;
-    src_s += src_stride;
   }
 }
 
@@ -547,17 +545,18 @@ fn deblock_h_size6<T: Pixel>(
 
 // Assumes rec[0] and src[0] are set 3 taps back from the edge.
 // Accesses six taps, accumulates four pixels into the tally
-fn sse_size6<T: Pixel>(
-  rec: &[T], src: &[T], tally: &mut [i64; MAX_LOOP_FILTER + 2],
-  rec_pitch: usize, src_pitch: usize, rec_stride: usize, src_stride: usize,
+fn sse_size6<'a, T: Pixel>(
+  rec: &PlaneSlice<'a, T>,
+  src: &PlaneSlice<'a, T>,
+  tally: &mut [i64; MAX_LOOP_FILTER + 2],
+  rec_pitch: usize,
+  src_pitch: usize,
   bd: usize
 ) {
-  let mut rec_s = 0;
-  let mut src_s = 0;
   let flat = 1 << bd - 8;
-  for _i in 0..4 {
-    let p = &rec[rec_s..]; // six taps
-    let a = &src[src_s + src_pitch..]; // four pixels to compare so offset one forward
+  for y in 0..4 {
+    let p = &rec[y]; // six taps
+    let a = &src[y][src_pitch..]; // four pixels to compare so offset one forward
     let p2: i32 = p[0].as_();
     let p1: i32 = p[rec_pitch].as_();
     let p0: i32 = p[rec_pitch * 2].as_();
@@ -610,9 +609,6 @@ fn sse_size6<T: Pixel>(
       tally[nhev] -= sse_narrow2;
       tally[nhev] += sse_narrow4;
     }
-
-    rec_s += rec_stride;
-    src_s += src_stride;
   }
 }
 
@@ -723,17 +719,18 @@ fn deblock_h_size8<T: Pixel>(
 
 // Assumes rec[0] and src[0] are set 4 taps back from the edge.
 // Accesses eight taps, accumulates six pixels into the tally
-fn sse_size8<T: Pixel>(
-  rec: &[T], src: &[T], tally: &mut [i64; MAX_LOOP_FILTER + 2],
-  rec_pitch: usize, src_pitch: usize, rec_stride: usize, src_stride: usize,
+fn sse_size8<'a, T: Pixel>(
+  rec: &PlaneSlice<'a, T>,
+  src: &PlaneSlice<'a, T>,
+  tally: &mut [i64; MAX_LOOP_FILTER + 2],
+  rec_pitch: usize,
+  src_pitch: usize,
   bd: usize
 ) {
-  let mut rec_s = 0;
-  let mut src_s = 0;
   let flat = 1 << bd - 8;
-  for _i in 0..4 {
-    let p = &rec[rec_s..]; // eight taps
-    let a = &src[src_s + src_pitch..]; // six pixels to compare so offset one forward
+  for y in 0..4 {
+    let p = &rec[y]; // eight taps
+    let a = &src[y][src_pitch..]; // six pixels to compare so offset one forward
     let p3: i32 = p[0].as_();
     let p2: i32 = p[rec_pitch].as_();
     let p1: i32 = p[rec_pitch * 2].as_();
@@ -789,9 +786,6 @@ fn sse_size8<T: Pixel>(
       tally[nhev] -= sse_narrow2;
       tally[nhev] += sse_narrow4;
     }
-
-    src_s += src_stride;
-    rec_s += rec_stride;
   }
 }
 
@@ -899,17 +893,18 @@ fn deblock_h_size14<T: Pixel>(
 
 // Assumes rec[0] and src[0] are set 7 taps back from the edge.
 // Accesses fourteen taps, accumulates twelve pixels into the tally
-fn sse_size14<T: Pixel>(
-  rec: &[T], src: &[T], tally: &mut [i64; MAX_LOOP_FILTER + 2],
-  rec_pitch: usize, src_pitch: usize, rec_stride: usize, src_stride: usize,
+fn sse_size14<'a, T: Pixel>(
+  rec: &PlaneSlice<'a, T>,
+  src: &PlaneSlice<'a, T>,
+  tally: &mut [i64; MAX_LOOP_FILTER + 2],
+  rec_pitch: usize,
+  src_pitch: usize,
   bd: usize
 ) {
-  let mut rec_s = 0;
-  let mut src_s = 0;
   let flat = 1 << bd - 8;
-  for _i in 0..4 {
-    let p = &rec[rec_s..]; // 14 taps
-    let a = &src[src_s + src_pitch..]; // 12 pixels to compare so offset one forward
+  for y in 0..4 {
+    let p = &rec[y]; // 14 taps
+    let a = &src[y][src_pitch..]; // 12 pixels to compare so offset one forward
     let p6: i32 = p[0].as_();
     let p5: i32 = p[rec_pitch].as_();
     let p4: i32 = p[rec_pitch * 2].as_();
@@ -1013,9 +1008,6 @@ fn sse_size14<T: Pixel>(
       tally[nhev] -= sse_narrow2;
       tally[nhev] += sse_narrow4;
     }
-
-    rec_s += rec_stride;
-    src_s += src_stride;
   }
 }
 
@@ -1070,59 +1062,51 @@ fn sse_v_edge<T: Pixel>(
     let filter_size =
       deblock_size(block, prev_block, rec_plane, pli, true, block_edge);
     if filter_size > 0 {
-      let po = bo.plane_offset(&rec_plane.cfg); // rec and src have identical subsampling
+      let po = {
+        let mut po = bo.plane_offset(&rec_plane.cfg); // rec and src have identical subsampling
+        po.x -= (filter_size >> 1) as isize;
+        po
+      };
       let rec_slice = rec_plane.slice(&po);
       let src_slice = src_plane.slice(&po);
-      let rec_tmp = rec_slice.go_left(filter_size >> 1);
-      let src_tmp = src_slice.go_left(filter_size >> 1);
-      let rec = rec_tmp.as_slice();
-      let src = src_tmp.as_slice();
       match filter_size {
         4 => {
           sse_size4(
-            rec,
-            src,
+            &rec_slice,
+            &src_slice,
             tally,
             1,
             1,
-            rec_plane.cfg.stride,
-            src_plane.cfg.stride,
             bd
           );
         }
         6 => {
           sse_size6(
-            rec,
-            src,
+            &rec_slice,
+            &src_slice,
             tally,
             1,
             1,
-            rec_plane.cfg.stride,
-            src_plane.cfg.stride,
             bd
           );
         }
         8 => {
           sse_size8(
-            rec,
-            src,
+            &rec_slice,
+            &src_slice,
             tally,
             1,
             1,
-            rec_plane.cfg.stride,
-            src_plane.cfg.stride,
             bd
           );
         }
         14 => {
           sse_size14(
-            rec,
-            src,
+            &rec_slice,
+            &src_slice,
             tally,
             1,
             1,
-            rec_plane.cfg.stride,
-            src_plane.cfg.stride,
             bd
           );
         }
@@ -1183,21 +1167,19 @@ fn sse_h_edge<T: Pixel>(
     let filter_size =
       deblock_size(block, prev_block, rec_plane, pli, true, block_edge);
     if filter_size > 0 {
-      let po = bo.plane_offset(&rec_plane.cfg); // rec and src have identical subsampling
+      let po = {
+        let mut po = bo.plane_offset(&rec_plane.cfg); // rec and src have identical subsampling
+        po.x -= (filter_size >> 1) as isize;
+        po
+      };
       let rec_slice = rec_plane.slice(&po);
       let src_slice = src_plane.slice(&po);
-      let rec_tmp = rec_slice.go_up(filter_size >> 1);
-      let src_tmp = src_slice.go_up(filter_size >> 1);
-      let rec = rec_tmp.as_slice();
-      let src = src_tmp.as_slice();
       match filter_size {
         4 => {
           sse_size4(
-            rec,
-            src,
+            &rec_slice,
+            &src_slice,
             tally,
-            rec_plane.cfg.stride,
-            src_plane.cfg.stride,
             1,
             1,
             bd
@@ -1205,11 +1187,9 @@ fn sse_h_edge<T: Pixel>(
         }
         6 => {
           sse_size6(
-            rec,
-            src,
+            &rec_slice,
+            &src_slice,
             tally,
-            rec_plane.cfg.stride,
-            src_plane.cfg.stride,
             1,
             1,
             bd
@@ -1217,11 +1197,9 @@ fn sse_h_edge<T: Pixel>(
         }
         8 => {
           sse_size8(
-            rec,
-            src,
+            &rec_slice,
+            &src_slice,
             tally,
-            rec_plane.cfg.stride,
-            src_plane.cfg.stride,
             1,
             1,
             bd
@@ -1229,11 +1207,9 @@ fn sse_h_edge<T: Pixel>(
         }
         14 => {
           sse_size14(
-            rec,
-            src,
+            &rec_slice,
+            &src_slice,
             tally,
-            rec_plane.cfg.stride,
-            src_plane.cfg.stride,
             1,
             1,
             bd

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -919,12 +919,9 @@ fn write_obus<T: Pixel>(
 
 /// Write into `dst` the difference between the blocks at `src1` and `src2`
 fn diff<T: Pixel>(dst: &mut [i16], src1: &PlaneSlice<'_, T>, src2: &PlaneSlice<'_, T>, width: usize, height: usize) {
-  let src1_stride = src1.plane.cfg.stride;
-  let src2_stride = src2.plane.cfg.stride;
-
   for ((l, s1), s2) in dst.chunks_mut(width).take(height)
-    .zip(src1.as_slice().chunks(src1_stride))
-    .zip(src2.as_slice().chunks(src2_stride)) {
+    .zip(src1.rows_iter())
+    .zip(src2.rows_iter()) {
       for ((r, v1), v2) in l.iter_mut().zip(s1).zip(s2) {
         *r = i16::cast_from(*v1) - i16::cast_from(*v2);
       }

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -149,7 +149,7 @@ fn sgrproj_box_sum_slow<T: Pixel>(a: &mut i32, b: &mut i32,
     // clamp vertically to stripe limits
     let ly = clamp(cropped_y, stripe_y - 2, stripe_y + stripe_h as isize + 1);
     // Reslice to avoid a negative X index.
-    let p = src_plane.reslice(x - r as isize,ly).as_slice();
+    let p = &src_plane.reslice(x - r as isize,ly)[0];
     // left-hand addressing limit
     let left = cmp::max(0, r as isize - x - src_plane.x) as usize;
     // right-hand addressing limit
@@ -185,7 +185,7 @@ fn sgrproj_box_sum_fastxy_r1<T: Pixel>(a: &mut i32, b: &mut i32, x: isize, y: is
   let mut ssq:i32 = 0;
   let mut sum:i32 = 0;
   for yi in -1..=1 {
-    let x = p.reslice(x - 1, y + yi).as_slice();
+    let x = &p.reslice(x - 1, y + yi)[0];
     ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
       i32::cast_from(x[1]) * i32::cast_from(x[1]) +
       i32::cast_from(x[2]) * i32::cast_from(x[2]);
@@ -201,7 +201,7 @@ fn sgrproj_box_sum_fastxy_r2<T: Pixel>(a: &mut i32, b: &mut i32, x: isize, y: is
   let mut ssq:i32 = 0;
   let mut sum:i32 = 0;
   for yi in -2..=2 {
-    let x = p.reslice(x - 2, y + yi).as_slice();
+    let x = &p.reslice(x - 2, y + yi)[0];
     ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
       i32::cast_from(x[1]) * i32::cast_from(x[1]) +
       i32::cast_from(x[2]) * i32::cast_from(x[2]) +
@@ -237,7 +237,7 @@ fn sgrproj_box_sum_fastx_r1<T: Pixel>(a: &mut i32, b: &mut i32,
     let cropped_y = clamp(yi, -src_plane.y, src_h - 1);
     // clamp vertically to stripe limits
     let ly = clamp(cropped_y, stripe_y - 2, stripe_y + stripe_h as isize + 1);
-    let x = src_plane.reslice(x - 1, ly).as_slice();
+    let x = &src_plane.reslice(x - 1, ly)[0];
     ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
       i32::cast_from(x[1]) * i32::cast_from(x[1]) +
       i32::cast_from(x[2]) * i32::cast_from(x[2]);
@@ -269,7 +269,7 @@ fn sgrproj_box_sum_fastx_r2<T: Pixel>(a: &mut i32, b: &mut i32,
     let cropped_y = clamp(yi, -src_plane.y, src_h as isize - 1);
     // clamp vertically to stripe limits
     let ly = clamp(cropped_y, stripe_y - 2, stripe_y + stripe_h as isize + 1);
-    let x = src_plane.reslice(x - 2, ly).as_slice();
+    let x = &src_plane.reslice(x - 2, ly)[0];
     ssq += i32::cast_from(x[0]) * i32::cast_from(x[0]) +
       i32::cast_from(x[1]) * i32::cast_from(x[1]) +
       i32::cast_from(x[2]) * i32::cast_from(x[2]) +

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -413,10 +413,10 @@ mod native {
     let intermediate_bits = 4 - if bit_depth == 12 { 2 } else { 0 };
     match (col_frac, row_frac) {
       (0, 0) => {
-        let src_slice = src.as_slice();
         for r in 0..height {
+          let src_slice = &src[r];
           for c in 0..width {
-            dst_slice[r * dst_stride + c] = src_slice[r * ref_stride + c];
+            dst_slice[r * dst_stride + c] = src_slice[c];
           }
         }
       }

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -262,15 +262,15 @@ mod nasm {
           UninitializedAlignedArray();
         let mut src8: [u8; (128 + 7) * (128 + 7)] =
           unsafe { mem::uninitialized() };
-        convert_slice_2d(
-          &mut src8,
-          width + 7,
-          src.go_left(3).go_up(3).as_slice(),
-          src.plane.cfg.stride,
-          width + 7,
-          height + 7
-        );
         unsafe {
+          convert_slice_2d(
+            src8.as_mut_ptr(),
+            width + 7,
+            src.go_left(3).go_up(3).as_ptr(),
+            src.plane.cfg.stride,
+            width + 7,
+            height + 7
+          );
           select_put_fn_avx2(mode_x, mode_y)(
             dst8.array.as_mut_ptr(),
             width as isize,
@@ -281,17 +281,17 @@ mod nasm {
             col_frac,
             row_frac
           );
+          let dst_stride = dst.plane.cfg.stride;
+          let dst_slice = dst.as_mut_slice();
+          convert_slice_2d(
+            dst_slice.as_mut_ptr(),
+            dst_stride,
+            dst8.array.as_ptr(),
+            width,
+            width,
+            height
+          );
         }
-        let dst_stride = dst.plane.cfg.stride;
-        let dst_slice = dst.as_mut_slice();
-        convert_slice_2d(
-          dst_slice,
-          dst_stride,
-          &dst8.array,
-          width,
-          width,
-          height
-        );
         return;
       }
     }
@@ -308,15 +308,15 @@ mod nasm {
     if is_x86_feature_detected!("avx2") && bit_depth == 8 {
       let mut src8: [u8; (128 + 7) * (128 + 7)] =
         unsafe { mem::uninitialized() };
-      convert_slice_2d(
-        &mut src8,
-        width + 7,
-        src.go_left(3).go_up(3).as_slice(),
-        src.plane.cfg.stride,
-        width + 7,
-        height + 7
-      );
       unsafe {
+        convert_slice_2d(
+          src8.as_mut_ptr(),
+          width + 7,
+          src.go_left(3).go_up(3).as_ptr(),
+          src.plane.cfg.stride,
+          width + 7,
+          height + 7
+        );
         select_prep_fn_avx2(mode_x, mode_y)(
           tmp.as_mut_ptr(),
           src8[(width + 7) * 3 + 3..].as_ptr(),
@@ -351,17 +351,17 @@ mod nasm {
           width as i32,
           height as i32
         );
+        let dst_stride = dst.plane.cfg.stride;
+        let dst_slice = dst.as_mut_slice();
+        convert_slice_2d(
+          dst_slice.as_mut_ptr(),
+          dst_stride,
+          dst8.array.as_ptr(),
+          width,
+          width,
+          height
+        );
       }
-      let dst_stride = dst.plane.cfg.stride;
-      let dst_slice = dst.as_mut_slice();
-      convert_slice_2d(
-        dst_slice,
-        dst_stride,
-        &dst8.array,
-        width,
-        width,
-        height
-      );
       return;
     } else {
       super::native::mc_avg(dst, tmp1, tmp2, width, height, bit_depth);

--- a/src/me.rs
+++ b/src/me.rs
@@ -86,8 +86,8 @@ mod nasm {
       for c in (0..blk_w).step_by(step_size) {
         let org_slice = plane_org.subslice(c, r);
         let ref_slice = plane_ref.subslice(c, r);
-        let org_ptr = org_slice.as_slice().as_ptr();
-        let ref_ptr = ref_slice.as_slice().as_ptr();
+        let org_ptr = org_slice.as_ptr();
+        let ref_ptr = ref_slice.as_ptr();
         // FIXME for now, T == u16
         let org_ptr = org_ptr as *const u16;
         let ref_ptr = ref_ptr as *const u16;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -893,7 +893,7 @@ pub fn get_intra_edges<'a, T: Pixel>(
     // Needs top
     if needs_top {
       if y != 0 {
-        above[..tx_size.width()].copy_from_slice(&dst.go_up(1).as_slice()[..tx_size.width()]);
+        above[..tx_size.width()].copy_from_slice(&dst.go_up(1)[0][..tx_size.width()]);
       } else {
         let val = if x != 0 { dst.go_left(1).p(0, 0) } else { T::cast_from(base - 1) };
         for v in above[..tx_size.width()].iter_mut() {
@@ -927,7 +927,7 @@ pub fn get_intra_edges<'a, T: Pixel>(
       };
       if num_avail > 0 {
         above[tx_size.width()..tx_size.width() + num_avail]
-        .copy_from_slice(&dst.go_up(1).as_slice()[tx_size.width()..tx_size.width() + num_avail]);
+        .copy_from_slice(&dst.go_up(1)[0][tx_size.width()..tx_size.width() + num_avail]);
       }
       if num_avail < tx_size.height() {
         let val = above[tx_size.width() + num_avail - 1];

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -10,7 +10,7 @@
 use std::iter::FusedIterator;
 use std::fmt::{Debug, Display, Formatter};
 use std::mem;
-use std::ops::Range;
+use std::ops::{Index, Range};
 
 use crate::util::*;
 
@@ -410,6 +410,13 @@ impl<'a, T: Pixel> PlaneSlice<'a, T> {
     let new_x =
       (self.x + add_x as isize + self.plane.cfg.xorigin as isize) as usize;
     self.plane.data[new_y * self.plane.cfg.stride + new_x]
+  }
+}
+
+impl<'a, T: Pixel> Index<usize> for PlaneSlice<'a, T> {
+  type Output = [T];
+  fn index(&self, index: usize) -> &Self::Output {
+    self.row(index)
   }
 }
 

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -375,24 +375,6 @@ impl<'a, T: Pixel> PlaneSlice<'a, T> {
     }
   }
 
-  pub fn as_slice(&self) -> &'a [T] {
-    let stride = self.plane.cfg.stride;
-    let base = (self.y + self.plane.cfg.yorigin as isize) as usize * stride
-      + (self.x + self.plane.cfg.xorigin as isize) as usize;
-    &self.plane.data[base..]
-  }
-
-  pub fn as_slice_clamped(&self) -> &'a [T] {
-    let stride = self.plane.cfg.stride;
-    let y = (self.y.min(self.plane.cfg.height as isize)
-      + self.plane.cfg.yorigin as isize)
-      .max(0) as usize;
-    let x = (self.x.min(self.plane.cfg.width as isize)
-      + self.plane.cfg.xorigin as isize)
-      .max(0) as usize;
-    &self.plane.data[y * stride + x..]
-  }
-
   pub fn clamp(&self) -> PlaneSlice<'a, T> {
     PlaneSlice {
       plane: self.plane,
@@ -405,13 +387,6 @@ impl<'a, T: Pixel> PlaneSlice<'a, T> {
         .min(self.plane.cfg.height as isize)
         .max(-(self.plane.cfg.yorigin as isize))
     }
-  }
-
-  pub fn as_slice_w_width(&self, width: usize) -> &'a [T] {
-    let stride = self.plane.cfg.stride;
-    let base = (self.y + self.plane.cfg.yorigin as isize) as usize * stride
-      + (self.x + self.plane.cfg.xorigin as isize) as usize;
-    &self.plane.data[base..base + width]
   }
 
   pub fn iter_width(&self, width: usize) -> IterWidth<'a, T> {

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -145,6 +145,14 @@ impl<T: Pixel> Plane<T> {
     PlaneMutSlice { plane: self, x: po.x, y: po.y }
   }
 
+  pub fn as_slice(&self) -> PlaneSlice<'_, T> {
+    self.slice(&PlaneOffset { x: 0, y: 0 })
+  }
+
+  pub fn as_mut_slice(&mut self) -> PlaneMutSlice<'_, T> {
+    self.mut_slice(&PlaneOffset { x: 0, y: 0 })
+  }
+
   #[inline]
   fn index(&self, x: usize, y: usize) -> usize {
     (y + self.cfg.yorigin) * self.cfg.stride + (x + self.cfg.xorigin)

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -138,10 +138,8 @@ pub fn sse_wxh<T: Pixel>(
 
   let mut sse: u64 = 0;
   for j in 0..h {
-    let src1j = src1.subslice(0, j);
-    let src2j = src2.subslice(0, j);
-    let s1 = src1j.as_slice_w_width(w);
-    let s2 = src2j.as_slice_w_width(w);
+    let s1 = &src1[j][..w];
+    let s2 = &src2[j][..w];
 
     let row_sse = s1
       .iter()

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1539,36 +1539,36 @@ mod nasm {
           }
         }
 
-        // copy output to dst8 so that the results of the inverse transform
-        //   can be added to it
-        convert_slice_2d(
-          &mut dst8.array,
-          Self::W,
-          output,
-          stride,
-          Self::W,
-          Self::H
-        );
-
-        // perform the inverse transform
         unsafe {
+          // copy output to dst8 so that the results of the inverse transform
+          //   can be added to it
+          convert_slice_2d(
+            dst8.array.as_mut_ptr(),
+            Self::W,
+            output.as_ptr(),
+            stride,
+            Self::W,
+            Self::H
+          );
+
+          // perform the inverse transform
           Self::match_tx_type(tx_type)(
             dst8.array.as_mut_ptr(),
             Self::W as isize,
             coeff16.array.as_ptr(),
             (coeff_w * coeff_h) as i32
           );
-        }
 
-        // copy back to output
-        convert_slice_2d(
-          output,
-          stride,
-          &dst8.array,
-          Self::W,
-          Self::W,
-          Self::H
-        );
+          // copy back to output
+          convert_slice_2d(
+            output.as_mut_ptr(),
+            stride,
+            dst8.array.as_ptr(),
+            Self::W,
+            Self::W,
+            Self::H
+          );
+        }
       } else {
         <Self as super::native::InvTxfm2D>::inv_txfm2d_add(
           input, output, stride, tx_type, bd,

--- a/src/util.rs
+++ b/src/util.rs
@@ -292,20 +292,19 @@ pub fn round_shift(value: i32, bit: usize) -> i32 {
   (value + (1 << bit >> 1)) >> bit
 }
 
-pub fn convert_slice_2d<NEW, OLD>(
-  dst: &mut [NEW], dst_stride: usize, src: &[OLD], src_stride: usize,
+pub unsafe fn convert_slice_2d<NEW, OLD>(
+  dst: *mut NEW, dst_stride: usize, src: *const OLD, src_stride: usize,
   width: usize, height: usize
 )
 where
   NEW: CastFromPrimitive<OLD> + Copy + 'static,
   OLD: Copy + 'static,
 {
-  for r in 0..height {
-    for (a, b) in dst[r * dst_stride..r * dst_stride + width]
-      .iter_mut()
-      .zip(src[r * src_stride..r * src_stride + width].iter())
-    {
-      *a = NEW::cast_from(*b);
+  for y in 0..height {
+    for x in 0..width {
+      let p_dst = dst.add(y * dst_stride + x);
+      let p_src = src.add(y * src_stride + x);
+      *p_dst = NEW::cast_from(*p_src);
     }
   }
 }


### PR DESCRIPTION
Currently, many functions access rectangular regions of planes (spanning multiple rows) via a primitive slice to the whole plane along with the stride information.

This strategy is not compatible with tiling, since this borrows the memory belonging to other tiles.

This is basically what I explained in https://github.com/xiph/rav1e/issues/631#issuecomment-456088577.

Therefore, only expose separate rows in `PlaneSlice`.

Concretely, here are the changes from the caller point of view:

```rust
// get a specific row

// before
let row = plane_slice.as_slice()[y * stride..(y + 1) * stride];
// or if we don't care about the end
let row = plane_slice.as_slice()[y * stride..];

// after
let row = &plane_slice[y];
```

```rust
// get a component value

// before
let value = plane_slice.as_slice()[y * stride + x];

// after
let value = plane_slice[y][x];
```

```rust
// iterate over rows

// before
for row in plane_slice.as_slice().chunks(stride).take(height) {
    let _first_four_values = &row[..4];
}

// after
for row in plane_slice.rows_iter() {
    let _first_four_values = &row[..4];
}
```

Note that in itself, it does not solve the incompatibility with tiles (`PlaneSlice` itself still borrows the whole plane primitive slice). This is only the first step to remove all usages of raw slice + stride information, so that we can then replace `PlaneSlice` by a tile-specific "plane region" structure which does not borrow memory outside the tile (cf #821).

For now, I only submit changes for `PlaneSlice`. I will submit similar changes for `PlaneMutSlice` once I get feedbacks on this one (and when it's finished).