### PR TITLE
Use FrameBlocks and CDFContext by reference

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -43,12 +43,12 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
   let sequence = Sequence::new(&Default::default());
   let mut fi = FrameInvariants::<u16>::new(config, sequence);
   let mut w = ec::WriterEncoder::new();
-  let fc = CDFContext::new(fi.base_q_idx);
+  let mut fc = CDFContext::new(fi.base_q_idx);
   let mut fb = FrameBlocks::new(fi.sb_width * 16, fi.sb_height * 16);
   let bc = BlockContext::new(&mut fb);
   let mut fs = FrameState::new(&fi);
   // For now, restoration unit size is locked to superblock size.
-  let mut cw = ContextWriter::new(fc, bc);
+  let mut cw = ContextWriter::new(&mut fc, bc);
 
   let tx_type = TxType::DCT_DCT;
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -44,7 +44,8 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
   let mut fi = FrameInvariants::<u16>::new(config, sequence);
   let mut w = ec::WriterEncoder::new();
   let fc = CDFContext::new(fi.base_q_idx);
-  let bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
+  let mut fb = FrameBlocks::new(fi.sb_width * 16, fi.sb_height * 16);
+  let bc = BlockContext::new(&mut fb);
   let mut fs = FrameState::new(&fi);
   // For now, restoration unit size is locked to superblock size.
   let mut cw = ContextWriter::new(fc, bc);
@@ -113,7 +114,8 @@ fn cdef_frame_bench(b: &mut Bencher, width: usize, height: usize) {
   };
   let sequence = Sequence::new(&Default::default());
   let fi = FrameInvariants::<u16>::new(config, sequence);
-  let bc = BlockContext::new(fi.sb_width * 16, fi.sb_height * 16);
+  let mut fb = FrameBlocks::new(fi.sb_width * 16, fi.sb_height * 16);
+  let bc = BlockContext::new(&mut fb);
   let mut fs = FrameState::new(&fi);
 
   b.iter(|| cdef_filter_frame(&fi, &mut fs.rec, &bc.blocks));

--- a/src/context.rs
+++ b/src/context.rs
@@ -1907,14 +1907,14 @@ pub struct ContextWriterCheckpoint {
 
 pub struct ContextWriter<'a> {
   pub bc: BlockContext<'a>,
-  pub fc: CDFContext,
+  pub fc: &'a mut CDFContext,
   #[cfg(debug)]
   fc_map: Option<FieldMap> // For debugging purposes
 }
 
 impl<'a> ContextWriter<'a> {
   #[allow(clippy::let_and_return)]
-  pub fn new(fc: CDFContext, bc: BlockContext<'a>) -> Self {
+  pub fn new(fc: &'a mut CDFContext, bc: BlockContext<'a>) -> Self {
     #[allow(unused_mut)]
     let mut cw = ContextWriter {
       fc,
@@ -3785,13 +3785,13 @@ impl<'a> ContextWriter<'a> {
 
   pub fn checkpoint(&mut self) -> ContextWriterCheckpoint {
     ContextWriterCheckpoint {
-      fc: self.fc,
+      fc: *self.fc,
       bc: self.bc.checkpoint()
     }
   }
 
   pub fn rollback(&mut self, checkpoint: &ContextWriterCheckpoint) {
-    self.fc = checkpoint.fc;
+    *self.fc = checkpoint.fc;
     self.bc.rollback(&checkpoint.bc);
     #[cfg(debug)] {
       if self.fc_map.is_some() {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1442,8 +1442,7 @@ pub struct BlockContextCheckpoint {
   left_coeff_context: [[u8; MAX_MIB_SIZE]; PLANES],
 }
 
-#[derive(Clone)]
-pub struct BlockContext {
+pub struct BlockContext<'a> {
   pub cdef_coded: bool,
   pub code_deltas: bool,
   pub update_seg: bool,
@@ -1454,16 +1453,16 @@ pub struct BlockContext {
   left_tx_context: [u8; MAX_MIB_SIZE],
   above_coeff_context: [Vec<u8>; PLANES],
   left_coeff_context: [[u8; MAX_MIB_SIZE]; PLANES],
-  pub blocks: FrameBlocks,
+  pub blocks: &'a mut FrameBlocks,
 }
 
-impl BlockContext {
-  pub fn new(cols: usize, rows: usize) -> BlockContext {
+impl<'a> BlockContext<'a> {
+  pub fn new(blocks: &'a mut FrameBlocks) -> Self {
     // Align power of two
-    let aligned_cols = (cols + ((1 << MAX_MIB_SIZE_LOG2) - 1))
+    let aligned_cols = (blocks.cols + ((1 << MAX_MIB_SIZE_LOG2) - 1))
       & !((1 << MAX_MIB_SIZE_LOG2) - 1);
     let above_coeff_context_size =
-      cols << (MI_SIZE_LOG2 - TxSize::width_log2(TxSize::TX_4X4));
+      blocks.cols << (MI_SIZE_LOG2 - TxSize::width_log2(TxSize::TX_4X4));
 
     BlockContext {
       cdef_coded: false,
@@ -1480,7 +1479,7 @@ impl BlockContext {
         vec![0; above_coeff_context_size]
       ],
       left_coeff_context: [[0; MAX_MIB_SIZE]; PLANES],
-      blocks: FrameBlocks::new(cols, rows),
+      blocks,
     }
   }
 
@@ -1906,17 +1905,16 @@ pub struct ContextWriterCheckpoint {
   pub bc: BlockContextCheckpoint,
 }
 
-#[derive(Clone)]
-pub struct ContextWriter {
-  pub bc: BlockContext,
+pub struct ContextWriter<'a> {
+  pub bc: BlockContext<'a>,
   pub fc: CDFContext,
   #[cfg(debug)]
   fc_map: Option<FieldMap> // For debugging purposes
 }
 
-impl ContextWriter {
+impl<'a> ContextWriter<'a> {
   #[allow(clippy::let_and_return)]
-  pub fn new(fc: CDFContext, bc: BlockContext) -> Self {
+  pub fn new(fc: CDFContext, bc: BlockContext<'a>) -> Self {
     #[allow(unused_mut)]
     let mut cw = ContextWriter {
       fc,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2031,7 +2031,8 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
     }
   };
 
-  let bc = BlockContext::new(fi.w_in_b, fi.h_in_b);
+  let mut blocks = FrameBlocks::new(fi.w_in_b, fi.h_in_b);
+  let bc = BlockContext::new(&mut blocks);
   // For now, restoration unit size is locked to superblock size.
   let mut cw = ContextWriter::new(fc, bc);
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2022,7 +2022,7 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
     crate::me::FullSearch::estimate_motion_ss2
   };
 
-  let fc = if fi.primary_ref_frame == PRIMARY_REF_NONE {
+  let mut fc = if fi.primary_ref_frame == PRIMARY_REF_NONE {
     CDFContext::new(fi.base_q_idx)
   } else {
     match fi.rec_buffer.frames[fi.ref_frames[fi.primary_ref_frame as usize] as usize] {
@@ -2034,7 +2034,7 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
   let mut blocks = FrameBlocks::new(fi.w_in_b, fi.h_in_b);
   let bc = BlockContext::new(&mut blocks);
   // For now, restoration unit size is locked to superblock size.
-  let mut cw = ContextWriter::new(fc, bc);
+  let mut cw = ContextWriter::new(&mut fc, bc);
 
   let frame_pmvs = build_coarse_pmvs(fi, fs);
   // main loop
@@ -2214,7 +2214,7 @@ fn encode_tile<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) -> Vec
     fs.t.print_code();
   }
 
-  fs.cdfs = cw.fc;
+  fs.cdfs = fc;
   fs.cdfs.reset_counts();
 
   w.done()


### PR DESCRIPTION
There will be one instance of `BlockContext` and `ContextWriter`  per-tile.

However, they owned respectively `FrameBlocks` and `CDFContext`, which will survive tile-encoding to be used frame-wise, so they will have a longer lifetime.

Therefore, make `BlockContext` and `ContextWriter` reference `FrameBlocks` and `CDFContext` (instead of taking ownership).  