### PR TITLE
Do not pass both BlockOffset and PlaneOffset

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1175,6 +1175,15 @@ impl BlockOffset {
     }
   }
 
+  /// Convert to plane offset without decimation
+  #[inline]
+  pub fn to_luma_plane_offset(self) -> PlaneOffset {
+    PlaneOffset {
+      x: (self.x as isize) << BLOCK_TO_PLANE_SHIFT,
+      y: (self.y as isize) << BLOCK_TO_PLANE_SHIFT,
+    }
+  }
+
   pub fn y_in_sb(self) -> usize {
     self.y % MAX_MIB_SIZE
   }


### PR DESCRIPTION
In motion estimation, several functions received both the offset expressed in blocks and in pixels for the luma plane. This information is redundant: a block offset is trivially convertible to a luma plane offset.

With tiling, we need to manage both absolute offsets (relative to the frame) and offsets relative to the current tile. This will be more simple without duplication.