### PR TITLE
Enable the Clippy's ptr_arg lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ jobs:
          - cargo doc --verbose
          - rustup component add clippy
          - cargo clippy --version
-         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::erasing_op -A clippy::identity_op -A clippy::if_same_then_else -A clippy::len_zero -A clippy::manual_memcpy -A clippy::needless_range_loop -A clippy::neg_multiply -A clippy::precedence -A clippy::ptr_arg -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose
+         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::erasing_op -A clippy::identity_op -A clippy::if_same_then_else -A clippy::len_zero -A clippy::manual_memcpy -A clippy::needless_range_loop -A clippy::neg_multiply -A clippy::precedence -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose

--- a/src/me.rs
+++ b/src/me.rs
@@ -155,7 +155,7 @@ fn get_mv_range(
 
 pub fn get_subset_predictors<T: Pixel>(
   fi: &FrameInvariants<T>, bo: &BlockOffset, cmv: MotionVector,
-  frame_mvs: &Vec<MotionVector>, frame_ref_opt: &Option<Arc<ReferenceFrame<T>>>,
+  frame_mvs: &[MotionVector], frame_ref_opt: &Option<Arc<ReferenceFrame<T>>>,
   ref_slot: usize
 ) -> (Vec<MotionVector>) {
   let mut predictors = Vec::new();

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -996,7 +996,7 @@ pub fn rdo_partition_decision<T: Pixel>(
   cw: &mut ContextWriter, w_pre_cdef: &mut dyn Writer, w_post_cdef: &mut dyn Writer,
   bsize: BlockSize, bo: &BlockOffset,
   cached_block: &RDOOutput, pmvs: &[[Option<MotionVector>; REF_FRAMES]; 5],
-  partition_types: &Vec<PartitionType>,
+  partition_types: &[PartitionType],
 ) -> RDOOutput {
   let mut best_partition = cached_block.part_type;
   let mut best_rd = cached_block.rd_cost;


### PR DESCRIPTION
This PR enables the Clippy's [ptr_arg](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg) lint, and fixes all warnings caused by it.