### PR TITLE
Full ASM AVX2 accelerated version of the SAD functions

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -31,87 +31,37 @@ mod nasm {
 
   use libc;
 
-  extern {
-    fn rav1e_sad_4x4_hbd_ssse3(
-      src: *const u16, src_stride: libc::ptrdiff_t, dst: *const u16,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad_8x8_hbd10_ssse3(
-      src: *const u16, src_stride: libc::ptrdiff_t, dst: *const u16,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad_16x16_hbd_ssse3(
-      src: *const u16, src_stride: libc::ptrdiff_t, dst: *const u16,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad_32x32_hbd10_ssse3(
-      src: *const u16, src_stride: libc::ptrdiff_t, dst: *const u16,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad_64x64_hbd10_ssse3(
-      src: *const u16, src_stride: libc::ptrdiff_t, dst: *const u16,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad_128x128_hbd10_ssse3(
-      src: *const u16, src_stride: libc::ptrdiff_t, dst: *const u16,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad4x4_sse2(
-      src: *const u8, src_stride: libc::ptrdiff_t, dst: *const u8,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad8x8_sse2(
-      src: *const u8, src_stride: libc::ptrdiff_t, dst: *const u8,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad16x16_sse2(
-      src: *const u8, src_stride: libc::ptrdiff_t, dst: *const u8,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad32x32_sse2(
-      src: *const u8, src_stride: libc::ptrdiff_t, dst: *const u8,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad64x64_sse2(
-      src: *const u8, src_stride: libc::ptrdiff_t, dst: *const u8,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad128x128_sse2(
-      src: *const u8, src_stride: libc::ptrdiff_t, dst: *const u8,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad16x16_avx2(
-      src: *const u8, src_stride: libc::ptrdiff_t, dst: *const u8,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad32x32_avx2(
-      src: *const u8, src_stride: libc::ptrdiff_t, dst: *const u8,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad64x64_avx2(
-      src: *const u8, src_stride: libc::ptrdiff_t, dst: *const u8,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
-
-    fn rav1e_sad128x128_avx2(
-      src: *const u8, src_stride: libc::ptrdiff_t, dst: *const u8,
-      dst_stride: libc::ptrdiff_t
-    ) -> u32;
+  macro_rules! declare_asm_sad {
+    ($(($name: ident, $T: ident)),+) => (
+      $(
+        extern { fn $name (
+          src: *const $T, src_stride: libc::ptrdiff_t, dst: *const $T,
+          dst_stride: libc::ptrdiff_t
+        ) -> u32; }
+      )+
+    )
   }
+
+  declare_asm_sad![
+    (rav1e_sad_4x4_hbd_ssse3, u16),
+    (rav1e_sad_8x8_hbd10_ssse3, u16),
+    (rav1e_sad_16x16_hbd_ssse3, u16),
+    (rav1e_sad_32x32_hbd10_ssse3, u16),
+    (rav1e_sad_64x64_hbd10_ssse3, u16),
+    (rav1e_sad_128x128_hbd10_ssse3, u16),
+
+    (rav1e_sad4x4_sse2, u8),
+    (rav1e_sad8x8_sse2, u8),
+    (rav1e_sad16x16_sse2, u8),
+    (rav1e_sad32x32_sse2, u8),
+    (rav1e_sad64x64_sse2, u8),
+    (rav1e_sad128x128_sse2, u8),
+
+    (rav1e_sad16x16_avx2, u8),
+    (rav1e_sad32x32_avx2, u8),
+    (rav1e_sad64x64_avx2, u8),
+    (rav1e_sad128x128_avx2, u8)
+  ];
 
   #[target_feature(enable = "ssse3")]
   unsafe fn sad_hbd_ssse3(

--- a/src/x86/sad_avx.asm
+++ b/src/x86/sad_avx.asm
@@ -84,7 +84,7 @@ cglobal sad%1x%2_avg, 5, ARCH_X86_64 + %3, 6, src, src_stride, \
   jg .loop
 
   vextracti128         xm1, m0, 1
-  paddw                xm0, xm1
+  paddd                xm0, xm1
 
   movhlps              xm1, xm0
   paddd                xm0, xm1


### PR DESCRIPTION
Here are the `cargo bench get_sad` run on my  Core i7-8550U CPU @ 1.80GHz laptop.
The most significant performance improvement is confirmed on non-squared blocks but square blocks seems also to benefit.
```
get_sad/(BLOCK_4X4, 8)  time:   [10.148 ns 10.204 ns 10.257 ns]                                    
                        change: [-22.251% -21.840% -21.407%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  1 (1.00%) high mild
  18 (18.00%) high severe
get_sad/(BLOCK_4X8, 8)  time:   [12.625 ns 12.698 ns 12.778 ns]                                    
                        change: [-50.362% -49.793% -49.211%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
get_sad/(BLOCK_8X4, 8)  time:   [10.208 ns 10.256 ns 10.308 ns]                                    
                        change: [-55.692% -55.143% -54.568%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  11 (11.00%) high mild
  1 (1.00%) high severe
get_sad/(BLOCK_8X8, 8)  time:   [12.388 ns 12.445 ns 12.505 ns]                                    
                        change: [-12.964% -12.000% -11.028%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  10 (10.00%) high mild
get_sad/(BLOCK_8X16, 8) time:   [16.157 ns 16.225 ns 16.299 ns]                                     
                        change: [-43.530% -42.999% -42.466%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
get_sad/(BLOCK_16X8, 8) time:   [13.672 ns 13.679 ns 13.688 ns]                                     
                        change: [-47.666% -47.163% -46.621%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
get_sad/(BLOCK_16X16, 8)                                                                             
                        time:   [17.041 ns 17.072 ns 17.108 ns]
                        change: [-10.794% -10.083% -9.3559%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
get_sad/(BLOCK_16X32, 8)                                                                            
                        time:   [24.149 ns 24.252 ns 24.363 ns]
                        change: [-36.284% -35.693% -35.111%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
get_sad/(BLOCK_32X16, 8)                                                                             
                        time:   [16.993 ns 17.057 ns 17.145 ns]
                        change: [-52.326% -51.977% -51.612%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  9 (9.00%) high mild
get_sad/(BLOCK_32X32, 8)                                                                            
                        time:   [23.698 ns 23.786 ns 23.886 ns]
                        change: [-8.7849% -7.8591% -6.9016%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild
get_sad/(BLOCK_32X64, 8)                                                                            
                        time:   [38.133 ns 38.316 ns 38.473 ns]
                        change: [-28.200% -27.554% -26.902%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
get_sad/(BLOCK_64X32, 8)                                                                            
                        time:   [38.675 ns 38.981 ns 39.261 ns]
                        change: [-24.617% -23.853% -23.090%] (p = 0.00 < 0.05)
                        Performance has improved.
get_sad/(BLOCK_64X64, 8)                                                                            
                        time:   [68.341 ns 68.656 ns 68.959 ns]
                        change: [-0.4613% +0.7237% +1.9711%] (p = 0.25 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  10 (10.00%) high mild
get_sad/(BLOCK_64X128, 8)                                                                            
                        time:   [136.04 ns 136.22 ns 136.46 ns]
                        change: [-5.5594% -3.4873% -0.5906%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  10 (10.00%) high mild
  6 (6.00%) high severe
get_sad/(BLOCK_128X64, 8)                                                                            
                        time:   [114.38 ns 114.56 ns 114.86 ns]
                        change: [-17.058% -16.128% -15.029%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  1 (1.00%) high mild
  18 (18.00%) high severe
get_sad/(BLOCK_128X128, 8)                                                                             
                        time:   [515.33 ns 519.87 ns 524.37 ns]
                        change: [-4.0953% -2.7513% -1.4043%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
get_sad/(BLOCK_4X16, 8) time:   [16.553 ns 16.614 ns 16.682 ns]                                     
                        change: [-57.334% -56.895% -56.487%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
get_sad/(BLOCK_16X4, 8) time:   [11.039 ns 11.099 ns 11.169 ns]                                     
                        change: [-66.710% -66.279% -65.773%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
get_sad/(BLOCK_8X32, 8) time:   [24.293 ns 24.557 ns 24.802 ns]                                    
                        change: [-46.865% -46.245% -45.610%] (p = 0.00 < 0.05)
                        Performance has improved.
get_sad/(BLOCK_32X8, 8) time:   [14.876 ns 15.132 ns 15.370 ns]                                     
                        change: [-62.559% -62.141% -61.711%] (p = 0.00 < 0.05)
                        Performance has improved.
get_sad/(BLOCK_16X64, 8)                                                                            
                        time:   [39.623 ns 39.828 ns 40.034 ns]
                        change: [-39.537% -38.976% -38.398%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
get_sad/(BLOCK_64X16, 8)                                                                            
                        time:   [25.490 ns 25.889 ns 26.307 ns]
                        change: [-58.323% -57.694% -57.090%] (p = 0.00 < 0.05)
                        Performance has improved.
```