### PR TITLE
Do not pass both (blk_w, blk_h) and BlockSize

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -350,7 +350,7 @@ pub trait MotionEstimation {
     bo: BlockOffset, lambda: u32, pmv: [MotionVector; 2],
     mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
     blk_w: usize, blk_h: usize, best_mv: &mut MotionVector,
-    lowest_cost: &mut u64, ref_frame: usize, bsize: BlockSize
+    lowest_cost: &mut u64, ref_frame: usize
   );
 
   fn motion_estimation<T: Pixel> (
@@ -380,7 +380,7 @@ pub trait MotionEstimation {
 
         Self::sub_pixel_me(fi, fs, rec, bo, lambda, pmv,
                            mvx_min, mvx_max, mvy_min, mvy_max, blk_w, blk_h,
-                           &mut best_mv, &mut lowest_cost, ref_frame, bsize);
+                           &mut best_mv, &mut lowest_cost, ref_frame);
 
         best_mv
       }
@@ -483,7 +483,6 @@ impl MotionEstimation for DiamondSearch {
     pmv: [MotionVector; 2], mvx_min: isize, mvx_max: isize,
     mvy_min: isize, mvy_max: isize, blk_w: usize, blk_h: usize,
     best_mv: &mut MotionVector, lowest_cost: &mut u64, ref_frame: usize,
-    _bsize: BlockSize
   )
   {
     let predictors = vec![*best_mv];
@@ -591,15 +590,13 @@ impl MotionEstimation for FullSearch {
     fi: &FrameInvariants<T>, fs: &FrameState<T>, _rec: &Arc<ReferenceFrame<T>>,
     bo: BlockOffset, lambda: u32,
     pmv: [MotionVector; 2], mvx_min: isize, mvx_max: isize,
-    mvy_min: isize, mvy_max: isize, _blk_w: usize, _blk_h: usize,
+    mvy_min: isize, mvy_max: isize, blk_w: usize, blk_h: usize,
     best_mv: &mut MotionVector, lowest_cost: &mut u64, ref_frame: usize,
-    bsize: BlockSize
   )
   {
     telescopic_subpel_search(
       fi,
       fs,
-      bsize,
       bo.to_luma_plane_offset(),
       lambda,
       ref_frame,
@@ -608,6 +605,8 @@ impl MotionEstimation for FullSearch {
       mvx_max,
       mvy_min,
       mvy_max,
+      blk_w,
+      blk_h,
       best_mv,
       lowest_cost
     );
@@ -812,14 +811,12 @@ fn compute_mv_rd_cost<T: Pixel>(
 }
 
 fn telescopic_subpel_search<T: Pixel>(
-  fi: &FrameInvariants<T>, fs: &FrameState<T>, bsize: BlockSize, po: PlaneOffset,
+  fi: &FrameInvariants<T>, fs: &FrameState<T>, po: PlaneOffset,
   lambda: u32, ref_frame: usize, pmv: [MotionVector; 2],
   mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
+  blk_w: usize, blk_h: usize,
   best_mv: &mut MotionVector, lowest_cost: &mut u64
 ) {
-  let blk_w = bsize.width();
-  let blk_h = bsize.height();
-
   let mode = PredictionMode::NEWMV;
 
   let mut steps = vec![8, 4, 2];


### PR DESCRIPTION
This is redundant. For consistency, keep `blk_w` and `blk_h`.