### PR TITLE
Refactor encode-decode tests to reduce duplication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ bindgen = { version = "0.47.1", optional = true }
 [dev-dependencies]
 criterion = "0.2"
 pretty_assertions = "0.5.1"
+interpolate_name = "0.2.1"
 
 [[bin]]
 name = "rav1e"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@ extern crate dav1d_sys;
 
 #[cfg(test)]
 #[macro_use]
+extern crate interpolate_name;
+
+#[cfg(test)]
+#[macro_use]
 extern crate pretty_assertions;
 
 pub mod ec;
@@ -50,6 +54,9 @@ pub use crate::api::*;
 pub use crate::encoder::*;
 pub use crate::header::*;
 pub use crate::util::{CastFromPrimitive, Pixel};
+
+#[cfg(all(test, any(feature="decode_test", feature="decode_test_dav1d")))]
+mod test_encode_decode;
 
 #[cfg(all(test, feature="decode_test"))]
 mod test_encode_decode_aom;

--- a/src/test_encode_decode.rs
+++ b/src/test_encode_decode.rs
@@ -1,0 +1,302 @@
+// Copyright (c) 2018, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+use super::*;
+use rand::{ChaChaRng, Rng};
+use std::sync::Arc;
+use crate::util::Pixel;
+#[cfg(feature="decode_test")]
+use crate::test_encode_decode_aom::AomDecoder;
+#[cfg(feature="decode_test_dav1d")]
+use crate::test_encode_decode_dav1d::Dav1dDecoder;
+
+fn fill_frame<T: Pixel>(ra: &mut ChaChaRng, frame: &mut Frame<T>) {
+  for plane in frame.planes.iter_mut() {
+    let stride = plane.cfg.stride;
+    for row in plane.data.chunks_mut(stride) {
+      for pixel in row {
+        let v: u8 = ra.gen();
+        *pixel = T::cast_from(v);
+      }
+    }
+  }
+}
+
+pub(crate) fn read_frame_batch<T: Pixel>(ctx: &mut Context<T>, ra: &mut ChaChaRng) {
+  while ctx.needs_more_lookahead() {
+    let mut input = ctx.new_frame();
+    fill_frame(ra, Arc::get_mut(&mut input).unwrap());
+
+    let _ = ctx.send_frame(Some(input));
+  }
+  if !ctx.needs_more_frames(ctx.get_frame_count()) {
+    ctx.flush();
+  }
+}
+
+pub(crate) trait TestDecoder {
+  fn setup_decoder(w: usize, h: usize) -> Self where Self: Sized;
+  fn encode_decode(
+    &mut self, w: usize, h: usize, speed: usize, quantizer: usize,
+    limit: usize, bit_depth: usize, chroma_sampling: ChromaSampling,
+    min_keyint: u64, max_keyint: u64, low_latency: bool, bitrate: i32
+  );
+}
+
+pub(crate) fn compare_plane<T: Ord + std::fmt::Debug>(
+  rec: &[T], rec_stride: usize, dec: &[T], dec_stride: usize, width: usize,
+  height: usize
+) {
+  for line in rec.chunks(rec_stride).zip(dec.chunks(dec_stride)).take(height) {
+    assert_eq!(&line.0[..width], &line.1[..width]);
+  }
+}
+
+pub(crate) fn setup_encoder<T: Pixel>(
+  w: usize, h: usize, speed: usize, quantizer: usize, bit_depth: usize,
+  chroma_sampling: ChromaSampling, min_keyint: u64, max_keyint: u64,
+  low_latency: bool, bitrate: i32
+) -> Context<T> {
+  let mut enc = EncoderConfig::with_speed_preset(speed);
+  enc.quantizer = quantizer;
+  enc.min_key_frame_interval = min_keyint;
+  enc.max_key_frame_interval = max_keyint;
+  enc.low_latency = low_latency;
+  enc.width = w;
+  enc.height = h;
+  enc.bit_depth = bit_depth;
+  enc.chroma_sampling = chroma_sampling;
+  enc.bitrate = bitrate;
+
+  let cfg = Config {
+    enc
+  };
+
+  cfg.new_context()
+}
+
+// TODO: support non-multiple-of-16 dimensions
+static DIMENSION_OFFSETS: &[(usize, usize)] =
+  &[(0, 0), (4, 4), (8, 8), (16, 16)];
+
+fn speed(s: usize, decoder: &str) {
+  let quantizer = 100;
+  let limit = 5;
+  let w = 64;
+  let h = 80;
+
+  for b in DIMENSION_OFFSETS.iter() {
+      let w = w + b.0;
+      let h = h + b.1;
+      let mut dec = get_decoder(decoder, w as usize, h as usize);
+      dec.encode_decode(w, h, s, quantizer, limit, 8, Default::default(), 15, 15, true, 0);
+  }
+}
+
+macro_rules! test_speeds {
+  ($($S:expr),+) => {
+    $(
+        paste::item!{
+            #[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+            #[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+            #[ignore]
+            fn [<speed_ $S>](decoder: &str) {
+                speed($S, decoder)
+            }
+        }
+    )*
+  }
+}
+
+test_speeds!{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
+
+macro_rules! test_dimensions {
+  ($(($W:expr, $H:expr)),+) => {
+    $(
+        paste::item!{
+            #[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+            #[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+            fn [<dimension_ $W x $H>](decoder: &str) {
+                dimension($W, $H, decoder)
+            }
+        }
+    )*
+  }
+}
+
+test_dimensions!{
+  (8, 8),
+  (16, 16),
+  (32, 32),
+  (64, 64),
+  (128, 128),
+  (256, 256),
+  (512, 512),
+  (1024, 1024),
+  (2048, 2048),
+  (258, 258),
+  (260, 260),
+  (262, 262),
+  (264, 264),
+  (265, 265)
+}
+
+fn dimension(w: usize, h: usize, decoder: &str) {
+  let quantizer = 100;
+  let limit = 1;
+  let speed = 10;
+
+  let mut dec = get_decoder(decoder, w as usize, h as usize);
+  dec.encode_decode(w, h, speed, quantizer, limit, 8, Default::default(), 15, 15, true, 0);
+}
+
+#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+fn quantizer(decoder: &str) {
+  let limit = 5;
+  let w = 64;
+  let h = 80;
+  let speed = 10;
+
+  for b in DIMENSION_OFFSETS.iter() {
+    for &q in [80, 100, 120].iter() {
+      let mut dec = get_decoder(decoder, b.0, b.1);
+      dec.encode_decode(w + b.0, h + b.1, speed, q, limit, 8, Default::default(), 15, 15, true, 0);
+    }
+  }
+}
+
+#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+fn bitrate(decoder: &str) {
+  let limit = 5;
+  let w = 64;
+  let h = 80;
+  let speed = 10;
+
+  for &q in [172, 220, 252, 255].iter() {
+    for &r in [100, 1000, 10_000].iter() {
+      let mut dec = get_decoder(decoder, w as usize, h as usize);
+      dec.encode_decode(w, h, speed, q, limit, 8, Default::default(), 15, 15, true, r);
+    }
+  }
+}
+
+#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+fn keyframes(decoder: &str) {
+  let limit = 12;
+  let w = 64;
+  let h = 80;
+  let speed = 9;
+  let q = 100;
+
+  let mut dec = get_decoder(decoder, w as usize, h as usize);
+  dec.encode_decode(w, h, speed, q, limit, 8, Default::default(), 6, 6, true, 0);
+}
+
+#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+fn reordering(decoder: &str) {
+  let limit = 12;
+  let w = 64;
+  let h = 80;
+  let speed = 10;
+  let q = 100;
+
+  for keyint in &[4, 5, 6] {
+    let mut dec = get_decoder(decoder, w as usize, h as usize);
+    dec.encode_decode(w, h, speed, q, limit, 8, Default::default(), *keyint, *keyint, false, 0);
+  }
+}
+
+#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+fn reordering_short_video(decoder: &str) {
+  // Regression test for https://github.com/xiph/rav1e/issues/890
+  let limit = 2;
+  let w = 64;
+  let h = 80;
+  let speed = 10;
+  let q = 100;
+  let keyint = 12;
+
+  let mut dec = get_decoder(decoder, w as usize, h as usize);
+  dec.encode_decode(w, h, speed, q, limit, 8, Default::default(), keyint, keyint, false, 0);
+}
+
+#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+#[ignore]
+fn odd_size_frame_with_full_rdo(decoder: &str) {
+  let limit = 3;
+  let w = 512 + 32 + 16 + 5;
+  let h = 512 + 16 + 5;
+  let speed = 0;
+  let qindex = 100;
+
+  let mut dec = get_decoder(decoder, w as usize, h as usize);
+  dec.encode_decode(w, h, speed, qindex, limit, 8, Default::default(), 15, 15, true, 0);
+}
+
+#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+fn all_bit_depths(decoder: &str) {
+  let quantizer = 100;
+  let limit = 3; // Include inter frames
+  let speed = 0; // Test as many tools as possible
+  let w = 64;
+  let h = 80;
+
+  // 8-bit
+  let mut dec = get_decoder(decoder, w as usize, h as usize);
+  dec.encode_decode(w, h, speed, quantizer, limit, 8, Default::default(), 15, 15, true, 0);
+
+  // 10-bit
+  let mut dec = get_decoder(decoder, w as usize, h as usize);
+  dec.encode_decode(w, h, speed, quantizer, limit, 10, Default::default(), 15, 15, true, 0);
+
+  // 12-bit
+  let mut dec = get_decoder(decoder, w as usize, h as usize);
+  dec.encode_decode(w, h, speed, quantizer, limit, 12, Default::default(), 15, 15, true, 0);
+}
+
+#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+fn chroma_sampling(decoder: &str) {
+  let quantizer = 100;
+  let limit = 3; // Include inter frames
+  let speed = 0; // Test as many tools as possible
+  let w = 64;
+  let h = 80;
+
+  // TODO: bump keyint when inter is supported
+
+  // 4:2:0
+  let mut dec = get_decoder(decoder, w as usize, h as usize);
+  dec.encode_decode(w, h, speed, quantizer, limit, 8, ChromaSampling::Cs420, 1, 1, true, 0);
+
+  // 4:2:2
+  let mut dec = get_decoder(decoder, w as usize, h as usize);
+  dec.encode_decode(w, h, speed, quantizer, limit, 8, ChromaSampling::Cs422, 1, 1, true, 0);
+
+  // 4:4:4
+  let mut dec = get_decoder(decoder, w as usize, h as usize);
+  dec.encode_decode(w, h, speed, quantizer, limit, 8, ChromaSampling::Cs444, 1, 1, true, 0);
+}
+
+fn get_decoder(decoder: &str, w: usize, h: usize) -> Box<dyn TestDecoder> {
+  match decoder {
+    #[cfg(feature="decode_test")]
+    "aom" => Box::new(AomDecoder::setup_decoder(w, h)),
+    #[cfg(feature="decode_test_dav1d")]
+    "dav1d" => Box::new(Dav1dDecoder::setup_decoder(w, h)),
+    _ => unimplemented!()
+  }
+}

--- a/src/test_encode_decode_dav1d.rs
+++ b/src/test_encode_decode_dav1d.rs
@@ -8,272 +8,127 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use super::*;
-use rand::{ChaChaRng, Rng, SeedableRng};
+use rand::{ChaChaRng, SeedableRng};
 use std::{mem, ptr, slice};
 use std::collections::VecDeque;
-use std::sync::Arc;
-use crate::util::Pixel;
+use crate::util::{Pixel, CastFromPrimitive};
+use crate::test_encode_decode::{compare_plane, read_frame_batch, setup_encoder, TestDecoder};
 
 use dav1d_sys::*;
 
-fn fill_frame<T: Pixel>(ra: &mut ChaChaRng, frame: &mut Frame<T>) {
-  for plane in frame.planes.iter_mut() {
-    let stride = plane.cfg.stride;
-    for row in plane.data.chunks_mut(stride) {
-      for pixel in row {
-        let v: u8 = ra.gen();
-        *pixel = v as u16;
-      }
-    }
-  }
-}
-
-fn read_frame_batch<T: Pixel>(ctx: &mut Context<T>, ra: &mut ChaChaRng) {
-  while ctx.needs_more_lookahead() {
-    let mut input = ctx.new_frame();
-    fill_frame(ra, Arc::get_mut(&mut input).unwrap());
-
-    let _ = ctx.send_frame(Some(input));
-  }
-  if !ctx.needs_more_frames(ctx.get_frame_count()) {
-    ctx.flush();
-  }
-}
-
-struct Decoder {
+pub(crate) struct Dav1dDecoder {
   dec: *mut Dav1dContext
 }
 
-fn setup_decoder() -> Decoder {
-  unsafe {
-    let mut settings = mem::uninitialized();
-    let mut dec: Decoder = mem::uninitialized();
+impl TestDecoder for Dav1dDecoder {
+  fn setup_decoder(_w: usize, _h: usize) -> Self {
+    unsafe {
+      let mut settings = mem::uninitialized();
+      let mut dec: Dav1dDecoder = mem::uninitialized();
 
-    dav1d_default_settings(&mut settings);
+      dav1d_default_settings(&mut settings);
 
-    let ret = dav1d_open(&mut dec.dec, &settings);
+      let ret = dav1d_open(&mut dec.dec, &settings);
 
-    if ret != 0 {
-      panic!("Cannot instantiate the decoder {}", ret);
+      if ret != 0 {
+        panic!("Cannot instantiate the decoder {}", ret);
+      }
+
+      dec
     }
+  }
 
-    dec
+  fn encode_decode(
+    &mut self, w: usize, h: usize, speed: usize, quantizer: usize,
+    limit: usize, bit_depth: usize, chroma_sampling: ChromaSampling,
+    min_keyint: u64, max_keyint: u64, low_latency: bool, bitrate: i32
+  ) {
+    let mut ra = ChaChaRng::from_seed([0; 32]);
+
+    let mut ctx: Context<u16> =
+      setup_encoder(w, h, speed, quantizer, bit_depth, chroma_sampling,
+                    min_keyint, max_keyint, low_latency, bitrate);
+    ctx.set_limit(limit as u64);
+
+    println!("Encoding {}x{} speed {} quantizer {}", w, h, speed, quantizer);
+    #[cfg(feature="dump_ivf")]
+      let mut out = std::fs::File::create(&format!("out-{}x{}-s{}-q{}-{:?}.ivf",
+                                                   w, h, speed, quantizer, chroma_sampling)).unwrap();
+
+    #[cfg(feature="dump_ivf")]
+      ivf::write_ivf_header(&mut out, w, h, 30, 1);
+
+    let mut rec_fifo = VecDeque::new();
+
+    for _ in 0..limit {
+      read_frame_batch(&mut ctx, &mut ra);
+
+      let mut done = false;
+      let mut corrupted_count = 0;
+      while !done {
+        let res = ctx.receive_packet();
+        if let Ok(pkt) = res {
+          println!("Encoded packet {}", pkt.number);
+          #[cfg(feature="dump_ivf")]
+            ivf::write_ivf_frame(&mut out, pkt.number, &pkt.data);
+
+          if let Some(pkt_rec) = pkt.rec {
+            rec_fifo.push_back(pkt_rec.clone());
+          }
+
+          let packet = pkt.data;
+
+          unsafe {
+            let mut data: Dav1dData = mem::zeroed();
+            println!("Decoding frame {}", pkt.number);
+            let ptr = dav1d_data_create(&mut data, packet.len());
+            ptr::copy_nonoverlapping(packet.as_ptr(), ptr, packet.len());
+            let ret = dav1d_send_data(
+              self.dec, &mut data
+            );
+            println!("Decoded. -> {}", ret);
+            if ret != 0 {
+              corrupted_count += 1;
+            }
+
+            if ret == 0 {
+              loop {
+                let mut pic: Dav1dPicture = mem::zeroed();
+                println!("Retrieving frame");
+                let ret = dav1d_get_picture(self.dec, &mut pic);
+                println!("Retrieved.");
+                if ret == -(EAGAIN as i32) {
+                  done = true;
+                  break;
+                }
+                if ret != 0 {
+                  panic!("Decode fail");
+                }
+
+                let rec = rec_fifo.pop_front().unwrap();
+                compare_pic(&pic, &rec, bit_depth, w, h);
+              }
+            }
+          }
+        } else {
+          done = true;
+        }
+      }
+      assert_eq!(corrupted_count, 0);
+    }
   }
 }
 
-impl Drop for Decoder {
+impl Drop for Dav1dDecoder {
   fn drop(&mut self) {
     unsafe { dav1d_close(&mut self.dec) };
   }
 }
 
-fn setup_encoder(
-  w: usize, h: usize, speed: usize, quantizer: usize, bit_depth: usize,
-  chroma_sampling: ChromaSampling, min_keyint: u64, max_keyint: u64,
-  low_latency: bool, bitrate: i32
-) -> Context {
-
-  let mut enc = EncoderConfig::with_speed_preset(speed);
-  enc.quantizer = quantizer;
-  enc.min_key_frame_interval = min_keyint;
-  enc.max_key_frame_interval = max_keyint;
-  enc.low_latency = low_latency;
-  enc.width = w;
-  enc.height = h;
-  enc.bit_depth = bit_depth;
-  enc.chroma_sampling = chroma_sampling;
-  enc.bitrate = bitrate;
-
-  let cfg = Config {
-    enc
-  };
-
-  cfg.new_context()
-}
-
-// TODO: support non-multiple-of-16 dimensions
-static DIMENSION_OFFSETS: &[(usize, usize)] =
-  &[(0, 0), (4, 4), (8, 8), (16, 16)];
-
-fn speed(s: usize) {
-  let quantizer = 100;
-  let limit = 5;
-  let w = 64;
-  let h = 80;
-
-  for b in DIMENSION_OFFSETS.iter() {
-      encode_decode(w + b.0, h + b.1, s, quantizer, limit, 8, Default::default(), 15, 15, true, 0);
-  }
-}
-
-macro_rules! test_speeds {
-  ($($S:expr),+) => {
-    $(
-        paste::item!{
-            #[test]
-            #[ignore]
-            fn [<speed_ $S>]() {
-                speed($S)
-            }
-        }
-    )*
-  }
-}
-
-test_speeds!{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
-
-macro_rules! test_dimensions {
-  ($(($W:expr, $H:expr)),+) => {
-    $(
-        paste::item!{
-            #[test]
-            fn [<dimension_ $W x $H>]() {
-                dimension($W, $H)
-            }
-        }
-    )*
-  }
-}
-
-test_dimensions!{
-  (8, 8),
-  (16, 16),
-  (32, 32),
-  (64, 64),
-  (128, 128),
-  (256, 256),
-  (512, 512),
-  (1024, 1024),
-  (2048, 2048),
-  (258, 258),
-  (260, 260),
-  (262, 262),
-  (264, 264),
-  (265, 265)
-}
-
-fn dimension(w: usize, h: usize) {
-  let quantizer = 100;
-  let limit = 1;
-  let speed = 4;
-
-  encode_decode(w, h, speed, quantizer, limit, 8, Default::default(), 15, 15, true, 0);
-}
-
-#[test]
-fn quantizer() {
-  let limit = 5;
-  let w = 64;
-  let h = 80;
-  let speed = 4;
-
-  for b in DIMENSION_OFFSETS.iter() {
-    for &q in [80, 100, 120].iter() {
-      encode_decode(w + b.0, h + b.1, speed, q, limit, 8, Default::default(), 15, 15, true, 0);
-    }
-  }
-}
-
-#[test]
-fn bitrate() {
-  let limit = 5;
-  let w = 64;
-  let h = 80;
-  let speed = 4;
-
-  for &q in [172, 220, 252, 255].iter() {
-    for &r in [100, 1000, 10_000].iter() {
-      encode_decode(w, h, speed, q, limit, 8, Default::default(), 15, 15, true, r);
-    }
-  }
-}
-
-#[test]
-fn keyframes() {
-  let limit = 12;
-  let w = 64;
-  let h = 80;
-  let speed = 10;
-  let q = 100;
-
-  encode_decode(w, h, speed, q, limit, 8, Default::default(), 6, 6, true, 0);
-}
-
-#[test]
-fn reordering() {
-  let limit = 12;
-  let w = 64;
-  let h = 80;
-  let speed = 10;
-  let q = 100;
-
-  for keyint in &[4, 5, 6] {
-    encode_decode(w, h, speed, q, limit, 8, Default::default(), *keyint, *keyint, false, 0);
-  }
-}
-
-#[test]
-#[ignore]
-fn odd_size_frame_with_full_rdo() {
-  let limit = 3;
-  let w = 512 + 32 + 16 + 5;
-  let h = 512 + 16 + 5;
-  let speed = 0;
-  let qindex = 100;
-
-  encode_decode(w, h, speed, qindex, limit, 8, Default::default(), 15, 15, true, 0);
-}
-
-fn high_bd(bits: usize) {
-  let quantizer = 100;
-  let limit = 3; // Include inter frames
-  let speed = 0; // Test as many tools as possible
-  let w = 64;
-  let h = 80;
-
-  encode_decode(w, h, speed, quantizer, limit, bits, Default::default(), 15, 15, true, 0);
-}
-
-#[test]
-fn chroma_sampling() {
-  let quantizer = 100;
-  let limit = 3; // Include inter frames
-  let speed = 0; // Test as many tools as possible
-  let w = 64;
-  let h = 80;
-
-  // TODO: bump keyint when inter is supported
-
-  // 4:2:2
-  encode_decode(w, h, speed, quantizer, limit, 8, ChromaSampling::Cs422, 1, 1, true, 0);
-
-  // 4:4:4
-  encode_decode(w, h, speed, quantizer, limit, 8, ChromaSampling::Cs444, 1, 1, true, 0);
-}
-
-#[test]
-fn high_bd_10() {
-  high_bd(10);
-}
-
-#[test]
-fn high_bd_12() {
-  high_bd(12);
-}
-
-fn compare_plane<T: Ord + std::fmt::Debug>(
-  rec: &[T], rec_stride: usize, dec: &[T], dec_stride: usize, width: usize,
-  height: usize
-) {
-  for line in rec.chunks(rec_stride).zip(dec.chunks(dec_stride)).take(height) {
-    assert_eq!(&line.0[..width], &line.1[..width]);
-  }
-}
-
-fn compare_pic(pic: &Dav1dPicture, frame: &Frame, bit_depth: usize, width: usize, height: usize) {
+fn compare_pic<T: Pixel>(pic: &Dav1dPicture, frame: &Frame<T>, bit_depth: usize, width: usize, height: usize) {
   use plane::Plane;
 
-  let cmp_plane = |data, stride, frame_plane: &Plane| {
+  let cmp_plane = |data, stride, frame_plane: &Plane<T>| {
     let w = width >> frame_plane.cfg.xdec;
     let h = height >> frame_plane.cfg.ydec;
     let rec_stride = frame_plane.cfg.stride;
@@ -288,7 +143,7 @@ fn compare_pic(pic: &Dav1dPicture, frame: &Frame, bit_depth: usize, width: usize
       };
 
       let rec: Vec<u16> =
-        frame_plane.data_origin().iter().map(|&v| v).collect();
+        frame_plane.data_origin().iter().map(|&v| u16::cast_from(v)).collect();
 
       compare_plane::<u16>(&rec[..], rec_stride, dec, stride, w, h);
     } else {
@@ -300,7 +155,7 @@ fn compare_pic(pic: &Dav1dPicture, frame: &Frame, bit_depth: usize, width: usize
       };
 
       let rec: Vec<u8> =
-        frame_plane.data_origin().iter().map(|&v| v as u8).collect();
+        frame_plane.data_origin().iter().map(|&v| u8::cast_from(v)).collect();
 
       compare_plane::<u8>(&rec[..], rec_stride, dec, stride, w, h);
     }
@@ -312,104 +167,4 @@ fn compare_pic(pic: &Dav1dPicture, frame: &Frame, bit_depth: usize, width: usize
   cmp_plane(pic.data[0], lstride, &frame.planes[0]);
   cmp_plane(pic.data[1], cstride, &frame.planes[1]);
   cmp_plane(pic.data[2], cstride, &frame.planes[2]);
-}
-
-fn encode_decode(
-  w: usize, h: usize, speed: usize, quantizer: usize, limit: usize,
-  bit_depth: usize, chroma_sampling: ChromaSampling, min_keyint: u64,
-  max_keyint: u64, low_latency: bool, bitrate: i32
-) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
-
-  let dec = setup_decoder();
-  let mut ctx =
-    setup_encoder(w, h, speed, quantizer, bit_depth, chroma_sampling,
-                  min_keyint, max_keyint, low_latency, bitrate);
-  ctx.set_limit(limit as u64);
-
-  println!("Encoding {}x{} speed {} quantizer {}", w, h, speed, quantizer);
-  #[cfg(feature="dump_ivf")]
-  let mut out = std::fs::File::create(&format!("out-{}x{}-s{}-q{}-{:?}.ivf",
-                                           w, h, speed, quantizer, chroma_sampling)).unwrap();
-
-  #[cfg(feature="dump_ivf")]
-  ivf::write_ivf_header(&mut out, w, h, 30, 1);
-
-  let mut rec_fifo = VecDeque::new();
-
-  for _ in 0..limit {
-    read_frame_batch(&mut ctx, &mut ra);
-
-    let mut done = false;
-    let mut corrupted_count = 0;
-    while !done {
-      let res = ctx.receive_packet();
-      if let Ok(pkt) = res {
-        println!("Encoded packet {}", pkt.number);
-        #[cfg(feature="dump_ivf")]
-        ivf::write_ivf_frame(&mut out, pkt.number, &pkt.data);
-
-        if let Some(pkt_rec) = pkt.rec {
-          rec_fifo.push_back(pkt_rec.clone());
-        }
-
-        let packet = pkt.data;
-
-        unsafe {
-          let mut data: Dav1dData = mem::zeroed();
-          println!("Decoding frame {}", pkt.number);
-          let mut ptr = dav1d_data_create(&mut data, packet.len());
-          ptr::copy_nonoverlapping(packet.as_ptr(), ptr, packet.len());
-          let ret = dav1d_send_data(
-            dec.dec, &mut data
-          );
-          println!("Decoded. -> {}", ret);
-          if ret != 0 { /*
-            let error_msg = aom_codec_error(&mut dec.dec);
-            println!(
-              "  Decode codec_decode failed: {}",
-              CStr::from_ptr(error_msg).to_string_lossy()
-            );
-            let detail = aom_codec_error_detail(&mut dec.dec);
-            if !detail.is_null() {
-              println!(
-                "  Decode codec_decode failed {}",
-                CStr::from_ptr(detail).to_string_lossy()
-              );
-            } */
-
-            corrupted_count += 1;
-          }
-
-          if ret == 0 {
-            loop {
-              let mut pic: Dav1dPicture = mem::zeroed();
-              println!("Retrieving frame");
-              let ret = dav1d_get_picture(dec.dec, &mut pic);
-              println!("Retrieved.");
-              if ret == -(EAGAIN as i32) {
-                done = true;
-                break;
-              }
-              if ret != 0 {
-                /* let detail = aom_codec_error_detail(&mut dec.dec);
-                panic!(
-                  "Decode codec_control failed {}",
-                  CStr::from_ptr(detail).to_string_lossy()
-                );
-                */
-                panic!("Decode fail");
-              }
-
-              let rec = rec_fifo.pop_front().unwrap();
-              compare_pic(&pic, &rec, bit_depth, w, h);
-            }
-          }
-        }
-      } else {
-        done = true;
-      }
-    }
-    assert_eq!(corrupted_count, 0);
-  }
 }


### PR DESCRIPTION
Closes #956

Some dav1d tests are known to fail due to rounding errors.
This is an existing issue and is not resolved in this commit.