### PR TITLE
Optimize debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ bench = false
 name = "bench"
 harness = false
 
+[profile.dev]
+opt-level = 3  # unoptimized builds are unusable for video encoding
+
 [profile.release]
 codegen-units = 1  # if > 1 enables parallel code generation which improves
                    # compile times, but prevents some optimizations.


### PR DESCRIPTION
Unoptimized builds are unusable for video encoding.

Always building in release mode is not a good solution, because we still want to distinguish debug builds, having `debug_assert!()` enabled, from release builds.