### PR TITLE
Fix block offset half-resolution mismatch

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -511,7 +511,6 @@ impl MotionEstimation for DiamondSearch {
     blk_w: usize, blk_h: usize,
     best_mv: &mut MotionVector, lowest_cost: &mut u64
   ) {
-    let bo_adj_h = BlockOffset { x: bo_adj.x >> 1, y: bo_adj.y >> 1 };
     let po = PlaneOffset {
       x: (bo_adj.x as isize) << BLOCK_TO_PLANE_SHIFT >> 1,
       y: (bo_adj.y as isize) << BLOCK_TO_PLANE_SHIFT >> 1,
@@ -519,7 +518,7 @@ impl MotionEstimation for DiamondSearch {
     for omv in pmvs.iter() {
       if let Some(pmv) = omv {
         let mut predictors = get_subset_predictors::<T>(
-          bo_adj_h,
+          bo_adj,
           MotionVector{row: pmv.row, col: pmv.col},
           fi.w_in_b, fi.h_in_b,
           &frame_mvs, frame_ref_opt, 0


### PR DESCRIPTION
The first commit is just a refactor for consistency/simplicity.

The function `get_subset_predictors()` was called with block offset relative to the half-resolution frame, but used to index `FrameMotionVectors` relative to the full-resolution frame. The second commit passes the expected (IIUC) block offset.

For info, here are the [AWCY results](https://beta.arewecompressedyet.com/?job=rom1v_ref%402019-04-02T16%3A29%3A43.335Z&job=rom1v_test%402019-04-02T16%3A12%3A16.865Z).
Some values increase a little, some others decrease a little.

---

Related: what do you think about https://github.com/xiph/rav1e/issues/1171?