### PR TITLE
Remove some unnecessary Arc

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -337,7 +337,7 @@ pub fn get_subset_predictors<T: Pixel>(
 
 pub trait MotionEstimation {
   fn full_pixel_me<T: Pixel>(
-    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>,
+    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &ReferenceFrame<T>,
     bo: BlockOffset, lambda: u32,
     cmv: MotionVector, pmv: [MotionVector; 2],
     mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
@@ -346,7 +346,7 @@ pub trait MotionEstimation {
   );
 
   fn sub_pixel_me<T: Pixel>(
-    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>,
+    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &ReferenceFrame<T>,
     bo: BlockOffset, lambda: u32, pmv: [MotionVector; 2],
     mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
     blk_w: usize, blk_h: usize, best_mv: &mut MotionVector,
@@ -431,7 +431,7 @@ pub trait MotionEstimation {
     fi: &FrameInvariants<T>, fs: &FrameState<T>,
     pmvs: &[Option<MotionVector>; 3], bo_adj_h: BlockOffset,
     frame_mvs: &FrameMotionVectors, frame_ref_opt: &Option<Arc<ReferenceFrame<T>>>,
-    po: PlaneOffset, rec: &Arc<ReferenceFrame<T>>,
+    po: PlaneOffset, rec: &ReferenceFrame<T>,
     global_mv: [MotionVector; 2], lambda: u32,
     mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
     blk_w: usize, blk_h: usize,
@@ -444,7 +444,7 @@ pub struct FullSearch {}
 
 impl MotionEstimation for DiamondSearch {
   fn full_pixel_me<T: Pixel>(
-    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>,
+    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &ReferenceFrame<T>,
     bo: BlockOffset, lambda: u32,
     cmv: MotionVector, pmv: [MotionVector; 2], mvx_min: isize, mvx_max: isize,
     mvy_min: isize, mvy_max: isize, blk_w: usize, blk_h: usize,
@@ -478,7 +478,7 @@ impl MotionEstimation for DiamondSearch {
   }
 
   fn sub_pixel_me<T: Pixel>(
-    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>,
+    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &ReferenceFrame<T>,
     bo: BlockOffset, lambda: u32,
     pmv: [MotionVector; 2], mvx_min: isize, mvx_max: isize,
     mvy_min: isize, mvy_max: isize, blk_w: usize, blk_h: usize,
@@ -512,7 +512,7 @@ impl MotionEstimation for DiamondSearch {
     fi: &FrameInvariants<T>, fs: &FrameState<T>,
     pmvs: &[Option<MotionVector>; 3], bo_adj_h: BlockOffset,
     frame_mvs: &FrameMotionVectors, frame_ref_opt: &Option<Arc<ReferenceFrame<T>>>,
-    po: PlaneOffset, rec: &Arc<ReferenceFrame<T>>,
+    po: PlaneOffset, rec: &ReferenceFrame<T>,
     global_mv: [MotionVector; 2], lambda: u32,
     mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
     blk_w: usize, blk_h: usize,
@@ -549,7 +549,7 @@ impl MotionEstimation for DiamondSearch {
 
 impl MotionEstimation for FullSearch {
   fn full_pixel_me<T: Pixel>(
-    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &Arc<ReferenceFrame<T>>,
+    fi: &FrameInvariants<T>, fs: &FrameState<T>, rec: &ReferenceFrame<T>,
     bo: BlockOffset, lambda: u32,
     cmv: MotionVector, pmv: [MotionVector; 2], mvx_min: isize, mvx_max: isize,
     mvy_min: isize, mvy_max: isize, blk_w: usize, blk_h: usize,
@@ -587,7 +587,7 @@ impl MotionEstimation for FullSearch {
   }
 
   fn sub_pixel_me<T: Pixel>(
-    fi: &FrameInvariants<T>, fs: &FrameState<T>, _rec: &Arc<ReferenceFrame<T>>,
+    fi: &FrameInvariants<T>, fs: &FrameState<T>, _rec: &ReferenceFrame<T>,
     bo: BlockOffset, lambda: u32,
     pmv: [MotionVector; 2], mvx_min: isize, mvx_max: isize,
     mvy_min: isize, mvy_max: isize, blk_w: usize, blk_h: usize,
@@ -616,7 +616,7 @@ impl MotionEstimation for FullSearch {
     fi: &FrameInvariants<T>, fs: &FrameState<T>,
     pmvs: &[Option<MotionVector>; 3], _bo_adj_h: BlockOffset,
     _frame_mvs: &FrameMotionVectors, _frame_ref_opt: &Option<Arc<ReferenceFrame<T>>>,
-    po: PlaneOffset, rec: &Arc<ReferenceFrame<T>>,
+    po: PlaneOffset, rec: &ReferenceFrame<T>,
     _global_mv: [MotionVector; 2], lambda: u32,
     mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
     blk_w: usize, blk_h: usize,

--- a/src/me.rs
+++ b/src/me.rs
@@ -265,7 +265,7 @@ fn get_mv_range(
 pub fn get_subset_predictors<T: Pixel>(
   bo: BlockOffset, cmv: MotionVector,
   w_in_b: usize, h_in_b: usize,
-  frame_mvs: &FrameMotionVectors, frame_ref_opt: &Option<Arc<ReferenceFrame<T>>>,
+  frame_mvs: &FrameMotionVectors, frame_ref_opt: Option<&ReferenceFrame<T>>,
   ref_frame_id: usize
 ) -> (Vec<MotionVector>) {
   let mut predictors = Vec::new();
@@ -406,7 +406,7 @@ pub trait MotionEstimation {
 
       let global_mv = [MotionVector{row: 0, col: 0}; 2];
       let frame_mvs = &fs.frame_mvs[ref_frame];
-      let frame_ref_opt = &fi.rec_buffer.frames[fi.ref_frames[0] as usize];
+      let frame_ref_opt = fi.rec_buffer.frames[fi.ref_frames[0] as usize].as_ref().map(Arc::as_ref);
 
       let mut lowest_cost = std::u64::MAX;
       let mut best_mv = MotionVector::default();
@@ -430,7 +430,7 @@ pub trait MotionEstimation {
   fn me_ss2<T: Pixel>(
     fi: &FrameInvariants<T>, fs: &FrameState<T>,
     pmvs: &[Option<MotionVector>; 3], bo_adj_h: BlockOffset,
-    frame_mvs: &FrameMotionVectors, frame_ref_opt: &Option<Arc<ReferenceFrame<T>>>,
+    frame_mvs: &FrameMotionVectors, frame_ref_opt: Option<&ReferenceFrame<T>>,
     po: PlaneOffset, rec: &ReferenceFrame<T>,
     global_mv: [MotionVector; 2], lambda: u32,
     mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
@@ -451,7 +451,7 @@ impl MotionEstimation for DiamondSearch {
     best_mv: &mut MotionVector, lowest_cost: &mut u64, ref_frame: usize
   ) {
     let frame_mvs = &fs.frame_mvs[ref_frame - LAST_FRAME];
-    let frame_ref = &fi.rec_buffer.frames[fi.ref_frames[0] as usize];
+    let frame_ref = fi.rec_buffer.frames[fi.ref_frames[0] as usize].as_ref().map(Arc::as_ref);
     let predictors =
       get_subset_predictors(bo, cmv, fi.w_in_b, fi.h_in_b, frame_mvs, frame_ref, ref_frame - LAST_FRAME);
 
@@ -511,7 +511,7 @@ impl MotionEstimation for DiamondSearch {
   fn me_ss2<T: Pixel>(
     fi: &FrameInvariants<T>, fs: &FrameState<T>,
     pmvs: &[Option<MotionVector>; 3], bo_adj_h: BlockOffset,
-    frame_mvs: &FrameMotionVectors, frame_ref_opt: &Option<Arc<ReferenceFrame<T>>>,
+    frame_mvs: &FrameMotionVectors, frame_ref_opt: Option<&ReferenceFrame<T>>,
     po: PlaneOffset, rec: &ReferenceFrame<T>,
     global_mv: [MotionVector; 2], lambda: u32,
     mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,
@@ -615,7 +615,7 @@ impl MotionEstimation for FullSearch {
   fn me_ss2<T: Pixel>(
     fi: &FrameInvariants<T>, fs: &FrameState<T>,
     pmvs: &[Option<MotionVector>; 3], _bo_adj_h: BlockOffset,
-    _frame_mvs: &FrameMotionVectors, _frame_ref_opt: &Option<Arc<ReferenceFrame<T>>>,
+    _frame_mvs: &FrameMotionVectors, _frame_ref_opt: Option<&ReferenceFrame<T>>,
     po: PlaneOffset, rec: &ReferenceFrame<T>,
     _global_mv: [MotionVector; 2], lambda: u32,
     mvx_min: isize, mvx_max: isize, mvy_min: isize, mvy_max: isize,


### PR DESCRIPTION
Some functions accepting an `Arc` don't want to share ownership: they just require a reference.