### PR TITLE
Remove unnecessary explicit lifetimes

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -55,7 +55,7 @@ fn first_max_element(elems: &[i32]) -> (usize, i32) {
 // in a particular direction. Since each direction have the same sum(x^2) term,
 // that term is never computed. See Section 2, step 2, of:
 // http://jmvalin.ca/notes/intra_paint.pdf
-fn cdef_find_dir<'a, T: Pixel>(img: &PlaneSlice<'a, T>, var: &mut i32, coeff_shift: usize) -> i32 {
+fn cdef_find_dir<T: Pixel>(img: &PlaneSlice<'_, T>, var: &mut i32, coeff_shift: usize) -> i32 {
   let mut cost: [i32; 8] = [0; 8];
   let mut partial: [[i32; 15]; 8] = [[0; 15]; 8];
   for i in 0..8 {

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -306,8 +306,8 @@ fn filter_wide14_12(
 }
 
 #[inline]
-fn copy_horizontal<'a, T: Pixel>(
-  dst: &mut PlaneMutSlice<'a, T>, x: usize, y: usize, src: &[i32]
+fn copy_horizontal<T: Pixel>(
+  dst: &mut PlaneMutSlice<'_, T>, x: usize, y: usize, src: &[i32]
 ) {
   let row = &mut dst[y][x..];
   for (dst, src) in row.iter_mut().take(src.len()).zip(src) {
@@ -316,8 +316,8 @@ fn copy_horizontal<'a, T: Pixel>(
 }
 
 #[inline]
-fn copy_vertical<'a, T: Pixel>(
-  dst: &mut PlaneMutSlice<'a, T>, x: usize, y: usize, src: &[i32]
+fn copy_vertical<T: Pixel>(
+  dst: &mut PlaneMutSlice<'_, T>, x: usize, y: usize, src: &[i32]
 ) {
   for (i, v) in src.iter().enumerate() {
     let p = &mut dst[y + i][x];
@@ -388,8 +388,8 @@ fn deblock_size4_inner(
 }
 
 // Assumes rec[0] is set 2 taps back from the edge
-fn deblock_v_size4<'a, T: Pixel>(
-  rec: &mut PlaneMutSlice<'a, T>, level: usize, bd: usize
+fn deblock_v_size4<T: Pixel>(
+  rec: &mut PlaneMutSlice<'_, T>, level: usize, bd: usize
 ) {
   for y in 0..4 {
     let p = &rec[y];
@@ -406,8 +406,8 @@ fn deblock_v_size4<'a, T: Pixel>(
 }
 
 // Assumes rec[0] is set 2 taps back from the edge
-fn deblock_h_size4<'a, T: Pixel>(
-  rec: &mut PlaneMutSlice<'a, T>, level: usize, bd: usize
+fn deblock_h_size4<T: Pixel>(
+  rec: &mut PlaneMutSlice<'_, T>, level: usize, bd: usize
 ) {
   for x in 0..4 {
     let vals = [
@@ -424,9 +424,9 @@ fn deblock_h_size4<'a, T: Pixel>(
 
 // Assumes rec[0] and src[0] are set 2 taps back from the edge.
 // Accesses four taps, accumulates four pixels into the tally
-fn sse_size4<'a, T: Pixel>(
-  rec: &PlaneSlice<'a, T>,
-  src: &PlaneSlice<'a, T>,
+fn sse_size4<T: Pixel>(
+  rec: &PlaneSlice<'_, T>,
+  src: &PlaneSlice<'_, T>,
   tally: &mut [i64; MAX_LOOP_FILTER + 2],
   rec_pitch: usize,
   src_pitch: usize,
@@ -517,8 +517,8 @@ fn deblock_size6_inner(
 }
 
 // Assumes slice[0] is set 3 taps back from the edge
-fn deblock_v_size6<'a, T: Pixel>(
-  rec: &mut PlaneMutSlice<'a, T>, level: usize, bd: usize
+fn deblock_v_size6<T: Pixel>(
+  rec: &mut PlaneMutSlice<'_, T>, level: usize, bd: usize
 ) {
   for y in 0..4 {
     let p = &rec[y];
@@ -537,8 +537,8 @@ fn deblock_v_size6<'a, T: Pixel>(
 }
 
 // Assumes slice[0] is set 3 taps back from the edge
-fn deblock_h_size6<'a, T: Pixel>(
-  rec: &mut PlaneMutSlice<'a, T>, level: usize, bd: usize
+fn deblock_h_size6<T: Pixel>(
+  rec: &mut PlaneMutSlice<'_, T>, level: usize, bd: usize
 ) {
   for x in 0..4 {
     let vals = [
@@ -557,9 +557,9 @@ fn deblock_h_size6<'a, T: Pixel>(
 
 // Assumes rec[0] and src[0] are set 3 taps back from the edge.
 // Accesses six taps, accumulates four pixels into the tally
-fn sse_size6<'a, T: Pixel>(
-  rec: &PlaneSlice<'a, T>,
-  src: &PlaneSlice<'a, T>,
+fn sse_size6<T: Pixel>(
+  rec: &PlaneSlice<'_, T>,
+  src: &PlaneSlice<'_, T>,
   tally: &mut [i64; MAX_LOOP_FILTER + 2],
   rec_pitch: usize,
   src_pitch: usize,
@@ -686,8 +686,8 @@ fn deblock_size8_inner (
 }
 
 // Assumes rec[0] is set 4 taps back from the edge
-fn deblock_v_size8<'a, T: Pixel>(
-  rec: &mut PlaneMutSlice<'a, T>, level: usize, bd: usize
+fn deblock_v_size8<T: Pixel>(
+  rec: &mut PlaneMutSlice<'_, T>, level: usize, bd: usize
 ) {
   for y in 0..4 {
     let p = &rec[y];
@@ -708,8 +708,8 @@ fn deblock_v_size8<'a, T: Pixel>(
 }
 
 // Assumes rec[0] is set 4 taps back from the edge
-fn deblock_h_size8<'a, T: Pixel>(
-  rec: &mut PlaneMutSlice<'a, T>, level: usize, bd: usize
+fn deblock_h_size8<T: Pixel>(
+  rec: &mut PlaneMutSlice<'_, T>, level: usize, bd: usize
 ) {
   for x in 0..4 {
     let vals = [
@@ -730,9 +730,9 @@ fn deblock_h_size8<'a, T: Pixel>(
 
 // Assumes rec[0] and src[0] are set 4 taps back from the edge.
 // Accesses eight taps, accumulates six pixels into the tally
-fn sse_size8<'a, T: Pixel>(
-  rec: &PlaneSlice<'a, T>,
-  src: &PlaneSlice<'a, T>,
+fn sse_size8<T: Pixel>(
+  rec: &PlaneSlice<'_, T>,
+  src: &PlaneSlice<'_, T>,
   tally: &mut [i64; MAX_LOOP_FILTER + 2],
   rec_pitch: usize,
   src_pitch: usize,
@@ -847,8 +847,8 @@ fn deblock_size14_inner(
 }
 
 // Assumes rec[0] is set 7 taps back from the edge
-fn deblock_v_size14<'a, T: Pixel>(
-  rec: &mut PlaneMutSlice<'a, T>, level: usize, bd: usize
+fn deblock_v_size14<T: Pixel>(
+  rec: &mut PlaneMutSlice<'_, T>, level: usize, bd: usize
 ) {
   for y in 0..4 {
     let p = &rec[y];
@@ -875,8 +875,8 @@ fn deblock_v_size14<'a, T: Pixel>(
 }
 
 // Assumes rec[0] is set 7 taps back from the edge
-fn deblock_h_size14<'a, T: Pixel>(
-  rec: &mut PlaneMutSlice<'a, T>, level: usize, bd: usize
+fn deblock_h_size14<T: Pixel>(
+  rec: &mut PlaneMutSlice<'_, T>, level: usize, bd: usize
 ) {
   for x in 0..4 {
     let vals = [
@@ -903,9 +903,9 @@ fn deblock_h_size14<'a, T: Pixel>(
 
 // Assumes rec[0] and src[0] are set 7 taps back from the edge.
 // Accesses fourteen taps, accumulates twelve pixels into the tally
-fn sse_size14<'a, T: Pixel>(
-  rec: &PlaneSlice<'a, T>,
-  src: &PlaneSlice<'a, T>,
+fn sse_size14<T: Pixel>(
+  rec: &PlaneSlice<'_, T>,
+  src: &PlaneSlice<'_, T>,
   tally: &mut [i64; MAX_LOOP_FILTER + 2],
   rec_pitch: usize,
   src_pitch: usize,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -250,8 +250,8 @@ mod nasm {
     );
   }
 
-  pub fn put_8tap<'a, T: Pixel>(
-    dst: &'a mut PlaneMutSlice<'a, T>, src: PlaneSlice<'_, T>, width: usize,
+  pub fn put_8tap<T: Pixel>(
+    dst: &mut PlaneMutSlice<'_, T>, src: PlaneSlice<'_, T>, width: usize,
     height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
     mode_y: FilterMode, bit_depth: usize
   ) {
@@ -334,8 +334,8 @@ mod nasm {
     }
   }
 
-  pub fn mc_avg<'a, T: Pixel>(
-    dst: &'a mut PlaneMutSlice<'a, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
+  pub fn mc_avg<T: Pixel>(
+    dst: &mut PlaneMutSlice<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
     height: usize, bit_depth: usize
   ) {
     if is_x86_feature_detected!("avx2") && bit_depth == 8 {
@@ -397,8 +397,8 @@ mod native {
     SUBPEL_FILTERS[filter_idx][frac as usize]
   }
 
-  pub fn put_8tap<'a, T: Pixel>(
-    dst: &'a mut PlaneMutSlice<'a, T>, src: PlaneSlice<'_, T>, width: usize,
+  pub fn put_8tap<T: Pixel>(
+    dst: &mut PlaneMutSlice<'_, T>, src: PlaneSlice<'_, T>, width: usize,
     height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
     mode_y: FilterMode, bit_depth: usize
   ) {
@@ -562,8 +562,8 @@ mod native {
     }
   }
 
-  pub fn mc_avg<'a, T: Pixel>(
-    dst: &'a mut PlaneMutSlice<'a, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
+  pub fn mc_avg<T: Pixel>(
+    dst: &mut PlaneMutSlice<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
     height: usize, bit_depth: usize
   ) {
     let max_sample_val = ((1 << bit_depth) - 1) as i32;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -816,11 +816,11 @@ pub enum MvJointType {
   MV_JOINT_HNZVNZ = 3  /* Both components nonzero */
 }
 
-pub fn get_intra_edges<'a, T: Pixel>(
-  dst: &'a PlaneSlice<'a, T>,
+pub fn get_intra_edges<T: Pixel>(
+  dst: &PlaneSlice<'_, T>,
   tx_size: TxSize,
   bit_depth: usize,
-  plane_cfg: &'a PlaneConfig,
+  plane_cfg: &PlaneConfig,
   frame_w_in_b: usize,
   frame_h_in_b: usize,
   opt_mode: Option<PredictionMode>
@@ -982,8 +982,8 @@ pub fn get_intra_edges<'a, T: Pixel>(
 }
 
 impl PredictionMode {
-  pub fn predict_intra<'a, T: Pixel>(
-    self, dst: &'a mut PlaneMutSlice<'a, T>, tx_size: TxSize, bit_depth: usize,
+  pub fn predict_intra<T: Pixel>(
+    self, dst: &mut PlaneMutSlice<'_, T>, tx_size: TxSize, bit_depth: usize,
     ac: &[i16], alpha: i16, edge_buf: &AlignedArray<[T; 4 * MAX_TX_SIZE + 1]>
   ) {
     assert!(self.is_intra());
@@ -1033,8 +1033,8 @@ impl PredictionMode {
   }
 
   #[inline(always)]
-  fn predict_intra_inner<'a, B: Intra<T>, T: Pixel>(
-    self, dst: &'a mut PlaneMutSlice<'a, T>, bit_depth: usize, ac: &[i16],
+  fn predict_intra_inner<B: Intra<T>, T: Pixel>(
+    self, dst: &mut PlaneMutSlice<'_, T>, bit_depth: usize, ac: &[i16],
     alpha: i16, edge_buf: &AlignedArray<[T; 4 * MAX_TX_SIZE + 1]>
   ) {
     // left pixels are order from bottom to top and right-aligned
@@ -1136,9 +1136,9 @@ impl PredictionMode {
     self >= PredictionMode::V_PRED && self <= PredictionMode::D63_PRED
   }
 
-  pub fn predict_inter<'a, T: Pixel>(
+  pub fn predict_inter<T: Pixel>(
     self, fi: &FrameInvariants<T>, p: usize, po: &PlaneOffset,
-    dst: &'a mut PlaneMutSlice<'a, T>, width: usize, height: usize,
+    dst: &mut PlaneMutSlice<'_, T>, width: usize, height: usize,
     ref_frames: [usize; 2], mvs: [MotionVector; 2]
   ) {
     assert!(!self.is_intra());

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -218,7 +218,7 @@ where
   T: Pixel,
 {
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_dc<'a>(output: &mut PlaneMutSlice<'a, T>, above: &[T], left: &[T]) {
+  fn pred_dc(output: &mut PlaneMutSlice<'_, T>, above: &[T], left: &[T]) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
     {
       if size_of::<T>() == 1 && is_x86_feature_detected!("avx2") {
@@ -247,7 +247,7 @@ where
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_dc_128<'a>(output: &mut PlaneMutSlice<'a, T>, bit_depth: usize) {
+  fn pred_dc_128(output: &mut PlaneMutSlice<'_, T>, bit_depth: usize) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
     {
       if size_of::<T>() == 1 && is_x86_feature_detected!("avx2") {
@@ -272,7 +272,7 @@ where
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_dc_left<'a>(output: &mut PlaneMutSlice<'a, T>, _above: &[T], left: &[T]) {
+  fn pred_dc_left(output: &mut PlaneMutSlice<'_, T>, _above: &[T], left: &[T]) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
     {
       if size_of::<T>() == 1 && is_x86_feature_detected!("avx2") {
@@ -296,7 +296,7 @@ where
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_dc_top<'a>(output: &mut PlaneMutSlice<'a, T>, above: &[T], _left: &[T]) {
+  fn pred_dc_top(output: &mut PlaneMutSlice<'_, T>, above: &[T], _left: &[T]) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
     {
       if size_of::<T>() == 1 && is_x86_feature_detected!("avx2") {
@@ -320,7 +320,7 @@ where
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_h<'a>(output: &mut PlaneMutSlice<'a, T>, left: &[T]) {
+  fn pred_h(output: &mut PlaneMutSlice<'_, T>, left: &[T]) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
     {
       if size_of::<T>() == 1 && is_x86_feature_detected!("avx2") {
@@ -346,7 +346,7 @@ where
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_v<'a>(output: &mut PlaneMutSlice<'a, T>, above: &[T]) {
+  fn pred_v(output: &mut PlaneMutSlice<'_, T>, above: &[T]) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
     {
       if size_of::<T>() == 1 && is_x86_feature_detected!("avx2") {
@@ -368,8 +368,8 @@ where
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_paeth<'a>(
-    output: &mut PlaneMutSlice<'a, T>, above: &[T], left: &[T],
+  fn pred_paeth(
+    output: &mut PlaneMutSlice<'_, T>, above: &[T], left: &[T],
     above_left: T
   ) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
@@ -413,8 +413,8 @@ where
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_smooth<'a>(
-    output: &mut PlaneMutSlice<'a, T>, above: &[T], left: &[T]
+  fn pred_smooth(
+    output: &mut PlaneMutSlice<'_, T>, above: &[T], left: &[T]
   ) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
     {
@@ -478,8 +478,8 @@ where
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_smooth_h<'a>(
-    output: &mut PlaneMutSlice<'a, T>, above: &[T], left: &[T]
+  fn pred_smooth_h(
+    output: &mut PlaneMutSlice<'_, T>, above: &[T], left: &[T]
   ) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
     {
@@ -529,8 +529,8 @@ where
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_smooth_v<'a>(
-    output: &mut PlaneMutSlice<'a, T>, above: &[T], left: &[T]
+  fn pred_smooth_v(
+    output: &mut PlaneMutSlice<'_, T>, above: &[T], left: &[T]
   ) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
     {
@@ -631,8 +631,8 @@ where
     }
   }
 
-  fn pred_cfl_inner<'a>(
-    output: &mut PlaneMutSlice<'a, T>, ac: &[i16], alpha: i16, bit_depth: usize
+  fn pred_cfl_inner(
+    output: &mut PlaneMutSlice<'_, T>, ac: &[i16], alpha: i16, bit_depth: usize
   ) {
     if alpha == 0 {
       return;
@@ -665,8 +665,8 @@ where
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_cfl<'a>(
-    output: &mut PlaneMutSlice<'a, T>, ac: &[i16], alpha: i16, bit_depth: usize,
+  fn pred_cfl(
+    output: &mut PlaneMutSlice<'_, T>, ac: &[i16], alpha: i16, bit_depth: usize,
     above: &[T], left: &[T]
   ) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
@@ -689,8 +689,8 @@ where
     Self::pred_cfl_inner(output, &ac, alpha, bit_depth);
   }
 
-  fn pred_cfl_128<'a>(
-    output: &mut PlaneMutSlice<'a, T>, ac: &[i16], alpha: i16, bit_depth: usize
+  fn pred_cfl_128(
+    output: &mut PlaneMutSlice<'_, T>, ac: &[i16], alpha: i16, bit_depth: usize
   ) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
     {
@@ -712,8 +712,8 @@ where
     Self::pred_cfl_inner(output, &ac, alpha, bit_depth);
   }
 
-  fn pred_cfl_left<'a>(
-    output: &mut PlaneMutSlice<'a, T>, ac: &[i16], alpha: i16, bit_depth: usize,
+  fn pred_cfl_left(
+    output: &mut PlaneMutSlice<'_, T>, ac: &[i16], alpha: i16, bit_depth: usize,
     above: &[T], left: &[T]
   ) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
@@ -736,8 +736,8 @@ where
     Self::pred_cfl_inner(output, &ac, alpha, bit_depth);
   }
 
-  fn pred_cfl_top<'a>(
-    output: &mut PlaneMutSlice<'a, T>, ac: &[i16], alpha: i16, bit_depth: usize,
+  fn pred_cfl_top(
+    output: &mut PlaneMutSlice<'_, T>, ac: &[i16], alpha: i16, bit_depth: usize,
     above: &[T], left: &[T]
   ) {
     #[cfg(all(target_arch = "x86_64", not(windows), feature = "nasm"))]
@@ -761,8 +761,8 @@ where
   }
 
   #[cfg_attr(feature = "comparative_bench", inline(never))]
-  fn pred_directional<'a>(
-    output: &mut PlaneMutSlice<'a, T>, above: &[T], left: &[T], top_left: &[T], angle: usize, bit_depth: usize
+  fn pred_directional(
+    output: &mut PlaneMutSlice<'_, T>, above: &[T], left: &[T], top_left: &[T], angle: usize, bit_depth: usize
   ) {
     let sample_max = ((1 << bit_depth) - 1) as i32;
     let _angle_delta = 0;
@@ -931,8 +931,8 @@ pub mod test {
         );
       }
 
-      fn $fn_4x4<'a>(
-        output: &mut PlaneMutSlice<'a, u16>, above: &[u16], left: &[u16]
+      fn $fn_4x4(
+        output: &mut PlaneMutSlice<'_, u16>, above: &[u16], left: &[u16]
       ) {
         let mut left = left.to_vec();
         left.reverse();
@@ -969,8 +969,8 @@ pub mod test {
     );
   }
 
-  pub fn pred_cfl_4x4<'a>(
-    output: &mut PlaneMutSlice<'a, u16>, ac: &[i16], alpha: i16, bd: i32
+  pub fn pred_cfl_4x4(
+    output: &mut PlaneMutSlice<'_, u16>, ac: &[i16], alpha: i16, bd: i32
   ) {
     let mut ac32 = [0; 4*32];
     for (l32, l) in ac32.chunks_mut(32).zip(ac.chunks(4).take(4)) {

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1517,8 +1517,8 @@ mod nasm {
   pub trait InvTxfm2D: super::native::InvTxfm2D {
     fn match_tx_type(tx_type: TxType) -> InvTxfmFunc;
 
-    fn inv_txfm2d_add<'a, T>(
-      input: &[i32], output: &mut PlaneMutSlice<'a, T>, tx_type: TxType,
+    fn inv_txfm2d_add<T>(
+      input: &[i32], output: &mut PlaneMutSlice<'_, T>, tx_type: TxType,
       bd: usize
     ) where
       T: Pixel,
@@ -1682,8 +1682,8 @@ mod native {
   pub trait InvTxfm2D: Dim {
     const INTERMEDIATE_SHIFT: usize;
 
-    fn inv_txfm2d_add<'a, T: Pixel>(
-      input: &[i32], output: &mut PlaneMutSlice<'a, T>, tx_type: TxType,
+    fn inv_txfm2d_add<T: Pixel>(
+      input: &[i32], output: &mut PlaneMutSlice<'_, T>, tx_type: TxType,
       bd: usize
     ) where
       T: Pixel,
@@ -1777,8 +1777,8 @@ macro_rules! impl_iht_fns {
   ($(($W:expr, $H:expr)),+) => {
     $(
       paste::item! {
-        pub fn [<iht $W x $H _add>]<'a, T: Pixel>(
-          input: &[i32], output: &mut PlaneMutSlice<'a, T>, tx_type: TxType,
+        pub fn [<iht $W x $H _add>]<T: Pixel>(
+          input: &[i32], output: &mut PlaneMutSlice<'_, T>, tx_type: TxType,
           bit_depth: usize
         ) where
           T: Pixel,

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -175,8 +175,8 @@ pub fn forward_transform(
   }
 }
 
-pub fn inverse_transform_add<'a, T: Pixel>(
-  input: &[i32], output: &mut PlaneMutSlice<'a, T>, tx_size: TxSize,
+pub fn inverse_transform_add<T: Pixel>(
+  input: &[i32], output: &mut PlaneMutSlice<'_, T>, tx_size: TxSize,
   tx_type: TxType, bit_depth: usize
 ) {
   assert!(mem::size_of::<T>() == 2, "only implemented for u16 for now");


### PR DESCRIPTION
In #1035 and #1043, I added many unnecessary explicit lifetimes. Let's fix that (and some others).

---

Most of the replacements are equivalent, and some of them relax unnecessary constraints. For example:

```rust
&'a mut Type<'a>
```

is rewritten:

```
&mut Type<'_>
```

In that case, the lifetime of the reference need not be the same as the one bound to the type.

<https://doc.rust-lang.org/nightly/edition-guide/rust-2018/ownership-and-lifetimes/the-anonymous-lifetime.html>
<https://doc.rust-lang.org/book/ch19-02-advanced-lifetimes.html#the-anonymous-lifetime>