### PR TITLE
Drop a redundant entry

### DIFF
--- a/ivf/Cargo.toml
+++ b/ivf/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Thomas Daede <tdaede@xiph.org>"]
 edition = "2018"
 description = "Simple ivf muxer"
 license = "BSD-2"
-license-file = "LICENSE"
 homepage = "https://github.com/xiph/rav1e"
 
 [dependencies]


### PR DESCRIPTION
Avoid a cargo warning.

The license file itself is redundant, but some downstream apparently need it.