### PR TITLE
AVX-2 accelerated SAD functions to speedup motion estimation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -49,7 +49,8 @@ fn main() {
                 "src/x86/itx.asm",
                 "src/x86/mc.asm",
                 "src/x86/me.asm",
-                "src/x86/sad_sse2.asm"
+                "src/x86/sad_sse2.asm",
+                "src/x86/sad_avx.asm"
             ],
             &[&config_include_arg, "-Isrc/"]
         );

--- a/src/x86/sad_avx.asm
+++ b/src/x86/sad_avx.asm
@@ -1,0 +1,256 @@
+;
+; Copyright (c) 2016, Alliance for Open Media. All rights reserved
+;
+; This source code is subject to the terms of the BSD 2 Clause License and
+; the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+; was not distributed with this source code in the LICENSE file, you can
+; obtain it at www.aomedia.org/license/software. If the Alliance for Open
+; Media Patent License 1.0 was not distributed with this source code in the
+; PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+;
+
+;
+
+%include "config.asm"
+%include "ext/x86/x86inc.asm"
+
+SECTION .text
+
+%macro SAD_FN 4
+%if %4 == 0
+%if %3 == 5
+cglobal sad%1x%2, 4, %3, 5, src, src_stride, ref, ref_stride, n_rows
+%else ; %3 == 7
+cglobal sad%1x%2, 4, %3, 6, src, src_stride, ref, ref_stride, \
+                            src_stride3, ref_stride3, n_rows
+%endif ; %3 == 5/7
+%else ; avg
+%if %3 == 5
+cglobal sad%1x%2_avg, 5, 1 + %3, 5, src, src_stride, ref, ref_stride, \
+                                    second_pred, n_rows
+%else ; %3 == 7
+cglobal sad%1x%2_avg, 5, ARCH_X86_64 + %3, 6, src, src_stride, \
+                                              ref, ref_stride, \
+                                              second_pred, \
+                                              src_stride3, ref_stride3
+%if ARCH_X86_64
+%define n_rowsd r7d
+%else ; x86-32
+%define n_rowsd dword r0m
+%endif ; x86-32/64
+%endif ; %3 == 5/7
+%endif ; avg/sad
+  movsxdifnidn src_strideq, src_strided
+  movsxdifnidn ref_strideq, ref_strided
+%if %3 == 7
+  lea         src_stride3q, [src_strideq*3]
+  lea         ref_stride3q, [ref_strideq*3]
+%endif ; %3 == 7
+%endmacro
+
+; unsigned int aom_sad128x128_avx2(uint8_t *src, int src_stride,
+;                                  uint8_t *ref, int ref_stride);
+%macro SAD128XN 1-2 0
+  SAD_FN 128, %1, 5, %2
+  mov              n_rowsd, %1
+  pxor                  m0, m0
+
+.loop:
+  movu                  m1, [refq]
+  movu                  m2, [refq+32]
+  movu                  m3, [refq+64]
+  movu                  m4, [refq+96]
+%if %2 == 1
+  vpavgb                m1, [second_predq+mmsize*0]
+  vpavgb                m2, [second_predq+mmsize*1]
+  vpavgb                m3, [second_predq+mmsize*2]
+  vpavgb                m4, [second_predq+mmsize*3]
+  lea         second_predq, [second_predq+mmsize*4]
+%endif
+  vpsadbw               m1, [srcq]
+  vpsadbw               m2, [srcq+32]
+  vpsadbw               m3, [srcq+64]
+  vpsadbw               m4, [srcq+96]
+
+  add                 refq, ref_strideq
+  add                 srcq, src_strideq
+
+  vpaddd                m1, m2
+  vpaddd                m3, m4
+  vpaddd                m0, m1
+  vpaddd                m0, m3
+
+  dec              n_rowsd
+  jg .loop
+
+  vextracti128         xm1, m0, 1
+  paddw                xm0, xm1
+
+  movhlps              xm1, xm0
+  paddd                xm0, xm1
+  movd                 eax, xm0
+
+  RET
+%endmacro
+
+INIT_YMM avx2
+SAD128XN 128     ; sad128x128_avx2
+SAD128XN 128, 1  ; sad128x128_avg_avx2
+SAD128XN 64      ; sad128x64_avx2
+SAD128XN 64, 1   ; sad128x64_avg_avx2
+
+
+; unsigned int aom_sad64x64_avx2(uint8_t *src, int src_stride,
+;                               uint8_t *ref, int ref_stride);
+%macro SAD64XN 1-2 0
+  SAD_FN 64, %1, 5, %2
+  mov              n_rowsd, %1/2
+  pxor                  m0, m0
+.loop:
+  movu                  m1, [refq]
+  movu                  m2, [refq+32]
+  movu                  m3, [refq+ref_strideq]
+  movu                  m4, [refq+ref_strideq+32]
+%if %2 == 1
+  vpavgb                m1, [second_predq+mmsize*0]
+  vpavgb                m2, [second_predq+mmsize*1]
+  vpavgb                m3, [second_predq+mmsize*2]
+  vpavgb                m4, [second_predq+mmsize*3]
+  lea         second_predq, [second_predq+mmsize*4]
+%endif
+  vpsadbw               m1, [srcq]
+  vpsadbw               m2, [srcq+32]
+  vpsadbw               m3, [srcq+src_strideq]
+  vpsadbw               m4, [srcq+src_strideq+32]
+
+  vpaddd                m1, m2
+  vpaddd                m3, m4
+  lea                 refq, [refq+ref_strideq*2]
+  vpaddd                m0, m1
+  lea                 srcq, [srcq+src_strideq*2]
+  vpaddd                m0, m3
+  dec              n_rowsd
+  jg .loop
+
+  vextracti128         xm1, m0, 1
+  paddd                xm0, xm1
+
+  movhlps              xm1, xm0
+  paddd                xm0, xm1
+  movd                 eax, xm0
+  RET
+%endmacro
+
+INIT_YMM avx2
+SAD64XN 128     ; sad64x128_avx2
+SAD64XN 128, 1  ; sad64x128_avg_avx2
+SAD64XN 64 ; sad64x64_avx2
+SAD64XN 32 ; sad64x32_avx2
+SAD64XN 64, 1 ; sad64x64_avg_avx2
+SAD64XN 32, 1 ; sad64x32_avg_avx2
+SAD64XN 16 ; sad64x16_avx2
+SAD64XN 16, 1 ; sad64x16_avg_avx2
+
+
+; unsigned int aom_sad32x32_avx2(uint8_t *src, int src_stride,
+;                               uint8_t *ref, int ref_stride);
+%macro SAD32XN 1-2 0
+  SAD_FN 32, %1, 7, %2
+  mov              n_rowsd, %1/4
+  pxor                  m0, m0
+.loop:
+  movu                  m1, [refq]
+  movu                  m2, [refq+ref_strideq]
+  movu                  m3, [refq+ref_strideq*2]
+  movu                  m4, [refq+ref_stride3q]
+%if %2 == 1
+  vpavgb                m1, [second_predq+mmsize*0]
+  vpavgb                m2, [second_predq+mmsize*1]
+  vpavgb                m3, [second_predq+mmsize*2]
+  vpavgb                m4, [second_predq+mmsize*3]
+  lea         second_predq, [second_predq+mmsize*4]
+%endif
+  psadbw                m1, [srcq]
+  psadbw                m2, [srcq+src_strideq]
+  psadbw                m3, [srcq+src_strideq*2]
+  psadbw                m4, [srcq+src_stride3q]
+
+  vpaddd                m1, m2
+  vpaddd                m3, m4
+  lea                 refq, [refq+ref_strideq*4]
+  vpaddd                m0, m1
+  lea                 srcq, [srcq+src_strideq*4]
+  vpaddd                m0, m3
+  dec              n_rowsd
+  jg .loop
+
+  vextracti128         xm1, m0, 1
+  paddd                xm0, xm1
+
+  movhlps              xm1, xm0
+  paddd                xm0, xm1
+  movd                 eax, xm0
+  RET
+%endmacro
+
+INIT_YMM avx2
+SAD32XN 64 ; sad32x64_avx2
+SAD32XN 32 ; sad32x32_avx2
+SAD32XN 16 ; sad32x16_avx2
+SAD32XN 64, 1 ; sad32x64_avg_avx2
+SAD32XN 32, 1 ; sad32x32_avg_avx2
+SAD32XN 16, 1 ; sad32x16_avg_avx2
+SAD32XN 8 ; sad_32x8_avx2
+SAD32XN 8, 1 ; sad_32x8_avg_avx2
+
+; unsigned int aom_sad16x{8,16}_avx2(uint8_t *src, int src_stride,
+;                                   uint8_t *ref, int ref_stride);
+%macro SAD16XN 1-2 0
+  SAD_FN 16, %1, 7, %2
+  mov              n_rowsd, %1/4
+  pxor                  m0, m0
+
+.loop:
+  movu                  m1, [refq]
+  vinsertf128           m1, [refq+ref_strideq], 1
+  movu                  m2, [refq+ref_strideq*2]
+  vinsertf128           m2, [refq+ref_stride3q], 1
+%if %2 == 1
+  vpavgb                m1, [second_predq+mmsize*0]
+  vpavgb                m2, [second_predq+mmsize*1]
+  lea         second_predq, [second_predq+mmsize*4]
+%endif
+  movu                  m3, [srcq]
+  vinsertf128           m3, [srcq+src_strideq], 1
+  movu                  m4, [srcq+src_strideq*2]
+  vinsertf128           m4, [srcq+src_stride3q], 1
+  psadbw                m1, m3
+  psadbw                m2, m4
+  lea                 refq, [refq+ref_strideq*4]
+  paddd                 m0, m1
+  lea                 srcq, [srcq+src_strideq*4]
+  paddd                 m0, m2
+  dec              n_rowsd
+  jg .loop
+
+  vextracti128         xm1, m0, 1
+  paddd                xm0, xm1
+
+  movhlps              xm1, xm0
+  paddd                xm0, xm1
+  movd                 eax, xm0
+  RET
+%endmacro
+
+INIT_YMM avx2
+SAD16XN 32 ; sad16x32_avx2
+SAD16XN 16 ; sad16x16_avx2
+SAD16XN  8 ; sad16x8_avx2
+SAD16XN 32, 1 ; sad16x32_avg_avx2
+SAD16XN 16, 1 ; sad16x16_avg_avx2
+SAD16XN  8, 1 ; sad16x8_avg_avx2
+SAD16XN 4 ; sad_16x4_avx2
+SAD16XN 4, 1 ; sad_16x4_avg_avx2
+SAD16XN 64 ; sad_16x64_avx2
+SAD16XN 64, 1 ; sad_16x64_avg_avx2
+


### PR DESCRIPTION
Here are the obtained bench results with a unaligned accesses:
```
Benchmarking get_sad/BLOCK_4X4: Collecting 100 samples in estimated 5.0000 s (28                                                                                get_sad/BLOCK_4X4       time:   [12.919 ns 12.926 ns 12.935 ns]
                        change: [-7.8931% -7.7870% -7.6862%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
Benchmarking get_sad/BLOCK_4X8: Collecting 100 samples in estimated 5.0000 s (21                                                                                get_sad/BLOCK_4X8       time:   [19.543 ns 19.551 ns 19.561 ns]
                        change: [-6.0339% -5.9476% -5.8651%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
Benchmarking get_sad/BLOCK_8X4: Collecting 100 samples in estimated 5.0000 s (22                                                                                get_sad/BLOCK_8X4       time:   [18.048 ns 18.063 ns 18.082 ns]
                        change: [-5.5344% -5.4019% -5.2604%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low severe
  5 (5.00%) high mild
  8 (8.00%) high severe
Benchmarking get_sad/BLOCK_8X8: Collecting 100 samples in estimated 5.0001 s (27                                                                                get_sad/BLOCK_8X8       time:   [13.736 ns 13.742 ns 13.747 ns]
                        change: [-6.8187% -6.7357% -6.6548%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_8X16: Collecting 100 samples in estimated 5.0001 s (1                                                                                get_sad/BLOCK_8X16      time:   [22.036 ns 22.047 ns 22.059 ns]
                        change: [-2.7995% -2.6955% -2.5958%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
Benchmarking get_sad/BLOCK_16X8: Collecting 100 samples in estimated 5.0001 s (2                                                                                get_sad/BLOCK_16X8      time:   [20.582 ns 20.604 ns 20.629 ns]
                        change: [-3.0224% -2.7958% -2.6272%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_16X16: Collecting 100 samples in estimated 5.0001 s (                                                                                get_sad/BLOCK_16X16     time:   [17.758 ns 17.768 ns 17.778 ns]
                        change: [-51.338% -51.294% -51.248%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_16X32: Collecting 100 samples in estimated 5.0001 s (                                                                                get_sad/BLOCK_16X32     time:   [29.969 ns 29.987 ns 30.005 ns]
                        change: [-54.651% -54.593% -54.540%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) low severe
  4 (4.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_32X16: Collecting 100 samples in estimated 5.0000 s (                                                                                get_sad/BLOCK_32X16     time:   [29.423 ns 29.441 ns 29.461 ns]
                        change: [-54.971% -54.927% -54.884%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_32X32: Collecting 100 samples in estimated 5.0000 s (                                                                                get_sad/BLOCK_32X32     time:   [25.039 ns 25.069 ns 25.098 ns]
                        change: [-79.765% -79.739% -79.716%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 22 outliers among 100 measurements (22.00%)
  8 (8.00%) low severe
  3 (3.00%) low mild
  7 (7.00%) high mild
  4 (4.00%) high severe
Benchmarking get_sad/BLOCK_32X64: Collecting 100 samples in estimated 5.0002 s (                                                                                get_sad/BLOCK_32X64     time:   [45.083 ns 45.121 ns 45.157 ns]
                        change: [-81.788% -81.762% -81.733%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) low severe
  4 (4.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking get_sad/BLOCK_64X32: Collecting 100 samples in estimated 5.0002 s (                                                                                get_sad/BLOCK_64X32     time:   [43.684 ns 43.728 ns 43.773 ns]
                        change: [-82.089% -82.060% -82.033%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  8 (8.00%) low severe
  4 (4.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe
Benchmarking get_sad/BLOCK_64X64: Collecting 100 samples in estimated 5.0004 s (                                                                                get_sad/BLOCK_64X64     time:   [62.709 ns 62.743 ns 62.782 ns]
                        change: [-86.687% -86.669% -86.651%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_64X128: Collecting 100 samples in estimated 5.0001 s                                                                                 get_sad/BLOCK_64X128    time:   [166.02 ns 169.76 ns 173.26 ns]
                        change: [-83.166% -82.930% -82.702%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 22 outliers among 100 measurements (22.00%)
  22 (22.00%) high severe
Benchmarking get_sad/BLOCK_128X64: Collecting 100 samples in estimated 5.0006 s                                                                                 get_sad/BLOCK_128X64    time:   [119.19 ns 119.35 ns 119.54 ns]
                        change: [-87.075% -87.055% -87.034%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
Benchmarking get_sad/BLOCK_128X128: Collecting 100 samples in estimated 5.0030 s                                                                                get_sad/BLOCK_128X128   time:   [523.51 ns 524.07 ns 524.70 ns]
                        change: [-74.082% -74.040% -73.998%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
Benchmarking get_sad/BLOCK_4X16: Collecting 100 samples in estimated 5.0000 s (1                                                                                get_sad/BLOCK_4X16      time:   [32.774 ns 32.787 ns 32.801 ns]
                        change: [-3.7121% -3.6143% -3.5287%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_16X4: Collecting 100 samples in estimated 5.0000 s (1                                                                                get_sad/BLOCK_16X4      time:   [28.848 ns 28.881 ns 28.929 ns]
                        change: [-2.8088% -2.6928% -2.5612%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  8 (8.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_8X32: Collecting 100 samples in estimated 5.0002 s (1                                                                                get_sad/BLOCK_8X32      time:   [38.372 ns 38.385 ns 38.399 ns]
                        change: [-1.5874% -1.4598% -1.3111%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
Benchmarking get_sad/BLOCK_32X8: Collecting 100 samples in estimated 5.0002 s (1                                                                                get_sad/BLOCK_32X8      time:   [35.230 ns 35.265 ns 35.289 ns]
                        change: [-1.9183% -1.7353% -1.5565%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 21 outliers among 100 measurements (21.00%)
  9 (9.00%) low severe
  9 (9.00%) high mild
  3 (3.00%) high severe
Benchmarking get_sad/BLOCK_16X64: Collecting 100 samples in estimated 5.0003 s (                                                                                get_sad/BLOCK_16X64     time:   [54.226 ns 54.266 ns 54.309 ns]
                        change: [-56.833% -56.792% -56.752%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  8 (8.00%) low mild
  4 (4.00%) high mild
  6 (6.00%) high severe
Benchmarking get_sad/BLOCK_64X16: Collecting 100 samples in estimated 5.0002 s (                                                                                get_sad/BLOCK_64X16     time:   [52.418 ns 52.458 ns 52.506 ns]
                        change: [-56.556% -56.511% -56.462%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  8 (8.00%) low mild
  5 (5.00%) high mild
  6 (6.00%) high severe
```