### PR TITLE
Remove "superframe anti emulation" byte

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2216,9 +2216,7 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
   fs.cdfs = cw.fc;
   fs.cdfs.reset_counts();
 
-  let mut h = w.done();
-  h.push(0); // superframe anti emulation
-  h
+  w.done()
 }
 
 #[allow(unused)]


### PR DESCRIPTION
TD-Linux on IRC:

> superframe anti emulation was dropped from the spec mid development