### PR TITLE
Implement chroma-from-luma for 4:2:2 and 4:4:4

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -237,13 +237,13 @@ impl BlockSize {
     self.width_log2() == self.height_log2()
   }
 
-  pub fn is_sub8x8(self) -> bool {
-    self.width_log2().min(self.height_log2()) < 3
+  pub fn is_sub8x8(self, xdec: usize, ydec: usize) -> bool {
+    xdec != 0 && self.width_log2() == 2 || ydec != 0 && self.height_log2() == 2
   }
 
-  pub fn sub8x8_offset(self) -> (isize, isize) {
-    let offset_x: isize = if self.width_log2() == 2 { -1 } else { 0 };
-    let offset_y: isize = if self.height_log2() == 2 { -1 } else { 0 };
+  pub fn sub8x8_offset(self, xdec: usize, ydec: usize) -> (isize, isize) {
+    let offset_x = if xdec != 0 && self.width_log2() == 2 { -1 } else { 0 };
+    let offset_y = if ydec != 0 && self.height_log2() == 2 { -1 } else { 0 };
 
     (offset_x, offset_y)
   }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -804,8 +804,7 @@ pub fn rdo_mode_decision<T: Pixel>(
     });
   }
 
-  if best.mode_luma.is_intra() && is_chroma_block && bsize.cfl_allowed() &&
-    fi.config.chroma_sampling == ChromaSampling::Cs420 { // FIXME: 4:2:2/4:4:4 unimplemented
+  if best.mode_luma.is_intra() && is_chroma_block && bsize.cfl_allowed() {
     let chroma_mode = PredictionMode::UV_CFL_PRED;
     let cw_checkpoint = cw.checkpoint();
     let wr: &mut dyn Writer = &mut WriterCounter::new();


### PR DESCRIPTION
Rate-distortion optimization for chroma-from-luma was skipped for subsamplings other than 4:2:0 due to `luma_ac()`, `is_sub8x8()` and `sub8x8_offset()` not accounting for them. Complete the implementation for all allowed subsamplings.