### PR TITLE
Avoid unneeded mutable borrows on BlockContext

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -205,7 +205,7 @@ fn adjust_strength(strength: i32, var: i32) -> i32 {
 
 pub fn cdef_analyze_superblock<T: Pixel>(
   in_frame: &Frame<T>,
-  bc_global: &mut BlockContext,
+  bc_global: &BlockContext,
   sbo: SuperBlockOffset,
   sbo_global: SuperBlockOffset,
   bit_depth: usize,
@@ -332,7 +332,7 @@ pub fn cdef_filter_superblock<T: Pixel>(
   fi: &FrameInvariants<T>,
   in_frame: &Frame<u16>,
   out_frame: &mut Frame<T>,
-  bc_global: &mut BlockContext,
+  bc_global: &BlockContext,
   sbo: SuperBlockOffset,
   sbo_global: SuperBlockOffset,
   cdef_index: u8,
@@ -420,7 +420,7 @@ pub fn cdef_filter_superblock<T: Pixel>(
 // CDEF parameters are stored for each 64 by 64 block of pixels.
 // The CDEF filter is applied on each 8 by 8 block of pixels.
 // Reference: http://av1-spec.argondesign.com/av1-spec/av1-spec.html#cdef-process
-pub fn cdef_filter_frame<T: Pixel>(fi: &FrameInvariants<T>, rec: &mut Frame<T>, bc: &mut BlockContext) {
+pub fn cdef_filter_frame<T: Pixel>(fi: &FrameInvariants<T>, rec: &mut Frame<T>, bc: &BlockContext) {
   // Each filter block is 64x64, except right and/or bottom for non-multiple-of-64 sizes.
   // FIXME: 128x128 SB support will break this, we need FilterBlockOffset etc.
   let fb_width = (rec.planes[0].cfg.width + 63) / 64;

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -1229,7 +1229,7 @@ fn sse_h_edge<T: Pixel>(
 
 // Deblocks all edges, vertical and horizontal, in a single plane
 pub fn deblock_plane<T: Pixel>(
-  deblock: &DeblockState, p: &mut Plane<T>, pli: usize, bc: &mut BlockContext,
+  deblock: &DeblockState, p: &mut Plane<T>, pli: usize, bc: &BlockContext,
   bd: usize
 ) {
   let xdec = p.cfg.xdec;
@@ -1333,7 +1333,7 @@ pub fn deblock_plane<T: Pixel>(
 // sse count of all edges in a single plane, accumulates into vertical and horizontal counts
 fn sse_plane<T: Pixel>(
   rec: &Plane<T>, src: &Plane<T>, v_sse: &mut [i64; MAX_LOOP_FILTER + 2],
-  h_sse: &mut [i64; MAX_LOOP_FILTER + 2], pli: usize, bc: &mut BlockContext,
+  h_sse: &mut [i64; MAX_LOOP_FILTER + 2], pli: usize, bc: &BlockContext,
   bd: usize
 ) {
   let xdec = rec.cfg.xdec;
@@ -1359,14 +1359,14 @@ fn sse_plane<T: Pixel>(
 
 // Deblocks all edges in all planes of a frame
 pub fn deblock_filter_frame<T: Pixel>(
-  fs: &mut FrameState<T>, bc: &mut BlockContext, bit_depth: usize
+  fs: &mut FrameState<T>, bc: &BlockContext, bit_depth: usize
 ) {
   for pli in 0..PLANES {
     deblock_plane(&fs.deblock, &mut fs.rec.planes[pli], pli, bc, bit_depth);
   }
 }
 
-fn sse_optimize<T: Pixel>(fs: &mut FrameState<T>, bc: &mut BlockContext, bit_depth: usize) {
+fn sse_optimize<T: Pixel>(fs: &mut FrameState<T>, bc: &BlockContext, bit_depth: usize) {
   assert!(MAX_LOOP_FILTER < 999);
   // i64 allows us to accumulate a total of ~ 35 bits worth of pixels
   assert!(
@@ -1425,7 +1425,7 @@ fn sse_optimize<T: Pixel>(fs: &mut FrameState<T>, bc: &mut BlockContext, bit_dep
 }
 
 pub fn deblock_filter_optimize<T: Pixel>(
-  fi: &FrameInvariants<T>, fs: &mut FrameState<T>, bc: &mut BlockContext) {
+  fi: &FrameInvariants<T>, fs: &mut FrameState<T>, bc: &BlockContext) {
   if fi.config.speed_settings.fast_deblock {
     let q = ac_q(fi.base_q_idx, 0, fi.sequence.bit_depth) as i32;
     let level = clamp(

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2144,9 +2144,9 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
     }
   }
   /* TODO: Don't apply if lossless */
-  deblock_filter_optimize(fi, fs, &mut cw.bc);
+  deblock_filter_optimize(fi, fs, &cw.bc);
   if fs.deblock.levels[0] != 0 || fs.deblock.levels[1] != 0 {
-    deblock_filter_frame(fs, &mut cw.bc, fi.sequence.bit_depth);
+    deblock_filter_frame(fs, &cw.bc, fi.sequence.bit_depth);
   }
     // Until the loop filters are pipelined, we'll need to keep
     // around a copy of both the pre- and post-cdef frame.
@@ -2154,7 +2154,7 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
 
     /* TODO: Don't apply if lossless */
     if fi.sequence.enable_cdef {
-      cdef_filter_frame(fi, &mut fs.rec, &mut cw.bc);
+      cdef_filter_frame(fi, &mut fs.rec, &cw.bc);
     }
     /* TODO: Don't apply if lossless */
     if fi.sequence.enable_restoration {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1308,7 +1308,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T
   // If LRF choice changed for any plane, repeat last two steps.
   let bd = fi.sequence.bit_depth;
   let cdef_data = cdef_input.as_ref().map(|input| {
-    (input, cdef_analyze_superblock(input, &mut cw.bc, sbo_0, sbo, bd))
+    (input, cdef_analyze_superblock(input, &cw.bc, sbo_0, sbo, bd))
   });
   let mut first_loop = true;
   loop {
@@ -1321,7 +1321,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T
           let mut cost = [0.; PLANES];
           let mut cost_acc = 0.;
           cdef_filter_superblock(fi, &cdef_input, &mut lrf_input,
-                                 &mut cw.bc, sbo_0, sbo, cdef_index as u8, &cdef_dirs);
+                                 &cw.bc, sbo_0, sbo, cdef_index as u8, &cdef_dirs);
           for pli in 0..3 {
             match best_lrf[pli] {
               RestorationFilter::None{} => {
@@ -1370,7 +1370,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T
       // need cdef output from best index, not just last iteration
       if let Some((cdef_input, cdef_dirs)) = cdef_data.as_ref() {
         cdef_filter_superblock(fi, &cdef_input, &mut lrf_input,
-                               &mut cw.bc, sbo_0, sbo, best_index as u8, &cdef_dirs);
+                               &cw.bc, sbo_0, sbo, best_index as u8, &cdef_dirs);
       }
 
       // Wiener LRF decision coming soon


### PR DESCRIPTION
BlockContext was borrowed but only read.