### PR TITLE
Update frame_pmvs[] as soon as better MVs are available for topdown p…

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1561,7 +1561,7 @@ pub fn encode_block_with_modes<T: Pixel>(
 fn encode_partition_bottomup<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>, cw: &mut ContextWriter,
   w_pre_cdef: &mut dyn Writer, w_post_cdef: &mut dyn Writer, bsize: BlockSize,
-  bo: BlockOffset, pmvs: &[[Option<MotionVector>; REF_FRAMES]; 5],
+  bo: BlockOffset, pmvs: &mut [[Option<MotionVector>; REF_FRAMES]; 5],
   ref_rd_cost: f64
 ) -> (RDOOutput) {
   let rdo_type = RDOType::PixelDistRealRate;
@@ -1611,7 +1611,7 @@ fn encode_partition_bottomup<T: Pixel>(
     } else {
       ((bo.x & 32) >> 5) + ((bo.y & 32) >> 4) + 1
     };
-    let spmvs = &pmvs[pmv_idx];
+    let spmvs = &mut pmvs[pmv_idx];
 
     let mode_decision = rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs);
 
@@ -1778,7 +1778,7 @@ fn encode_partition_topdown<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>,
   cw: &mut ContextWriter, w_pre_cdef: &mut dyn Writer, w_post_cdef: &mut dyn Writer,
   bsize: BlockSize, bo: BlockOffset, block_output: &Option<RDOOutput>,
-  pmvs: &[[Option<MotionVector>; REF_FRAMES]; 5]
+  pmvs: &mut [[Option<MotionVector>; REF_FRAMES]; 5]
 ) {
 
   if bo.x >= cw.bc.blocks.cols || bo.y >= cw.bc.blocks.rows {
@@ -1856,7 +1856,7 @@ fn encode_partition_topdown<T: Pixel>(
         } else {
           ((bo.x & 32) >> 5) + ((bo.y & 32) >> 4) + 1
         };
-        let spmvs = &pmvs[pmv_idx];
+        let spmvs = &mut pmvs[pmv_idx];
 
         // Make a prediction mode decision for blocks encoded with no rdo_partition_decision call (e.g. edges)
         rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs)
@@ -2199,12 +2199,12 @@ fn encode_tile<T: Pixel>(
       if fi.config.speed_settings.encode_bottomup {
         encode_partition_bottomup(fi, fs, &mut cw,
                                   &mut w_pre_cdef, &mut w_post_cdef,
-                                  BlockSize::BLOCK_64X64, bo, &pmvs, std::f64::MAX);
+                                  BlockSize::BLOCK_64X64, bo, &mut pmvs, std::f64::MAX);
       }
       else {
         encode_partition_topdown(fi, fs, &mut cw,
                                  &mut w_pre_cdef, &mut w_post_cdef,
-                                 BlockSize::BLOCK_64X64, bo, &None, &pmvs);
+                                 BlockSize::BLOCK_64X64, bo, &None, &mut pmvs);
       }
 
       // CDEF has to be decided before loop restoration, but coded after.

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -456,7 +456,7 @@ impl Default for EncodingSettings {
 pub fn rdo_mode_decision<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>,
   cw: &mut ContextWriter, bsize: BlockSize, bo: BlockOffset,
-  pmvs: &[Option<MotionVector>]
+  pmvs: &mut [Option<MotionVector>]
 ) -> RDOPartitionOutput {
   let mut best = EncodingSettings::default();
 
@@ -525,8 +525,12 @@ pub fn rdo_mode_decision<T: Pixel>(
       let ref_slot = ref_slot_set[i] as usize;
       let cmv = pmvs[ref_slot].unwrap();
 
-
       let b_me = motion_estimation(fi, fs, bsize, bo, ref_frames[0], cmv, pmv);
+
+      if !fi.config.speed_settings.encode_bottomup &&
+        (bsize == BlockSize::BLOCK_32X32 || bsize == BlockSize::BLOCK_64X64) {
+          pmvs[ref_slot] = Some(b_me);
+      };
 
       mvs_from_me.push([
         b_me,
@@ -1107,7 +1111,7 @@ pub fn rdo_partition_decision<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>,
   cw: &mut ContextWriter, w_pre_cdef: &mut dyn Writer, w_post_cdef: &mut dyn Writer,
   bsize: BlockSize, bo: BlockOffset,
-  cached_block: &RDOOutput, pmvs: &[[Option<MotionVector>; REF_FRAMES]; 5],
+  cached_block: &RDOOutput, pmvs: &mut [[Option<MotionVector>; REF_FRAMES]; 5],
   partition_types: &[PartitionType], rdo_type: RDOType
 ) -> RDOOutput {
   let mut best_partition = cached_block.part_type;
@@ -1139,7 +1143,7 @@ pub fn rdo_partition_decision<T: Pixel>(
           ((bo.x & 32) >> 5) + ((bo.y & 32) >> 4) + 1
         };
 
-        let spmvs = &pmvs[pmv_idx];
+        let spmvs = &mut pmvs[pmv_idx];
 
         let mode_decision = rdo_mode_decision(fi, fs, cw, bsize, bo, spmvs);
         child_modes.push(mode_decision);
@@ -1187,7 +1191,7 @@ pub fn rdo_partition_decision<T: Pixel>(
         for (&offset, pmv_idx) in partitions.iter().zip(pmv_idxs) {
           let mode_decision =
             rdo_mode_decision(fi, fs, cw, subsize, offset,
-                              &pmvs[pmv_idx]);
+                              &mut pmvs[pmv_idx]);
 
           rd_cost_sum += mode_decision.rd_cost;
 


### PR DESCRIPTION
#1074 

For topdown partition search, as soon as better (compared to those from initial coarse motion estimation) 64x64 or 32x32 MV is available, update them in frame_pmvs[ ]

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.1691 | -0.0341 | -0.1063 |  -0.1481 | -0.1275 | -0.1056 |    -0.1293 |

[AWCY result for default speed 5](https://beta.arewecompressedyet.com/?job=master-bc1ffd6b3f527e4708abbba55ab466311a223a58&job=test0_update_frame_pmvs%402019-04-03T22%3A01%3A10.541Z)