### PR TITLE
Add struct FrameMotionVectors

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -156,7 +156,7 @@ pub struct ReferenceFrame<T: Pixel> {
   pub input_hres: Plane<T>,
   pub input_qres: Plane<T>,
   pub cdfs: CDFContext,
-  pub frame_mvs: Vec<Vec<MotionVector>>,
+  pub frame_mvs: Vec<FrameMotionVectors>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -392,7 +392,7 @@ pub struct FrameState<T: Pixel> {
   pub deblock: DeblockState,
   pub segmentation: SegmentationState,
   pub restoration: RestorationState,
-  pub frame_mvs: Vec<Vec<MotionVector>>,
+  pub frame_mvs: Vec<FrameMotionVectors>,
   pub t: RDOTracker,
 }
 
@@ -420,7 +420,13 @@ impl<T: Pixel> FrameState<T> {
       deblock: Default::default(),
       segmentation: Default::default(),
       restoration: rs,
-      frame_mvs: vec![vec![MotionVector::default(); fi.w_in_b * fi.h_in_b]; REF_FRAMES],
+      frame_mvs: {
+        let mut vec = Vec::with_capacity(REF_FRAMES);
+        for _ in 0..REF_FRAMES {
+          vec.push(FrameMotionVectors::new(fi.w_in_b, fi.h_in_b));
+        }
+        vec
+      },
       t: RDOTracker::new()
     }
   }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -520,8 +520,7 @@ pub fn rdo_mode_decision<T: Pixel>(
       let frame_mvs = &mut fs.frame_mvs[ref_slot as usize];
       for mi_y in (bo.y)..(bo.y + bsize.height_mi()) {
         for mi_x in (bo.x)..(bo.x + bsize.width_mi()) {
-          let offset = mi_y * fi.w_in_b + mi_x;
-          frame_mvs[offset] = b_me;
+          frame_mvs[mi_y][mi_x] = b_me;
         }
       }
 


### PR DESCRIPTION
The motion vectors were stored in a `Vec<Vec<MotionVector>>`.

The innermost `Vec` contains a flatten matrix (`fi.w_in_b` x `fi.h_in_b`) of `MotionVector`s, and there are `REF_FRAMES` instances of them (the outermost `Vec`).

Introduce a typed structure to replace the innermost `Vec`:
 - this improves readability;
 - this allows to expose it as a 2D array, thanks to `Index` and `IndexMut` traits;
 - this will allow to split it into (non-overlapping) tiled views, containing only the motion vectors for a bounded region of the plane (see <https://github.com/xiph/rav1e/pull/1126>).