### PR TITLE
Avoid out-of-slice accesses from PlaneMutSlice (alternative)

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -958,7 +958,15 @@ pub fn encode_tx_block<T: Pixel>(
 
   if mode.is_intra() {
     let bit_depth = fi.sequence.bit_depth;
-    let edge_buf = get_intra_edges(&rec.slice(po), tx_size, bit_depth, &fs.input.planes[p].cfg, fi.w_in_b, fi.h_in_b, Some(mode));
+    let edge_buf = get_intra_edges(
+      &rec.edged_slice(po, 1, 1),
+      tx_size,
+      bit_depth,
+      &fs.input.planes[p].cfg,
+      fi.w_in_b,
+      fi.h_in_b,
+      Some(mode),
+    );
     mode.predict_intra(&mut rec.mut_slice(po), tx_size, bit_depth, &ac, alpha, &edge_buf);
   }
 

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -568,17 +568,6 @@ impl<'a, T: Pixel> PlaneMutSlice<'a, T> {
   }
 
   // FIXME: code duplication with PlaneSlice
-
-  /// A slice starting i pixels above the current one.
-  pub fn go_up(&self, i: usize) -> PlaneSlice<'_, T> {
-    PlaneSlice { plane: self.plane, x: self.x, y: self.y - i as isize }
-  }
-
-  /// A slice starting i pixels to the left of the current one.
-  pub fn go_left(&self, i: usize) -> PlaneSlice<'_, T> {
-    PlaneSlice { plane: self.plane, x: self.x - i as isize, y: self.y }
-  }
-
   pub fn p(&self, add_x: usize, add_y: usize) -> T {
     let new_y =
       (self.y + add_y as isize + self.plane.cfg.yorigin as isize) as usize;

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -190,6 +190,19 @@ impl<T: Pixel> Plane<T> {
   }
 
   #[inline]
+  pub fn edged_slice(&self, po: &PlaneOffset, left_edge: usize, top_edge: usize) -> EdgedPlaneSlice<'_, T> {
+    debug_assert!(po.x >= 0);
+    debug_assert!(po.y >= 0);
+    let left_edge = left_edge.min(po.x as usize);
+    let top_edge = top_edge.min(po.y as usize);
+    let edged_po = PlaneOffset {
+      x: po.x - left_edge as isize,
+      y: po.y - top_edge as isize,
+    };
+    EdgedPlaneSlice { ps: self.slice(&edged_po), left_edge, top_edge }
+  }
+
+  #[inline]
   fn index(&self, x: usize, y: usize) -> usize {
     (y + self.cfg.yorigin) * self.cfg.stride + (x + self.cfg.xorigin)
   }
@@ -585,6 +598,18 @@ impl<'a, T: Pixel> Index<usize> for PlaneMutSlice<'a, T> {
 impl<'a, T: Pixel> IndexMut<usize> for PlaneMutSlice<'a, T> {
   fn index_mut(&mut self, index: usize) -> &mut Self::Output {
     self.row_mut(index)
+  }
+}
+
+pub struct EdgedPlaneSlice<'a, T: Pixel> {
+  pub ps: PlaneSlice<'a, T>,
+  pub left_edge: usize,
+  pub top_edge: usize,
+}
+
+impl<T: Pixel> EdgedPlaneSlice<'_, T> {
+  pub fn without_edges(&self) -> PlaneSlice<'_, T> {
+    self.ps.subslice(self.left_edge, self.top_edge)
   }
 }
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -723,7 +723,15 @@ pub fn rdo_mode_decision<T: Pixel>(
       let edge_buf = {
         let rec = &mut fs.rec.planes[0];
         let po = bo.plane_offset(&rec.cfg);
-        get_intra_edges(&rec.slice(&po), tx_size, fi.sequence.bit_depth, &fs.input.planes[0].cfg, fi.w_in_b, fi.h_in_b, None)
+        get_intra_edges(
+          &rec.edged_slice(&po, 1, 1),
+          tx_size,
+          fi.sequence.bit_depth,
+          &fs.input.planes[0].cfg,
+          fi.w_in_b,
+          fi.h_in_b,
+          None
+        )
       };
       intra_mode_set
         .iter()
@@ -903,7 +911,7 @@ pub fn rdo_cfl_alpha<T: Pixel>(
       (-16i16..17i16)
         .min_by_key(|&alpha| {
           let edge_buf = get_intra_edges(
-            &rec.slice(&po),
+            &rec.edged_slice(&po, 1, 1),
             uv_tx_size,
             bit_depth,
             &input.cfg,


### PR DESCRIPTION
This is an alternative to #1071.

This PR introduces a new structure to hold a slice with its edges, so that a subslice never exceeds its parent slice, and uses it to get rid of `go_up()` and `go_left()` from `PlaneMutSlice`.

I think the resulting code is less confusing than #1071.