### PR TITLE
Separate quantizers for chroma planes

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -816,20 +816,20 @@ impl<T: Pixel> FrameInvariants<T> {
   }
 
   pub fn set_quantizers(&mut self, qps: &QuantizerParameters) {
-    self.base_q_idx = qps.ac_qi;
-    // TODO: Separate qi values for each color plane.
+    self.base_q_idx = qps.ac_qi[0];
     if self.frame_type != FrameType::KEY {
       self.cdef_bits = 3 - ((self.base_q_idx.max(128) - 128) >> 5);
     } else {
       self.cdef_bits = 3;
     }
-    self.base_q_idx = qps.ac_qi;
-    // TODO: Separate qi values for each color plane.
-    debug_assert!(qps.dc_qi as i32 - qps.ac_qi as i32 >= -128);
-    debug_assert!((qps.dc_qi as i32 - qps.ac_qi as i32) < 128);
+    let base_q_idx = self.base_q_idx as i32;
     for pi in 0..3 {
-      self.dc_delta_q[pi] = (qps.dc_qi as i32 - qps.ac_qi as i32) as i8;
-      self.ac_delta_q[pi] = 0;
+      debug_assert!(qps.dc_qi[pi] as i32 - base_q_idx >= -128);
+      debug_assert!((qps.dc_qi[pi] as i32 - base_q_idx) < 128);
+      debug_assert!(qps.ac_qi[pi] as i32 - base_q_idx >= -128);
+      debug_assert!((qps.ac_qi[pi] as i32 - base_q_idx) < 128);
+      self.dc_delta_q[pi] = (qps.dc_qi[pi] as i32 - base_q_idx) as i8;
+      self.ac_delta_q[pi] = (qps.ac_qi[pi] as i32 - base_q_idx) as i8;
     }
     self.lambda =
       qps.lambda * ((1 << (2 * (self.sequence.bit_depth - 8))) as f64);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -321,7 +321,7 @@ impl Sequence {
       level,
       tier,
       film_grain_params_present: false,
-      separate_uv_delta_q: false,
+      separate_uv_delta_q: true,
     }
   }
 


### PR DESCRIPTION
Plumb the quantizer indices through from rate-control and mimic the plane-level quantizer interpolation from Daala.

[AWCY results at default speed](https://beta.arewecompressedyet.com/?job=master-bda810b66b57c0c128d5bc8f689b0db802f80c77&job=uv-delta-q%402019-04-12T15%3A37%3A57.659Z):

|   PSNR |  PSNR Cb |  PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000 |
|   ---: |     ---: |     ---: |     ---: |   ---: |    ---: |       ---: |
| 7.2036 | -31.2794 | -49.6207 |   7.7265 | 6.8570 |  7.2429 |    -8.7732 |

<details>

|                                                       Video |    PSNR | PSNR HVS |    SSIM | CIEDE 2000 |  PSNR Cb |  PSNR Cr |   APSNR | APSNR Cb | APSNR Cr | MS SSIM |    VMAF |
|                                                        ---: |    ---: |     ---: |    ---: |       ---: |     ---: |     ---: |    ---: |     ---: |     ---: |    ---: |    ---: |
|                                           DOTA2_60f_420.y4m | 11.1268 |  12.0717 | 10.0769 |   -12.5930 | -30.8587 | -48.1205 | 11.0865 | -30.8699 | -48.3774 | 10.7325 | 14.8912 |
|                             KristenAndSara_1280x720_60f.y4m |  4.6745 |   4.8617 |  4.5267 |   -10.9558 | -28.8464 | -47.9659 |  4.6588 | -28.9244 | -48.0537 |  4.8290 |  4.5633 |
|                                       MINECRAFT_60f_420.y4m |  5.1076 |   5.9450 |  5.7413 |   -14.0644 | -42.8454 | -59.1651 |  4.9470 | -42.7909 | -59.3187 |  6.3367 |  5.6742 |
|             Netflix_Aerial_1920x1080_60fps_8bit_420_60f.y4m |  5.9504 |   6.7244 |  5.5362 |    -8.1065 | -42.6399 | -65.9015 |  5.9301 | -42.6180 | -65.8809 |  5.9122 |  6.0878 |
|               Netflix_Boat_1920x1080_60fps_8bit_420_60f.y4m |  4.4873 |   4.8955 |  4.3376 |    -9.1882 | -40.1366 | -60.2839 |  4.4568 | -40.0942 | -60.3384 |  4.4715 |  3.8253 |
|          Netflix_Crosswalk_1920x1080_60fps_8bit_420_60f.y4m |  7.1624 |   7.1294 |  7.4743 |   -11.5393 | -33.2421 | -49.5550 |  7.1602 | -33.2575 | -49.6209 |  7.4504 |  7.8124 |
|          Netflix_DrivingPOV_1280x720_60fps_8bit_420_60f.y4m |  4.2082 |   4.7158 |  4.2003 |   -10.3913 | -37.6913 | -55.8752 |  4.1398 | -37.7619 | -56.1874 |  4.4246 |  4.0099 |
|         Netflix_FoodMarket_1920x1080_60fps_8bit_420_60f.y4m |  6.5164 |   6.7107 |  6.2597 |   -12.4382 | -37.5429 | -53.2313 |  6.4979 | -37.5458 | -53.2361 |  6.4992 |  7.1406 |
|        Netflix_PierSeaside_1920x1080_60fps_8bit_420_60f.y4m |  7.7722 |   8.3500 |  7.3876 |   -11.6884 | -32.9802 | -55.2864 |  7.6615 | -33.1250 | -55.4514 |  7.9431 |  5.4416 |
|       Netflix_RollerCoaster_1280x720_60fps_8bit_420_60f.y4m |  8.5446 |   8.7928 |  7.5321 |    -9.9571 | -25.8039 | -49.6628 |  8.4625 | -26.2803 | -49.9920 |  7.7773 |  7.4621 |
| Netflix_SquareAndTimelapse_1920x1080_60fps_8bit_420_60f.y4m |  6.1161 |   6.4163 |  5.8071 |   -12.1741 | -34.9695 | -49.5378 |  6.0630 | -35.0054 | -49.7482 |  5.9578 |  6.8908 |
|         Netflix_TunnelFlag_1920x1080_60fps_8bit_420_60f.y4m |  3.9835 |   4.1729 |  3.8672 |    -8.3482 | -32.9982 | -49.1392 |  3.9047 | -33.0322 | -49.1752 |  3.9071 |  2.9288 |
|                                       STARCRAFT_60f_420.y4m |  7.2424 |   7.8154 |  6.8790 |   -12.6794 | -31.2808 | -48.2838 |  7.2359 | -31.3058 | -48.3891 |  7.1818 | 10.9314 |
|                                         aspen_1080p_60f.y4m |  6.6666 |   6.7781 |  5.8453 |    -5.3301 | -33.6902 | -58.9307 |  6.6645 | -33.7124 | -58.9503 |  6.1128 |  5.9745 |
|                                       blue_sky_360p_60f.y4m |  8.9852 |   9.2048 |  7.8430 |    -6.4629 | -28.4338 | -51.7721 |  8.7848 | -28.8084 | -51.9296 |  8.1429 |  8.0463 |
|                                             dark70p_60f.y4m | 21.4121 |  23.7776 | 20.0116 |    28.4614 |  33.2394 |  -7.6094 | 21.0622 |  26.8018 | -12.3388 | 21.8626 | 21.4863 |
|                              ducks_take_off_1080p50_60f.y4m | 21.3906 |  23.4030 | 21.6217 |    -0.2497 | -34.7320 | -59.6134 | 20.8927 | -34.7386 | -59.6260 | 22.5447 | 19.6632 |
|                                      gipsrestat720p_60f.y4m |  5.0122 |   4.8568 |  4.7501 |   -10.5176 | -31.9499 | -51.0496 |  5.0006 | -31.9485 | -51.0644 |  4.8424 |  5.8354 |
|                                         kirland360p_60f.y4m |  7.7179 |   7.4720 |  6.3506 |   -10.4033 | -21.6842 | -32.7464 |  7.7614 | -21.6823 | -32.6209 |  7.0818 |  3.6460 |
|                                        life_1080p30_60f.y4m |  6.8087 |   7.9100 |  5.4878 |    -9.4296 | -26.0995 | -40.7243 |  6.7485 | -26.2350 | -41.3275 |  6.3059 |  7.3851 |
|                                          niklas360p_60f.y4m |  6.5164 |   7.5506 |  7.1857 |   -13.6174 | -36.1095 | -48.7550 |  6.4476 | -36.3165 | -49.4066 |  7.9833 |  5.1189 |
|                                      red_kayak_360p_60f.y4m |  2.4226 |   2.8801 |  2.3799 |   -14.3881 | -52.0597 | -73.1067 |  2.4305 | -51.9327 | -73.5033 |  2.8218 |  2.3477 |
|                                   rush_hour_1080p25_60f.y4m |  8.3534 |   8.4862 |  8.3902 |   -15.2959 | -35.9476 | -42.0589 |  8.4026 | -35.9048 | -42.4181 |  8.6296 |  7.3107 |
|                                     shields_640x360_60f.y4m |  9.2594 |  10.3366 |  8.5869 |    -3.6186 | -32.5793 | -51.1682 |  9.2489 | -32.5839 | -51.0866 |  8.9131 | 12.0705 |
|                                   speed_bag_640x360_60f.y4m |  7.4708 |   7.6370 |  7.5800 |    -8.1284 | -23.3327 | -43.2162 |  7.4593 | -23.2274 | -43.2422 |  7.5583 |  5.6036 |
|                                  thaloundeskmtg360p_60f.y4m |  6.2436 |   6.6384 |  6.3707 |    -7.0141 | -28.8893 | -41.1347 |  6.7519 | -28.9089 | -40.8858 |  6.4104 |  5.1456 |
|                                touchdown_pass_1080p_60f.y4m |  4.6876 |   4.5669 |  3.4909 |    -9.4541 | -44.4989 | -57.8866 |  4.6899 | -44.4677 | -58.0271 |  3.5626 |  6.2825 |
|                                   vidyo1_720p_60fps_60f.y4m |  4.7205 |   4.9026 |  4.2298 |   -10.9790 | -32.1624 | -49.3146 |  4.7120 | -32.1599 | -49.3449 |  4.4097 |  3.6702 |
|                                   vidyo4_720p_60fps_60f.y4m |  3.8464 |   4.1402 |  3.7521 |   -13.3172 | -33.0180 | -51.7764 |  3.7987 | -33.0218 | -51.8130 |  3.9457 |  3.9568 |
|                                           wikipedia_420.y4m |  1.7027 |   2.6527 |  2.2092 |    -9.3285 | -24.5981 | -35.7478 |  1.7182 | -24.6328 | -36.0561 |  2.7349 |  1.1454 |

</details>