### PR TITLE
get_sad() Parameter rearrangement

### DIFF
--- a/benches/me.rs
+++ b/benches/me.rs
@@ -48,7 +48,7 @@ fn run_sad_bench<T: Pixel>(b: &mut Bencher, &(bs, bit_depth): &(BlockSize, usize
 
   b.iter(|| {
     let _ =
-      black_box(me::get_sad(&plane_org, &plane_ref, bsh, bsw, bit_depth));
+      black_box(me::get_sad(&plane_org, &plane_ref, bsw, bsh, bit_depth));
   })
 }
 


### PR DESCRIPTION
The [comment](https://github.com/xiph/rav1e/pull/1111#issuecomment-472889389) points out that the order of parameters in the get_sad() function is not as per the usual norm of WxH
This pull tries to solve that.