### PR TITLE
Cache the cargo directory in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,11 @@ before_install:
 
 cache:
   directories:
-  - "$HOME/.cache/sccache"
+  - $HOME/.cargo
+  - $HOME/.cache/sccache
+
+before_cache:
+  - rm -rf $HOME/.cargo/registry
 
 after_script:
 - sccache -s

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,8 @@ on_success:
     - sccache -s
 
 cache:
+    - '%USERPROFILE%\.cargo\bin'
+    - '%USERPROFILE%\.cargo\.crates.toml'
     - '%LOCALAPPDATA%\Mozilla\sccache'
 
 build_script:


### PR DESCRIPTION
This is potentially a substantial saving on the time spent in the prelude of CI tasks. The downsides are less clear than with sccache. Proceeding with cautious optimism.