### PR TITLE
Enable the Clippy's if_same_then_else lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,4 @@ jobs:
          - cargo doc --verbose
          - rustup component add clippy
          - cargo clippy --version
-         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::if_same_then_else -A clippy::len_zero -A clippy::needless_range_loop -A clippy::precedence -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose
+         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::len_zero -A clippy::needless_range_loop -A clippy::precedence -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose

--- a/src/context.rs
+++ b/src/context.rs
@@ -2549,11 +2549,8 @@ impl ContextWriter {
   ) -> usize {
     assert!(ref_frames[0] != NONE_FRAME);
     if ref_frames[0] < REF_FRAMES {
-      if ref_frames[0] != INTRA_FRAME {
-        /* TODO: convert global mv to an mv here */
-      } else {
-        /* TODO: set the global mv ref to invalid here */
-      }
+      // TODO: If ref_frames[0] != INTRA_FRAME, convert global mv to an mv;
+      // otherwise, set the global mv ref to invalid.
     }
 
     if ref_frames[0] != INTRA_FRAME {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1854,10 +1854,7 @@ fn encode_partition_topdown<T: Pixel>(
     PARTITION_SPLIT |
     PARTITION_HORZ |
     PARTITION_VERT => {
-      let num_modes = if partition == PARTITION_SPLIT { 1 }
-      else { 1 };
-
-      if rdo_output.part_modes.len() >= num_modes {
+      if !rdo_output.part_modes.is_empty() {
         // The optimal prediction modes for each split block is known from an rdo_partition_decision() call
         assert!(subsize != BlockSize::BLOCK_INVALID);
 


### PR DESCRIPTION
This PR enables the Clippy's [if_same_then_else](https://rust-lang.github.io/rust-clippy/master/index.html#if_same_then_else) lint, and fixes all errors caused by it.