### PR TITLE
Remove fake-genericity from sad functions

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -92,7 +92,7 @@ mod nasm {
   }
 
   #[target_feature(enable = "ssse3")]
-  unsafe fn sad_ssse3(
+  unsafe fn sad_hbd_ssse3(
     plane_org: &PlaneSlice<'_, u16>, plane_ref: &PlaneSlice<'_, u16>, blk_h: usize,
     blk_w: usize, bit_depth: usize
   ) -> u32 {
@@ -175,7 +175,7 @@ mod nasm {
         return unsafe {
           let plane_org = &*(plane_org as *const _ as *const PlaneSlice<'_, u16>);
           let plane_ref = &*(plane_ref as *const _ as *const PlaneSlice<'_, u16>);
-          sad_ssse3(plane_org, plane_ref, blk_h, blk_w, bit_depth)
+          sad_hbd_ssse3(plane_org, plane_ref, blk_h, blk_w, bit_depth)
         };
       }
       if mem::size_of::<T>() == 1 && is_x86_feature_detected!("sse2") && blk_h >= 4 && blk_w >= 4 {


### PR DESCRIPTION
The functions `sad_ssse3()` and `sad_sse2()` only support `u16` and `u8` respectively, so they are not generic.

Make the caller pass the expected type.

![sad](https://user-images.githubusercontent.com/543275/54131793-5c975600-4413-11e9-911d-6c2c54623831.gif)