### PR TITLE
Enable the Clippy's len_zero lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,4 @@ jobs:
          - cargo doc --verbose
          - rustup component add clippy
          - cargo clippy --version
-         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::len_zero -A clippy::needless_range_loop -A clippy::precedence -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose
+         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::needless_range_loop -A clippy::precedence -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1235,12 +1235,12 @@ pub fn encode_block_b<T: Pixel>(
           assert!(0 == mvs[0].col);
         }
       } else if luma_mode == PredictionMode::NEARESTMV {
-        if mv_stack.len() > 0 {
-          assert!(mv_stack[0].this_mv.row == mvs[0].row);
-          assert!(mv_stack[0].this_mv.col == mvs[0].col);
+        if mv_stack.is_empty() {
+          assert_eq!(mvs[0].row, 0);
+          assert_eq!(mvs[0].col, 0);
         } else {
-          assert!(0 == mvs[0].row);
-          assert!(0 == mvs[0].col);
+          assert_eq!(mvs[0].row, mv_stack[0].this_mv.row);
+          assert_eq!(mvs[0].col, mv_stack[0].this_mv.col);
         }
       }
     } else {
@@ -1654,7 +1654,7 @@ fn encode_partition_bottomup<T: Pixel>(
         best_rd = rd_cost;
         best_partition = partition;
         if partition != PartitionType::PARTITION_SPLIT {
-          assert!(child_modes.len() > 0);
+          assert!(!child_modes.is_empty());
           rdo_output.part_modes = child_modes;
         }
       }
@@ -1664,8 +1664,7 @@ fn encode_partition_bottomup<T: Pixel>(
 
     // If the best partition is not PARTITION_SPLIT, recode it
     if best_partition != PartitionType::PARTITION_SPLIT {
-
-        assert!(rdo_output.part_modes.len() > 0);
+        assert!(!rdo_output.part_modes.is_empty());
 
         cw.rollback(&cw_checkpoint);
         w_pre_cdef.rollback(&w_pre_checkpoint);
@@ -1841,10 +1840,13 @@ fn encode_partition_topdown<T: Pixel>(
               }
             }
           if mode_luma == PredictionMode::NEWMV && mvs[0].row == 0 && mvs[0].col == 0 {
-            mode_luma =
-              if mv_stack.len() == 0 { PredictionMode::NEARESTMV }
-            else if mv_stack.len() == 1 { PredictionMode::NEAR0MV }
-            else { PredictionMode::GLOBALMV };
+            mode_luma = if mv_stack.is_empty() {
+              PredictionMode::NEARESTMV
+            } else if mv_stack.len() == 1 {
+              PredictionMode::NEAR0MV
+            } else {
+              PredictionMode::GLOBALMV
+            };
           }
           mode_chroma = mode_luma;
         }

--- a/src/me.rs
+++ b/src/me.rs
@@ -285,7 +285,7 @@ pub fn get_subset_predictors<T: Pixel>(
     }
   }
 
-  if predictors.len() > 0 {
+  if !predictors.is_empty() {
     let mut median_mv = MotionVector::default();
     for mv in predictors.iter() {
       median_mv = median_mv + *mv;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -490,7 +490,7 @@ pub fn rdo_mode_decision<T: Pixel>(
         ref_slot_set.push(slot_idx);
       }
     }
-    assert!(ref_frames_set.len() != 0);
+    assert!(!ref_frames_set.is_empty());
   }
 
   let mut mode_set: Vec<(PredictionMode, usize)> = Vec::new();
@@ -509,7 +509,7 @@ pub fn rdo_mode_decision<T: Pixel>(
 
     if fi.frame_type == FrameType::INTER {
       let mut pmv = [MotionVector::default(); 2];
-      if mv_stack.len() > 0 { pmv[0] = mv_stack[0].this_mv; }
+      if !mv_stack.is_empty() { pmv[0] = mv_stack[0].this_mv; }
       if mv_stack.len() > 1 { pmv[1] = mv_stack[1].this_mv; }
       let ref_slot = ref_slot_set[i] as usize;
       let cmv = pmvs[ref_slot].unwrap();
@@ -532,7 +532,7 @@ pub fn rdo_mode_decision<T: Pixel>(
       for &x in RAV1E_INTER_MODES_MINIMAL {
         mode_set.push((x, i));
       }
-      if mv_stack.len() >= 1 {
+      if !mv_stack.is_empty() {
         mode_set.push((PredictionMode::NEAR0MV, i));
       }
       if mv_stack.len() >= 2 {
@@ -678,13 +678,13 @@ pub fn rdo_mode_decision<T: Pixel>(
   };
 
   if fi.frame_type != FrameType::INTER {
-    assert!(mode_set.len() == 0);
+    assert!(mode_set.is_empty());
   }
 
   mode_set.iter().for_each(|&(luma_mode, i)| {
     let mvs = match luma_mode {
       PredictionMode::NEWMV | PredictionMode::NEW_NEWMV => mvs_from_me[i],
-      PredictionMode::NEARESTMV | PredictionMode::NEAREST_NEARESTMV => if mv_stacks[i].len() > 0 {
+      PredictionMode::NEARESTMV | PredictionMode::NEAREST_NEARESTMV => if !mv_stacks[i].is_empty() {
         [mv_stacks[i][0].this_mv, mv_stacks[i][0].comp_mv]
       } else {
         [MotionVector::default(); 2]


### PR DESCRIPTION
This PR enables the Clippy's [len_zero](https://rust-lang.github.io/rust-clippy/master/index.html#len_zero) lint, and fixes all warnings caused by it.