### PR TITLE
WIP: Fix Arm64 Windows builds on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,13 @@ image: Visual Studio 2019
 environment:
   host: x86_64-pc-windows-msvc
   matrix:
-    - platform: x86_64
-      target: x86_64-pc-windows-msvc
-      channel: stable
+    - #platform: x86_64
+      #target: x86_64-pc-windows-msvc
+      #channel: stable
     - platform: arm64
       target: aarch64-pc-windows-msvc
       channel: nightly
+      build_para: "--no-default-features --features=binaries"
 matrix:
   allow_failures:
     - platform: arm64
@@ -37,7 +38,7 @@ cache:
     - '%LOCALAPPDATA%\Mozilla\sccache'
 
 build_script:
-    - cargo build --release --target=%target%
+    - cargo build --release --target=%target% %build_para%
 
 test_script:
     - cargo test --target=%target% --verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,9 @@ image: Visual Studio 2019
 environment:
   host: x86_64-pc-windows-msvc
   matrix:
-    - #platform: x86_64
-      #target: x86_64-pc-windows-msvc
-      #channel: stable
+   # - platform: x86_64
+   #   target: x86_64-pc-windows-msvc
+   #   channel: stable
     - platform: arm64
       target: aarch64-pc-windows-msvc
       channel: nightly


### PR DESCRIPTION
Now that the winapi crashes have been fixed upstream, I tried to get the Arm64 Windows builds working again. See https://ci.appveyor.com/project/EwoutH/rav1e.

Currently, AppVeyor seems to fail on compiling another dependency, [paste](https://github.com/dtolnay/paste).

```
   Compiling paste v0.1.5
error: linking with `link.exe` failed: exit code: 1112
  |
  = note: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Tools\\MSVC\\14.16.27023\\bin\\HostX64\\x64\\link.exe" "/NOLOGO" "/NXCOMPAT" "/LIBPATH:C:\\Users\\appveyor\\.rustup\\toolchains\\nightly-x86_64-pc-windows-msvc\\lib\\rustlib\\aarch64-pc-windows-msvc\\lib" "C:\\projects\\rav1e\\target\\aarch64-pc-windows-msvc\\release\\deps\\rav1e-ea777a993130cf0c.rav1e.8w2jlir1-cgu.0.rcgu.o" "/OUT:C:\\projects\\rav1e\\target\\aarch64-pc-windows-msvc\\release\\deps\\rav1e-ea777a993130cf0c.exe" "/OPT:REF,ICF" "/DEBUG" "/NATVIS:C:\\Users\\appveyor\\.rustup\\toolchains\\nightly-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\intrinsic.natvis" "/NATVIS:C:\\Users\\appveyor\\.rustup\\toolchains\\nightly-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\liballoc.natvis" "/NATVIS:C:\\Users\\appveyor\\.rustup\\toolchains\\nightly-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\libcore.natvis" "/LIBPATH:C:\\projects\\rav1e\\target\\aarch64-pc-windows-msvc\\release\\deps" "/LIBPATH:C:\\projects\\rav1e\\target\\release\\deps" "/LIBPATH:C:\\Users\\appveyor\\.rustup\\toolchains\\nightly-x86_64-pc-windows-msvc\\lib\\rustlib\\aarch64-pc-windows-msvc\\lib" "C:\\Users\\appveyor\\.rustup\\toolchains\\nightly-x86_64-pc-windows-msvc\\lib\\rustlib\\aarch64-pc-windows-msvc\\lib\\libcompiler_builtins-cc0bf6ece960e8d2.rlib" "advapi32.lib" "ws2_32.lib" "userenv.lib" "msvcrt.lib"
  = note: advapi32.lib(ADVAPI32.dll) : fatal error LNK1112: module machine type 'x64' conflicts with target machine type 'ARM64'
          
error: aborting due to previous error
error: Could not compile `rav1e`.
```