### PR TITLE
Use optimization level 3 for dev builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ name = "bench"
 harness = false
 
 [profile.dev]
-opt-level = 2
+opt-level = 3
 
 [profile.release]
 codegen-units = 1  # if > 1 enables parallel code generation which improves


### PR DESCRIPTION
This is required for a lot of inlining to happen, most critically
for the RefType eq method, which otherwise obliterates perf.