### PR TITLE
Create RefFrame enum.

### DIFF
--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -14,8 +14,8 @@ use crate::DeblockState;
 use crate::FrameInvariants;
 use crate::FrameState;
 use crate::FrameType;
-use crate::partition::*;
 use crate::partition::PredictionMode::*;
+use crate::partition::RefType::*;
 use crate::plane::*;
 use crate::quantize::*;
 use crate::util::Pixel;
@@ -67,7 +67,7 @@ fn deblock_adjusted_level(
     let l5 = level >> 5;
     clamp(
       level as i32
-        + ((deblock.ref_deltas[reference] as i32) << l5)
+        + ((deblock.ref_deltas[reference.to_index()] as i32) << l5)
         + if reference == INTRA_FRAME {
           0
         } else {

--- a/src/header.rs
+++ b/src/header.rs
@@ -688,7 +688,7 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
 
     // global motion
     if !fi.intra_only {
-      for i in LAST_FRAME..=ALTREF_FRAME {
+      for i in 0..7 {
         let mode = fi.globalmv_transformation_type[i];
         self.write_bit(mode != GlobalMVMode::IDENTITY)?;
         if mode != GlobalMVMode::IDENTITY {


### PR DESCRIPTION
Moves all functions that previously used usize to this type.
Instead of direct conversions to a slot number, use a to_index fn.

This also changes the size of the global mv state and context
ref counting arrays as they don't need LAST_FRAME.