### PR TITLE
Add option to skip n frames of a video

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -28,6 +28,7 @@ pub struct CliOptions {
   pub io: EncoderIO,
   pub enc: EncoderConfig,
   pub limit: usize,
+  pub skip: usize,
   pub verbose: bool,
 }
 
@@ -81,6 +82,13 @@ pub fn parse_cli() -> CliOptions {
         .help("Maximum number of frames to encode")
         .short("l")
         .long("limit")
+        .takes_value(true)
+        .default_value("0")
+    )
+    .arg(
+      Arg::with_name("SKIP")
+        .help("Skip n number of frames and encode")
+        .long("skip")
         .takes_value(true)
         .default_value("0")
     )
@@ -268,6 +276,7 @@ pub fn parse_cli() -> CliOptions {
     io,
     enc: parse_config(&matches),
     limit: matches.value_of("LIMIT").unwrap().parse().unwrap(),
+    skip: matches.value_of("SKIP").unwrap().parse().unwrap(),
     verbose: matches.is_present("VERBOSE"),
   }
 }

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -144,6 +144,12 @@ fn main() {
   );
 
   ctx.set_limit(cli.limit as u64);
+  let mut frame_current_count = 0;
+
+  while frame_current_count <= cli.skip {
+       y4m_dec.read_frame().expect("Skipped more frames than in the input");
+       frame_current_count+=1;
+  }
 
   while let Ok(frame_info) = process_frame(&mut ctx, &mut cli.io.output, &mut y4m_dec, y4m_enc.as_mut()) {
     for frame in frame_info {


### PR DESCRIPTION
In x265 and other encoders, there are options to skip n number of frames while in rav1e, as_of_now we don't have support to skip n frames.
With this users can skip n frames easily.
For example:
```
cargo run --release --bin rav1e  /Volumes/buildBox/rav1e/dummyData/ducks_take_off_420_720p50.y4m --skip 450 --limit 454 -o test.ivf -v
    Finished release [optimized] target(s) in 0.77s
     Running `target/release/rav1e /Volumes/buildBox/rav1e/dummyData/ducks_take_off_420_720p50.y4m --skip 450 --limit 454 -o test.ivf -v`
1280x720 @ 50/1 fps
newLimit 4
Frame 0 - Key frame - 181632 bytes - encoded 1/4 frames, 0.083 fps, 70950.00 Kb/s, est. size: 0.69 MB, est. time: 36 s
Frame 1 - Inter frame - 82332 bytes - encoded 2/4 frames, 0.065 fps, 51555.47 Kb/s, est. size: 0.50 MB, est. time: 31 s
Frame 2 - Inter frame - 5 bytes - encoded 3/4 frames, 0.098 fps, 34370.96 Kb/s, est. size: 0.34 MB, est. time: 10 s
Frame 3 - Inter frame - 37949 bytes - encoded 4/4 frames, 0.095 fps, 29484.18 Kb/s, est. size: 0.29 MB, est. time: 0 s

Key Frames:      1    avg size:  181632 B
Inter:           3    avg size:   40095 B
Intra Only:      0    avg size:       0 B
Switch:          0    avg size:       0 B
```
```
cargo run --release --bin rav1e  /Volumes/buildBox/rav1e/dummyData/ducks_take_off_420_720p50.y4m --skip 450 -o test.ivf -v
   Compiling rav1e v0.1.0 (/Volumes/buildBox/rav1e/rav1e)
    Finished release [optimized] target(s) in 40.86s
     Running `target/release/rav1e /Volumes/buildBox/rav1e/dummyData/ducks_take_off_420_720p50.y4m --skip 450 -o test.ivf -v`
1280x720 @ 50/1 fps
Frame 0 - Key frame - 181632 bytes - encoded 1 frames, 0.079 fps, 70950.00 Kb/s
```

Fix #1016 