### PR TITLE
Replace at() and at_mut() by operator[]

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -221,10 +221,10 @@ pub fn cdef_analyze_superblock<T: Pixel>(
       // in the main frame.
       let global_block_offset = sbo_global.block_offset(bx<<1, by<<1);
       if global_block_offset.x < bc_global.cols && global_block_offset.y < bc_global.rows {
-        let skip = bc_global.blocks.at(global_block_offset).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by)).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx, 2*by+1)).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
+        let skip = bc_global.blocks[global_block_offset].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx+1, 2*by)].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx, 2*by+1)].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx+1, 2*by+1)].skip;
 
         if !skip {
           let mut var: i32 = 0;
@@ -358,10 +358,10 @@ pub fn cdef_filter_superblock<T: Pixel>(
     for bx in 0..8 {
       let global_block_offset = sbo_global.block_offset(bx<<1, by<<1);
       if global_block_offset.x < bc_global.cols && global_block_offset.y < bc_global.rows {
-        let skip = bc_global.blocks.at(global_block_offset).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by)).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx, 2*by+1)).skip
-          & bc_global.blocks.at(sbo_global.block_offset(2*bx+1, 2*by+1)).skip;
+        let skip = bc_global.blocks[global_block_offset].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx+1, 2*by)].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx, 2*by+1)].skip
+          & bc_global.blocks[sbo_global.block_offset(2*bx+1, 2*by+1)].skip;
         if !skip {
           let dir = cdef_dirs.dir[bx][by];
           let var = cdef_dirs.var[bx][by];
@@ -480,7 +480,7 @@ pub fn cdef_filter_frame<T: Pixel>(fi: &FrameInvariants<T>, rec: &mut Frame<T>, 
   for fby in 0..fb_height {
     for fbx in 0..fb_width {
       let sbo = SuperBlockOffset { x: fbx, y: fby };
-      let cdef_index = bc.blocks.at(sbo.block_offset(0, 0)).cdef_index;
+      let cdef_index = bc.blocks[sbo.block_offset(0, 0)].cdef_index;
       let cdef_dirs = cdef_analyze_superblock(&cdef_frame, bc, sbo, sbo, fi.sequence.bit_depth);
       cdef_filter_superblock(fi, &cdef_frame, rec, bc, sbo, sbo, cdef_index, &cdef_dirs);
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1422,6 +1422,23 @@ impl IndexMut<usize> for FrameBlocks {
   }
 }
 
+// for convenience, also index by BlockOffset
+
+impl Index<BlockOffset> for FrameBlocks {
+  type Output = Block;
+  #[inline]
+  fn index(&self, bo: BlockOffset) -> &Self::Output {
+    &self[bo.y][bo.x]
+  }
+}
+
+impl IndexMut<BlockOffset> for FrameBlocks {
+  #[inline]
+  fn index_mut(&mut self, bo: BlockOffset) -> &mut Self::Output {
+    &mut self[bo.y][bo.x]
+  }
+}
+
 #[derive(Clone)]
 pub struct BlockContextCheckpoint {
   cdef_coded: bool,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1321,14 +1321,6 @@ impl FrameBlocks {
     }
   }
 
-  pub fn at_mut(&mut self, bo: BlockOffset) -> &mut Block {
-    &mut self[bo.y][bo.x]
-  }
-
-  pub fn at(&self, bo: BlockOffset) -> &Block {
-    &self[bo.y][bo.x]
-  }
-
   #[inline]
   pub fn above_of(&self, bo: BlockOffset) -> &Block {
     &self[bo.y - 1][bo.x]
@@ -2122,7 +2114,7 @@ impl ContextWriter {
       depth - 1
     }
 
-    debug_assert!(!self.bc.blocks.at(bo).is_inter());
+    debug_assert!(!self.bc.blocks[bo].is_inter());
     debug_assert!(bsize.greater_than(BlockSize::BLOCK_4X4));
 
     let tx_size_ctx = self.get_tx_size_context(bo, bsize);
@@ -2424,7 +2416,7 @@ impl ContextWriter {
 
     let mut i = 0;
     while i < end_mi {
-      let cand = bc.blocks.at(bo.with_offset(col_offset + i as isize, row_offset));
+      let cand = &bc.blocks[bo.with_offset(col_offset + i as isize, row_offset)];
 
       let n4_w = cand.n4_w;
       let mut len = cmp::min(target_n4_w, n4_w);
@@ -2479,7 +2471,7 @@ impl ContextWriter {
 
     let mut i = 0;
     while i < end_mi {
-      let cand = bc.blocks.at(bo.with_offset(col_offset, row_offset + i as isize));
+      let cand = &bc.blocks[bo.with_offset(col_offset, row_offset + i as isize)];
       let n4_h = cand.n4_h;
       let mut len = cmp::min(target_n4_h, n4_h);
       if use_step_16 {
@@ -2515,7 +2507,7 @@ impl ContextWriter {
 
     let weight = 2 * BLOCK_8X8.width_mi() as u32;
     /* Always assume its within a tile, probably wrong */
-    self.add_ref_mv_candidate(ref_frames, self.bc.blocks.at(bo), mv_stack, weight, newmv_count, is_compound)
+    self.add_ref_mv_candidate(ref_frames, &self.bc.blocks[bo], mv_stack, weight, newmv_count, is_compound)
   }
 
   fn add_offset(&mut self, mv_stack: &mut Vec<CandidateMV>) {
@@ -2657,7 +2649,7 @@ impl ContextWriter {
             bo.with_offset(-1, idx as isize)
           };
 
-          let blk = &self.bc.blocks.at(rbo);
+          let blk = &self.bc.blocks[rbo];
           self.add_extra_mv_candidate(
             blk, ref_frames, mv_stack, fi, is_compound,
             &mut ref_id_count, &mut ref_id_mvs, &mut ref_diff_count, &mut ref_diff_mvs
@@ -2785,7 +2777,7 @@ impl ContextWriter {
           }
         }
       }
-      self.bc.blocks.at_mut(bo).neighbors_ref_counts = ref_counts;
+      self.bc.blocks[bo].neighbors_ref_counts = ref_counts;
   }
 
   fn ref_count_ctx(counts0: usize, counts1: usize) -> usize {
@@ -2799,7 +2791,7 @@ impl ContextWriter {
   }
 
   fn get_ref_frame_ctx_b0(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks[bo].neighbors_ref_counts;
 
     let fwd_cnt = ref_counts[LAST_FRAME.to_index()] + ref_counts[LAST2_FRAME.to_index()] +
                   ref_counts[LAST3_FRAME.to_index()] + ref_counts[GOLDEN_FRAME.to_index()];
@@ -2811,7 +2803,7 @@ impl ContextWriter {
   }
 
   fn get_pred_ctx_brfarf2_or_arf(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks[bo].neighbors_ref_counts;
 
     let brfarf2_count = ref_counts[BWDREF_FRAME.to_index()] + ref_counts[ALTREF2_FRAME.to_index()];
     let arf_count = ref_counts[ALTREF_FRAME.to_index()];
@@ -2820,7 +2812,7 @@ impl ContextWriter {
   }
 
   fn get_pred_ctx_ll2_or_l3gld(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks[bo].neighbors_ref_counts;
 
     let l_l2_count = ref_counts[LAST_FRAME.to_index()] + ref_counts[LAST2_FRAME.to_index()];
     let l3_gold_count = ref_counts[LAST3_FRAME.to_index()] + ref_counts[GOLDEN_FRAME.to_index()];
@@ -2829,7 +2821,7 @@ impl ContextWriter {
   }
 
   fn get_pred_ctx_last_or_last2(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks[bo].neighbors_ref_counts;
 
     let l_count = ref_counts[LAST_FRAME.to_index()];
     let l2_count = ref_counts[LAST2_FRAME.to_index()];
@@ -2838,7 +2830,7 @@ impl ContextWriter {
   }
 
   fn get_pred_ctx_last3_or_gold(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks[bo].neighbors_ref_counts;
 
     let l3_count = ref_counts[LAST3_FRAME.to_index()];
     let gold_count = ref_counts[GOLDEN_FRAME.to_index()];
@@ -2847,7 +2839,7 @@ impl ContextWriter {
   }
 
   fn get_pred_ctx_brf_or_arf2(&mut self, bo: BlockOffset) -> usize {
-    let ref_counts = self.bc.blocks.at(bo).neighbors_ref_counts;
+    let ref_counts = self.bc.blocks[bo].neighbors_ref_counts;
 
     let brf_count = ref_counts[BWDREF_FRAME.to_index()];
     let arf2_count = ref_counts[ALTREF2_FRAME.to_index()];
@@ -2861,10 +2853,10 @@ impl ContextWriter {
     let avail_up = bo.y > 0;
     let bo_left = bo.with_offset(-1, 0);
     let bo_up = bo.with_offset(0, -1);
-    let above0 = if avail_up { self.bc.blocks.at(bo_up).ref_frames[0] } else { INTRA_FRAME };
-    let above1 = if avail_up { self.bc.blocks.at(bo_up).ref_frames[1] } else { NONE_FRAME };
-    let left0 = if avail_left { self.bc.blocks.at(bo_left).ref_frames[0] } else { INTRA_FRAME };
-    let left1 = if avail_left { self.bc.blocks.at(bo_left).ref_frames[1] } else { NONE_FRAME };
+    let above0 = if avail_up { self.bc.blocks[bo_up].ref_frames[0] } else { INTRA_FRAME };
+    let above1 = if avail_up { self.bc.blocks[bo_up].ref_frames[1] } else { NONE_FRAME };
+    let left0 = if avail_left { self.bc.blocks[bo_left].ref_frames[0] } else { INTRA_FRAME };
+    let left1 = if avail_left { self.bc.blocks[bo_left].ref_frames[1] } else { NONE_FRAME };
     let left_single = left1 == NONE_FRAME;
     let above_single = above1 == NONE_FRAME;
     let left_intra = left0 == INTRA_FRAME;
@@ -2908,10 +2900,10 @@ impl ContextWriter {
     let avail_up = bo.y > 0;
     let bo_left = bo.with_offset(-1, 0);
     let bo_up = bo.with_offset(0, -1);
-    let above0 = if avail_up { self.bc.blocks.at(bo_up).ref_frames[0] } else { INTRA_FRAME };
-    let above1 = if avail_up { self.bc.blocks.at(bo_up).ref_frames[1] } else { NONE_FRAME };
-    let left0 = if avail_left { self.bc.blocks.at(bo_left).ref_frames[0] } else { INTRA_FRAME };
-    let left1 = if avail_left { self.bc.blocks.at(bo_left).ref_frames[1] } else { NONE_FRAME };
+    let above0 = if avail_up { self.bc.blocks[bo_up].ref_frames[0] } else { INTRA_FRAME };
+    let above1 = if avail_up { self.bc.blocks[bo_up].ref_frames[1] } else { NONE_FRAME };
+    let left0 = if avail_left { self.bc.blocks[bo_left].ref_frames[0] } else { INTRA_FRAME };
+    let left1 = if avail_left { self.bc.blocks[bo_left].ref_frames[1] } else { NONE_FRAME };
     let left_single = left1 == NONE_FRAME;
     let above_single = above1 == NONE_FRAME;
     let left_intra = left0 == INTRA_FRAME;
@@ -2957,11 +2949,11 @@ impl ContextWriter {
   }
 
   pub fn write_ref_frames<T: Pixel>(&mut self, w: &mut dyn Writer, fi: &FrameInvariants<T>, bo: BlockOffset) {
-    let rf = self.bc.blocks.at(bo).ref_frames;
-    let sz = self.bc.blocks.at(bo).n4_w.min(self.bc.blocks.at(bo).n4_h);
+    let rf = self.bc.blocks[bo].ref_frames;
+    let sz = self.bc.blocks[bo].n4_w.min(self.bc.blocks[bo].n4_h);
 
     /* TODO: Handle multiple references */
-    let comp_mode = self.bc.blocks.at(bo).has_second_ref();
+    let comp_mode = self.bc.blocks[bo].has_second_ref();
 
     if fi.reference_mode != ReferenceMode::SINGLE && sz >= 2 {
       let ctx = self.get_comp_mode_ctx(bo);
@@ -3206,7 +3198,7 @@ impl ContextWriter {
       self.bc.blocks.set_segmentation_idx(bo, bsize, pred);
       return;
     }
-    let seg_idx = self.bc.blocks.at(bo).segmentation_idx;
+    let seg_idx = self.bc.blocks[bo].segmentation_idx;
     let coded_id = self.neg_interleave(seg_idx as i32, pred as i32, (last_active_segid + 1) as i32);
     symbol_with_update!(self, w, coded_id as u32, &mut self.fc.spatial_segmentation_cdfs[cdf_index as usize]);
   }
@@ -3341,7 +3333,7 @@ impl ContextWriter {
 
   pub fn write_block_deblock_deltas(&mut self, w: &mut dyn Writer,
                                     bo: BlockOffset, multi: bool) {
-      let block = self.bc.blocks.at(bo);
+      let block = &self.bc.blocks[bo];
       let deltas = if multi { FRAME_LF_COUNT + PLANES - 3 } else { 1 };
       for i in 0..deltas {
           let delta = block.deblock_deltas[i];

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -92,7 +92,7 @@ fn deblock_left<'a, T: Pixel>(
   let bo = BlockOffset { x: in_bo.x | xdec, y: in_bo.y | ydec };
 
   // We already know we're not at the upper/left corner, so prev_block is in frame
-  bc.blocks.at(bo.with_offset(-1 << xdec, 0))
+  &bc.blocks[bo.with_offset(-1 << xdec, 0)]
 }
 
 fn deblock_up<'a, T: Pixel>(
@@ -106,7 +106,7 @@ fn deblock_up<'a, T: Pixel>(
   let bo = BlockOffset { x: in_bo.x | xdec, y: in_bo.y | ydec };
 
   // We already know we're not at the upper/left corner, so prev_block is in frame
-  bc.blocks.at(bo.with_offset(0, -1 << ydec))
+  &bc.blocks[bo.with_offset(0, -1 << ydec)]
 }
 
 // Must be called on a tx edge, and not on a frame edge.  This is enforced above the call.
@@ -1029,7 +1029,7 @@ fn filter_v_edge<T: Pixel>(
   deblock: &DeblockState, bc: &BlockContext, bo: BlockOffset, p: &mut Plane<T>,
   pli: usize, bd: usize, xdec: usize, ydec: usize
 ) {
-  let block = bc.blocks.at(bo);
+  let block = &bc.blocks[bo];
   let txsize = if pli==0 { block.txsize } else { block.bsize.largest_uv_tx_size(xdec, ydec) };
   let tx_edge = bo.x >> xdec & (txsize.width_mi() - 1) == 0;
   if tx_edge {
@@ -1067,7 +1067,7 @@ fn sse_v_edge<T: Pixel>(
   bc: &BlockContext, bo: BlockOffset, rec_plane: &Plane<T>, src_plane: &Plane<T>,
   tally: &mut [i64; MAX_LOOP_FILTER + 2], pli: usize, bd: usize, xdec: usize, ydec: usize
 ) {
-  let block = bc.blocks.at(bo);
+  let block = &bc.blocks[bo];
   let txsize = if pli==0 { block.txsize } else { block.bsize.largest_uv_tx_size(xdec, ydec) };
   let tx_edge = bo.x >> xdec & (txsize.width_mi() - 1) == 0;
   if tx_edge {
@@ -1134,7 +1134,7 @@ fn filter_h_edge<T: Pixel>(
   deblock: &DeblockState, bc: &BlockContext, bo: BlockOffset, p: &mut Plane<T>,
   pli: usize, bd: usize, xdec: usize, ydec: usize
 ) {
-  let block = bc.blocks.at(bo);
+  let block = &bc.blocks[bo];
   let txsize = if pli==0 { block.txsize } else { block.bsize.largest_uv_tx_size(xdec, ydec) };
   let tx_edge = bo.y >> ydec & (txsize.height_mi() - 1) == 0;
   if tx_edge {
@@ -1172,7 +1172,7 @@ fn sse_h_edge<T: Pixel>(
   bc: &BlockContext, bo: BlockOffset, rec_plane: &Plane<T>, src_plane: &Plane<T>,
   tally: &mut [i64; MAX_LOOP_FILTER + 2], pli: usize, bd: usize, xdec: usize, ydec: usize
 ) {
-  let block = bc.blocks.at(bo);
+  let block = &bc.blocks[bo];
   let txsize = if pli==0 { block.txsize } else { block.bsize.largest_uv_tx_size(xdec, ydec) };
   let tx_edge = bo.y >> ydec & (txsize.height_mi() - 1) == 0;
   if tx_edge {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -950,7 +950,7 @@ fn diff<T: Pixel>(dst: &mut [i16], src1: &PlaneSlice<'_, T>, src2: &PlaneSlice<'
 
 fn get_qidx<T: Pixel>(fi: &FrameInvariants<T>, fs: &FrameState<T>, cw: &ContextWriter, bo: BlockOffset) -> u8 {
   let mut qidx = fi.base_q_idx;
-  let sidx = cw.bc.blocks.at(bo).segmentation_idx as usize;
+  let sidx = cw.bc.blocks[bo].segmentation_idx as usize;
   if fs.segmentation.features[sidx][SegLvl::SEG_LVL_ALT_Q as usize] {
     let delta = fs.segmentation.data[sidx][SegLvl::SEG_LVL_ALT_Q as usize];
     qidx = clamp((qidx as i16) + delta, 0, 255) as u8;
@@ -1072,11 +1072,11 @@ pub fn motion_compensate<T: Pixel>(
     if p > 0 && bsize < BlockSize::BLOCK_8X8 {
       let mut some_use_intra = false;
       if bsize == BlockSize::BLOCK_4X4 || bsize == BlockSize::BLOCK_4X8 {
-        some_use_intra |= cw.bc.blocks.at(bo.with_offset(-1,0)).mode.is_intra(); };
+        some_use_intra |= cw.bc.blocks[bo.with_offset(-1,0)].mode.is_intra(); };
       if !some_use_intra && bsize == BlockSize::BLOCK_4X4 || bsize == BlockSize::BLOCK_8X4 {
-        some_use_intra |= cw.bc.blocks.at(bo.with_offset(0,-1)).mode.is_intra(); };
+        some_use_intra |= cw.bc.blocks[bo.with_offset(0,-1)].mode.is_intra(); };
       if !some_use_intra && bsize == BlockSize::BLOCK_4X4 {
-        some_use_intra |= cw.bc.blocks.at(bo.with_offset(-1,-1)).mode.is_intra(); };
+        some_use_intra |= cw.bc.blocks[bo.with_offset(-1,-1)].mode.is_intra(); };
 
       if some_use_intra {
         luma_mode.predict_inter(fi, p, po, &mut rec.mut_slice(po), plane_bsize.width(),
@@ -1085,13 +1085,13 @@ pub fn motion_compensate<T: Pixel>(
         assert!(xdec == 1 && ydec == 1);
         // TODO: these are absolutely only valid for 4:2:0
         if bsize == BlockSize::BLOCK_4X4 {
-          let mv0 = cw.bc.blocks.at(bo.with_offset(-1,-1)).mv;
-          let rf0 = cw.bc.blocks.at(bo.with_offset(-1,-1)).ref_frames;
-          let mv1 = cw.bc.blocks.at(bo.with_offset(0,-1)).mv;
-          let rf1 = cw.bc.blocks.at(bo.with_offset(0,-1)).ref_frames;
+          let mv0 = cw.bc.blocks[bo.with_offset(-1,-1)].mv;
+          let rf0 = cw.bc.blocks[bo.with_offset(-1,-1)].ref_frames;
+          let mv1 = cw.bc.blocks[bo.with_offset(0,-1)].mv;
+          let rf1 = cw.bc.blocks[bo.with_offset(0,-1)].ref_frames;
           let po1 = PlaneOffset { x: po.x+2, y: po.y };
-          let mv2 = cw.bc.blocks.at(bo.with_offset(-1,0)).mv;
-          let rf2 = cw.bc.blocks.at(bo.with_offset(-1,0)).ref_frames;
+          let mv2 = cw.bc.blocks[bo.with_offset(-1,0)].mv;
+          let rf2 = cw.bc.blocks[bo.with_offset(-1,0)].ref_frames;
           let po2 = PlaneOffset { x: po.x, y: po.y+2 };
           let po3 = PlaneOffset { x: po.x+2, y: po.y+2 };
           luma_mode.predict_inter(fi, p, po, &mut rec.mut_slice(po), 2, 2, rf0, mv0);
@@ -1100,15 +1100,15 @@ pub fn motion_compensate<T: Pixel>(
           luma_mode.predict_inter(fi, p, po3, &mut rec.mut_slice(po3), 2, 2, ref_frames, mvs);
         }
         if bsize == BlockSize::BLOCK_8X4 {
-          let mv1 = cw.bc.blocks.at(bo.with_offset(0,-1)).mv;
-          let rf1 = cw.bc.blocks.at(bo.with_offset(0,-1)).ref_frames;
+          let mv1 = cw.bc.blocks[bo.with_offset(0,-1)].mv;
+          let rf1 = cw.bc.blocks[bo.with_offset(0,-1)].ref_frames;
           luma_mode.predict_inter(fi, p, po, &mut rec.mut_slice(po), 4, 2, rf1, mv1);
           let po3 = PlaneOffset { x: po.x, y: po.y+2 };
           luma_mode.predict_inter(fi, p, po3, &mut rec.mut_slice(po3), 4, 2, ref_frames, mvs);
         }
         if bsize == BlockSize::BLOCK_4X8 {
-          let mv2 = cw.bc.blocks.at(bo.with_offset(-1,0)).mv;
-          let rf2 = cw.bc.blocks.at(bo.with_offset(-1,0)).ref_frames;
+          let mv2 = cw.bc.blocks[bo.with_offset(-1,0)].mv;
+          let rf2 = cw.bc.blocks[bo.with_offset(-1,0)].ref_frames;
           luma_mode.predict_inter(fi, p, po, &mut rec.mut_slice(po), 2, 4, rf2, mv2);
           let po3 = PlaneOffset { x: po.x+2, y: po.y };
           luma_mode.predict_inter(fi, p, po3, &mut rec.mut_slice(po3), 2, 4, ref_frames, mvs);

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1243,7 +1243,7 @@ fn rdo_loop_plane_error<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T>
     for bx in 0..sb_blocks {
       let bo = sbo.block_offset(bx<<1, by<<1);
       if bo.x < bc.cols && bo.y < bc.rows {
-        let skip = bc.blocks.at(bo).skip;
+        let skip = bc.blocks[bo].skip;
         if !skip {
           let in_plane = &fs.input.planes[pli];
           let in_po = sbo.block_offset(bx<<1, by<<1).plane_offset(&in_plane.cfg);


### PR DESCRIPTION
For convenience, implement `Index` and `IndexMut` traits with `BlockOffset` index for `FrameBlocks`. That way, we can index a block directly from a `BlockOffset`:

```rust
let bo = BlockOffset { x, y };
// before
bc.blocks.at_mut(bo).neighbors_ref_counts = ref_counts;
// after
bc.blocks[bo].neighbors_ref_counts = ref_counts;
```
---

This is a superficial change, but I propose it now because I will do (did on my local branch) it for the tiled version on my local branch.