### PR TITLE
Add a speed setting for CDEF

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -132,7 +132,8 @@ pub struct SpeedSettings {
   pub prediction_modes: PredictionModesSetting,
   pub include_near_mvs: bool,
   pub no_scene_detection: bool,
-  pub diamond_me: bool
+  pub diamond_me: bool,
+  pub cdef: bool
 }
 
 impl Default for SpeedSettings {
@@ -150,6 +151,7 @@ impl Default for SpeedSettings {
       include_near_mvs: false,
       no_scene_detection: false,
       diamond_me: false,
+      cdef: false,
     }
   }
 }
@@ -169,6 +171,7 @@ impl SpeedSettings {
       include_near_mvs: Self::include_near_mvs_preset(speed),
       no_scene_detection: Self::no_scene_detection_preset(speed),
       diamond_me: Self::diamond_me_preset(speed),
+      cdef: Self::cdef_preset(speed),
     }
   }
 
@@ -241,6 +244,10 @@ impl SpeedSettings {
   ///
   /// TODO: Revisit this setting if full search quality improves in the future.
   fn diamond_me_preset(_speed: usize) -> bool {
+    true
+  }
+
+  fn cdef_preset(_speed: usize) -> bool {
     true
   }
 }

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -434,7 +434,7 @@ fn parse_config(matches: &ArgMatches<'_>) -> EncoderConfig {
 fn apply_speed_test_cfg(cfg: &mut EncoderConfig, setting: &str) {
   match setting {
     "baseline" => {
-      // Use default settings
+      cfg.speed_settings = SpeedSettings::default();
     },
     "min_block_size_4x4" => {
       cfg.speed_settings.min_block_size = BlockSize::BLOCK_4X4;

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -484,6 +484,9 @@ fn apply_speed_test_cfg(cfg: &mut EncoderConfig, setting: &str) {
     "diamond_me" => {
       cfg.speed_settings.diamond_me = true;
     }
+    "cdef" => {
+      cfg.speed_settings.cdef = true;
+    }
     setting => {
       panic!("Unrecognized speed test setting {}", setting);
     }

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -203,7 +203,7 @@ fn adjust_strength(strength: i32, var: i32) -> i32 {
 // boundaries (padding is untouched here).
 
 pub fn cdef_analyze_superblock<T: Pixel>(
-  in_frame: &mut Frame<T>,
+  in_frame: &Frame<T>,
   bc_global: &mut BlockContext,
   sbo: &SuperBlockOffset,
   sbo_global: &SuperBlockOffset,
@@ -227,7 +227,7 @@ pub fn cdef_analyze_superblock<T: Pixel>(
 
         if !skip {
           let mut var: i32 = 0;
-          let in_plane = &mut in_frame.planes[0];
+          let in_plane = &in_frame.planes[0];
           let in_po = sbo.plane_offset(&in_plane.cfg);
           let in_slice = in_plane.slice(&in_po);
           dir.dir[bx][by] = cdef_find_dir(&in_slice.reslice(8 * bx as isize + 2,
@@ -329,7 +329,7 @@ pub fn cdef_empty_frame<T: Pixel, U: Pixel>(f: &Frame<T>) -> Frame<U> {
 // cdef_index is taken from the block context
 pub fn cdef_filter_superblock<T: Pixel>(
   fi: &FrameInvariants<T>,
-  in_frame: &mut Frame<u16>,
+  in_frame: &Frame<u16>,
   out_frame: &mut Frame<T>,
   bc_global: &mut BlockContext,
   sbo: &SuperBlockOffset,
@@ -367,13 +367,13 @@ pub fn cdef_filter_superblock<T: Pixel>(
           for p in 0..3 {
             let out_plane = &mut out_frame.planes[p];
             let out_po = sbo.plane_offset(&out_plane.cfg);
-            let in_plane = &mut in_frame.planes[p];
+            let in_plane = &in_frame.planes[p];
             let in_po = sbo.plane_offset(&in_plane.cfg);
             let xdec = in_plane.cfg.xdec;
             let ydec = in_plane.cfg.ydec;
 
             let in_stride = in_plane.cfg.stride;
-            let in_slice = &in_plane.mut_slice(&in_po);
+            let in_slice = &in_plane.slice(&in_po);
             let out_stride = out_plane.cfg.stride;
             let out_slice = &mut out_plane.mut_slice(&out_po);
 
@@ -480,8 +480,8 @@ pub fn cdef_filter_frame<T: Pixel>(fi: &FrameInvariants<T>, rec: &mut Frame<T>, 
     for fbx in 0..fb_width {
       let sbo = SuperBlockOffset { x: fbx, y: fby };
       let cdef_index = bc.at(&sbo.block_offset(0, 0)).cdef_index;
-      let cdef_dirs = cdef_analyze_superblock(&mut cdef_frame, bc, &sbo, &sbo, fi.sequence.bit_depth);
-      cdef_filter_superblock(fi, &mut cdef_frame, rec, bc, &sbo, &sbo, cdef_index, &cdef_dirs);
+      let cdef_dirs = cdef_analyze_superblock(&cdef_frame, bc, &sbo, &sbo, fi.sequence.bit_depth);
+      cdef_filter_superblock(fi, &cdef_frame, rec, bc, &sbo, &sbo, cdef_index, &cdef_dirs);
     }
   }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -310,7 +310,7 @@ impl Sequence {
       enable_ref_frame_mvs: false,
       enable_warped_motion: false,
       enable_superres: false,
-      enable_cdef: true,
+      enable_cdef: config.speed_settings.cdef,
       enable_restoration: config.chroma_sampling != ChromaSampling::Cs422 &&
         config.chroma_sampling != ChromaSampling::Cs444, // FIXME: not working yet
       operating_points_cnt_minus_1: 0,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1275,22 +1275,26 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
   let mut best_cost_acc = -1.;
   let mut best_cost = [-1.; PLANES];
   let sbo_0 = SuperBlockOffset { x: 0, y: 0 };
-  let mut lrf_input;
-  let mut lrf_output;
-  let mut cdef_input;
 
-  assert!(fi.sequence.enable_cdef);
   // all stages; reconstruction goes to cdef so it must be additionally padded
   // TODO: use the new plane padding mechanism rather than this old kludge.  Will require
   // altering CDEF code a little.
-  cdef_input = cdef_sb_padded_frame_copy(fi, sbo, &fs.rec, 2);
-  lrf_input = cdef_sb_frame(fi, &fs.rec);
-  lrf_output = cdef_sb_frame(fi, &fs.rec);
-  // FIXME: T:T padded frame copy required for CDEF disabled path.
-  // no cdef; unpadded reconstruction offered directly to LRF optimization
-  // cdef_input = cdef_empty_frame(&fs.rec);
-  // lrf_input = cdef_sb_padded_frame_copy(fi, sbo, &fs.rec, 0);
-  // lrf_output = cdef_sb_frame(fi, &fs.rec);
+  let mut cdef_input = None;
+  let mut lrf_input = cdef_sb_frame(fi, &fs.rec);
+  let mut lrf_output = cdef_sb_frame(fi, &fs.rec);
+  if fi.sequence.enable_cdef {
+    cdef_input = Some(cdef_sb_padded_frame_copy(fi, sbo, &fs.rec, 2));
+  } else {
+    for p in 0..3 {
+      let po = sbo.plane_offset(&fs.rec.planes[p].cfg);
+      let PlaneConfig { width, height, .. } = lrf_input.planes[p].cfg;
+      for (rec, inp) in fs.rec.planes[p].slice(&po).rows_iter().zip(
+        lrf_input.planes[p].as_mut_slice().rows_iter_mut()
+      ).take(height) {
+        inp[..width].copy_from_slice(&rec[..width]);
+      }
+    }
+  }
 
   let mut lrf_any_uncoded = false;
   if fi.sequence.enable_restoration {
@@ -1308,14 +1312,16 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
   // Try all CDEF options with current LRF; if new CDEF+LRF choice is better, select it.
   // Try all LRF options with current CDEF; if new CDEF+LRF choice is better, select it.
   // If LRF choice changed for any plane, repeat last two steps.
-  let cdef_dirs = cdef_analyze_superblock(&cdef_input, &mut cw.bc,
-                                          &sbo_0, &sbo, fi.sequence.bit_depth);
+  let bd = fi.sequence.bit_depth;
+  let cdef_data = cdef_input.as_ref().map(|input| {
+    (input, cdef_analyze_superblock(input, &mut cw.bc, &sbo_0, &sbo, bd))
+  });
   let mut first_loop = true;
   loop {
     // check for [new] cdef index if cdef is enabled.
     let mut cdef_change = false;
     let prev_best_index = best_index;
-    if fi.sequence.enable_cdef {
+    if let Some((cdef_input, cdef_dirs)) = cdef_data.as_ref() {
       for cdef_index in 0..(1<<fi.cdef_bits) {
         if cdef_index != prev_best_index {
           let mut cost = [0.; PLANES];
@@ -1370,7 +1376,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
     let mut lrf_change = false;
     if fi.sequence.enable_restoration && lrf_any_uncoded {
       // need cdef output from best index, not just last iteration
-      if fi.sequence.enable_cdef {
+      if let Some((cdef_input, cdef_dirs)) = cdef_data.as_ref() {
         cdef_filter_superblock(fi, &cdef_input, &mut lrf_input,
                                &mut cw.bc, &sbo_0, &sbo, best_index as u8, &cdef_dirs);
       }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1308,7 +1308,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
   // Try all CDEF options with current LRF; if new CDEF+LRF choice is better, select it.
   // Try all LRF options with current CDEF; if new CDEF+LRF choice is better, select it.
   // If LRF choice changed for any plane, repeat last two steps.
-  let cdef_dirs = cdef_analyze_superblock(&mut cdef_input, &mut cw.bc,
+  let cdef_dirs = cdef_analyze_superblock(&cdef_input, &mut cw.bc,
                                           &sbo_0, &sbo, fi.sequence.bit_depth);
   let mut first_loop = true;
   loop {
@@ -1320,7 +1320,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
         if cdef_index != prev_best_index {
           let mut cost = [0.; PLANES];
           let mut cost_acc = 0.;
-          cdef_filter_superblock(fi, &mut cdef_input, &mut lrf_input,
+          cdef_filter_superblock(fi, &cdef_input, &mut lrf_input,
                                  &mut cw.bc, &sbo_0, &sbo, cdef_index as u8, &cdef_dirs);
           for pli in 0..3 {
             match best_lrf[pli] {
@@ -1371,7 +1371,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
     if fi.sequence.enable_restoration && lrf_any_uncoded {
       // need cdef output from best index, not just last iteration
       if fi.sequence.enable_cdef {
-        cdef_filter_superblock(fi, &mut cdef_input, &mut lrf_input,
+        cdef_filter_superblock(fi, &cdef_input, &mut lrf_input,
                                &mut cw.bc, &sbo_0, &sbo, best_index as u8, &cdef_dirs);
       }
 


### PR DESCRIPTION
This facilitates testing the the impact on complexity and efficiency of enabling CDEF. This also restores the logic for when CDEF is disabled, which was temporarily removed while enabling `u8` encdoing paths. AWCY results at [default settings](https://beta.arewecompressedyet.com/?job=master-97fc520bf6c65cd8a2fb8e0a3333d3e658faccf3&job=cdef-speed-setting-else%402019-03-11T12%3A46%3A40.215Z) show no change in output.