### PR TITLE
Cast before left shift in native prep_8tap

### DIFF
--- a/src/mc.rs
+++ b/src/mc.rs
@@ -460,7 +460,7 @@ mod native {
           let src_slice = &src[r];
           for c in 0..width {
             tmp[r * width + c] =
-              i16::cast_from(src_slice[c] << intermediate_bits);
+              i16::cast_from(src_slice[c]) << intermediate_bits;
           }
         }
       }

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -282,8 +282,7 @@ mod nasm {
     col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,
     bit_depth: usize
   ) {
-    // disabled temporarily due to native/asm mismatches
-    if mem::size_of::<T>() == 0 /* FIXME */ && is_x86_feature_detected!("avx2") {
+    if mem::size_of::<T>() == 1 && is_x86_feature_detected!("avx2") {
       debug_assert!(bit_depth == 8);
       let src_stride = src.plane.cfg.stride as isize;
       unsafe {


### PR DESCRIPTION
Fixes the underlying issue of #1115. 