### PR TITLE
Use the Index trait ([]) instead of .get().unwrap()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ jobs:
          - cargo doc --verbose
          - rustup component add clippy
          - cargo clippy --version
-         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::erasing_op -A clippy::get_unwrap -A clippy::identity_op -A clippy::if_same_then_else -A clippy::len_zero -A clippy::manual_memcpy -A clippy::needless_range_loop -A clippy::neg_multiply -A clippy::precedence -A clippy::ptr_arg -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose
+         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::erasing_op -A clippy::identity_op -A clippy::if_same_then_else -A clippy::len_zero -A clippy::manual_memcpy -A clippy::needless_range_loop -A clippy::neg_multiply -A clippy::precedence -A clippy::ptr_arg -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose

--- a/src/api.rs
+++ b/src/api.rs
@@ -727,7 +727,7 @@ impl<T: Pixel> Context<T> {
         idx = self.idx;
       }
 
-      if !self.needs_more_frames(self.frame_data.get(&idx).unwrap().number) {
+      if !self.needs_more_frames(self.frame_data[&idx].number) {
         self.idx += 1;
         return Err(EncoderStatus::EnoughData);
       }


### PR DESCRIPTION
This PR enables the Clippy's [get_unwrap](https://rust-lang.github.io/rust-clippy/master/index.html#get_unwrap) lint, and fixes all warnings caused by it.