### PR TITLE
Enable LTO on release and bench builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,11 @@ opt-level = 2
 codegen-units = 1  # if > 1 enables parallel code generation which improves
                    # compile times, but prevents some optimizations.
                    # Passes `-C codegen-units`. Ignored when `lto = true`.
+lto = true
 
 [profile.bench]
 codegen-units = 1
+lto = true
 
 [workspace]
 members = ["ivf"]


### PR DESCRIPTION
This shows a pretty nice improvement of ~15% on encode block
benchmarks.