### PR TITLE
sad_sse2: remove unnecessary memory alignment

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -132,15 +132,11 @@ mod nasm {
     plane_org: &PlaneSlice<'_, u8>, plane_ref: &PlaneSlice<'_, u8>, blk_h: usize,
     blk_w: usize
   ) -> u32 {
-    // FIXME unaligned blocks coming from hres/qres ME search
-    let ptr_align_log2 = (plane_org.as_ptr() as usize).trailing_zeros() as usize;
-    // The largest unaligned-safe function is for 8x8
-    let ptr_align = 1 << ptr_align_log2.max(3);
     let mut sum = 0 as u32;
     let org_stride = plane_org.plane.cfg.stride as libc::ptrdiff_t;
     let ref_stride = plane_ref.plane.cfg.stride as libc::ptrdiff_t;
     assert!(blk_h >= 4 && blk_w >= 4);
-    let step_size = blk_h.min(blk_w).min(ptr_align);
+    let step_size = blk_h.min(blk_w);
     let func = match step_size.ilog() {
       3 => rav1e_sad4x4_sse2,
       4 => rav1e_sad8x8_sse2,


### PR DESCRIPTION
The sad functions in sad_sse2.asm uses movu instructions (translated to
movupd) that performs a unaligned loads.

Here are some results of `cargo bench get_sad` on a Intel Core i7-7700 CPU. It improves the performance for most of the cases. However, please note that the 128x128 sad function seems badly impacted. It is however not currently used since AFAIK rav1e do not yet support 128x128 super-blocs.

```
Benchmarking get_sad/BLOCK_4X4: Collecting 100 samples in estimated 5.0001 s (29                                                                                get_sad/BLOCK_4X4       time:   [12.379 ns 12.385 ns 12.391 ns]
                        change: [-11.512% -11.423% -11.347%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  9 (9.00%) high mild
  6 (6.00%) high severe
Benchmarking get_sad/BLOCK_4X8: Collecting 100 samples in estimated 5.0001 s (21                                                                                get_sad/BLOCK_4X8       time:   [18.929 ns 18.940 ns 18.955 ns]
                        change: [-9.4539% -9.3187% -9.2025%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
Benchmarking get_sad/BLOCK_8X4: Collecting 100 samples in estimated 5.0000 s (23                                                                                get_sad/BLOCK_8X4       time:   [17.347 ns 17.356 ns 17.366 ns]
                        change: [-9.5948% -9.5067% -9.4251%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_8X8: Collecting 100 samples in estimated 5.0001 s (27                                                                                get_sad/BLOCK_8X8       time:   [13.503 ns 13.507 ns 13.512 ns]
                        change: [-8.9707% -8.8890% -8.8136%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  1 (1.00%) high severe
Benchmarking get_sad/BLOCK_8X16: Collecting 100 samples in estimated 5.0001 s (1                                                                                get_sad/BLOCK_8X16      time:   [21.730 ns 21.746 ns 21.766 ns]
                        change: [-4.4937% -4.3604% -4.2517%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
Benchmarking get_sad/BLOCK_16X8: Collecting 100 samples in estimated 5.0000 s (2                                                                                get_sad/BLOCK_16X8      time:   [20.303 ns 20.314 ns 20.326 ns]
                        change: [-5.3330% -5.2426% -5.1586%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_16X16: Collecting 100 samples in estimated 5.0000 s (                                                                                get_sad/BLOCK_16X16     time:   [16.588 ns 16.599 ns 16.612 ns]
                        change: [-5.3791% -5.2668% -5.1583%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
Benchmarking get_sad/BLOCK_16X32: Collecting 100 samples in estimated 5.0001 s (                                                                                get_sad/BLOCK_16X32     time:   [28.091 ns 28.102 ns 28.113 ns]
                        change: [-4.7441% -4.5562% -4.4071%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
Benchmarking get_sad/BLOCK_32X16: Collecting 100 samples in estimated 5.0001 s (                                                                                get_sad/BLOCK_32X16     time:   [26.815 ns 26.835 ns 26.860 ns]
                        change: [-3.6822% -3.6022% -3.5250%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
Benchmarking get_sad/BLOCK_32X32: Collecting 100 samples in estimated 5.0001 s (                                                                                get_sad/BLOCK_32X32     time:   [30.035 ns 30.053 ns 30.077 ns]
                        change: [-5.3560% -5.2713% -5.1858%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_32X64: Collecting 100 samples in estimated 5.0001 s (                                                                                get_sad/BLOCK_32X64     time:   [53.693 ns 53.724 ns 53.759 ns]
                        change: [-4.5706% -4.3756% -4.1990%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
Benchmarking get_sad/BLOCK_64X32: Collecting 100 samples in estimated 5.0000 s (                                                                                get_sad/BLOCK_64X32     time:   [56.226 ns 56.251 ns 56.277 ns]
                        change: [-5.3154% -5.1992% -5.0904%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking get_sad/BLOCK_64X64: Collecting 100 samples in estimated 5.0004 s (                                                                                get_sad/BLOCK_64X64     time:   [80.905 ns 80.992 ns 81.103 ns]
                        change: [-1.8663% -1.7587% -1.6566%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
Benchmarking get_sad/BLOCK_64X128: Collecting 100 samples in estimated 5.0000 s                                                                                 get_sad/BLOCK_64X128    time:   [172.58 ns 172.68 ns 172.79 ns]
                        change: [+2.3376% +2.4818% +2.6191%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe
Benchmarking get_sad/BLOCK_128X64: Collecting 100 samples in estimated 5.0001 s                                                                                 get_sad/BLOCK_128X64    time:   [158.78 ns 158.89 ns 159.01 ns]
                        change: [-0.4821% -0.3719% -0.2650%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_128X128: Collecting 100 samples in estimated 5.0020 s                                                                                get_sad/BLOCK_128X128   time:   [557.17 ns 557.51 ns 557.92 ns]
                        change: [+42.795% +43.477% +44.259%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
Benchmarking get_sad/BLOCK_4X16: Collecting 100 samples in estimated 5.0001 s (1                                                                                get_sad/BLOCK_4X16      time:   [32.119 ns 32.134 ns 32.150 ns]
                        change: [-5.1325% -5.0535% -4.9712%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
Benchmarking get_sad/BLOCK_16X4: Collecting 100 samples in estimated 5.0000 s (1                                                                                get_sad/BLOCK_16X4      time:   [27.999 ns 28.015 ns 28.036 ns]
                        change: [-5.7160% -5.5984% -5.4845%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
Benchmarking get_sad/BLOCK_8X32: Collecting 100 samples in estimated 5.0001 s (1                                                                                get_sad/BLOCK_8X32      time:   [38.088 ns 38.111 ns 38.137 ns]
                        change: [-2.8110% -2.7342% -2.6541%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
Benchmarking get_sad/BLOCK_32X8: Collecting 100 samples in estimated 5.0001 s (1                                                                                get_sad/BLOCK_32X8      time:   [33.696 ns 33.715 ns 33.735 ns]
                        change: [-3.6693% -3.5910% -3.5214%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
Benchmarking get_sad/BLOCK_16X64: Collecting 100 samples in estimated 5.0001 s (                                                                                get_sad/BLOCK_16X64     time:   [49.788 ns 49.839 ns 49.898 ns]
                        change: [-1.6309% -1.5152% -1.3942%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
Benchmarking get_sad/BLOCK_64X16: Collecting 100 samples in estimated 5.0000 s (                                                                                get_sad/BLOCK_64X16     time:   [45.942 ns 45.982 ns 46.028 ns]
                        change: [-2.1344% -2.0508% -1.9531%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) high mild
  5 (5.00%) high severe
```