### PR TITLE
Set default number of threads to 2

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -47,7 +47,7 @@ pub fn parse_cli() -> CliOptions {
         .help("Set the threadpool size")
         .long("threads")
         .takes_value(true)
-        .default_value("0")
+        .default_value("2")
     )
     // INPUT/OUTPUT
     .arg(


### PR DESCRIPTION
As a temporary measure related to #1064, set default number of threads to 2 to avoid slowing things down on systems with lots of available threads.