### PR TITLE
Rename "plane" to "planes"

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3031,7 +3031,7 @@ impl ContextWriter {
       }
       RestorationFilter::Sgrproj{set, xqd} => {
         // Does *not* use 'RESTORE_SGRPROJ' but rather just '2'
-        let rp = &rs.plane[pli];
+        let rp = &rs.planes[pli];
         let mut bits = w.symbol_bits(2, &self.fc.lrf_switchable_cdf[..nsym]) +
           ((SGRPROJ_PARAMS_BITS as u32) << OD_BITRES);
         for i in 0..2 {
@@ -3054,7 +3054,7 @@ impl ContextWriter {
     if !fi.allow_intrabc { // TODO: also disallow if lossless
       for pli in 0..PLANES {
         let code;
-        let rp = &mut rs.plane[pli];
+        let rp = &mut rs.planes[pli];
         {
           let ru = &mut rp.restoration_unit_as_mut(sbo);
           code = !ru.coded;

--- a/src/header.rs
+++ b/src/header.rs
@@ -849,8 +849,8 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
       let mut use_lrf = false;
       let mut use_chroma_lrf = false;
       for i in 0..PLANES {
-        self.write(2, rs.plane[i].lrf_type)?; // filter type by plane
-        if rs.plane[i].lrf_type != RESTORE_NONE {
+        self.write(2, rs.planes[i].lrf_type)?; // filter type by plane
+        if rs.planes[i].lrf_type != RESTORE_NONE {
           use_lrf = true;
           if i > 0 {
             use_chroma_lrf = true;
@@ -860,17 +860,17 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
       if use_lrf {
         // The Y shift value written here indicates shift up from superblock size
         if !fi.sequence.use_128x128_superblock {
-          self.write(1, if rs.plane[0].unit_size > 64 { 1 } else { 0 })?;
+          self.write(1, if rs.planes[0].unit_size > 64 { 1 } else { 0 })?;
         }
-        if rs.plane[0].unit_size > 64 {
-          self.write(1, if rs.plane[0].unit_size > 128 { 1 } else { 0 })?;
+        if rs.planes[0].unit_size > 64 {
+          self.write(1, if rs.planes[0].unit_size > 128 { 1 } else { 0 })?;
         }
 
         if use_chroma_lrf {
           if fi.sequence.chroma_sampling == ChromaSampling::Cs420 {
             self.write(
               1,
-              if rs.plane[0].unit_size > rs.plane[1].unit_size {
+              if rs.planes[0].unit_size > rs.planes[1].unit_size {
                 1
               } else {
                 0

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -864,7 +864,7 @@ impl RestorationPlane {
 
 #[derive(Clone, Debug)]
 pub struct RestorationState {
-  pub plane: [RestorationPlane; PLANES]
+  pub planes: [RestorationPlane; PLANES]
 }
 
 impl RestorationState {
@@ -890,21 +890,23 @@ impl RestorationState {
     let rows = ((fi.height + (y_unit_size >> 1)) / y_unit_size).max(1);
 
     RestorationState {
-      plane: [RestorationPlane::new(RESTORE_SWITCHABLE, y_unit_size, y_unit_log2 - y_sb_log2,
-                                    0, cols, rows),
-              RestorationPlane::new(RESTORE_SWITCHABLE, uv_unit_size, uv_unit_log2 - uv_sb_log2,
-                                    stripe_uv_decimate, cols, rows),
-              RestorationPlane::new(RESTORE_SWITCHABLE, uv_unit_size, uv_unit_log2 - uv_sb_log2,
-                                    stripe_uv_decimate, cols, rows)],
+      planes: [
+        RestorationPlane::new(RESTORE_SWITCHABLE, y_unit_size, y_unit_log2 - y_sb_log2,
+                              0, cols, rows),
+        RestorationPlane::new(RESTORE_SWITCHABLE, uv_unit_size, uv_unit_log2 - uv_sb_log2,
+                              stripe_uv_decimate, cols, rows),
+        RestorationPlane::new(RESTORE_SWITCHABLE, uv_unit_size, uv_unit_log2 - uv_sb_log2,
+                              stripe_uv_decimate, cols, rows)
+      ],
     }
   }
 
   pub fn restoration_unit(&self, sbo: &SuperBlockOffset, pli: usize) -> &RestorationUnit {
-    self.plane[pli].restoration_unit(sbo)
+    self.planes[pli].restoration_unit(sbo)
   }
 
   pub fn restoration_unit_as_mut(&mut self, sbo: &SuperBlockOffset, pli: usize) -> &mut RestorationUnit {
-    self.plane[pli].restoration_unit_as_mut(sbo)
+    self.planes[pli].restoration_unit_as_mut(sbo)
   }
 
   pub fn lrf_filter_frame<T: Pixel>(&mut self, out: &mut Frame<T>, pre_cdef: &Frame<T>,
@@ -920,7 +922,7 @@ impl RestorationState {
     let stripe_n = (fi.height + 7) / 64 + 1;
 
     for pli in 0..PLANES {
-      let rp = &self.plane[pli];
+      let rp = &self.planes[pli];
       let xdec = out.planes[pli].cfg.xdec;
       let ydec = out.planes[pli].cfg.ydec;
       let crop_w = fi.width + (1 << xdec >> 1) >> xdec;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1190,7 +1190,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
   let mut lrf_any_uncoded = false;
   if fi.sequence.enable_restoration {
     for pli in 0..PLANES {
-      let ru = fs.restoration.plane[pli].restoration_unit(sbo);
+      let ru = fs.restoration.planes[pli].restoration_unit(sbo);
       if !ru.coded {
         lrf_any_uncoded = true;
         break;
@@ -1274,7 +1274,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
 
       // SgrProj LRF decision
       for pli in 0..3 {
-        let ru = fs.restoration.plane[pli].restoration_unit(sbo);
+        let ru = fs.restoration.planes[pli].restoration_unit(sbo);
         if !ru.coded {
           for set in 0..16 {
             let in_plane = &fs.input.planes[pli];  // reference
@@ -1328,7 +1328,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
 
   if fi.sequence.enable_restoration {
     for pli in 0..PLANES {
-      let ru = fs.restoration.plane[pli].restoration_unit_as_mut(sbo);
+      let ru = fs.restoration.planes[pli].restoration_unit_as_mut(sbo);
       if !ru.coded {
         ru.filter = best_lrf[pli];
       }


### PR DESCRIPTION
In `RestorationState`, the field is an array of 3 planes, so use the plural form (as in `Frame::planes`).

---

(I was annoyed by sometimes writing `plane` and sometimes `planes` for the same meaning, and that way the naming in my tiling structures may be consistent)