### PR TITLE
Refactor FrameBlocks

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -221,10 +221,10 @@ pub fn cdef_analyze_superblock<T: Pixel>(
       // in the main frame.
       let global_block_offset = sbo_global.block_offset(bx<<1, by<<1);
       if global_block_offset.x < bc_global.cols && global_block_offset.y < bc_global.rows {
-        let skip = bc_global.at(global_block_offset).skip
-          & bc_global.at(sbo_global.block_offset(2*bx+1, 2*by)).skip
-          & bc_global.at(sbo_global.block_offset(2*bx, 2*by+1)).skip
-          & bc_global.at(sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
+        let skip = bc_global.blocks.at(global_block_offset).skip
+          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by)).skip
+          & bc_global.blocks.at(sbo_global.block_offset(2*bx, 2*by+1)).skip
+          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
 
         if !skip {
           let mut var: i32 = 0;
@@ -358,10 +358,10 @@ pub fn cdef_filter_superblock<T: Pixel>(
     for bx in 0..8 {
       let global_block_offset = sbo_global.block_offset(bx<<1, by<<1);
       if global_block_offset.x < bc_global.cols && global_block_offset.y < bc_global.rows {
-        let skip = bc_global.at(global_block_offset).skip
-          & bc_global.at(sbo_global.block_offset(2*bx+1, 2*by)).skip
-          & bc_global.at(sbo_global.block_offset(2*bx, 2*by+1)).skip
-          & bc_global.at(sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
+        let skip = bc_global.blocks.at(global_block_offset).skip
+          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by)).skip
+          & bc_global.blocks.at(sbo_global.block_offset(2*bx, 2*by+1)).skip
+          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
         if !skip {
           let dir = cdef_dirs.dir[bx][by];
           let var = cdef_dirs.var[bx][by];
@@ -480,7 +480,7 @@ pub fn cdef_filter_frame<T: Pixel>(fi: &FrameInvariants<T>, rec: &mut Frame<T>, 
   for fby in 0..fb_height {
     for fbx in 0..fb_width {
       let sbo = SuperBlockOffset { x: fbx, y: fby };
-      let cdef_index = bc.at(sbo.block_offset(0, 0)).cdef_index;
+      let cdef_index = bc.blocks.at(sbo.block_offset(0, 0)).cdef_index;
       let cdef_dirs = cdef_analyze_superblock(&cdef_frame, bc, sbo, sbo, fi.sequence.bit_depth);
       cdef_filter_superblock(fi, &cdef_frame, rec, bc, sbo, sbo, cdef_index, &cdef_dirs);
     }

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -221,10 +221,10 @@ pub fn cdef_analyze_superblock<T: Pixel>(
       // in the main frame.
       let global_block_offset = sbo_global.block_offset(bx<<1, by<<1);
       if global_block_offset.x < bc_global.cols && global_block_offset.y < bc_global.rows {
-        let skip = bc_global.blocks.at(global_block_offset).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by)).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx, 2*by+1)).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
+        let skip = bc_global.blocks[global_block_offset].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx+1, 2*by)].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx, 2*by+1)].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx+1, 2*by+1)].skip;
 
         if !skip {
           let mut var: i32 = 0;
@@ -358,10 +358,10 @@ pub fn cdef_filter_superblock<T: Pixel>(
     for bx in 0..8 {
       let global_block_offset = sbo_global.block_offset(bx<<1, by<<1);
       if global_block_offset.x < bc_global.cols && global_block_offset.y < bc_global.rows {
-        let skip = bc_global.blocks.at(global_block_offset).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by)).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx, 2*by+1)).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
+        let skip = bc_global.blocks[global_block_offset].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx+1, 2*by)].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx, 2*by+1)].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx+1, 2*by+1)].skip;
         if !skip {
           let dir = cdef_dirs.dir[bx][by];
           let var = cdef_dirs.var[bx][by];
@@ -480,7 +480,7 @@ pub fn cdef_filter_frame<T: Pixel>(fi: &FrameInvariants<T>, rec: &mut Frame<T>, 
   for fby in 0..fb_height {
     for fbx in 0..fb_width {
       let sbo = SuperBlockOffset { x: fbx, y: fby };
-      let cdef_index = bc.blocks.at(sbo.block_offset(0, 0)).cdef_index;
+      let cdef_index = bc.blocks[sbo.block_offset(0, 0)].cdef_index;
       let cdef_dirs = cdef_analyze_superblock(&cdef_frame, bc, sbo, sbo, fi.sequence.bit_depth);
       cdef_filter_superblock(fi, &cdef_frame, rec, bc, sbo, sbo, cdef_index, &cdef_dirs);
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1315,25 +1315,11 @@ impl FrameBlocks {
   }
 
   pub fn set_ref_frames(&mut self, bo: BlockOffset, bsize: BlockSize, r: [usize; 2]) {
-    let bw = bsize.width_mi();
-    let bh = bsize.height_mi();
-
-    for y in 0..bh {
-      for x in 0..bw {
-        self[bo.y + y as usize][bo.x + x as usize].ref_frames = r;
-      }
-    }
+    self.for_each(bo, bsize, |block| block.ref_frames = r);
   }
 
   pub fn set_motion_vectors(&mut self, bo: BlockOffset, bsize: BlockSize, mvs: [MotionVector; 2]) {
-    let bw = bsize.width_mi();
-    let bh = bsize.height_mi();
-
-    for y in 0..bh {
-      for x in 0..bw {
-        self[bo.y + y as usize][bo.x + x as usize].mv = mvs;
-      }
-    }
+    self.for_each(bo, bsize, |block| block.mv = mvs);
   }
 
   pub fn set_cdef(&mut self, sbo: SuperBlockOffset, cdef_index: u8) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1545,17 +1545,9 @@ impl BlockContext {
   }
 
   fn skip_context(&mut self, bo: BlockOffset) -> usize {
-    let above_skip = if bo.y > 0 {
-      self.above_of(bo).skip as usize
-    } else {
-      0
-    };
-    let left_skip = if bo.x > 0 {
-      self.left_of(bo).skip as usize
-    } else {
-      0
-    };
-    above_skip + left_skip
+    let above_skip = bo.y > 0 && self.above_of(bo).skip;
+    let left_skip = bo.x > 0 && self.left_of(bo).skip;
+    above_skip as usize + left_skip as usize
   }
 
   pub fn set_skip(&mut self, bo: BlockOffset, bsize: BlockSize, skip: bool) {
@@ -1626,13 +1618,9 @@ impl BlockContext {
           (above_intra || left_intra) as usize
         }
       }
-      (true, _) | (_, true) =>
-        2 * if has_above {
-          !self.above_of(bo).is_inter() as usize
-        } else {
-          !self.left_of(bo).is_inter() as usize
-        },
-      (_, _) => 0
+      (true, false) => if self.above_of(bo).is_inter() { 0 } else { 2 },
+      (false, true) => if self.left_of(bo).is_inter() { 0 } else { 2 },
+      _ => 0
     }
   }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1266,6 +1266,92 @@ impl FrameBlocks {
       rows,
     }
   }
+
+  pub fn at_mut(&mut self, bo: BlockOffset) -> &mut Block {
+    &mut self[bo.y][bo.x]
+  }
+
+  pub fn at(&self, bo: BlockOffset) -> &Block {
+    &self[bo.y][bo.x]
+  }
+
+  pub fn for_each<F>(&mut self, bo: BlockOffset, bsize: BlockSize, f: F)
+  where
+    F: Fn(&mut Block) -> ()
+  {
+    let bw = bsize.width_mi();
+    let bh = bsize.height_mi();
+    for y in 0..bh {
+      for x in 0..bw {
+        f(&mut self[bo.y + y as usize][bo.x + x as usize]);
+      }
+    }
+  }
+
+  pub fn set_mode(
+    &mut self, bo: BlockOffset, bsize: BlockSize, mode: PredictionMode
+  ) {
+    self.for_each(bo, bsize, |block| block.mode = mode);
+  }
+
+  pub fn set_block_size(&mut self, bo: BlockOffset, bsize: BlockSize) {
+    let n4_w = bsize.width_mi();
+    let n4_h = bsize.height_mi();
+    self.for_each(bo, bsize, |block| { block.n4_w = n4_w; block.n4_h = n4_h } );
+  }
+
+  pub fn set_tx_size(&mut self, bo: BlockOffset, txsize: TxSize) {
+    let tx_w = txsize.width_mi();
+    let tx_h = txsize.height_mi();
+    self.for_each(bo, txsize.block_size(), |block| { block.tx_w = tx_w; block.tx_h = tx_h } );
+  }
+
+  pub fn set_skip(&mut self, bo: BlockOffset, bsize: BlockSize, skip: bool) {
+    self.for_each(bo, bsize, |block| block.skip = skip);
+  }
+
+  pub fn set_segmentation_idx(&mut self, bo: BlockOffset, bsize: BlockSize, idx: u8) {
+    self.for_each(bo, bsize, |block| block.segmentation_idx = idx);
+  }
+
+  pub fn set_ref_frames(&mut self, bo: BlockOffset, bsize: BlockSize, r: [usize; 2]) {
+    let bw = bsize.width_mi();
+    let bh = bsize.height_mi();
+
+    for y in 0..bh {
+      for x in 0..bw {
+        self[bo.y + y as usize][bo.x + x as usize].ref_frames = r;
+      }
+    }
+  }
+
+  pub fn set_motion_vectors(&mut self, bo: BlockOffset, bsize: BlockSize, mvs: [MotionVector; 2]) {
+    let bw = bsize.width_mi();
+    let bh = bsize.height_mi();
+
+    for y in 0..bh {
+      for x in 0..bw {
+        self[bo.y + y as usize][bo.x + x as usize].mv = mvs;
+      }
+    }
+  }
+
+  pub fn set_cdef(&mut self, sbo: SuperBlockOffset, cdef_index: u8) {
+    let bo = sbo.block_offset(0, 0);
+    // Checkme: Is 16 still the right block unit for 128x128 superblocks?
+    let bw = cmp::min(bo.x + MAX_MIB_SIZE, self.cols);
+    let bh = cmp::min(bo.y + MAX_MIB_SIZE, self.rows);
+    for y in bo.y..bh {
+      for x in bo.x..bw {
+        self[y as usize][x as usize].cdef_index = cdef_index;
+      }
+    }
+  }
+
+  pub fn get_cdef(&mut self, sbo: SuperBlockOffset) -> u8 {
+    let bo = sbo.block_offset(0, 0);
+    self[bo.y][bo.x].cdef_index
+  }
 }
 
 impl Index<usize> for FrameBlocks {
@@ -1304,7 +1390,7 @@ pub struct BlockContext {
   left_partition_context: [u8; MAX_MIB_SIZE],
   above_coeff_context: [Vec<u8>; PLANES],
   left_coeff_context: [[u8; MAX_MIB_SIZE]; PLANES],
-  blocks: FrameBlocks,
+  pub blocks: FrameBlocks,
 }
 
 impl BlockContext {
@@ -1350,27 +1436,6 @@ impl BlockContext {
     self.left_partition_context = checkpoint.left_partition_context;
     self.above_coeff_context = checkpoint.above_coeff_context.clone();
     self.left_coeff_context = checkpoint.left_coeff_context;
-  }
-
-  pub fn at_mut(&mut self, bo: BlockOffset) -> &mut Block {
-    &mut self.blocks[bo.y][bo.x]
-  }
-
-  pub fn at(&self, bo: BlockOffset) -> &Block {
-    &self.blocks[bo.y][bo.x]
-  }
-
-  pub fn for_each<F>(&mut self, bo: BlockOffset, bsize: BlockSize, f: F)
-  where
-    F: Fn(&mut Block) -> ()
-  {
-    let bw = bsize.width_mi();
-    let bh = bsize.height_mi();
-    for y in 0..bh {
-      for x in 0..bw {
-        f(&mut self.blocks[bo.y + y as usize][bo.x + x as usize]);
-      }
-    }
   }
 
   pub fn set_dc_sign(&mut self, cul_level: &mut u32, dc_val: i32) {
@@ -1457,28 +1522,6 @@ impl BlockContext {
     //TODO(anyone): Call reset_left_tx_context() here.
   }
 
-  pub fn set_mode(
-    &mut self, bo: BlockOffset, bsize: BlockSize, mode: PredictionMode
-  ) {
-    self.for_each(bo, bsize, |block| block.mode = mode);
-  }
-
-  pub fn set_block_size(&mut self, bo: BlockOffset, bsize: BlockSize) {
-    let n4_w = bsize.width_mi();
-    let n4_h = bsize.height_mi();
-    self.for_each(bo, bsize, |block| { block.n4_w = n4_w; block.n4_h = n4_h } );
-  }
-
-  pub fn set_tx_size(&mut self, bo: BlockOffset, txsize: TxSize) {
-    let tx_w = txsize.width_mi();
-    let tx_h = txsize.height_mi();
-    self.for_each(bo, txsize.block_size(), |block| { block.tx_w = tx_w; block.tx_h = tx_h } );
-  }
-
-  pub fn get_mode(&mut self, bo: BlockOffset) -> PredictionMode {
-    self.blocks[bo.y][bo.x].mode
-  }
-
   fn partition_plane_context(
     &self, bo: BlockOffset, bsize: BlockSize
   ) -> usize {
@@ -1524,53 +1567,6 @@ impl BlockContext {
     let above_skip = bo.y > 0 && self.blocks[bo.y - 1][bo.x].skip;
     let left_skip = bo.x > 0 && self.blocks[bo.y][bo.x - 1].skip;
     above_skip as usize + left_skip as usize
-  }
-
-  pub fn set_skip(&mut self, bo: BlockOffset, bsize: BlockSize, skip: bool) {
-    self.for_each(bo, bsize, |block| block.skip = skip);
-  }
-
-  pub fn set_segmentation_idx(&mut self, bo: BlockOffset, bsize: BlockSize, idx: u8) {
-    self.for_each(bo, bsize, |block| block.segmentation_idx = idx);
-  }
-
-  pub fn set_ref_frames(&mut self, bo: BlockOffset, bsize: BlockSize, r: [usize; 2]) {
-    let bw = bsize.width_mi();
-    let bh = bsize.height_mi();
-
-    for y in 0..bh {
-      for x in 0..bw {
-        self.blocks[bo.y + y as usize][bo.x + x as usize].ref_frames = r;
-      }
-    }
-  }
-
-  pub fn set_motion_vectors(&mut self, bo: BlockOffset, bsize: BlockSize, mvs: [MotionVector; 2]) {
-    let bw = bsize.width_mi();
-    let bh = bsize.height_mi();
-
-    for y in 0..bh {
-      for x in 0..bw {
-        self.blocks[bo.y + y as usize][bo.x + x as usize].mv = mvs;
-      }
-    }
-  }
-
-  pub fn set_cdef(&mut self, sbo: SuperBlockOffset, cdef_index: u8) {
-    let bo = sbo.block_offset(0, 0);
-    // Checkme: Is 16 still the right block unit for 128x128 superblocks?
-    let bw = cmp::min(bo.x + MAX_MIB_SIZE, self.blocks.cols);
-    let bh = cmp::min(bo.y + MAX_MIB_SIZE, self.blocks.rows);
-    for y in bo.y..bh {
-      for x in bo.x..bw {
-        self.blocks[y as usize][x as usize].cdef_index = cdef_index;
-      }
-    }
-  }
-
-  pub fn get_cdef(&mut self, sbo: SuperBlockOffset) -> u8 {
-    let bo = sbo.block_offset(0, 0);
-    self.blocks[bo.y][bo.x].cdef_index
   }
 
   // The mode info data structure has a one element border above and to the
@@ -2231,7 +2227,7 @@ impl ContextWriter {
 
     let mut i = 0;
     while i < end_mi {
-      let cand = bc.at(bo.with_offset(col_offset + i as isize, row_offset));
+      let cand = bc.blocks.at(bo.with_offset(col_offset + i as isize, row_offset));
 
       let n4_w = cand.n4_w;
       let mut len = cmp::min(target_n4_w, n4_w);
@@ -2286,7 +2282,7 @@ impl ContextWriter {
 
     let mut i = 0;
     while i < end_mi {
-      let cand = bc.at(bo.with_offset(col_offset, row_offset + i as isize));
+      let cand = bc.blocks.at(bo.with_offset(col_offset, row_offset + i as isize));
       let n4_h = cand.n4_h;
       let mut len = cmp::min(target_n4_h, n4_h);
       if use_step_16 {
@@ -2322,7 +2318,7 @@ impl ContextWriter {
 
     let weight = 2 * BLOCK_8X8.width_mi() as u32;
     /* Always assume its within a tile, probably wrong */
-    self.add_ref_mv_candidate(ref_frames, self.bc.at(bo), mv_stack, weight, newmv_count, is_compound)
+    self.add_ref_mv_candidate(ref_frames, self.bc.blocks.at(bo), mv_stack, weight, newmv_count, is_compound)
   }
 
   fn add_offset(&mut self, mv_stack: &mut Vec<CandidateMV>) {
@@ -2464,7 +2460,7 @@ impl ContextWriter {
             bo.with_offset(-1, idx as isize)
           };
 
-          let blk = &self.bc.at(rbo);
+          let blk = &self.bc.blocks.at(rbo);
           self.add_extra_mv_candidate(
             blk, ref_frames, mv_stack, fi, is_compound,
             &mut ref_id_count, &mut ref_id_mvs, &mut ref_diff_count, &mut ref_diff_mvs
@@ -2592,7 +2588,7 @@ impl ContextWriter {
           }
         }
       }
-      self.bc.at_mut(bo).neighbors_ref_counts = ref_counts;
+      self.bc.blocks.at_mut(bo).neighbors_ref_counts = ref_counts;
   }
 
   fn ref_count_ctx(counts0: usize, counts1: usize) -> usize {
@@ -2606,7 +2602,7 @@ impl ContextWriter {
   }
 
   fn get_ref_frame_ctx_b0(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
 
     let fwd_cnt = ref_counts[LAST_FRAME] + ref_counts[LAST2_FRAME] +
                   ref_counts[LAST3_FRAME] + ref_counts[GOLDEN_FRAME];
@@ -2618,7 +2614,7 @@ impl ContextWriter {
   }
 
   fn get_pred_ctx_brfarf2_or_arf(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
 
     let brfarf2_count = ref_counts[BWDREF_FRAME] + ref_counts[ALTREF2_FRAME];
     let arf_count = ref_counts[ALTREF_FRAME];
@@ -2627,7 +2623,7 @@ impl ContextWriter {
   }
 
   fn get_pred_ctx_ll2_or_l3gld(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
 
     let l_l2_count = ref_counts[LAST_FRAME] + ref_counts[LAST2_FRAME];
     let l3_gold_count = ref_counts[LAST3_FRAME] + ref_counts[GOLDEN_FRAME];
@@ -2636,7 +2632,7 @@ impl ContextWriter {
   }
 
   fn get_pred_ctx_last_or_last2(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
 
     let l_count = ref_counts[LAST_FRAME];
     let l2_count = ref_counts[LAST2_FRAME];
@@ -2645,7 +2641,7 @@ impl ContextWriter {
   }
 
   fn get_pred_ctx_last3_or_gold(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
 
     let l3_count = ref_counts[LAST3_FRAME];
     let gold_count = ref_counts[GOLDEN_FRAME];
@@ -2654,7 +2650,7 @@ impl ContextWriter {
   }
 
   fn get_pred_ctx_brf_or_arf2(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
 
     let brf_count = ref_counts[BWDREF_FRAME];
     let arf2_count = ref_counts[ALTREF2_FRAME];
@@ -2670,10 +2666,10 @@ impl ContextWriter {
     let avail_up = bo.y > 0;
     let bo_left = bo.with_offset(-1, 0);
     let bo_up = bo.with_offset(0, -1);
-    let above0 = if avail_up { self.bc.at(bo_up).ref_frames[0] } else { INTRA_FRAME };
-    let above1 = if avail_up { self.bc.at(bo_up).ref_frames[1] } else { NONE_FRAME };
-    let left0 = if avail_left { self.bc.at(bo_left).ref_frames[0] } else { INTRA_FRAME };
-    let left1 = if avail_left { self.bc.at(bo_left).ref_frames[1] } else { NONE_FRAME };
+    let above0 = if avail_up { self.bc.blocks.at(bo_up).ref_frames[0] } else { INTRA_FRAME };
+    let above1 = if avail_up { self.bc.blocks.at(bo_up).ref_frames[1] } else { NONE_FRAME };
+    let left0 = if avail_left { self.bc.blocks.at(bo_left).ref_frames[0] } else { INTRA_FRAME };
+    let left1 = if avail_left { self.bc.blocks.at(bo_left).ref_frames[1] } else { NONE_FRAME };
     let left_single = left1 == NONE_FRAME;
     let above_single = above1 == NONE_FRAME;
     let left_intra = left0 == INTRA_FRAME;
@@ -2717,10 +2713,10 @@ impl ContextWriter {
     let avail_up = bo.y > 0;
     let bo_left = bo.with_offset(-1, 0);
     let bo_up = bo.with_offset(0, -1);
-    let above0 = if avail_up { self.bc.at(bo_up).ref_frames[0] } else { INTRA_FRAME };
-    let above1 = if avail_up { self.bc.at(bo_up).ref_frames[1] } else { NONE_FRAME };
-    let left0 = if avail_left { self.bc.at(bo_left).ref_frames[0] } else { INTRA_FRAME };
-    let left1 = if avail_left { self.bc.at(bo_left).ref_frames[1] } else { NONE_FRAME };
+    let above0 = if avail_up { self.bc.blocks.at(bo_up).ref_frames[0] } else { INTRA_FRAME };
+    let above1 = if avail_up { self.bc.blocks.at(bo_up).ref_frames[1] } else { NONE_FRAME };
+    let left0 = if avail_left { self.bc.blocks.at(bo_left).ref_frames[0] } else { INTRA_FRAME };
+    let left1 = if avail_left { self.bc.blocks.at(bo_left).ref_frames[1] } else { NONE_FRAME };
     let left_single = left1 == NONE_FRAME;
     let above_single = above1 == NONE_FRAME;
     let left_intra = left0 == INTRA_FRAME;
@@ -2766,11 +2762,11 @@ impl ContextWriter {
   }
 
   pub fn write_ref_frames<T: Pixel>(&mut self, w: &mut dyn Writer, fi: &FrameInvariants<T>, bo: BlockOffset) {
-    let rf = self.bc.at(bo).ref_frames;
-    let sz = self.bc.at(bo).n4_w.min(self.bc.at(bo).n4_h);
+    let rf = self.bc.blocks.at(bo).ref_frames;
+    let sz = self.bc.blocks.at(bo).n4_w.min(self.bc.blocks.at(bo).n4_h);
 
     /* TODO: Handle multiple references */
-    let comp_mode = self.bc.at(bo).has_second_ref();
+    let comp_mode = self.bc.blocks.at(bo).has_second_ref();
 
     if fi.reference_mode != ReferenceMode::SINGLE && sz >= 2 {
       let ctx = self.get_comp_mode_ctx(bo);
@@ -3012,10 +3008,10 @@ impl ContextWriter {
                             bsize: BlockSize, skip: bool, last_active_segid: u8) {
     let ( pred, cdf_index ) = self.get_segment_pred(bo);
     if skip {
-      self.bc.set_segmentation_idx(bo, bsize, pred);
+      self.bc.blocks.set_segmentation_idx(bo, bsize, pred);
       return;
     }
-    let seg_idx = self.bc.at(bo).segmentation_idx;
+    let seg_idx = self.bc.blocks.at(bo).segmentation_idx;
     let coded_id = self.neg_interleave(seg_idx as i32, pred as i32, (last_active_segid + 1) as i32);
     symbol_with_update!(self, w, coded_id as u32, &mut self.fc.spatial_segmentation_cdfs[cdf_index as usize]);
   }
@@ -3150,7 +3146,7 @@ impl ContextWriter {
 
   pub fn write_block_deblock_deltas(&mut self, w: &mut dyn Writer,
                                     bo: BlockOffset, multi: bool) {
-      let block = self.bc.at(bo);
+      let block = self.bc.blocks.at(bo);
       let deltas = if multi { FRAME_LF_COUNT + PLANES - 3 } else { 1 };
       for i in 0..deltas {
           let delta = block.deblock_deltas[i];

--- a/src/context.rs
+++ b/src/context.rs
@@ -1355,6 +1355,23 @@ impl IndexMut<usize> for FrameBlocks {
   }
 }
 
+// for convenience, also index by BlockOffset
+
+impl Index<BlockOffset> for FrameBlocks {
+  type Output = Block;
+  #[inline]
+  fn index(&self, bo: BlockOffset) -> &Self::Output {
+    &self[bo.y][bo.x]
+  }
+}
+
+impl IndexMut<BlockOffset> for FrameBlocks {
+  #[inline]
+  fn index_mut(&mut self, bo: BlockOffset) -> &mut Self::Output {
+    &mut self[bo.y][bo.x]
+  }
+}
+
 #[derive(Clone)]
 pub struct BlockContextCheckpoint {
   cdef_coded: bool,

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -92,7 +92,7 @@ fn deblock_left<'a, T: Pixel>(
   let bo = BlockOffset { x: in_bo.x | xdec, y: in_bo.y | ydec };
 
   // We already know we're not at the upper/left corner, so prev_block is in frame
-  bc.at(bo.with_offset(-1 << xdec, 0))
+  bc.blocks.at(bo.with_offset(-1 << xdec, 0))
 }
 
 fn deblock_up<'a, T: Pixel>(
@@ -106,7 +106,7 @@ fn deblock_up<'a, T: Pixel>(
   let bo = BlockOffset { x: in_bo.x | xdec, y: in_bo.y | ydec };
 
   // We already know we're not at the upper/left corner, so prev_block is in frame
-  bc.at(bo.with_offset(0, -1 << ydec))
+  bc.blocks.at(bo.with_offset(0, -1 << ydec))
 }
 
 // Must be called on a tx edge, and not on a frame edge.  This is enforced above the call.
@@ -1025,7 +1025,7 @@ fn filter_v_edge<T: Pixel>(
   deblock: &DeblockState, bc: &BlockContext, bo: BlockOffset, p: &mut Plane<T>,
   pli: usize, bd: usize
 ) {
-  let block = bc.at(bo);
+  let block = bc.blocks.at(bo);
   let tx_edge = bo.x & (block.tx_w - 1) == 0;
   if tx_edge {
     let prev_block = deblock_left(bc, bo, p);
@@ -1062,7 +1062,7 @@ fn sse_v_edge<T: Pixel>(
   bc: &BlockContext, bo: BlockOffset, rec_plane: &Plane<T>, src_plane: &Plane<T>,
   tally: &mut [i64; MAX_LOOP_FILTER + 2], pli: usize, bd: usize
 ) {
-  let block = bc.at(bo);
+  let block = bc.blocks.at(bo);
   let tx_edge = bo.x & (block.tx_w - 1) == 0;
   if tx_edge {
     let prev_block = deblock_left(bc, bo, rec_plane);
@@ -1128,7 +1128,7 @@ fn filter_h_edge<T: Pixel>(
   deblock: &DeblockState, bc: &BlockContext, bo: BlockOffset, p: &mut Plane<T>,
   pli: usize, bd: usize
 ) {
-  let block = bc.at(bo);
+  let block = bc.blocks.at(bo);
   let tx_edge = bo.y & (block.tx_h - 1) == 0;
   if tx_edge {
     let prev_block = deblock_up(bc, bo, p);
@@ -1165,7 +1165,7 @@ fn sse_h_edge<T: Pixel>(
   bc: &BlockContext, bo: BlockOffset, rec_plane: &Plane<T>, src_plane: &Plane<T>,
   tally: &mut [i64; MAX_LOOP_FILTER + 2], pli: usize, bd: usize
 ) {
-  let block = bc.at(bo);
+  let block = bc.blocks.at(bo);
   let tx_edge = bo.y & (block.tx_h - 1) == 0;
   if tx_edge {
     let prev_block = deblock_up(bc, bo, rec_plane);

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -92,7 +92,7 @@ fn deblock_left<'a, T: Pixel>(
   let bo = BlockOffset { x: in_bo.x | xdec, y: in_bo.y | ydec };
 
   // We already know we're not at the upper/left corner, so prev_block is in frame
-  bc.blocks.at(bo.with_offset(-1 << xdec, 0))
+  &bc.blocks[bo.with_offset(-1 << xdec, 0)]
 }
 
 fn deblock_up<'a, T: Pixel>(
@@ -106,7 +106,7 @@ fn deblock_up<'a, T: Pixel>(
   let bo = BlockOffset { x: in_bo.x | xdec, y: in_bo.y | ydec };
 
   // We already know we're not at the upper/left corner, so prev_block is in frame
-  bc.blocks.at(bo.with_offset(0, -1 << ydec))
+  &bc.blocks[bo.with_offset(0, -1 << ydec)]
 }
 
 // Must be called on a tx edge, and not on a frame edge.  This is enforced above the call.
@@ -1025,7 +1025,7 @@ fn filter_v_edge<T: Pixel>(
   deblock: &DeblockState, bc: &BlockContext, bo: BlockOffset, p: &mut Plane<T>,
   pli: usize, bd: usize
 ) {
-  let block = bc.blocks.at(bo);
+  let block = &bc.blocks[bo];
   let tx_edge = bo.x & (block.tx_w - 1) == 0;
   if tx_edge {
     let prev_block = deblock_left(bc, bo, p);
@@ -1062,7 +1062,7 @@ fn sse_v_edge<T: Pixel>(
   bc: &BlockContext, bo: BlockOffset, rec_plane: &Plane<T>, src_plane: &Plane<T>,
   tally: &mut [i64; MAX_LOOP_FILTER + 2], pli: usize, bd: usize
 ) {
-  let block = bc.blocks.at(bo);
+  let block = &bc.blocks[bo];
   let tx_edge = bo.x & (block.tx_w - 1) == 0;
   if tx_edge {
     let prev_block = deblock_left(bc, bo, rec_plane);
@@ -1128,7 +1128,7 @@ fn filter_h_edge<T: Pixel>(
   deblock: &DeblockState, bc: &BlockContext, bo: BlockOffset, p: &mut Plane<T>,
   pli: usize, bd: usize
 ) {
-  let block = bc.blocks.at(bo);
+  let block = &bc.blocks[bo];
   let tx_edge = bo.y & (block.tx_h - 1) == 0;
   if tx_edge {
     let prev_block = deblock_up(bc, bo, p);
@@ -1165,7 +1165,7 @@ fn sse_h_edge<T: Pixel>(
   bc: &BlockContext, bo: BlockOffset, rec_plane: &Plane<T>, src_plane: &Plane<T>,
   tally: &mut [i64; MAX_LOOP_FILTER + 2], pli: usize, bd: usize
 ) {
-  let block = bc.blocks.at(bo);
+  let block = &bc.blocks[bo];
   let tx_edge = bo.y & (block.tx_h - 1) == 0;
   if tx_edge {
     let prev_block = deblock_up(bc, bo, rec_plane);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -939,7 +939,7 @@ fn diff<T: Pixel>(dst: &mut [i16], src1: &PlaneSlice<'_, T>, src2: &PlaneSlice<'
 
 fn get_qidx<T: Pixel>(fi: &FrameInvariants<T>, fs: &FrameState<T>, cw: &ContextWriter, bo: BlockOffset) -> u8 {
   let mut qidx = fi.base_q_idx;
-  let sidx = cw.bc.blocks.at(bo).segmentation_idx as usize;
+  let sidx = cw.bc.blocks[bo].segmentation_idx as usize;
   if fs.segmentation.features[sidx][SegLvl::SEG_LVL_ALT_Q as usize] {
     let delta = fs.segmentation.data[sidx][SegLvl::SEG_LVL_ALT_Q as usize];
     qidx = clamp((qidx as i16) + delta, 0, 255) as u8;
@@ -1061,11 +1061,11 @@ pub fn motion_compensate<T: Pixel>(
     if p > 0 && bsize < BlockSize::BLOCK_8X8 {
       let mut some_use_intra = false;
       if bsize == BlockSize::BLOCK_4X4 || bsize == BlockSize::BLOCK_4X8 {
-        some_use_intra |= cw.bc.blocks.at(bo.with_offset(-1,0)).mode.is_intra(); };
+        some_use_intra |= cw.bc.blocks[bo.with_offset(-1,0)].mode.is_intra(); };
       if !some_use_intra && bsize == BlockSize::BLOCK_4X4 || bsize == BlockSize::BLOCK_8X4 {
-        some_use_intra |= cw.bc.blocks.at(bo.with_offset(0,-1)).mode.is_intra(); };
+        some_use_intra |= cw.bc.blocks[bo.with_offset(0,-1)].mode.is_intra(); };
       if !some_use_intra && bsize == BlockSize::BLOCK_4X4 {
-        some_use_intra |= cw.bc.blocks.at(bo.with_offset(-1,-1)).mode.is_intra(); };
+        some_use_intra |= cw.bc.blocks[bo.with_offset(-1,-1)].mode.is_intra(); };
 
       if some_use_intra {
         luma_mode.predict_inter(fi, p, po, &mut rec.mut_slice(po), plane_bsize.width(),
@@ -1074,13 +1074,13 @@ pub fn motion_compensate<T: Pixel>(
         assert!(xdec == 1 && ydec == 1);
         // TODO: these are absolutely only valid for 4:2:0
         if bsize == BlockSize::BLOCK_4X4 {
-          let mv0 = cw.bc.blocks.at(bo.with_offset(-1,-1)).mv;
-          let rf0 = cw.bc.blocks.at(bo.with_offset(-1,-1)).ref_frames;
-          let mv1 = cw.bc.blocks.at(bo.with_offset(0,-1)).mv;
-          let rf1 = cw.bc.blocks.at(bo.with_offset(0,-1)).ref_frames;
+          let mv0 = cw.bc.blocks[bo.with_offset(-1,-1)].mv;
+          let rf0 = cw.bc.blocks[bo.with_offset(-1,-1)].ref_frames;
+          let mv1 = cw.bc.blocks[bo.with_offset(0,-1)].mv;
+          let rf1 = cw.bc.blocks[bo.with_offset(0,-1)].ref_frames;
           let po1 = PlaneOffset { x: po.x+2, y: po.y };
-          let mv2 = cw.bc.blocks.at(bo.with_offset(-1,0)).mv;
-          let rf2 = cw.bc.blocks.at(bo.with_offset(-1,0)).ref_frames;
+          let mv2 = cw.bc.blocks[bo.with_offset(-1,0)].mv;
+          let rf2 = cw.bc.blocks[bo.with_offset(-1,0)].ref_frames;
           let po2 = PlaneOffset { x: po.x, y: po.y+2 };
           let po3 = PlaneOffset { x: po.x+2, y: po.y+2 };
           luma_mode.predict_inter(fi, p, po, &mut rec.mut_slice(po), 2, 2, rf0, mv0);
@@ -1089,15 +1089,15 @@ pub fn motion_compensate<T: Pixel>(
           luma_mode.predict_inter(fi, p, po3, &mut rec.mut_slice(po3), 2, 2, ref_frames, mvs);
         }
         if bsize == BlockSize::BLOCK_8X4 {
-          let mv1 = cw.bc.blocks.at(bo.with_offset(0,-1)).mv;
-          let rf1 = cw.bc.blocks.at(bo.with_offset(0,-1)).ref_frames;
+          let mv1 = cw.bc.blocks[bo.with_offset(0,-1)].mv;
+          let rf1 = cw.bc.blocks[bo.with_offset(0,-1)].ref_frames;
           luma_mode.predict_inter(fi, p, po, &mut rec.mut_slice(po), 4, 2, rf1, mv1);
           let po3 = PlaneOffset { x: po.x, y: po.y+2 };
           luma_mode.predict_inter(fi, p, po3, &mut rec.mut_slice(po3), 4, 2, ref_frames, mvs);
         }
         if bsize == BlockSize::BLOCK_4X8 {
-          let mv2 = cw.bc.blocks.at(bo.with_offset(-1,0)).mv;
-          let rf2 = cw.bc.blocks.at(bo.with_offset(-1,0)).ref_frames;
+          let mv2 = cw.bc.blocks[bo.with_offset(-1,0)].mv;
+          let rf2 = cw.bc.blocks[bo.with_offset(-1,0)].ref_frames;
           luma_mode.predict_inter(fi, p, po, &mut rec.mut_slice(po), 2, 4, rf2, mv2);
           let po3 = PlaneOffset { x: po.x+2, y: po.y };
           luma_mode.predict_inter(fi, p, po3, &mut rec.mut_slice(po3), 2, 4, ref_frames, mvs);

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1233,7 +1233,7 @@ fn rdo_loop_plane_error<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T>
     for bx in 0..sb_blocks {
       let bo = sbo.block_offset(bx<<1, by<<1);
       if bo.x < bc.cols && bo.y < bc.rows {
-        let skip = bc.blocks.at(bo).skip;
+        let skip = bc.blocks[bo].skip;
         if !skip {
           let in_plane = &fs.input.planes[pli];
           let in_po = sbo.block_offset(bx<<1, by<<1).plane_offset(&in_plane.cfg);

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -384,7 +384,7 @@ pub fn rdo_tx_size_type<T: Pixel>(
       _ => unimplemented!()
     }
   };
-  cw.bc.set_tx_size(bo, tx_size);
+  cw.bc.blocks.set_tx_size(bo, tx_size);
   // Were we not hardcoded to TX_MODE_LARGEST, block tx size would be written here
 
   // Luma plane transform type decision
@@ -870,9 +870,9 @@ pub fn rdo_mode_decision<T: Pixel>(
     }
   }
 
-  cw.bc.set_mode(bo, bsize, best.mode_luma);
-  cw.bc.set_ref_frames(bo, bsize, best.ref_frames);
-  cw.bc.set_motion_vectors(bo, bsize, best.mvs);
+  cw.bc.blocks.set_mode(bo, bsize, best.mode_luma);
+  cw.bc.blocks.set_ref_frames(bo, bsize, best.ref_frames);
+  cw.bc.blocks.set_motion_vectors(bo, bsize, best.mvs);
 
   assert!(best.rd >= 0_f64);
 
@@ -1233,7 +1233,7 @@ fn rdo_loop_plane_error<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T>
     for bx in 0..sb_blocks {
       let bo = sbo.block_offset(bx<<1, by<<1);
       if bo.x < bc.cols && bo.y < bc.rows {
-        let skip = bc.at(bo).skip;
+        let skip = bc.blocks.at(bo).skip;
         if !skip {
           let in_plane = &fs.input.planes[pli];
           let in_po = sbo.block_offset(bx<<1, by<<1).plane_offset(&in_plane.cfg);
@@ -1426,7 +1426,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T
   }
 
   if cw.bc.cdef_coded {
-    cw.bc.set_cdef(sbo, best_index as u8);
+    cw.bc.blocks.set_cdef(sbo, best_index as u8);
   }
 
   if fi.sequence.enable_restoration {


### PR DESCRIPTION
I could have open several PR, but since these changes conflict with each other, I decided to open one for all. If necessary (e.g. if not all changes are accepted), I can split as needed.

_(To minimize confusion, I suggest to review per commit.)_

---

The first two commits remove `BlockContext` methods which return `Block`s by value.

> The methods above_of(), left_of() and above_left_of() returned the
> matching block by value, or a default block if the offset resulted in a
> block outside boundaries.
>
> The Block structure is quite big (std::mem::size_of::<Block>() == 136).
> For reading a field, it is probably not optimal to return a whole Block
> copy or a new default block (although the compiler might optimize such
> accesses).
>
> Moreover, the boundaries checks were often redundant, because already
> done by the callers.
>
> Instead, let the callers access the blocks by their index. This
> simplifies the BlockContext API (which will be adapted for tiling).

The next two commits move methods from `BlockContext` to `FrameBlocks` (they are very specific to blocks, and don't need the context).

For convenience, the last two commits implement `Index` and `IndexMut` traits with `BlockOffset` index for `FrameBlocks`. That way, we can index a block directly from a `BlockOffset`:

```rust
let bo = BlockOffset { x, y };
// before
bc.blocks.at_mut(bo).neighbors_ref_counts = ref_counts;
// after
bc.blocks[bo].neighbors_ref_counts = ref_counts;
```