### PR TITLE
Transorm block partition for intra

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -143,7 +143,7 @@ fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
   let fi = FrameInvariants::<u16>::new(config, sequence);
   let mut fs = FrameState::new(&fi);
   let offset = BlockOffset { x: 1, y: 1 };
-  b.iter(|| rdo_cfl_alpha(&mut fs, offset, bsize, fi.sequence.bit_depth, fi.sequence.chroma_sampling))
+  b.iter(|| rdo_cfl_alpha(&mut fs, offset, bsize, fi.sequence.bit_depth))
 }
 
 criterion_group!(intra_prediction, predict::pred_bench,);

--- a/src/context.rs
+++ b/src/context.rs
@@ -1318,6 +1318,8 @@ pub struct BlockContextCheckpoint {
   cdef_coded: bool,
   above_partition_context: Vec<u8>,
   left_partition_context: [u8; MAX_MIB_SIZE],
+  above_tx_context: Vec<u8>,
+  left_tx_context: [u8; MAX_MIB_SIZE],
   above_coeff_context: [Vec<u8>; PLANES],
   left_coeff_context: [[u8; MAX_MIB_SIZE]; PLANES],
 }
@@ -1332,6 +1334,8 @@ pub struct BlockContext {
   pub preskip_segid: bool,
   above_partition_context: Vec<u8>,
   left_partition_context: [u8; MAX_MIB_SIZE],
+  above_tx_context: Vec<u8>,
+  left_tx_context: [u8; MAX_MIB_SIZE],
   above_coeff_context: [Vec<u8>; PLANES],
   left_coeff_context: [[u8; MAX_MIB_SIZE]; PLANES],
   blocks: FrameBlocks,
@@ -1354,6 +1358,8 @@ impl BlockContext {
       preskip_segid: true,
       above_partition_context: vec![0; aligned_cols],
       left_partition_context: [0; MAX_MIB_SIZE],
+      above_tx_context: vec![0; aligned_cols],
+      left_tx_context: [0; MAX_MIB_SIZE],
       above_coeff_context: [
         vec![0; above_coeff_context_size],
         vec![0; above_coeff_context_size],
@@ -1369,6 +1375,8 @@ impl BlockContext {
       cdef_coded: self.cdef_coded,
       above_partition_context: self.above_partition_context.clone(),
       left_partition_context: self.left_partition_context,
+      above_tx_context: self.above_tx_context.clone(),
+      left_tx_context: self.left_tx_context,
       above_coeff_context: self.above_coeff_context.clone(),
       left_coeff_context: self.left_coeff_context,
     }
@@ -1378,6 +1386,8 @@ impl BlockContext {
     self.cdef_coded = checkpoint.cdef_coded;
     self.above_partition_context = checkpoint.above_partition_context.clone();
     self.left_partition_context = checkpoint.left_partition_context;
+    self.above_tx_context = checkpoint.above_tx_context.clone();
+    self.left_tx_context = checkpoint.left_tx_context;
     self.above_coeff_context = checkpoint.above_coeff_context.clone();
     self.left_coeff_context = checkpoint.left_coeff_context;
   }
@@ -1459,7 +1469,12 @@ impl BlockContext {
       *c = 0;
     }
   }
-  //TODO(anyone): Add reset_left_tx_context() here then call it in reset_left_contexts()
+
+  fn reset_left_tx_context(&mut self) {
+    for c in &mut self.left_tx_context {
+      *c = 0;
+    }
+  }
 
   pub fn reset_skip_context(
     &mut self, bo: BlockOffset, bsize: BlockSize, xdec: usize, ydec: usize
@@ -1508,7 +1523,7 @@ impl BlockContext {
     }
     BlockContext::reset_left_partition_context(self);
 
-    //TODO(anyone): Call reset_left_tx_context() here.
+    BlockContext::reset_left_tx_context(self);
   }
 
   pub fn set_mode(

--- a/src/context.rs
+++ b/src/context.rs
@@ -724,6 +724,7 @@ pub struct CDFContext {
   intra_tx_cdf:
     [[[[u16; TX_TYPES + 1]; INTRA_MODES]; TX_SIZE_SQR_CONTEXTS]; TX_SETS_INTRA],
   inter_tx_cdf: [[[u16; TX_TYPES + 1]; TX_SIZE_SQR_CONTEXTS]; TX_SETS_INTER],
+  tx_size_cdf: [[[u16; MAX_TX_DEPTH + 1 + 1]; TX_SIZE_CONTEXTS]; MAX_TX_CATS],
   skip_cdfs: [[u16; 3]; SKIP_CONTEXTS],
   intra_inter_cdfs: [[u16; 3]; INTRA_INTER_CONTEXTS],
   angle_delta_cdf: [[u16; 2 * MAX_ANGLE_DELTA + 1 + 1]; DIRECTIONAL_MODES],
@@ -785,6 +786,7 @@ impl CDFContext {
       refmv_cdf: default_refmv_cdf,
       intra_tx_cdf: default_intra_ext_tx_cdf,
       inter_tx_cdf: default_inter_ext_tx_cdf,
+      tx_size_cdf: default_tx_size_cdf,
       skip_cdfs: default_skip_cdfs,
       intra_inter_cdfs: default_intra_inter_cdf,
       angle_delta_cdf: default_angle_delta_cdf,
@@ -863,6 +865,11 @@ impl CDFContext {
       self.inter_tx_cdf[2][i][12] = 0;
       self.inter_tx_cdf[3][i][2] = 0;
     }
+
+    for i in 0..TX_SIZE_CONTEXTS { self.tx_size_cdf[0][i][MAX_TX_DEPTH] = 0; }
+    reset_2d!(self.tx_size_cdf[1]);
+    reset_2d!(self.tx_size_cdf[2]);
+    reset_2d!(self.tx_size_cdf[3]);
 
     reset_2d!(self.skip_cdfs);
     reset_2d!(self.intra_inter_cdfs);

--- a/src/context.rs
+++ b/src/context.rs
@@ -143,7 +143,7 @@ pub static max_txsize_rect_lookup: [TxSize; BlockSize::BLOCK_SIZES_ALL] = [
       TX_16X64,  TX_64X16
 ];
 
-static sub_tx_size_map: [TxSize; TxSize::TX_SIZES_ALL] = [
+pub static sub_tx_size_map: [TxSize; TxSize::TX_SIZES_ALL] = [
   TX_4X4,    // TX_4X4
   TX_4X4,    // TX_8X8
   TX_8X8,    // TX_16X16

--- a/src/context.rs
+++ b/src/context.rs
@@ -120,6 +120,29 @@ static av1_tx_ind: [[usize; TX_TYPES]; TX_SETS] = [
   [7, 8, 9, 12, 10, 11, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6]
 ];
 
+pub static max_txsize_rect_lookup: [TxSize; BlockSize::BLOCK_SIZES_ALL] = [
+      // 4X4
+      TX_4X4,
+      // 4X8,    8X4,      8X8
+      TX_4X8,    TX_8X4,   TX_8X8,
+      // 8X16,   16X8,     16X16
+      TX_8X16,   TX_16X8,  TX_16X16,
+      // 16X32,  32X16,    32X32
+      TX_16X32,  TX_32X16, TX_32X32,
+      // 32X64,  64X32,
+      TX_32X64,  TX_64X32,
+      // 64X64
+      TX_64X64,
+      // 64x128, 128x64,   128x128
+      TX_64X64,  TX_64X64, TX_64X64,
+      // 4x16,   16x4,
+      TX_4X16,   TX_16X4,
+      // 8x32,   32x8
+      TX_8X32,   TX_32X8,
+      // 16x64,  64x16
+      TX_16X64,  TX_64X16
+];
+
 static ss_size_lookup: [[[BlockSize; 2]; 2]; BlockSize::BLOCK_SIZES_ALL] = [
   //  ss_x == 0    ss_x == 0        ss_x == 1      ss_x == 1
   //  ss_y == 0    ss_y == 1        ss_y == 0      ss_y == 1

--- a/src/context.rs
+++ b/src/context.rs
@@ -1493,10 +1493,10 @@ impl BlockContext {
     self.for_each(bo, bsize, |block| { block.n4_w = n4_w; block.n4_h = n4_h } );
   }
 
-  pub fn set_tx_size(&mut self, bo: BlockOffset, txsize: TxSize) {
+  pub fn set_tx_size(&mut self, bo: BlockOffset, bsize: BlockSize, txsize: TxSize) {
     let tx_w = txsize.width_mi();
     let tx_h = txsize.height_mi();
-    self.for_each(bo, txsize.block_size(), |block| { block.tx_w = tx_w; block.tx_h = tx_h } );
+    self.for_each(bo, bsize, |block| { block.tx_w = tx_w; block.tx_h = tx_h } );
   }
 
   pub fn get_mode(&mut self, bo: BlockOffset) -> PredictionMode {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1261,10 +1261,10 @@ pub struct Block {
   pub mv: [MotionVector; 2],
   pub neighbors_ref_counts: [usize; TOTAL_REFS_PER_FRAME],
   pub cdef_index: u8,
+  pub bsize: BlockSize,
   pub n4_w: usize, /* block width in the unit of mode_info */
   pub n4_h: usize, /* block height in the unit of mode_info */
-  pub tx_w: usize, /* transform width in the unit of mode_info */
-  pub tx_h: usize, /* transform height in the unit of mode_info */
+  pub txsize: TxSize,
   // The block-level deblock_deltas are left-shifted by
   // fi.deblock.block_delta_shift and added to the frame-configured
   // deltas
@@ -1282,10 +1282,10 @@ impl Block {
       mv: [ MotionVector::default(); 2],
       neighbors_ref_counts: [0; TOTAL_REFS_PER_FRAME],
       cdef_index: 0,
+      bsize: BLOCK_64X64,
       n4_w: BLOCK_64X64.width_mi(),
       n4_h: BLOCK_64X64.height_mi(),
-      tx_w: TX_64X64.width_mi(),
-      tx_h: TX_64X64.height_mi(),
+      txsize: TX_64X64,
       deblock_deltas: [0, 0, 0, 0],
       segmentation_idx: 0,
     }
@@ -1583,13 +1583,11 @@ impl BlockContext {
   pub fn set_block_size(&mut self, bo: BlockOffset, bsize: BlockSize) {
     let n4_w = bsize.width_mi();
     let n4_h = bsize.height_mi();
-    self.for_each(bo, bsize, |block| { block.n4_w = n4_w; block.n4_h = n4_h } );
+    self.for_each(bo, bsize, |block| { block.bsize = bsize; block.n4_w = n4_w; block.n4_h = n4_h } );
   }
 
-  pub fn set_tx_size(&mut self, bo: BlockOffset, bsize: BlockSize, txsize: TxSize) {
-    let tx_w = txsize.width_mi();
-    let tx_h = txsize.height_mi();
-    self.for_each(bo, bsize, |block| { block.tx_w = tx_w; block.tx_h = tx_h } );
+  pub fn set_tx_size(&mut self, bo: BlockOffset, bsize: BlockSize, tx_size: TxSize) {
+    self.for_each(bo, bsize, |block| { block.txsize = tx_size } );
   }
 
   pub fn get_mode(&mut self, bo: BlockOffset) -> PredictionMode {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -546,6 +546,7 @@ pub struct FrameInvariants<T: Pixel> {
   pub use_tx_domain_rate: bool,
   pub inter_cfg: Option<InterPropsConfig>,
   pub enable_early_exit: bool,
+  pub tx_mode_select: bool,
 }
 
 pub(crate) fn pos_to_lvl(pos: u64, pyramid_depth: u64) -> u64 {
@@ -629,6 +630,7 @@ impl<T: Pixel> FrameInvariants<T> {
       inter_cfg: None,
       enable_early_exit: true,
       config,
+      tx_mode_select : false,
     }
   }
 
@@ -647,6 +649,7 @@ impl<T: Pixel> FrameInvariants<T> {
     for i in 0..INTER_REFS_PER_FRAME {
       fi.ref_frames[i] = 0;
     }
+    fi.tx_mode_select = false;
     fi
   }
 
@@ -683,6 +686,7 @@ impl<T: Pixel> FrameInvariants<T> {
     fi.frame_type = FrameType::INTER;
     fi.intra_only = false;
     fi.apply_inter_props_cfg(idx_in_segment);
+    fi.tx_mode_select = false;
     let inter_cfg = fi.inter_cfg.unwrap();
 
     fi.order_hint =

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -649,7 +649,13 @@ impl<T: Pixel> FrameInvariants<T> {
     for i in 0..INTER_REFS_PER_FRAME {
       fi.ref_frames[i] = 0;
     }
+
     fi.tx_mode_select = false;
+    // FIXME: tx partition for intra not supported for chroma 422
+    if fi.tx_mode_select {
+      if fi.sequence.chroma_sampling == ChromaSampling::Cs422 { fi.tx_mode_select = false; }
+    }
+
     fi
   }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1409,6 +1409,13 @@ pub fn write_tx_blocks<T: Pixel>(
   }
 
   if bw_uv > 0 && bh_uv > 0 {
+    // TODO: Disable these asserts temporarilly, since chroma_sampling_422_aom and chroma_sampling_444_aom
+    // tests seems trigerring them as well, which should not
+    // TODO: Not valid if partition > 64x64 && chroma != 420
+    /*if xdec == 1 && ydec == 1 {
+      assert!(bw_uv == 1, "bw_uv = {}, bh_uv = {}", bw_uv, bh_uv);
+      assert!(bh_uv == 1, "bw_uv = {}, bh_uv = {}", bw_uv, bh_uv);
+    }*/
     let uv_tx_type = if uv_tx_size.width() >= 32 || uv_tx_size.height() >= 32 {
       TxType::DCT_DCT
     } else {
@@ -1487,6 +1494,13 @@ pub fn write_tx_tree<T: Pixel>(
   let plane_bsize = get_plane_block_size(bsize, xdec, ydec);
 
   if bw_uv > 0 && bh_uv > 0 {
+    // TODO: Disable these asserts temporarilly, since chroma_sampling_422_aom and chroma_sampling_444_aom
+    // tests seems trigerring them as well, which should not
+    // TODO: Not valid if partition > 64x64 && chroma != 420
+    /*if xdec == 1 && ydec == 1 {
+      debug_assert!(bw_uv == 1, "bw_uv = {}, bh_uv = {}", bw_uv, bh_uv);
+      debug_assert!(bh_uv == 1, "bw_uv = {}, bh_uv = {}", bw_uv, bh_uv);
+    }*/
     let uv_tx_type = if has_coeff {tx_type} else {TxType::DCT_DCT}; // if inter mode, uv_tx_type == tx_type
 
     for p in 1..3 {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1168,6 +1168,7 @@ pub fn encode_block_b<T: Pixel>(
   }
   cw.bc.set_block_size(bo, bsize);
   cw.bc.set_mode(bo, bsize, luma_mode);
+  cw.bc.set_tx_size(bo, bsize, tx_size);
   cw.bc.set_ref_frames(bo, bsize, ref_frames);
   cw.bc.set_motion_vectors(bo, bsize, mvs);
 
@@ -1505,7 +1506,6 @@ pub fn encode_block_with_modes<T: Pixel>(
 
   debug_assert!((tx_size, tx_type) ==
                 rdo_tx_size_type(fi, fs, cw, bsize, bo, mode_luma, ref_frames, mvs, skip));
-  cw.bc.set_tx_size(bo, tx_size);
 
   let mut mv_stack = Vec::new();
   let is_compound = ref_frames[1] != NONE_FRAME;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1291,6 +1291,21 @@ pub fn encode_block_b<T: Pixel>(
     }
   }
 
+  // write tx_size here (for now, intra frame only)
+  // TODO: Add new field tx_mode to fi, then Use the condition, fi.tx_mode == TX_MODE_SELECT
+  if fi.tx_mode_select {
+    if bsize.greater_than(BlockSize::BLOCK_4X4) && !(is_inter && skip) {
+      if !is_inter {
+        cw.write_tx_size_intra(w, bo, bsize, tx_size);
+        cw.bc.update_tx_size_context(bo, bsize, tx_size, false);
+      } /*else {  // TODO (yushin): write_tx_size_inter(), i.e. var-tx
+
+      }*/
+    } else {
+      cw.bc.update_tx_size_context(bo, bsize, tx_size, is_inter && skip);
+    }
+  }
+
   if is_inter {
     motion_compensate(fi, fs, cw, luma_mode, ref_frames, mvs, bsize, bo, false);
     write_tx_tree(fi, fs, cw, w, luma_mode, bo, bsize, tx_size, tx_type, skip, false, rdo_type, for_rdo_use)

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1370,7 +1370,7 @@ pub fn write_tx_blocks<T: Pixel>(
 
   if luma_only { return tx_dist };
 
-  let uv_tx_size = bsize.largest_uv_tx_size(fi.sequence.chroma_sampling);
+  let uv_tx_size = bsize.largest_uv_tx_size(xdec, ydec);
 
   let mut bw_uv = (bw * tx_size.width_mi()) >> xdec;
   let mut bh_uv = (bh * tx_size.height_mi()) >> ydec;
@@ -1452,7 +1452,7 @@ pub fn write_tx_tree<T: Pixel>(
 
   if luma_only { return tx_dist };
 
-  let uv_tx_size = bsize.largest_uv_tx_size(fi.sequence.chroma_sampling);
+  let uv_tx_size = bsize.largest_uv_tx_size(xdec, ydec);
 
   let mut bw_uv = (bw * tx_size.width_mi()) >> xdec;
   let mut bh_uv = (bh * tx_size.height_mi()) >> ydec;

--- a/src/entropymode.rs
+++ b/src/entropymode.rs
@@ -19,7 +19,7 @@ const PALETTE_COLOR_INDEX_CONTEXTS: usize = 5;
 const CDFMAX: u16 = 32768;
 const BLOCK_SIZE_GROUPS: usize = 4;
 const RESTORE_SWITCHABLE_TYPES: usize = 3;
-const TX_SIZE_CONTEXTS: usize = 3;
+pub const TX_SIZE_CONTEXTS: usize = 3;
 
 // from seg_common.h
 const MAX_SEGMENTS: usize = 8;
@@ -29,8 +29,8 @@ const SEG_TEMPORAL_PRED_CTXS: usize = 3;
 // enums.h
 const TX_SIZE_LUMA_MIN: usize = TxSize::TX_4X4 as usize;
 const TX_SIZE_CTX_MIN: usize = (TX_SIZE_LUMA_MIN + 1);
-const MAX_TX_CATS: usize = (TxSize::TX_SIZES - TX_SIZE_CTX_MIN);
-const MAX_TX_DEPTH: usize = 2;
+pub const MAX_TX_CATS: usize = (TxSize::TX_SIZES - TX_SIZE_CTX_MIN);
+pub const MAX_TX_DEPTH: usize = 2;
 
 // LUTS ---------------------
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -664,7 +664,7 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     // loop restoration
     self.write_frame_lrf(fi, &fs.restoration)?;
 
-    self.write_bit(false)?; // tx mode == TX_MODE_SELECT ?
+    self.write_bit(fi.tx_mode_select)?; // tx mode
 
     let mut reference_select = false;
     if !fi.intra_only {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -423,6 +423,35 @@ impl BlockSize {
   pub fn subsize(self, partition: PartitionType) -> BlockSize {
     BlockSize::SUBSIZE_LOOKUP[partition as usize][self as usize]
   }
+
+  pub fn is_rect_tx_allowed(self) -> bool {
+    static LUT: [u8; BlockSize::BLOCK_SIZES_ALL] = [
+      0,  // BLOCK_4X4
+      1,  // BLOCK_4X8
+      1,  // BLOCK_8X4
+      0,  // BLOCK_8X8
+      1,  // BLOCK_8X16
+      1,  // BLOCK_16X8
+      0,  // BLOCK_16X16
+      1,  // BLOCK_16X32
+      1,  // BLOCK_32X16
+      0,  // BLOCK_32X32
+      1,  // BLOCK_32X64
+      1,  // BLOCK_64X32
+      0,  // BLOCK_64X64
+      0,  // BLOCK_64X128
+      0,  // BLOCK_128X64
+      0,  // BLOCK_128X128
+      1,  // BLOCK_4X16
+      1,  // BLOCK_16X4
+      1,  // BLOCK_8X32
+      1,  // BLOCK_32X8
+      1,  // BLOCK_16X64
+      1,  // BLOCK_64X16
+    ];
+
+    LUT[self as usize] == 1
+  }
 }
 
 /// Transform Size
@@ -578,6 +607,10 @@ impl TxSize {
       (64, 16) => TX_64X16,
       _ => unreachable!()
     }
+  }
+
+  pub fn is_rect(self) -> bool {
+    self.width_log2() != self.height_log2()
   }
 }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -13,7 +13,6 @@
 use std::ops;
 use self::BlockSize::*;
 use self::TxSize::*;
-use crate::api::ChromaSampling;
 use crate::context::*;
 use crate::encoder::FrameInvariants;
 use crate::mc::*;
@@ -193,47 +192,12 @@ impl BlockSize {
     }
   }
 
-  pub fn largest_uv_tx_size(self, chroma_sampling: ChromaSampling) -> TxSize {
-    match chroma_sampling {
-      ChromaSampling::Cs444 => match self {
-        BLOCK_64X64 | BLOCK_64X32 | BLOCK_32X64 |
-        BLOCK_128X128 | BLOCK_128X64 | BLOCK_64X128 => TX_32X32,
-        BLOCK_64X16 => TX_32X16,
-        BLOCK_16X64 => TX_16X32,
-        _ => self.tx_size()
-      },
-      ChromaSampling::Cs422 => match self {
-        BLOCK_4X4 | BLOCK_8X4 => TX_4X4,
-        BLOCK_8X8 => TX_4X8,
-        BLOCK_16X8 => TX_8X8,
-        BLOCK_16X16 => TX_8X16,
-        BLOCK_32X16 => TX_16X16,
-        BLOCK_32X32 => TX_16X32,
-        BLOCK_64X32 | BLOCK_64X64 |
-        BLOCK_128X64 | BLOCK_128X128 => TX_32X32,
-        BLOCK_16X4 => TX_8X4,
-        BLOCK_32X8 => TX_16X8,
-        BLOCK_64X16 => TX_32X16,
-        _ => unreachable!() // vertical splits are illegal in 4:2:2
-      },
-      ChromaSampling::Cs420 => match self {
-        BLOCK_4X4 | BLOCK_8X4 | BLOCK_4X8 | BLOCK_8X8 => TX_4X4,
-        BLOCK_8X16 | BLOCK_4X16 => TX_4X8,
-        BLOCK_16X8 | BLOCK_16X4 => TX_8X4,
-        BLOCK_16X16 => TX_8X8,
-        BLOCK_16X32 => TX_8X16,
-        BLOCK_32X16 => TX_16X8,
-        BLOCK_32X32 => TX_16X16,
-        BLOCK_32X64 => TX_16X32,
-        BLOCK_64X32 => TX_32X16,
-        BLOCK_8X32 => TX_4X16,
-        BLOCK_32X8 => TX_16X4,
-        BLOCK_16X64 => TX_8X32,
-        BLOCK_64X16 => TX_32X8,
-        _ => TX_32X32
-      }
-      ChromaSampling::Cs400 => unimplemented!()
-    }
+  pub fn largest_uv_tx_size(self, xdec: usize, ydec: usize) -> TxSize {
+    let plane_bsize = get_plane_block_size(self, xdec, ydec);
+    debug_assert!((plane_bsize as usize) < BlockSize::BLOCK_SIZES_ALL);
+    let uv_tx = max_txsize_rect_lookup[plane_bsize as usize];
+
+    av1_get_coded_tx_size(uv_tx)
   }
 
   pub fn is_sqr(self) -> bool {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -384,8 +384,6 @@ pub fn rdo_tx_size_type<T: Pixel>(
       _ => unimplemented!()
     }
   };
-  cw.bc.set_tx_size(bo, tx_size);
-  // Were we not hardcoded to TX_MODE_LARGEST, block tx size would be written here
 
   // Luma plane transform type decision
   let is_inter = !luma_mode.is_intra();

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -818,7 +818,7 @@ pub fn rdo_mode_decision<T: Pixel>(
       false
     );
     cw.rollback(&cw_checkpoint);
-    if let Some(cfl) = rdo_cfl_alpha(fs, bo, bsize, fi.sequence.bit_depth, fi.sequence.chroma_sampling) {
+    if let Some(cfl) = rdo_cfl_alpha(fs, bo, bsize, fi.sequence.bit_depth) {
       let wr: &mut dyn Writer = &mut WriterCounter::new();
       let tell = wr.tell_frac();
 
@@ -890,10 +890,10 @@ pub fn rdo_mode_decision<T: Pixel>(
 }
 
 pub fn rdo_cfl_alpha<T: Pixel>(
-  fs: &mut FrameState<T>, bo: BlockOffset, bsize: BlockSize, bit_depth: usize,
-  chroma_sampling: ChromaSampling
+  fs: &mut FrameState<T>, bo: BlockOffset, bsize: BlockSize, bit_depth: usize
 ) -> Option<CFLParams> {
-  let uv_tx_size = bsize.largest_uv_tx_size(chroma_sampling);
+  let PlaneConfig { xdec, ydec, .. } = fs.input.planes[1].cfg;
+  let uv_tx_size = bsize.largest_uv_tx_size(xdec, ydec);
 
   let mut ac: AlignedArray<[i16; 32 * 32]> = UninitializedAlignedArray();
   luma_ac(&mut ac.array, fs, bo, bsize);


### PR DESCRIPTION
Currently there is no RDO and split one leve partition of transforms for intra block.
Also, for intra frame only because enabling tx_mode_select (in frame header) in any inter frame requires necessary signaling of var-tx for inter mode blocks, which we don't have yet.

Deblocking is disabled since it causes mismatch between encoder and decoder's reconstructed images. Communicated with Monty and he figured out why and stared to modify deblocking filter code.