### PR TITLE
Add update_cdf_4 sse2 implementation.

### DIFF
--- a/src/ec.rs
+++ b/src/ec.rs
@@ -361,7 +361,7 @@ impl<S> WriterBase<S> {
   }
 
   // Function to update the CDF for Writer calls that do so.
-  fn update_cdf(cdf: &mut [u16], val: u32) {
+  pub fn update_cdf(cdf: &mut [u16], val: u32) {
     let nsymbs = cdf.len() - 1;
     let rate = 3 + (nsymbs >> 1).min(2) + (cdf[nsymbs] >> 4) as usize;
     cdf[nsymbs] += 1 - (cdf[nsymbs] >> 5);
@@ -373,6 +373,31 @@ impl<S> WriterBase<S> {
       } else {
         *v += (32768 - *v) >> rate;
       }
+    }
+  }
+
+  #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+  pub fn update_cdf_4_sse2(cdf: &mut [u16], val: u32) {
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::*;
+    let nsymbs = 4;
+    let rate = 3 + (nsymbs >> 1).min(2) + (cdf[nsymbs] >> 4) as usize;
+    cdf[nsymbs] += 1 - (cdf[nsymbs] >> 5);
+    #[target_feature(enable = "sse2")]
+    unsafe {
+      let val_idx = _mm_set_epi16(0, 0, 0, 0, 3, 2, 1, 0);
+      let val_splat = _mm_set1_epi16(val as i16);
+      let mask = _mm_cmpgt_epi16(val_splat, val_idx);
+      let v = _mm_loadl_epi64(cdf.as_ptr() as *const __m128i);
+      // *v -= *v >> rate;
+      let shrunk_v = _mm_sub_epi16(v, _mm_srl_epi16(v, _mm_cvtsi64_si128(rate as i64)));
+      // *v += (32768 - *v) >> rate;
+      let expanded_v = _mm_add_epi16(v, _mm_srl_epi16(
+        _mm_sub_epi16(_mm_set1_epi16(-32768), v),
+        _mm_cvtsi64_si128(rate as i64)
+      ));
+      let out_v = _mm_or_si128(_mm_andnot_si128(mask, shrunk_v), _mm_and_si128(mask, expanded_v));
+      _mm_storel_epi64(cdf.as_mut_ptr() as *mut __m128i, out_v);
     }
   }
 
@@ -535,7 +560,11 @@ where
       }
     }
     self.symbol(s, &cdf[..nsymbs]);
-    Self::update_cdf(cdf, s);
+    if cdf.len() == 5 && cfg!(target_feature = "sse2") {
+      Self::update_cdf_4_sse2(cdf, s);
+    } else {
+      Self::update_cdf(cdf, s);
+    }
   }
   /// Returns approximate cost for a symbol given a cumulative
   /// distribution function (CDF) table and current write state.
@@ -1004,6 +1033,17 @@ mod test {
     assert_eq!(r.symbol(&cdf), 2);
     assert_eq!(r.symbol(&cdf), 2);
     assert_eq!(r.symbol(&cdf), 2);
+  }
+
+  #[test]
+  fn update_cdf_4_sse2() {
+    let mut cdf = [7296, 3819, 1616, 0, 0];
+    let mut cdf2 = [7296, 3819, 1616, 0, 0];
+    for i in 0..4 {
+      WriterBase::<WriterRecorder>::update_cdf(&mut cdf, i);
+      WriterBase::<WriterRecorder>::update_cdf_4_sse2(&mut cdf2, i);
+      assert_eq!(cdf, cdf2);
+    }
   }
 
   #[test]


### PR DESCRIPTION
Trash benchmarks on my threadripper:
```
$ cargo bench update_cdf_4
    Finished release [optimized] target(s) in 0.08s
     Running target/release/deps/bench-0f4a29071020d296
update_cdf_4_native     time:   [8.6011 us 8.6224 us 8.6451 us]                                 
                        change: [-1.5134% -1.1721% -0.8184%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

update_cdf_4_sse2       time:   [3.0597 us 3.0648 us 3.0700 us]                               
                        change: [-1.2574% -0.8472% -0.4612%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

```

Will do real benchmarks on cannon lake in a bit.