### PR TITLE
Do not crash on very tiny images

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2008,7 +2008,7 @@ fn build_coarse_pmvs<T: Pixel>(fi: &FrameInvariants<T>, fs: &FrameState<T>) -> V
     }).collect()
   } else {
     // the block use for motion estimation would be smaller than the whole image
-    vec![[Some(Default::default()); REF_FRAMES]; fi.sb_width * fi.sb_height]
+    vec![[None; REF_FRAMES]; fi.sb_width * fi.sb_height]
   }
 }
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -521,7 +521,7 @@ pub fn rdo_mode_decision<T: Pixel>(
       if !mv_stack.is_empty() { pmv[0] = mv_stack[0].this_mv; }
       if mv_stack.len() > 1 { pmv[1] = mv_stack[1].this_mv; }
       let ref_slot = ref_slot_set[i] as usize;
-      let cmv = pmvs[ref_slot].unwrap();
+      let cmv = pmvs[ref_slot].unwrap_or_else(Default::default);
 
       let b_me = motion_estimation(fi, fs, bsize, bo, ref_frames[0], cmv, pmv);
 


### PR DESCRIPTION
Commit 8412ff0b70022180c63dffab38140770c410e75a avoided some crashes on tiny images, but it was incomplete: since it did not execute subsampled motion estimation with 32x32 blocks when the image was smaller, it left the array of `Option<MotionVector>` full of `None`, while `rdo_mode_decision()` unwrapped the values.

If the option is `None`, use a default `MotionVector` instead to fix the problem.