### PR TITLE
Make BlockOffset derive Copy

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -77,7 +77,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
               &mut cw,
               &mut w,
               p,
-              &bo,
+              bo,
               mode,
               tx_size,
               tx_type,
@@ -143,7 +143,7 @@ fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
   let fi = FrameInvariants::<u16>::new(config, sequence);
   let mut fs = FrameState::new(&fi);
   let offset = BlockOffset { x: 1, y: 1 };
-  b.iter(|| rdo_cfl_alpha(&mut fs, &offset, bsize, fi.sequence.bit_depth, fi.sequence.chroma_sampling))
+  b.iter(|| rdo_cfl_alpha(&mut fs, offset, bsize, fi.sequence.bit_depth, fi.sequence.chroma_sampling))
 }
 
 criterion_group!(intra_prediction, predict::pred_bench,);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -82,7 +82,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
               tx_size,
               tx_type,
               tx_size.block_size(),
-              &po,
+              po,
               false,
               ac,
               0,

--- a/benches/me.rs
+++ b/benches/me.rs
@@ -44,8 +44,8 @@ fn bench_get_sad(b: &mut Bencher, bs: &BlockSize) {
   let rec_plane = new_plane::<u16>(&mut ra, w, h);
   let po = PlaneOffset { x: 0, y: 0 };
 
-  let plane_org = input_plane.slice(&po);
-  let plane_ref = rec_plane.slice(&po);
+  let plane_org = input_plane.slice(po);
+  let plane_ref = rec_plane.slice(po);
 
   b.iter(|| {
     let _ =

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -206,8 +206,8 @@ fn adjust_strength(strength: i32, var: i32) -> i32 {
 pub fn cdef_analyze_superblock<T: Pixel>(
   in_frame: &Frame<T>,
   bc_global: &mut BlockContext,
-  sbo: &SuperBlockOffset,
-  sbo_global: &SuperBlockOffset,
+  sbo: SuperBlockOffset,
+  sbo_global: SuperBlockOffset,
   bit_depth: usize,
 ) -> CdefDirections {
   let coeff_shift = bit_depth as usize - 8;
@@ -259,7 +259,7 @@ pub fn cdef_sb_frame<T: Pixel>(fi: &FrameInvariants<T>, f: &Frame<T>) -> Frame<T
 }
 
 pub fn cdef_sb_padded_frame_copy<T: Pixel>(
-  fi: &FrameInvariants<T>, sbo: &SuperBlockOffset,
+  fi: &FrameInvariants<T>, sbo: SuperBlockOffset,
   f: &Frame<T>, pad: usize
 ) -> Frame<u16> {
   let ipad = pad as isize;
@@ -333,8 +333,8 @@ pub fn cdef_filter_superblock<T: Pixel>(
   in_frame: &Frame<u16>,
   out_frame: &mut Frame<T>,
   bc_global: &mut BlockContext,
-  sbo: &SuperBlockOffset,
-  sbo_global: &SuperBlockOffset,
+  sbo: SuperBlockOffset,
+  sbo_global: SuperBlockOffset,
   cdef_index: u8,
   cdef_dirs: &CdefDirections,
 ) {
@@ -481,8 +481,8 @@ pub fn cdef_filter_frame<T: Pixel>(fi: &FrameInvariants<T>, rec: &mut Frame<T>, 
     for fbx in 0..fb_width {
       let sbo = SuperBlockOffset { x: fbx, y: fby };
       let cdef_index = bc.at(sbo.block_offset(0, 0)).cdef_index;
-      let cdef_dirs = cdef_analyze_superblock(&cdef_frame, bc, &sbo, &sbo, fi.sequence.bit_depth);
-      cdef_filter_superblock(fi, &cdef_frame, rec, bc, &sbo, &sbo, cdef_index, &cdef_dirs);
+      let cdef_dirs = cdef_analyze_superblock(&cdef_frame, bc, sbo, sbo, fi.sequence.bit_depth);
+      cdef_filter_superblock(fi, &cdef_frame, rec, bc, sbo, sbo, cdef_index, &cdef_dirs);
     }
   }
 }

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -230,7 +230,7 @@ pub fn cdef_analyze_superblock<T: Pixel>(
           let mut var: i32 = 0;
           let in_plane = &in_frame.planes[0];
           let in_po = sbo.plane_offset(&in_plane.cfg);
-          let in_slice = in_plane.slice(&in_po);
+          let in_slice = in_plane.slice(in_po);
           dir.dir[bx][by] = cdef_find_dir(&in_slice.reslice(8 * bx as isize + 2,
                                                             8 * by as isize + 2),
                                           &mut var, coeff_shift) as u8;
@@ -290,7 +290,7 @@ pub fn cdef_sb_padded_frame_copy<T: Pixel>(
           out_row[x] = CDEF_VERY_LARGE;
         }
       } else {
-        let in_slice = f.planes[p].slice(&PlaneOffset {x:0, y:offset.y - ipad});
+        let in_slice = f.planes[p].slice(PlaneOffset {x:0, y:offset.y - ipad});
         let in_row = &in_slice[y as usize];
         // are we guaranteed to be all in frame this row?
         if offset.x < ipad || offset.x + (sb_size as isize >>xdec) + ipad >= w {
@@ -374,9 +374,9 @@ pub fn cdef_filter_superblock<T: Pixel>(
             let ydec = in_plane.cfg.ydec;
 
             let in_stride = in_plane.cfg.stride;
-            let in_slice = &in_plane.slice(&in_po);
+            let in_slice = &in_plane.slice(in_po);
             let out_stride = out_plane.cfg.stride;
-            let out_slice = &mut out_plane.mut_slice(&out_po);
+            let out_slice = &mut out_plane.mut_slice(out_po);
 
             let local_pri_strength;
             let local_sec_strength;

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -221,10 +221,10 @@ pub fn cdef_analyze_superblock<T: Pixel>(
       // in the main frame.
       let global_block_offset = sbo_global.block_offset(bx<<1, by<<1);
       if global_block_offset.x < bc_global.cols && global_block_offset.y < bc_global.rows {
-        let skip = bc_global.at(&global_block_offset).skip
-          & bc_global.at(&sbo_global.block_offset(2*bx+1, 2*by)).skip
-          & bc_global.at(&sbo_global.block_offset(2*bx, 2*by+1)).skip
-          & bc_global.at(&sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
+        let skip = bc_global.at(global_block_offset).skip
+          & bc_global.at(sbo_global.block_offset(2*bx+1, 2*by)).skip
+          & bc_global.at(sbo_global.block_offset(2*bx, 2*by+1)).skip
+          & bc_global.at(sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
 
         if !skip {
           let mut var: i32 = 0;
@@ -358,10 +358,10 @@ pub fn cdef_filter_superblock<T: Pixel>(
     for bx in 0..8 {
       let global_block_offset = sbo_global.block_offset(bx<<1, by<<1);
       if global_block_offset.x < bc_global.cols && global_block_offset.y < bc_global.rows {
-        let skip = bc_global.at(&global_block_offset).skip
-          & bc_global.at(&sbo_global.block_offset(2*bx+1, 2*by)).skip
-          & bc_global.at(&sbo_global.block_offset(2*bx, 2*by+1)).skip
-          & bc_global.at(&sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
+        let skip = bc_global.at(global_block_offset).skip
+          & bc_global.at(sbo_global.block_offset(2*bx+1, 2*by)).skip
+          & bc_global.at(sbo_global.block_offset(2*bx, 2*by+1)).skip
+          & bc_global.at(sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
         if !skip {
           let dir = cdef_dirs.dir[bx][by];
           let var = cdef_dirs.var[bx][by];
@@ -480,7 +480,7 @@ pub fn cdef_filter_frame<T: Pixel>(fi: &FrameInvariants<T>, rec: &mut Frame<T>, 
   for fby in 0..fb_height {
     for fbx in 0..fb_width {
       let sbo = SuperBlockOffset { x: fbx, y: fby };
-      let cdef_index = bc.at(&sbo.block_offset(0, 0)).cdef_index;
+      let cdef_index = bc.at(sbo.block_offset(0, 0)).cdef_index;
       let cdef_dirs = cdef_analyze_superblock(&cdef_frame, bc, &sbo, &sbo, fi.sequence.bit_depth);
       cdef_filter_superblock(fi, &cdef_frame, rec, bc, &sbo, &sbo, cdef_index, &cdef_dirs);
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1126,7 +1126,7 @@ pub const LOCAL_BLOCK_MASK: usize = (1 << SUPERBLOCK_TO_BLOCK_SHIFT) - 1;
 
 /// Absolute offset in superblocks inside a plane, where a superblock is defined
 /// to be an N*N square where N = (1 << SUPERBLOCK_TO_PLANE_SHIFT).
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct SuperBlockOffset {
   pub x: usize,
   pub y: usize
@@ -1134,7 +1134,7 @@ pub struct SuperBlockOffset {
 
 impl SuperBlockOffset {
   /// Offset of a block inside the current superblock.
-  pub fn block_offset(&self, block_x: usize, block_y: usize) -> BlockOffset {
+  pub fn block_offset(self, block_x: usize, block_y: usize) -> BlockOffset {
     BlockOffset {
       x: (self.x << SUPERBLOCK_TO_BLOCK_SHIFT) + block_x,
       y: (self.y << SUPERBLOCK_TO_BLOCK_SHIFT) + block_y
@@ -1142,7 +1142,7 @@ impl SuperBlockOffset {
   }
 
   /// Offset of the top-left pixel of this block.
-  pub fn plane_offset(&self, plane: &PlaneConfig) -> PlaneOffset {
+  pub fn plane_offset(self, plane: &PlaneConfig) -> PlaneOffset {
     PlaneOffset {
       x: (self.x as isize) << (SUPERBLOCK_TO_PLANE_SHIFT - plane.xdec),
       y: (self.y as isize) << (SUPERBLOCK_TO_PLANE_SHIFT - plane.ydec)
@@ -1545,7 +1545,7 @@ impl BlockContext {
     }
   }
 
-  pub fn set_cdef(&mut self, sbo: &SuperBlockOffset, cdef_index: u8) {
+  pub fn set_cdef(&mut self, sbo: SuperBlockOffset, cdef_index: u8) {
     let bo = sbo.block_offset(0, 0);
     // Checkme: Is 16 still the right block unit for 128x128 superblocks?
     let bw = cmp::min (bo.x + MAX_MIB_SIZE, self.blocks[bo.y as usize].len());
@@ -1557,7 +1557,7 @@ impl BlockContext {
     }
   }
 
-  pub fn get_cdef(&mut self, sbo: &SuperBlockOffset) -> u8 {
+  pub fn get_cdef(&mut self, sbo: SuperBlockOffset) -> u8 {
     let bo = sbo.block_offset(0, 0);
     self.blocks[bo.y][bo.x].cdef_index
   }
@@ -3041,7 +3041,7 @@ impl ContextWriter {
   }
 
   pub fn write_lrf<T: Pixel>(
-    &mut self, w: &mut dyn Writer, fi: &FrameInvariants<T>, rs: &mut RestorationState, sbo: &SuperBlockOffset
+    &mut self, w: &mut dyn Writer, fi: &FrameInvariants<T>, rs: &mut RestorationState, sbo: SuperBlockOffset
   ) {
     if !fi.allow_intrabc { // TODO: also disallow if lossless
       for pli in 0..PLANES {

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -1036,7 +1036,7 @@ fn filter_v_edge<T: Pixel>(
       let level = deblock_level(deblock, block, prev_block, pli, true);
       if level > 0 {
         let po = bo.plane_offset(&p.cfg);
-        let mut plane_slice = p.mut_slice(&po);
+        let mut plane_slice = p.mut_slice(po);
         plane_slice.x -= (filter_size >> 1) as isize;
         match filter_size {
           4 => {
@@ -1075,8 +1075,8 @@ fn sse_v_edge<T: Pixel>(
         po.x -= (filter_size >> 1) as isize;
         po
       };
-      let rec_slice = rec_plane.slice(&po);
-      let src_slice = src_plane.slice(&po);
+      let rec_slice = rec_plane.slice(po);
+      let src_slice = src_plane.slice(po);
       match filter_size {
         4 => {
           sse_size4(
@@ -1139,7 +1139,7 @@ fn filter_h_edge<T: Pixel>(
       let level = deblock_level(deblock, block, prev_block, pli, false);
       if level > 0 {
         let po = bo.plane_offset(&p.cfg);
-        let mut plane_slice = p.mut_slice(&po);
+        let mut plane_slice = p.mut_slice(po);
         plane_slice.y -= (filter_size >> 1) as isize;
         match filter_size {
           4 => {
@@ -1178,8 +1178,8 @@ fn sse_h_edge<T: Pixel>(
         po.x -= (filter_size >> 1) as isize;
         po
       };
-      let rec_slice = rec_plane.slice(&po);
-      let src_slice = src_plane.slice(&po);
+      let rec_slice = rec_plane.slice(po);
+      let src_slice = src_plane.slice(po);
       match filter_size {
         4 => {
           sse_size4(

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2124,11 +2124,11 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
       // CDEF has to be decided before loop restoration, but coded after.
       // loop restoration must be decided last but coded before anything else.
       if cw.bc.cdef_coded || fi.sequence.enable_restoration {
-        rdo_loop_decision(&sbo, fi, fs, &mut cw, &mut w);
+        rdo_loop_decision(sbo, fi, fs, &mut cw, &mut w);
       }
 
       if fi.sequence.enable_restoration {
-        cw.write_lrf(&mut w, fi, &mut fs.restoration, &sbo);
+        cw.write_lrf(&mut w, fi, &mut fs.restoration, sbo);
       }
 
       // Once loop restoration is coded, we can replay the initial block bits
@@ -2136,7 +2136,7 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
 
       if cw.bc.cdef_coded {
         // CDEF index must be written in the middle, we can code it now
-        let cdef_index = cw.bc.get_cdef(&sbo);
+        let cdef_index = cw.bc.get_cdef(sbo);
         cw.write_cdef(&mut w, cdef_index, fi.cdef_bits);
         // ...and then finally code what comes after the CDEF index
         w_post_cdef.replay(&mut w);

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -830,7 +830,7 @@ impl RestorationPlane {
     }
   }
 
-  fn restoration_unit_index(&self, sbo: &SuperBlockOffset) -> (usize, usize) {
+  fn restoration_unit_index(&self, sbo: SuperBlockOffset) -> (usize, usize) {
     (
       (sbo.x >> self.sb_shift).min(self.cols - 1),
       (sbo.y >> self.sb_shift).min(self.rows - 1),
@@ -847,12 +847,12 @@ impl RestorationPlane {
     )
   }
 
-  pub fn restoration_unit(&self, sbo: &SuperBlockOffset) -> &RestorationUnit {
+  pub fn restoration_unit(&self, sbo: SuperBlockOffset) -> &RestorationUnit {
     let (x, y) = self.restoration_unit_index(sbo);
     &self.units[y * self.cols + x]
   }
 
-  pub fn restoration_unit_as_mut(&mut self, sbo: &SuperBlockOffset) -> &mut RestorationUnit {
+  pub fn restoration_unit_as_mut(&mut self, sbo: SuperBlockOffset) -> &mut RestorationUnit {
     let (x, y) = self.restoration_unit_index(sbo);
     &mut self.units[y * self.cols + x]
   }
@@ -902,11 +902,11 @@ impl RestorationState {
     }
   }
 
-  pub fn restoration_unit(&self, sbo: &SuperBlockOffset, pli: usize) -> &RestorationUnit {
+  pub fn restoration_unit(&self, sbo: SuperBlockOffset, pli: usize) -> &RestorationUnit {
     self.planes[pli].restoration_unit(sbo)
   }
 
-  pub fn restoration_unit_as_mut(&mut self, sbo: &SuperBlockOffset, pli: usize) -> &mut RestorationUnit {
+  pub fn restoration_unit_as_mut(&mut self, sbo: SuperBlockOffset, pli: usize) -> &mut RestorationUnit {
     self.planes[pli].restoration_unit_as_mut(sbo)
   }
 

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -732,7 +732,7 @@ fn wiener_stripe_filter<T: Pixel>(coeffs: [[i8; 3]; 2], fi: &FrameInvariants<T>,
     stripe_h as isize - start_wi as isize
   }) as usize;
 
-  let mut out_slice = out.mut_slice(&PlaneOffset{x: 0, y: start_yi as isize});
+  let mut out_slice = out.mut_slice(PlaneOffset{x: 0, y: start_yi as isize});
 
   for xi in stripe_x..stripe_x+stripe_w {
     let n = cmp::min(7, crop_w as isize + 3 - xi as isize);
@@ -958,11 +958,11 @@ impl RestorationState {
                                     crop_w - x,
                                     (crop_h as isize - stripe_start_y) as usize,
                                     size, stripe_size,
-                                    &cdeffed.planes[pli].slice(&PlaneOffset{x: x as isize,
+                                    &cdeffed.planes[pli].slice(PlaneOffset{x: x as isize,
                                                                            y: stripe_start_y}),
-                                    &pre_cdef.planes[pli].slice(&PlaneOffset{x: x as isize,
+                                    &pre_cdef.planes[pli].slice(PlaneOffset{x: x as isize,
                                                                             y: stripe_start_y}),
-                                    &mut out.planes[pli].mut_slice(&PlaneOffset{x: x as isize,
+                                    &mut out.planes[pli].mut_slice(PlaneOffset{x: x as isize,
                                                                                y: stripe_start_y}));
             },
             RestorationFilter::None => {

--- a/src/me.rs
+++ b/src/me.rs
@@ -337,7 +337,7 @@ pub fn get_subset_predictors<T: Pixel>(
 
 pub trait MotionEstimation {
   fn full_pixel_me<T: Pixel>(
-    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>, po: &PlaneOffset,
+    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>, po: PlaneOffset,
     bo: BlockOffset, lambda: u32,
     cmv: MotionVector, pmv: [MotionVector; 2],
     mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
@@ -346,7 +346,7 @@ pub trait MotionEstimation {
   );
 
   fn sub_pixel_me<T: Pixel>(
-    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>, po: &PlaneOffset,
+    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>, po: PlaneOffset,
     bo: BlockOffset, lambda: u32, pmv: [MotionVector; 2],
     mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
     blk_w: usize, blk_h: usize, best_mv: &mut MotionVector,
@@ -379,12 +379,12 @@ pub trait MotionEstimation {
         let mut lowest_cost = std::u64::MAX;
         let mut best_mv = MotionVector::default();
 
-        Self::full_pixel_me(fi, fs, rec, &po, bo, lambda, cmv, pmv,
+        Self::full_pixel_me(fi, fs, rec, po, bo, lambda, cmv, pmv,
                            mvx_min, mvx_max, mvy_min, mvy_max, blk_w, blk_h,
                            &mut best_mv, &mut lowest_cost, ref_frame);
 
         let tmp_plane = Plane::new(blk_w, blk_h, 0, 0, 0, 0);
-        Self::sub_pixel_me(fi, fs, rec, &po, bo, lambda, pmv,
+        Self::sub_pixel_me(fi, fs, rec, po, bo, lambda, pmv,
                            mvx_min, mvx_max, mvy_min, mvy_max, blk_w, blk_h,
                            &mut best_mv, &mut lowest_cost, ref_frame,
                            tmp_plane, bsize);
@@ -452,7 +452,7 @@ pub struct FullSearch {}
 impl MotionEstimation for DiamondSearch {
   fn full_pixel_me<T: Pixel>(
     fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>,
-    po: &PlaneOffset, bo: BlockOffset, lambda: u32,
+    po: PlaneOffset, bo: BlockOffset, lambda: u32,
     cmv: MotionVector, pmv: [MotionVector; 2], mvx_min: isize, mvx_max: isize,
     mvy_min: isize, mvy_max: isize, blk_w: usize, blk_h: usize,
     best_mv: &mut MotionVector, lowest_cost: &mut u64, ref_frame: usize
@@ -464,7 +464,7 @@ impl MotionEstimation for DiamondSearch {
 
     diamond_me_search(
       fi,
-      &po,
+      po,
       &fs.input.planes[0],
       &rec.frame.planes[0],
       &predictors,
@@ -486,7 +486,7 @@ impl MotionEstimation for DiamondSearch {
 
   fn sub_pixel_me<T: Pixel>(
     fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>,
-    po: &PlaneOffset, _bo: BlockOffset, lambda: u32,
+    po: PlaneOffset, _bo: BlockOffset, lambda: u32,
     pmv: [MotionVector; 2], mvx_min: isize, mvx_max: isize,
     mvy_min: isize, mvy_max: isize, blk_w: usize, blk_h: usize,
     best_mv: &mut MotionVector, lowest_cost: &mut u64, ref_frame: usize,
@@ -496,7 +496,7 @@ impl MotionEstimation for DiamondSearch {
     let predictors = vec![*best_mv];
     diamond_me_search(
       fi,
-      &po,
+      po,
       &fs.input.planes[0],
       &rec.frame.planes[0],
       &predictors,
@@ -541,7 +541,7 @@ impl MotionEstimation for DiamondSearch {
         }
 
         diamond_me_search(
-          fi, &po,
+          fi, po,
           &fs.input_hres, &rec.input_hres,
           &predictors, fi.sequence.bit_depth,
           global_mv, lambda,
@@ -558,7 +558,7 @@ impl MotionEstimation for DiamondSearch {
 impl MotionEstimation for FullSearch {
   fn full_pixel_me<T: Pixel>(
     fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>,
-    po: &PlaneOffset, _bo: BlockOffset, lambda: u32,
+    po: PlaneOffset, _bo: BlockOffset, lambda: u32,
     cmv: MotionVector, pmv: [MotionVector; 2], mvx_min: isize, mvx_max: isize,
     mvy_min: isize, mvy_max: isize, blk_w: usize, blk_h: usize,
     best_mv: &mut MotionVector, lowest_cost: &mut u64, _ref_frame: usize
@@ -584,7 +584,7 @@ impl MotionEstimation for FullSearch {
       &rec.frame.planes[0],
       best_mv,
       lowest_cost,
-      &po,
+      po,
       2,
       fi.sequence.bit_depth,
       lambda,
@@ -595,7 +595,7 @@ impl MotionEstimation for FullSearch {
 
   fn sub_pixel_me<T: Pixel>(
     fi: &FrameInvariants<T>, fs: &FrameState<T>, _rec: &Arc<ReferenceFrame<T>>,
-    po: &PlaneOffset, _bo: BlockOffset, lambda: u32,
+    po: PlaneOffset, _bo: BlockOffset, lambda: u32,
     pmv: [MotionVector; 2], mvx_min: isize, mvx_max: isize,
     mvy_min: isize, mvy_max: isize, _blk_w: usize, _blk_h: usize,
     best_mv: &mut MotionVector, lowest_cost: &mut u64, ref_frame: usize,
@@ -606,7 +606,7 @@ impl MotionEstimation for FullSearch {
       fi,
       fs,
       bsize,
-      &po,
+      po,
       lambda,
       ref_frame,
       pmv,
@@ -648,7 +648,7 @@ impl MotionEstimation for FullSearch {
           &rec.input_hres,
           best_mv,
           lowest_cost,
-          &po,
+          po,
           1,
           fi.sequence.bit_depth,
           lambda,
@@ -662,7 +662,7 @@ impl MotionEstimation for FullSearch {
 
 fn get_best_predictor<T: Pixel>(
   fi: &FrameInvariants<T>,
-  po: &PlaneOffset, p_org: &Plane<T>, p_ref: &Plane<T>,
+  po: PlaneOffset, p_org: &Plane<T>, p_ref: &Plane<T>,
   predictors: &[MotionVector],
   bit_depth: usize, pmv: [MotionVector; 2], lambda: u32,
   mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
@@ -687,7 +687,7 @@ fn get_best_predictor<T: Pixel>(
 
 fn diamond_me_search<T: Pixel>(
   fi: &FrameInvariants<T>,
-  po: &PlaneOffset, p_org: &Plane<T>, p_ref: &Plane<T>,
+  po: PlaneOffset, p_org: &Plane<T>, p_ref: &Plane<T>,
   predictors: &[MotionVector],
   bit_depth: usize, pmv: [MotionVector; 2], lambda: u32,
   mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
@@ -724,7 +724,7 @@ fn diamond_me_search<T: Pixel>(
         };
 
         let rd_cost = get_mv_rd_cost(
-          fi, &po, p_org, p_ref, bit_depth,
+          fi, po, p_org, p_ref, bit_depth,
           pmv, lambda, mvx_min, mvx_max, mvy_min, mvy_max,
           blk_w, blk_h, cand_mv, tmp_plane_opt, ref_frame);
 
@@ -752,7 +752,7 @@ fn diamond_me_search<T: Pixel>(
 
 fn get_mv_rd_cost<T: Pixel>(
   fi: &FrameInvariants<T>,
-  po: &PlaneOffset, p_org: &Plane<T>, p_ref: &Plane<T>, bit_depth: usize,
+  po: PlaneOffset, p_org: &Plane<T>, p_ref: &Plane<T>, bit_depth: usize,
   pmv: [MotionVector; 2], lambda: u32,
   mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
   blk_w: usize, blk_h: usize,
@@ -769,25 +769,25 @@ fn get_mv_rd_cost<T: Pixel>(
   let plane_org = p_org.slice(po);
 
   if let Some(ref mut tmp_plane) = tmp_plane_opt {
-    let mut tmp_slice = &mut tmp_plane.mut_slice(&PlaneOffset { x: 0, y: 0 });
+    let mut tmp_slice = &mut tmp_plane.mut_slice(PlaneOffset { x: 0, y: 0 });
     PredictionMode::NEWMV.predict_inter(
       fi,
       0,
-      &po,
+      po,
       &mut tmp_slice,
       blk_w,
       blk_h,
       [ref_frame, NONE_FRAME],
       [cand_mv, MotionVector { row: 0, col: 0 }]
     );
-    let plane_ref = tmp_plane.slice(&PlaneOffset { x: 0, y: 0 });
+    let plane_ref = tmp_plane.slice(PlaneOffset { x: 0, y: 0 });
     compute_mv_rd_cost(
       fi, pmv, lambda, bit_depth, blk_w, blk_h, cand_mv,
       &plane_org, &plane_ref
     )
   } else {
     // Full pixel motion vector
-    let plane_ref = p_ref.slice(&PlaneOffset {
+    let plane_ref = p_ref.slice(PlaneOffset {
       x: po.x + (cand_mv.col / 8) as isize,
       y: po.y + (cand_mv.row / 8) as isize
     });
@@ -815,7 +815,7 @@ fn compute_mv_rd_cost<T: Pixel>(
 }
 
 fn telescopic_subpel_search<T: Pixel>(
-  fi: &FrameInvariants<T>, fs: &FrameState<T>, bsize: BlockSize, po: &PlaneOffset,
+  fi: &FrameInvariants<T>, fs: &FrameState<T>, bsize: BlockSize, po: PlaneOffset,
   lambda: u32, ref_frame: usize, pmv: [MotionVector; 2],
   mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
   tmp_plane: &mut Plane<T>, best_mv: &mut MotionVector, lowest_cost: &mut u64
@@ -853,12 +853,12 @@ fn telescopic_subpel_search<T: Pixel>(
 
         {
           let tmp_slice =
-            &mut tmp_plane.mut_slice(&PlaneOffset { x: 0, y: 0 });
+            &mut tmp_plane.mut_slice(PlaneOffset { x: 0, y: 0 });
 
           mode.predict_inter(
             fi,
             0,
-            &po,
+            po,
             tmp_slice,
             blk_w,
             blk_h,
@@ -867,8 +867,8 @@ fn telescopic_subpel_search<T: Pixel>(
           );
         }
 
-        let plane_org = fs.input.planes[0].slice(&po);
-        let plane_ref = tmp_plane.slice(&PlaneOffset { x: 0, y: 0 });
+        let plane_org = fs.input.planes[0].slice(po);
+        let plane_ref = tmp_plane.slice(PlaneOffset { x: 0, y: 0 });
 
         let sad = get_sad(&plane_org, &plane_ref, blk_h, blk_w, fi.sequence.bit_depth);
 
@@ -889,7 +889,7 @@ fn telescopic_subpel_search<T: Pixel>(
 fn full_search<T: Pixel>(
   x_lo: isize, x_hi: isize, y_lo: isize, y_hi: isize, blk_h: usize,
   blk_w: usize, p_org: &Plane<T>, p_ref: &Plane<T>, best_mv: &mut MotionVector,
-  lowest_cost: &mut u64, po: &PlaneOffset, step: usize, bit_depth: usize,
+  lowest_cost: &mut u64, po: PlaneOffset, step: usize, bit_depth: usize,
   lambda: u32, pmv: [MotionVector; 2], allow_high_precision_mv: bool
 ) {
     let search_range_y = (y_lo..=y_hi).step_by(step);
@@ -898,7 +898,7 @@ fn full_search<T: Pixel>(
 
     let (cost, mv) = search_area.map(|(y, x)| {
       let plane_org = p_org.slice(po);
-      let plane_ref = p_ref.slice(&PlaneOffset { x, y });
+      let plane_ref = p_ref.slice(PlaneOffset { x, y });
 
       let sad = get_sad(&plane_org, &plane_ref, blk_h, blk_w, bit_depth);
 
@@ -980,7 +980,7 @@ pub fn estimate_motion_ss4<T: Pixel>(
       &rec.input_qres,
       &mut best_mv,
       &mut lowest_cost,
-      &po,
+      po,
       1,
       fi.sequence.bit_depth,
       lambda,
@@ -1063,8 +1063,8 @@ pub mod test {
       let bsh = block.0.height();
       let po = PlaneOffset { x: 32, y: 40 };
 
-      let mut input_slice = input_plane.slice(&po);
-      let mut rec_slice = rec_plane.slice(&po);
+      let mut input_slice = input_plane.slice(po);
+      let mut rec_slice = rec_plane.slice(po);
 
       assert_eq!(
         block.1,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -921,7 +921,7 @@ pub fn get_intra_edges<T: Pixel>(
           tx_size.height() << plane_cfg.ydec
         );
 
-      let num_avail = if top_edge != 0 && has_tr(&bo, bsize) {
+      let num_avail = if top_edge != 0 && has_tr(bo, bsize) {
         tx_size.width().min(plane_cfg.width - x - tx_size.width())
       } else {
         0
@@ -952,7 +952,7 @@ pub fn get_intra_edges<T: Pixel>(
         tx_size.height() << plane_cfg.ydec
         );
 
-      let num_avail = if left_edge != 0 && has_bl(&bo, bsize) {
+      let num_avail = if left_edge != 0 && has_bl(bo, bsize) {
         tx_size.height().min(plane_cfg.height - y - tx_size.height())
       } else {
         0
@@ -1232,7 +1232,7 @@ pub enum TxSet {
   TX_SET_ALL16
 }
 
-pub fn has_tr(bo: &BlockOffset, bsize: BlockSize) -> bool {
+pub fn has_tr(bo: BlockOffset, bsize: BlockSize) -> bool {
   let sb_mi_size = BLOCK_64X64.width_mi(); /* Assume 64x64 for now */
   let mask_row = bo.y & LOCAL_BLOCK_MASK;
   let mask_col = bo.x & LOCAL_BLOCK_MASK;
@@ -1289,7 +1289,7 @@ pub fn has_tr(bo: &BlockOffset, bsize: BlockSize) -> bool {
   has_tr
 }
 
-pub fn has_bl(bo: &BlockOffset, bsize: BlockSize) -> bool {
+pub fn has_bl(bo: BlockOffset, bsize: BlockSize) -> bool {
   let sb_mi_size = BLOCK_64X64.width_mi(); /* Assume 64x64 for now */
   let mask_row = bo.y & LOCAL_BLOCK_MASK;
   let mask_col = bo.x & LOCAL_BLOCK_MASK;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -1133,7 +1133,7 @@ impl PredictionMode {
   }
 
   pub fn predict_inter<T: Pixel>(
-    self, fi: &FrameInvariants<T>, p: usize, po: &PlaneOffset,
+    self, fi: &FrameInvariants<T>, p: usize, po: PlaneOffset,
     dst: &mut PlaneMutSlice<'_, T>, width: usize, height: usize,
     ref_frames: [usize; 2], mvs: [MotionVector; 2]
   ) {
@@ -1144,7 +1144,7 @@ impl PredictionMode {
       ref_frames[1] > INTRA_FRAME && ref_frames[1] != NONE_FRAME;
 
     fn get_params<'a, T: Pixel>(
-      rec_plane: &'a Plane<T>, po: &PlaneOffset, mv: MotionVector
+      rec_plane: &'a Plane<T>, po: PlaneOffset, mv: MotionVector
     ) -> (i32, i32, PlaneSlice<'a, T>) {
       let rec_cfg = &rec_plane.cfg;
       let shift_row = 3 + rec_cfg.ydec;
@@ -1159,7 +1159,7 @@ impl PredictionMode {
         x: po.x + col_offset as isize - 3,
         y: po.y + row_offset as isize - 3
       };
-      (row_frac, col_frac, rec_plane.slice(&qo).clamp().subslice(3, 3))
+      (row_frac, col_frac, rec_plane.slice(qo).clamp().subslice(3, 3))
     };
 
     if !is_compound {

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -32,7 +32,7 @@ pub struct PlaneConfig {
 }
 
 /// Absolute offset in pixels inside a plane
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct PlaneOffset {
   pub x: isize,
   pub y: isize
@@ -248,24 +248,24 @@ impl<T: Pixel> Plane<T> {
     }
   }
 
-  pub fn slice(&self, po: &PlaneOffset) -> PlaneSlice<'_, T> {
+  pub fn slice(&self, po: PlaneOffset) -> PlaneSlice<'_, T> {
     PlaneSlice { plane: self, x: po.x, y: po.y }
   }
 
-  pub fn mut_slice(&mut self, po: &PlaneOffset) -> PlaneMutSlice<'_, T> {
+  pub fn mut_slice(&mut self, po: PlaneOffset) -> PlaneMutSlice<'_, T> {
     PlaneMutSlice { plane: self, x: po.x, y: po.y }
   }
 
   pub fn as_slice(&self) -> PlaneSlice<'_, T> {
-    self.slice(&PlaneOffset { x: 0, y: 0 })
+    self.slice(PlaneOffset { x: 0, y: 0 })
   }
 
   pub fn as_mut_slice(&mut self) -> PlaneMutSlice<'_, T> {
-    self.mut_slice(&PlaneOffset { x: 0, y: 0 })
+    self.mut_slice(PlaneOffset { x: 0, y: 0 })
   }
 
   #[inline]
-  pub fn edged_slice(&self, po: &PlaneOffset, left_edge: usize, top_edge: usize) -> EdgedPlaneSlice<'_, T> {
+  pub fn edged_slice(&self, po: PlaneOffset, left_edge: usize, top_edge: usize) -> EdgedPlaneSlice<'_, T> {
     debug_assert!(po.x >= 0);
     debug_assert!(po.y >= 0);
     let left_edge = left_edge.min(po.x as usize);
@@ -274,7 +274,7 @@ impl<T: Pixel> Plane<T> {
       x: po.x - left_edge as isize,
       y: po.y - top_edge as isize,
     };
-    EdgedPlaneSlice { ps: self.slice(&edged_po), left_edge, top_edge }
+    EdgedPlaneSlice { ps: self.slice(edged_po), left_edge, top_edge }
   }
 
   #[inline]

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1221,7 +1221,7 @@ pub fn rdo_partition_decision<T: Pixel>(
   }
 }
 
-fn rdo_loop_plane_error<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<T>,
+fn rdo_loop_plane_error<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T>,
                                   fs: &FrameState<T>, bc: &BlockContext,
                                   test: &Frame<T>, pli: usize) -> u64 {
   let sbo_0 = SuperBlockOffset { x: 0, y: 0 };
@@ -1258,7 +1258,7 @@ fn rdo_loop_plane_error<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<T
   err
 }
 
-pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<T>,
+pub fn rdo_loop_decision<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T>,
                                    fs: &mut FrameState<T>,
                                    cw: &mut ContextWriter, w: &mut dyn Writer) {
   assert!(fi.sequence.enable_cdef || fi.sequence.enable_restoration);
@@ -1308,7 +1308,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
   // If LRF choice changed for any plane, repeat last two steps.
   let bd = fi.sequence.bit_depth;
   let cdef_data = cdef_input.as_ref().map(|input| {
-    (input, cdef_analyze_superblock(input, &mut cw.bc, &sbo_0, &sbo, bd))
+    (input, cdef_analyze_superblock(input, &mut cw.bc, sbo_0, sbo, bd))
   });
   let mut first_loop = true;
   loop {
@@ -1321,7 +1321,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
           let mut cost = [0.; PLANES];
           let mut cost_acc = 0.;
           cdef_filter_superblock(fi, &cdef_input, &mut lrf_input,
-                                 &mut cw.bc, &sbo_0, &sbo, cdef_index as u8, &cdef_dirs);
+                                 &mut cw.bc, sbo_0, sbo, cdef_index as u8, &cdef_dirs);
           for pli in 0..3 {
             match best_lrf[pli] {
               RestorationFilter::None{} => {
@@ -1370,7 +1370,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
       // need cdef output from best index, not just last iteration
       if let Some((cdef_input, cdef_dirs)) = cdef_data.as_ref() {
         cdef_filter_superblock(fi, &cdef_input, &mut lrf_input,
-                               &mut cw.bc, &sbo_0, &sbo, best_index as u8, &cdef_dirs);
+                               &mut cw.bc, sbo_0, sbo, best_index as u8, &cdef_dirs);
       }
 
       // Wiener LRF decision coming soon
@@ -1426,7 +1426,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: &SuperBlockOffset, fi: &FrameInvariants<
   }
 
   if cw.bc.cdef_coded {
-    cw.bc.set_cdef(&sbo, best_index as u8);
+    cw.bc.set_cdef(sbo, best_index as u8);
   }
 
   if fi.sequence.enable_restoration {


### PR DESCRIPTION
`BlockOffset` has a size of 128 bits (the same as a slice), and is trivially copyable, so make it derive `Copy`.

Once it derives `Copy`, [clippy suggests to never pass it by reference](https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref).

So pass it by value everywhere to simplify usage.

In particular, this avoids lifetimes bounds where not necessary:

```diff

@@ -1044,8 +1044,8 @@ pub fn rdo_tx_type_decision<T: Pixel>(
   best_type
 }
 
-pub fn get_sub_partitions<'a>(four_partitions: &[&'a BlockOffset; 4],
-                              partition: PartitionType) -> Vec<&'a BlockOffset> {
+pub fn get_sub_partitions(four_partitions: &[BlockOffset; 4],
+                          partition: PartitionType) -> Vec<BlockOffset> {
   let mut partitions = vec![ four_partitions[0] ];
 
   if partition == PARTITION_NONE {
```

See <https://github.com/xiph/rav1e/pull/1126#issuecomment-474532123>.

---

This PR is basically a quick&dirty replacement:
```bash
find -name '*.rs' -exec sed -i 's/&BlockOffset/BlockOffset/g;s/&bo/bo/g' {} ';'
```
followed by around twenty manual fixes.

If you agree with this one, we should do it for `PlaneOffset` and `SuperBlockOffset`too.