### PR TITLE
Rework the internal encoding logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ quick_test = []
 arg_enum_proc_macro = "0.1.1"
 bitstream-io = "0.8"
 clap = { version = "2", optional = true, default-features = false }
+crossbeam = "0.7"
 libc = "0.2"
 rand = "0.5"
 y4m = { version = "0.3.2", optional = true }

--- a/src/api.rs
+++ b/src/api.rs
@@ -499,8 +499,10 @@ impl Config {
 }
 
 pub struct ContextInner<T: Pixel> {
+  /// Number of frames fed to the encoder
   frame_count: u64,
   limit: u64,
+  /// Last frame number being marked
   pub(crate) idx: u64,
   frames_processed: u64,
   /// Maps frame *number* to frames

--- a/src/api.rs
+++ b/src/api.rs
@@ -578,10 +578,18 @@ impl<T: Pixel> Context<T> {
     F: Into<Option<Arc<Frame<T>>>>,
     T: Pixel,
   {
+    // TODO:
+    // - move the scenechange detection here
+    // - once a segment is ready, set the inner limit to its boundary
+    // - call the inner receive until all the frames had been encoded and put the results in a
+    //   separate queue/channel
+    // - move all of this in a separate thread
     self.inner.send_frame(frame)
   }
 
   pub fn receive_packet(&mut self) -> Result<Packet<T>, EncoderStatus> {
+    // TODO:
+    // - receive packets from the queue/channel
     self.inner.receive_packet()
   }
 

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -83,7 +83,7 @@ fn process_frame<T: Pixel>(
 fn write_stats_file<T: Pixel>(ctx: &Context<T>, filename: &Path) -> Result<(), io::Error> {
   let file = File::create(filename)?;
   let writer = BufWriter::new(file);
-  serde_json::to_writer(writer, &ctx.first_pass_data).expect("Serialization should not fail");
+  serde_json::to_writer(writer, ctx.get_first_pass_data()).expect("Serialization should not fail");
   Ok(())
 }
 

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -7,7 +7,7 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use crate::api::Context;
+use crate::api::ContextInner;
 use crate::quantize::ac_q;
 use crate::quantize::dc_q;
 use crate::quantize::select_ac_qi;
@@ -540,7 +540,7 @@ impl RCState {
 
   // TODO: Separate quantizers for Cb and Cr.
   pub fn select_qi<T: Pixel>(
-    &self, ctx: &Context<T>, fti: usize, maybe_prev_log_base_q: Option<i64>
+    &self, ctx: &ContextInner<T>, fti: usize, maybe_prev_log_base_q: Option<i64>
   ) -> QuantizerParameters {
     // Is rate control active?
     if self.target_bitrate <= 0 {

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -549,8 +549,8 @@ impl RCState {
       // TODO: Rename "quantizer" something that indicates it is a quantizer
       //  index, and move it somewhere more sensible (or choose a better way to
       //  parameterize a "quality" configuration parameter).
-      let base_qi = ctx.config.enc.quantizer;
-      let bit_depth = ctx.config.enc.bit_depth as i32;
+      let base_qi = ctx.config.quantizer;
+      let bit_depth = ctx.config.bit_depth as i32;
       // We use the AC quantizer as the source quantizer since its quantizer
       //  tables have unique entries, while the DC tables do not.
       let ac_quantizer = ac_q(base_qi as u8, 0, bit_depth as usize) as i64;
@@ -598,7 +598,7 @@ impl RCState {
           //  in the binary log domain (binary exp and log aren't too bad):
           //  rate = exp2(log2(scale) - log2(quantizer)*exp)
           // There's no easy closed form solution, so we bisection searh for it.
-          let bit_depth = ctx.config.enc.bit_depth as i32;
+          let bit_depth = ctx.config.bit_depth as i32;
           // TODO: Proper handling of lossless.
           let mut log_qlo = blog64(dc_q(0, 0, bit_depth as usize) as i64)
             - q57(QSCALE + bit_depth - 8);

--- a/src/test_encode_decode.rs
+++ b/src/test_encode_decode.rs
@@ -370,7 +370,7 @@ fn chroma_sampling(decoder: &str, cs: ChromaSampling) {
   let quantizer = 100;
   let limit = 3; // Include inter frames
   let speed = 0; // Test as many tools as possible
-  let w = 64;
+  let w = 198;
   let h = 80;
 
   // TODO: bump keyint when inter is supported


### PR DESCRIPTION
- [ ] move the encoding loop in a stand alone thread (needed by #689)
- [x] feed the frames to the scenechange detector, queue them up until:
  - the scenechange is detected
  - the limit has been hit
  - a flush has been hit
- [ ] feed the group to the reordering logic and prepare the frame-invariants
- [ ] encode the groups using a threadpool