### PR TITLE
Return blocks by reference, not by value

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1638,17 +1638,9 @@ impl BlockContext {
   }
 
   fn skip_context(&mut self, bo: BlockOffset) -> usize {
-    let above_skip = if bo.y > 0 {
-      self.above_of(bo).skip as usize
-    } else {
-      0
-    };
-    let left_skip = if bo.x > 0 {
-      self.left_of(bo).skip as usize
-    } else {
-      0
-    };
-    above_skip + left_skip
+    let above_skip = bo.y > 0 && self.above_of(bo).skip;
+    let left_skip = bo.x > 0 && self.left_of(bo).skip;
+    above_skip as usize + left_skip as usize
   }
 
   pub fn set_skip(&mut self, bo: BlockOffset, bsize: BlockSize, skip: bool) {
@@ -1719,13 +1711,9 @@ impl BlockContext {
           (above_intra || left_intra) as usize
         }
       }
-      (true, _) | (_, true) =>
-        2 * if has_above {
-          !self.above_of(bo).is_inter() as usize
-        } else {
-          !self.left_of(bo).is_inter() as usize
-        },
-      (_, _) => 0
+      (true, false) => if self.above_of(bo).is_inter() { 0 } else { 2 },
+      (false, true) => if self.left_of(bo).is_inter() { 0 } else { 2 },
+      _ => 0
     }
   }
 


### PR DESCRIPTION
The methods `above_of()`, `left_of()` and `above_left_of()` returned the matching block by value, or a default block if the offset resulted in a block outside boundaries.

The Block structure is quite big (`std::mem::size_of::<Block>() == 120`). For reading a field, it is probably not optimal to return a whole `Block` copy or a new default block (although the compiler might optimize such accesses).

Moreover, the boundaries checks were often redundant, because already done by the callers.

Instead, let the callers check boundaries and return a reference to the matching block.