### PR TITLE
Remove unused convert_slice_2d()

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -293,20 +293,3 @@ pub fn msb(x: i32) -> i32 {
 pub fn round_shift(value: i32, bit: usize) -> i32 {
   (value + (1 << bit >> 1)) >> bit
 }
-
-pub unsafe fn convert_slice_2d<NEW, OLD>(
-  dst: *mut NEW, dst_stride: usize, src: *const OLD, src_stride: usize,
-  width: usize, height: usize
-)
-where
-  NEW: CastFromPrimitive<OLD> + Copy + 'static,
-  OLD: Copy + 'static,
-{
-  for y in 0..height {
-    for x in 0..width {
-      let p_dst = dst.add(y * dst_stride + x);
-      let p_src = src.add(y * src_stride + x);
-      *p_dst = NEW::cast_from(*p_src);
-    }
-  }
-}


### PR DESCRIPTION
Since commit 0a35174f959269c147a497e7ac4ee8843f393107, the function `convert_slice_2d()` is not used anymore.