### PR TITLE
Pass FrameBlocks instead of BlockContext

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -113,10 +113,10 @@ fn cdef_frame_bench(b: &mut Bencher, width: usize, height: usize) {
   };
   let sequence = Sequence::new(&Default::default());
   let fi = FrameInvariants::<u16>::new(config, sequence);
-  let mut bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
+  let bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
   let mut fs = FrameState::new(&fi);
 
-  b.iter(|| cdef_filter_frame(&fi, &mut fs.rec, &mut bc));
+  b.iter(|| cdef_filter_frame(&fi, &mut fs.rec, &bc.blocks));
 }
 
 fn cfl_rdo(c: &mut Criterion) {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2184,9 +2184,9 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
     }
   }
   /* TODO: Don't apply if lossless */
-  deblock_filter_optimize(fi, fs, &cw.bc);
+  deblock_filter_optimize(fi, fs, &cw.bc.blocks);
   if fs.deblock.levels[0] != 0 || fs.deblock.levels[1] != 0 {
-    deblock_filter_frame(fs, &cw.bc, fi.sequence.bit_depth);
+    deblock_filter_frame(fs, &cw.bc.blocks, fi.sequence.bit_depth);
   }
     // Until the loop filters are pipelined, we'll need to keep
     // around a copy of both the pre- and post-cdef frame.
@@ -2194,7 +2194,7 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
 
     /* TODO: Don't apply if lossless */
     if fi.sequence.enable_cdef {
-      cdef_filter_frame(fi, &mut fs.rec, &cw.bc);
+      cdef_filter_frame(fi, &mut fs.rec, &cw.bc.blocks);
     }
     /* TODO: Don't apply if lossless */
     if fi.sequence.enable_restoration {


### PR DESCRIPTION
`FrameBlocks` is part of the `BlockContext` structure. Many functions which used only the `FrameBlocks` (but not the other `BlockContext` fields) received a reference to the whole `BlockContext` as parameter.

`FrameBlocks` will survive tiles-encoding: it will be accessed through a tiled version for each tile, then frame-wise after all tiles are encoded.

However, `BlockContext` will only be used tile-wise: there will be one instance per tile, destroyed once the tile is encoded. Therefore, frame-wise functions may not receive the whole `BlockContext` anymore
(all tile-specific `BlockContext` instances won't exist anymore).