### PR TITLE
Enable the Clippy's precedence lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,4 @@ jobs:
          - cargo doc --verbose
          - rustup component add clippy
          - cargo clippy --version
-         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::needless_range_loop -A clippy::precedence -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose
+         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::collapsible_if -A clippy::cyclomatic_complexity -A clippy::needless_range_loop -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -195,8 +195,8 @@ unsafe fn cdef_filter_block<T: Pixel>(
 
 // We use the variance of an 8x8 block to adjust the effective filter strength.
 fn adjust_strength(strength: i32, var: i32) -> i32 {
-  let i = if (var >> 6) != 0 {cmp::min(msb(var >> 6), 12)} else {0};
-  if var!=0 {strength * (4 + i) + 8 >> 4} else {0}
+  let i = if (var >> 6) != 0 { cmp::min(msb(var >> 6), 12) } else { 0 };
+  if var != 0 { (strength * (4 + i) + 8) >> 4 } else { 0 }
 }
 
 // For convenience of use alongside cdef_filter_superblock, we assume
@@ -395,10 +395,10 @@ pub fn cdef_filter_superblock<T: Pixel>(
             unsafe {
               let xsize = 8 >> xdec;
               let ysize = 8 >> ydec;
-              assert!(out_slice.rows_iter().len() >= (8 * by >> ydec) + ysize);
-              assert!(in_slice.rows_iter().len() >= (8 * by >> ydec) + ysize + 4);
-              let dst = out_slice[8 * by >> ydec][8 * bx >> xdec..].as_mut_ptr();
-              let input = in_slice[8 * by >> ydec][8 * bx >> xdec..].as_ptr();
+              assert!(out_slice.rows_iter().len() >= ((8 * by) >> ydec) + ysize);
+              assert!(in_slice.rows_iter().len() >= ((8 * by) >> ydec) + ysize + 4);
+              let dst = out_slice[(8 * by) >> ydec][(8 * bx) >> xdec..].as_mut_ptr();
+              let input = in_slice[(8 * by) >> ydec][(8 * bx) >> xdec..].as_ptr();
               cdef_filter_block(dst,
                                 out_stride as isize,
                                 input,
@@ -429,8 +429,8 @@ pub fn cdef_filter_frame<T: Pixel>(fi: &FrameInvariants<T>, rec: &mut Frame<T>, 
   // Construct a padded copy of the reconstructed frame.
   let mut padded_px: [[usize; 2]; 3] = [[0; 2]; 3];
   for p in 0..3 {
-    padded_px[p][0] =  (fb_width*64 >> rec.planes[p].cfg.xdec) + 4;
-    padded_px[p][1] =  (fb_height*64 >> rec.planes[p].cfg.ydec) + 4;
+    padded_px[p][0] = ((fb_width * 64) >> rec.planes[p].cfg.xdec) + 4;
+    padded_px[p][1] = ((fb_height * 64) >> rec.planes[p].cfg.ydec) + 4;
   }
   let mut cdef_frame: Frame<u16> = Frame {
     planes: [

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -220,7 +220,7 @@ fn filter_narrow4_4(
     let test = clamp(base + 3, -128 << shift, (128 << shift) - 1) >> 3;
     filter2 == test
   });
-  let filter3 = filter1 + 1 >> 1;
+  let filter3 = (filter1 + 1) >> 1;
   [
     clamp(p1 + filter3, 0, (256 << shift) - 1),
     clamp(p0 + filter2, 0, (256 << shift) - 1),
@@ -252,10 +252,10 @@ fn filter_wide6_4(
   p2: i32, p1: i32, p0: i32, q0: i32, q1: i32, q2: i32
 ) -> [i32; 4] {
   [
-    p2*3 + p1*2 + p0*2 + q0   + (1<<2) >> 3,
-    p2   + p1*2 + p0*2 + q0*2 + q1   + (1<<2) >> 3,
-           p1   + p0*2 + q0*2 + q1*2 + q2   + (1<<2) >> 3,
-                  p0   + q0*2 + q1*2 + q2*3 + (1<<2) >> 3
+    (p2*3 + p1*2 + p0*2 + q0   + (1<<2)) >> 3,
+    (p2   + p1*2 + p0*2 + q0*2 + q1   + (1<<2)) >> 3,
+           (p1   + p0*2 + q0*2 + q1*2 + q2   + (1<<2)) >> 3,
+                  (p0   + q0*2 + q1*2 + q2*3 + (1<<2)) >> 3
   ]
 }
 
@@ -265,12 +265,12 @@ fn filter_wide8_6(
   p3: i32, p2: i32, p1: i32, p0: i32, q0: i32, q1: i32, q2: i32, q3: i32
 ) -> [i32; 6] {
   [
-    p3*3 + p2*2 + p1   + p0   + q0   + (1<<2) >> 3,
-    p3*2 + p2   + p1*2 + p0   + q0   + q1   + (1<<2) >> 3,
-    p3   + p2   + p1   + p0*2 + q0   + q1   + q2   +(1<<2) >> 3,
-           p2   + p1   + p0   + q0*2 + q1   + q2   + q3   + (1<<2) >> 3,
-                  p1   + p0   + q0   + q1*2 + q2   + q3*2 + (1<<2) >> 3,
-                         p0   + q0   + q1   + q2*2 + q3*3 + (1<<2) >> 3
+    (p3*3 + p2*2 + p1   + p0   + q0   + (1<<2)) >> 3,
+    (p3*2 + p2   + p1*2 + p0   + q0   + q1   + (1<<2)) >> 3,
+    (p3   + p2   + p1   + p0*2 + q0   + q1   + q2   +(1<<2)) >> 3,
+           (p2   + p1   + p0   + q0*2 + q1   + q2   + q3   + (1<<2)) >> 3,
+                  (p1   + p0   + q0   + q1*2 + q2   + q3*2 + (1<<2)) >> 3,
+                         (p0   + q0   + q1   + q2*2 + q3*3 + (1<<2)) >> 3
   ]
 }
 
@@ -290,18 +290,18 @@ fn filter_wide14_12(
   q1: i32, q2: i32, q3: i32, q4: i32, q5: i32, q6: i32
 ) -> [i32; 12] {
   [
-    p6*7 + p5*2 + p4*2 + p3   + p2   + p1   + p0   + q0   + (1<<3) >> 4,
-    p6*5 + p5*2 + p4*2 + p3*2 + p2   + p1   + p0   + q0   + q1   + (1<<3) >> 4,
-    p6*4 + p5   + p4*2 + p3*2 + p2*2 + p1   + p0   + q0   + q1   + q2   + (1<<3) >> 4,
-    p6*3 + p5   + p4   + p3*2 + p2*2 + p1*2 + p0   + q0   + q1   + q2   + q3   + (1<<3) >> 4,
-    p6*2 + p5   + p4   + p3   + p2*2 + p1*2 + p0*2 + q0   + q1   + q2   + q3   + q4   + (1<<3) >> 4,
-    p6   + p5   + p4   + p3   + p2   + p1*2 + p0*2 + q0*2 + q1   + q2   + q3   + q4   + q5   + (1<<3) >> 4,
-           p5   + p4   + p3   + p2   + p1   + p0*2 + q0*2 + q1*2 + q2   + q3   + q4   + q5   + q6 + (1<<3) >> 4,
-                  p4   + p3   + p2   + p1   + p0   + q0*2 + q1*2 + q2*2 + q3   + q4   + q5   + q6*2 + (1<<3) >> 4,
-                         p3   + p2   + p1   + p0   + q0   + q1*2 + q2*2 + q3*2 + q4   + q5   + q6*3 + (1<<3) >> 4,
-                                p2   + p1   + p0   + q0   + q1   + q2*2 + q3*2 + q4*2 + q5   + q6*4 + (1<<3) >> 4,
-                                       p1   + p0   + q0   + q1   + q2   + q3*2 + q4*2 + q5*2 + q6*5 + (1<<3) >> 4,
-                                              p0   + q0   + q1   + q2   + q3   + q4*2 + q5*2 + q6*7 + (1<<3) >> 4
+    (p6*7 + p5*2 + p4*2 + p3   + p2   + p1   + p0   + q0   + (1<<3)) >> 4,
+    (p6*5 + p5*2 + p4*2 + p3*2 + p2   + p1   + p0   + q0   + q1   + (1<<3)) >> 4,
+    (p6*4 + p5   + p4*2 + p3*2 + p2*2 + p1   + p0   + q0   + q1   + q2   + (1<<3)) >> 4,
+    (p6*3 + p5   + p4   + p3*2 + p2*2 + p1*2 + p0   + q0   + q1   + q2   + q3   + (1<<3)) >> 4,
+    (p6*2 + p5   + p4   + p3   + p2*2 + p1*2 + p0*2 + q0   + q1   + q2   + q3   + q4   + (1<<3)) >> 4,
+    (p6   + p5   + p4   + p3   + p2   + p1*2 + p0*2 + q0*2 + q1   + q2   + q3   + q4   + q5   + (1<<3)) >> 4,
+           (p5   + p4   + p3   + p2   + p1   + p0*2 + q0*2 + q1*2 + q2   + q3   + q4   + q5   + q6 + (1<<3)) >> 4,
+                  (p4   + p3   + p2   + p1   + p0   + q0*2 + q1*2 + q2*2 + q3   + q4   + q5   + q6*2 + (1<<3)) >> 4,
+                         (p3   + p2   + p1   + p0   + q0   + q1*2 + q2*2 + q3*2 + q4   + q5   + q6*3 + (1<<3)) >> 4,
+                                (p2   + p1   + p0   + q0   + q1   + q2*2 + q3*2 + q4*2 + q5   + q6*4 + (1<<3)) >> 4,
+                                       (p1   + p0   + q0   + q1   + q2   + q3*2 + q4*2 + q5*2 + q6*5 + (1<<3)) >> 4,
+                                              (p0   + q0   + q1   + q2   + q3   + q4*2 + q5*2 + q6*7 + (1<<3)) >> 4
   ]
 }
 
@@ -339,15 +339,15 @@ fn _level_to_limit(level: i32, shift: usize) -> i32 {
 }
 
 fn limit_to_level(limit: i32, shift: usize) -> i32 {
-  limit + (1 << shift) - 1 >> shift
+  (limit + (1 << shift) - 1) >> shift
 }
 
 fn _level_to_blimit(level: i32, shift: usize) -> i32 {
-  3 * level + 4 << shift
+  (3 * level + 4) << shift
 }
 
 fn blimit_to_level(blimit: i32, shift: usize) -> i32 {
-  ((blimit + (1 << shift) - 1 >> shift) - 2) / 3
+  (((blimit + (1 << shift) - 1) >> shift) - 2) / 3
 }
 
 fn _level_to_thresh(level: i32, shift: usize) -> i32 {
@@ -355,7 +355,7 @@ fn _level_to_thresh(level: i32, shift: usize) -> i32 {
 }
 
 fn thresh_to_level(thresh: i32, shift: usize) -> i32 {
-  thresh + (1 << shift) - 1 >> shift << 4
+  (thresh + (1 << shift) - 1) >> shift << 4
 }
 
 fn nhev4(p1: i32, p0: i32, q0: i32, q1: i32, shift: usize) -> usize {
@@ -502,7 +502,7 @@ fn deblock_size6_inner(
   bd: usize,
 ) -> Option<[i32; 4]> {
   if mask6(p2, p1, p0, q0, q1, q2, bd - 8) <= level {
-    let flat = 1 << bd - 8;
+    let flat = 1 << (bd - 8);
     let x = if flat6(p2, p1, p0, q0, q1, q2) <= flat {
       filter_wide6_4(p2, p1, p0, q0, q1, q2)
     } else if nhev4(p1, p0, q0, q1, bd - 8) <= level {
@@ -565,7 +565,7 @@ fn sse_size6<T: Pixel>(
   src_pitch: usize,
   bd: usize
 ) {
-  let flat = 1 << bd - 8;
+  let flat = 1 << (bd - 8);
   for y in 0..4 {
     let p = &rec[y]; // six taps
     let a = &src[y][src_pitch..]; // four pixels to compare so offset one forward
@@ -671,7 +671,7 @@ fn deblock_size8_inner (
   bd: usize,
 ) -> Option<[i32; 6]> {
   if mask8(p3, p2, p1, p0, q0, q1, q2, q3, bd - 8) <= level {
-    let flat = 1 << bd - 8;
+    let flat = 1 << (bd - 8);
     let x = if flat8(p3, p2, p1, p0, q0, q1, q2, q3) <= flat {
       filter_wide8_6(p3, p2, p1, p0, q0, q1, q2, q3)
     } else if nhev4(p1, p0, q0, q1, bd - 8) <= level {
@@ -738,7 +738,7 @@ fn sse_size8<T: Pixel>(
   src_pitch: usize,
   bd: usize
 ) {
-  let flat = 1 << bd - 8;
+  let flat = 1 << (bd - 8);
   for y in 0..4 {
     let p = &rec[y]; // eight taps
     let a = &src[y][src_pitch..]; // six pixels to compare so offset one forward
@@ -823,7 +823,7 @@ fn deblock_size14_inner(
 ) -> Option<[i32; 12]> {
   // 'mask' test
   if mask8(p3, p2, p1, p0, q0, q1, q2, q3, bd - 8) <= level {
-    let flat = 1 << bd - 8;
+    let flat = 1 << (bd - 8);
     // inner flatness test
     let x = if flat8(p3, p2, p1, p0, q0, q1, q2, q3) <= flat {
       // outer flatness test
@@ -911,7 +911,7 @@ fn sse_size14<T: Pixel>(
   src_pitch: usize,
   bd: usize
 ) {
-  let flat = 1 << bd - 8;
+  let flat = 1 << (bd - 8);
   for y in 0..4 {
     let p = &rec[y]; // 14 taps
     let a = &src[y][src_pitch..]; // 12 pixels to compare so offset one forward
@@ -1432,21 +1432,21 @@ pub fn deblock_filter_optimize<T: Pixel>(
       match fi.sequence.bit_depth {
         8 =>
           if fi.frame_type == FrameType::KEY {
-            q * 17563 - 421_574 + (1 << 18 >> 1) >> 18
+            (q * 17563 - 421_574 + (1 << 18 >> 1)) >> 18
           } else {
-            q * 6017 + 650_707 + (1 << 18 >> 1) >> 18
+            (q * 6017 + 650_707 + (1 << 18 >> 1)) >> 18
           },
         10 =>
           if fi.frame_type == FrameType::KEY {
-            (q * 20723 + 4_060_632 + (1 << 20 >> 1) >> 20) - 4
+            ((q * 20723 + 4_060_632 + (1 << 20 >> 1)) >> 20) - 4
           } else {
-            q * 20723 + 4_060_632 + (1 << 20 >> 1) >> 20
+            (q * 20723 + 4_060_632 + (1 << 20 >> 1)) >> 20
           },
         12 =>
           if fi.frame_type == FrameType::KEY {
-            (q * 20723 + 16_242_526 + (1 << 22 >> 1) >> 22) - 4
+            ((q * 20723 + 16_242_526 + (1 << 22 >> 1)) >> 22) - 4
           } else {
-            q * 20723 + 16_242_526 + (1 << 22 >> 1) >> 22
+            (q * 20723 + 16_242_526 + (1 << 22 >> 1)) >> 22
           },
         _ => {
           assert!(false);

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -375,8 +375,15 @@ impl<S> WriterBase<S> {
       }
     }
   }
+
   fn recenter(r: u32, v: u32) -> u32 {
-    if v > (r << 1) {v} else if v >= r {v - r << 1} else {(r - v << 1) - 1}
+    if v > (r << 1) {
+      v
+    } else if v >= r {
+      (v - r) << 1
+    } else {
+      ((r - v) << 1) - 1
+    }
   }
 
   #[cfg(debug)]
@@ -543,17 +550,16 @@ where
     debug_assert!(32768 <= self.rng);
     let rng = (self.rng >> 8) as u32;
     let fh = cdf[s as usize] as u32 >> EC_PROB_SHIFT;
-    let r =
-      if s > 0 {
-        let fl = cdf[s as usize - 1] as u32 >> EC_PROB_SHIFT;
-        (rng * fl >> 7 - EC_PROB_SHIFT) - (rng * fh >> 7 - EC_PROB_SHIFT) + EC_MIN_PROB
-      } else {
-        let nms1 = cdf.len() as u32 - s - 1;
-        self.rng as u32 - (rng * fh >> 7 - EC_PROB_SHIFT) - nms1 * EC_MIN_PROB
-      };
+    let r = if s > 0 {
+      let fl = cdf[s as usize - 1] as u32 >> EC_PROB_SHIFT;
+      ((rng * fl) >> (7 - EC_PROB_SHIFT)) - ((rng * fh) >> (7 - EC_PROB_SHIFT)) + EC_MIN_PROB
+    } else {
+      let nms1 = cdf.len() as u32 - s - 1;
+      self.rng as u32 - ((rng * fh) >> (7 - EC_PROB_SHIFT)) - nms1 * EC_MIN_PROB
+    };
 
     // The 9 here counteracts the offset of -9 baked into cnt.  Don't include a termination bit.
-    let pre = Self::frac_compute((self.cnt + 9) as u32, self.rng as u32);      
+    let pre = Self::frac_compute((self.cnt + 9) as u32, self.rng as u32);
     let d = 16 - r.ilog();
     let mut c = self.cnt;
     let mut sh = c + (d as i16);
@@ -598,10 +604,10 @@ where
       let l = msb(n as i32) as u8 + 1;
       let m = (1 << l) - n;
       if v < m {
-        self.literal(l-1, v);
+        self.literal(l - 1, v);
       } else {
-        self.literal(l-1, m + (v-m >> 1));
-        self.literal(1, (v-m) & 1);
+        self.literal(l - 1, m + ((v - m) >> 1));
+        self.literal(1, (v - m) & 1);
       }
     }
   }
@@ -613,10 +619,8 @@ where
     if n > 1 {
       let l = (msb(n as i32) + 1) as u32;
       let m = (1 << l) - n;
-      if v < m {
-        bits += l-1 << OD_BITRES;
-      } else {
-        bits += l-1 << OD_BITRES;
+      bits += (l - 1) << OD_BITRES;
+      if v >= m {
         bits += 1 << OD_BITRES;
       }
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -821,7 +821,7 @@ impl<T: Pixel> FrameInvariants<T> {
       self.ac_delta_q[pi] = 0;
     }
     self.lambda =
-      qps.lambda * ((1 << 2 * (self.sequence.bit_depth - 8)) as f64);
+      qps.lambda * ((1 << (2 * (self.sequence.bit_depth - 8))) as f64);
     self.me_lambda = self.lambda.sqrt();
   }
 }

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -285,7 +285,7 @@ pub struct IIRBessel2 {
 // The return value is 5.12.
 // TODO: Mark const once we can use local variables in a const function.
 fn warp_alpha(alpha: i32) -> i32 {
-  let i = (alpha*36 >> 24).min(16);
+  let i = ((alpha*36) >> 24).min(16);
   let t0 = ROUGH_TAN_LOOKUP[i as usize];
   let t1 = ROUGH_TAN_LOOKUP[i as usize + 1];
   let d = alpha*36 - (i << 24);
@@ -465,7 +465,7 @@ impl RCState {
     //  errors in the worst case.
     // The 256 frame maximum means we'll require 8-10 seconds of pre-buffering
     // at 24-30 fps, which is not unreasonable.
-    let reservoir_frame_delay = clamp(max_key_frame_interval*3 >> 1, 12, 256);
+    let reservoir_frame_delay = clamp((max_key_frame_interval*3) >> 1, 12, 256);
     // TODO: What are the limits on these?
     let npixels = (frame_width as i64)*(frame_height as i64);
     // Insane framerates or frame sizes mean insane bitrates.

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -197,8 +197,10 @@ fn cdef_dist_wxh_8x8<T: Pixel>(
   let dvar = (sum_d2 - ((sum_d as i64 * sum_d as i64 + 32) >> 6)) as f64;
   let sse = (sum_d2 + sum_s2 - 2 * sum_sd) as f64;
   //The two constants were tuned for CDEF, but can probably be better tuned for use in general RDO
-  let ssim_boost = (4033_f64 / 16_384_f64) * (svar + dvar + (16_384 << 2 * coeff_shift) as f64)
-    / f64::sqrt((16_265_089u64 << 4 * coeff_shift) as f64 + svar * dvar);
+  let ssim_boost =
+    (4033_f64 / 16_384_f64) *
+    (svar + dvar + (16_384 << (2 * coeff_shift)) as f64) /
+    f64::sqrt((16_265_089u64 << (4 * coeff_shift)) as f64 + svar * dvar);
   (sse * ssim_boost + 0.5_f64) as u64
 }
 


### PR DESCRIPTION
This PR enables the Clippy's [precedence](https://rust-lang.github.io/rust-clippy/master/index.html#precedence) lint, and fixes all warnings caused by it.