### PR TITLE
Enable the Clippy's manual_memcpy lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,4 @@ jobs:
          - cargo doc --verbose
          - rustup component add clippy
          - cargo clippy --version
-         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::if_same_then_else -A clippy::len_zero -A clippy::manual_memcpy -A clippy::needless_range_loop -A clippy::precedence -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose
+         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::if_same_then_else -A clippy::len_zero -A clippy::needless_range_loop -A clippy::precedence -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1363,9 +1363,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
             cdef_change = true;
             best_cost_acc = cost_acc;
             best_index = cdef_index;
-            for pli in 0..3 {
-              best_cost[pli] = cost[pli];
-            }
+            best_cost[..3].copy_from_slice(&cost[..3]);
           }
         }
       }

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -1599,27 +1599,19 @@ fn daala_fdct64<T: TxOperations>(input: &[T], output: &mut [T]) {
 }
 
 fn fidentity4<T: TxOperations>(input: &[T], output: &mut [T]) {
-  for i in 0..4 {
-    output[i] = input[i];
-  }
+  output[..4].copy_from_slice(&input[..4]);
 }
 
 fn fidentity8<T: TxOperations>(input: &[T], output: &mut [T]) {
-  for i in 0..8 {
-    output[i] = input[i];
-  }
+  output[..8].copy_from_slice(&input[..8]);
 }
 
 fn fidentity16<T: TxOperations>(input: &[T], output: &mut [T]) {
-  for i in 0..16 {
-    output[i] = input[i];
-  }
+  output[..16].copy_from_slice(&input[..16]);
 }
 
 fn fidentity32<T: TxOperations>(input: &[T], output: &mut [T]) {
-  for i in 0..32 {
-    output[i] = input[i];
-  }
+  output[..32].copy_from_slice(&input[..32]);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]


### PR DESCRIPTION
This PR enables the Clippy's [manual_memcpy](https://rust-lang.github.io/rust-clippy/master/index.html#manual_memcpy) lint, and fixes all warnings caused by it.