### PR TITLE
Avoid negative (and unsigned) block offsets

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2533,7 +2533,7 @@ impl ContextWriter {
                                            &mut newmv_count, bsize, is_compound);
       col_match |= found_match;
     }
-    if has_tr(bo, bsize) {
+    if has_tr(bo, bsize) && bo.y > 0 {
       let found_match = self.scan_blk_mbmi(bo.with_offset(target_n4_w as isize, -1), ref_frames, mv_stack,
                                            &mut newmv_count, is_compound);
       row_match |= found_match;
@@ -2546,7 +2546,7 @@ impl ContextWriter {
     /* Scan the second outer area. */
     let mut far_newmv_count: usize = 0; // won't be used
 
-    let found_match = self.scan_blk_mbmi(
+    let found_match = bo.x > 0 && bo.y > 0 && self.scan_blk_mbmi(
       bo.with_offset(-1, -1), ref_frames, mv_stack, &mut far_newmv_count, is_compound
     );
     row_match |= found_match;

--- a/src/context.rs
+++ b/src/context.rs
@@ -2810,12 +2810,20 @@ impl ContextWriter {
   fn get_comp_mode_ctx(&self, bo: BlockOffset) -> usize {
     let avail_left = bo.x > 0;
     let avail_up = bo.y > 0;
-    let bo_left = bo.with_offset(-1, 0);
-    let bo_up = bo.with_offset(0, -1);
-    let above0 = if avail_up { self.bc.blocks[bo_up].ref_frames[0] } else { INTRA_FRAME };
-    let above1 = if avail_up { self.bc.blocks[bo_up].ref_frames[1] } else { NONE_FRAME };
-    let left0 = if avail_left { self.bc.blocks[bo_left].ref_frames[0] } else { INTRA_FRAME };
-    let left1 = if avail_left { self.bc.blocks[bo_left].ref_frames[1] } else { NONE_FRAME };
+    let (left0, left1) = if avail_left {
+      let bo_left = bo.with_offset(-1, 0);
+      let ref_frames = &self.bc.blocks[bo_left].ref_frames;
+      (ref_frames[0], ref_frames[1])
+    } else {
+      (INTRA_FRAME, NONE_FRAME)
+    };
+    let (above0, above1) = if avail_up {
+      let bo_up = bo.with_offset(0, -1);
+      let ref_frames = &self.bc.blocks[bo_up].ref_frames;
+      (ref_frames[0], ref_frames[1])
+    } else {
+      (INTRA_FRAME, NONE_FRAME)
+    };
     let left_single = left1 == NONE_FRAME;
     let above_single = above1 == NONE_FRAME;
     let left_intra = left0 == INTRA_FRAME;
@@ -2857,12 +2865,20 @@ impl ContextWriter {
 
     let avail_left = bo.x > 0;
     let avail_up = bo.y > 0;
-    let bo_left = bo.with_offset(-1, 0);
-    let bo_up = bo.with_offset(0, -1);
-    let above0 = if avail_up { self.bc.blocks[bo_up].ref_frames[0] } else { INTRA_FRAME };
-    let above1 = if avail_up { self.bc.blocks[bo_up].ref_frames[1] } else { NONE_FRAME };
-    let left0 = if avail_left { self.bc.blocks[bo_left].ref_frames[0] } else { INTRA_FRAME };
-    let left1 = if avail_left { self.bc.blocks[bo_left].ref_frames[1] } else { NONE_FRAME };
+    let (left0, left1) = if avail_left {
+      let bo_left = bo.with_offset(-1, 0);
+      let ref_frames = &self.bc.blocks[bo_left].ref_frames;
+      (ref_frames[0], ref_frames[1])
+    } else {
+      (INTRA_FRAME, NONE_FRAME)
+    };
+    let (above0, above1) = if avail_up {
+      let bo_up = bo.with_offset(0, -1);
+      let ref_frames = &self.bc.blocks[bo_up].ref_frames;
+      (ref_frames[0], ref_frames[1])
+    } else {
+      (INTRA_FRAME, NONE_FRAME)
+    };
     let left_single = left1 == NONE_FRAME;
     let above_single = above1 == NONE_FRAME;
     let left_intra = left0 == INTRA_FRAME;

--- a/src/context.rs
+++ b/src/context.rs
@@ -1245,6 +1245,8 @@ impl BlockOffset {
   pub fn with_offset(self, col_offset: isize, row_offset: isize) -> BlockOffset {
     let x = self.x as isize + col_offset;
     let y = self.y as isize + row_offset;
+    debug_assert!(x >= 0);
+    debug_assert!(y >= 0);
 
     BlockOffset {
       x: x as usize,


### PR DESCRIPTION
The code was inspired by libaom, which calls `scan_blk_mbmi()` unconditionally:
<https://aomedia.googlesource.com/aom/+/9a7e8768d39793963725da754e61d8115e2404d0/av1/common/mvref_common.c#490>
<https://aomedia.googlesource.com/aom/+/9a7e8768d39793963725da754e61d8115e2404d0/av1/common/mvref_common.c#549>

However, the boundaries are checked in the implementation of `scan_blk_mbmi()`:
<https://aomedia.googlesource.com/aom/+/9a7e8768d39793963725da754e61d8115e2404d0/av1/common/mvref_common.c#251>

Check that the given offset will not make the resulting block offsets negative (and wrap).

Also refactor `get_comp_mode_ctx()` and `get_comp_ref_type_ctx()` to never create negative block offsets.

Fixes <https://github.com/xiph/rav1e/issues/1103>.