### PR TITLE
Allow unaligned sad_sse2 calls below 16x16

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -135,14 +135,13 @@ mod nasm {
     assert!(mem::size_of::<T>() == 1, "only implemented for u8 for now");
     // FIXME unaligned blocks coming from hres/qres ME search
     let ptr_align_log2 = (plane_org.as_ptr() as usize).trailing_zeros() as usize;
-    if ptr_align_log2 < 2 {
-      return super::native::get_sad(plane_org, plane_ref, blk_h, blk_w, 8);
-    }
+    // The largest unaligned-safe function is for 8x8
+    let ptr_align = 1 << ptr_align_log2.max(3);
     let mut sum = 0 as u32;
     let org_stride = (plane_org.plane.cfg.stride * mem::size_of::<T>()) as libc::ptrdiff_t;
     let ref_stride = (plane_ref.plane.cfg.stride * mem::size_of::<T>()) as libc::ptrdiff_t;
     assert!(blk_h >= 4 && blk_w >= 4);
-    let step_size = blk_h.min(blk_w).min(1 << ptr_align_log2);
+    let step_size = blk_h.min(blk_w).min(ptr_align);
     let func = match step_size.ilog() {
       3 => rav1e_sad4x4_sse2,
       4 => rav1e_sad8x8_sse2,


### PR DESCRIPTION
The initial fall-back logic was a bit too pessimistic since 4x4 and 8x8 don't have strict alignment requirements. This removes the fall-back to the Rust-native function on sub-16x16 alignment.
From an [AWCY run](https://beta.arewecompressedyet.com/?job=master-85c8e57e982cc81cd02877e94604605c8de6939b&job=sad-alignment%402019-03-08T09%3A27%3A01.118Z) we see a tiny improvement up to 0.4%.