### PR TITLE
Retrieve size from plane_cfg in get_intra_edges()

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -963,8 +963,6 @@ pub fn encode_tx_block<T: Pixel>(
       tx_size,
       bit_depth,
       &fs.input.planes[p].cfg,
-      fi.w_in_b,
-      fi.h_in_b,
       Some(mode),
     );
     mode.predict_intra(&mut rec.mut_slice(po), tx_size, bit_depth, &ac, alpha, &edge_buf);

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -821,8 +821,6 @@ pub fn get_intra_edges<T: Pixel>(
   tx_size: TxSize,
   bit_depth: usize,
   plane_cfg: &PlaneConfig,
-  frame_w_in_b: usize,
-  frame_h_in_b: usize,
   opt_mode: Option<PredictionMode>
 ) -> AlignedArray<[T; 4 * MAX_TX_SIZE + 1]> {
   let (left_edge, top_edge) = (dst.left_edge, dst.top_edge);
@@ -920,9 +918,7 @@ pub fn get_intra_edges<T: Pixel>(
         );
 
       let num_avail = if top_edge != 0 && has_tr(&bo, bsize) {
-        tx_size.width().min(
-          (MI_SIZE >> plane_cfg.xdec) * frame_w_in_b - x - tx_size.width()
-        )
+        tx_size.width().min(plane_cfg.width - x - tx_size.width())
       } else {
         0
       };
@@ -953,9 +949,7 @@ pub fn get_intra_edges<T: Pixel>(
         );
 
       let num_avail = if left_edge != 0 && has_bl(&bo, bsize) {
-        tx_size.height().min(
-          (MI_SIZE >> plane_cfg.ydec) * frame_h_in_b - y - tx_size.height()
-        )
+        tx_size.height().min(plane_cfg.height - y - tx_size.height())
       } else {
         0
       };

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -728,8 +728,6 @@ pub fn rdo_mode_decision<T: Pixel>(
           tx_size,
           fi.sequence.bit_depth,
           &fs.input.planes[0].cfg,
-          fi.w_in_b,
-          fi.h_in_b,
           None
         )
       };
@@ -915,8 +913,6 @@ pub fn rdo_cfl_alpha<T: Pixel>(
             uv_tx_size,
             bit_depth,
             &input.cfg,
-            0,
-            0,
             Some(PredictionMode::UV_CFL_PRED)
           );
           PredictionMode::UV_CFL_PRED.predict_intra(


### PR DESCRIPTION
To compute the number of available pixels in an edge, `get_intra_edges()` used `frame_w_in_b` (`MiCols`) and `frame_h_in_b` (`MiRows`), initialized [as follow](https://aomediacodec.github.io/av1-spec/#compute-image-size-function):

    MiCols = 2 * ( ( FrameWidth + 7 ) >> 3 )
    MiRows = 2 * ( ( FrameHeight + 7 ) >> 3 )


As a consequence, the sizes computed by `get_intra_edges()` were basically the frame size rounded up to the next multiple of 8 (i.e. including some
padding), decimated:

    (MI_SIZE >> plane_cfg.xdec) * frame_w_in_b
    (MI_SIZE >> plane_cfg.ydec) * frame_h_in_b

Using edges pixels in the frame padding here will make no sense with tiling, so it should be equivalent to just using the plane size.

---
I don't really know why it was implemented that way. Maybe there was a good reason.

![ihniwid](https://user-images.githubusercontent.com/543275/54314483-193c1380-45dc-11e9-8e6e-858b660527e0.jpg)