### PR TITLE
[RFC] Refactor restoration units

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3217,15 +3217,9 @@ impl<'a> ContextWriter<'a> {
   ) {
     if !fi.allow_intrabc { // TODO: also disallow if lossless
       for pli in 0..PLANES {
-        let code;
         let rp = &mut rs.planes[pli];
-        {
-          let ru = &mut rp.restoration_unit_as_mut(sbo);
-          code = !ru.coded;
-          ru.coded = true;
-        }
-        if code {
-          match rp.restoration_unit_as_mut(sbo).filter {
+        if let Some(filter) = rp.restoration_unit(sbo).map(|ru| ru.filter) {
+          match filter {
             RestorationFilter::None => {
               match rp.lrf_type {
                 RESTORE_WIENER => {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1299,16 +1299,8 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T
     }
   }
 
-  let mut lrf_any_uncoded = false;
-  if fi.sequence.enable_restoration {
-    for pli in 0..PLANES {
-      let ru = fs.restoration.planes[pli].restoration_unit(sbo);
-      if !ru.coded {
-        lrf_any_uncoded = true;
-        break;
-      }
-    }
-  }
+  let lrf_any_uncoded =
+    fi.sequence.enable_restoration && fs.restoration.has_restoration_unit(sbo);
 
   // CDEF/LRF decision iteration
   // Start with a default of CDEF 0 and RestorationFilter::None
@@ -1386,8 +1378,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T
 
       // SgrProj LRF decision
       for pli in 0..3 {
-        let ru = fs.restoration.planes[pli].restoration_unit(sbo);
-        if !ru.coded {
+        if fs.restoration.planes[pli].restoration_unit(sbo).is_some() {
           for set in 0..16 {
             let in_plane = &fs.input.planes[pli];  // reference
             let ipo = sbo.plane_offset(&in_plane.cfg);
@@ -1440,8 +1431,7 @@ pub fn rdo_loop_decision<T: Pixel>(sbo: SuperBlockOffset, fi: &FrameInvariants<T
 
   if fi.sequence.enable_restoration {
     for pli in 0..PLANES {
-      let ru = fs.restoration.planes[pli].restoration_unit_as_mut(sbo);
-      if !ru.coded {
+      if let Some(ru) = fs.restoration.planes[pli].restoration_unit_mut(sbo) {
         ru.filter = best_lrf[pli];
       }
     }


### PR DESCRIPTION
A restoration unit may contain several super-blocks, and may be "stretched" on borders, even across tile boundaries: <https://github.com/xiph/rav1e/issues/631#issuecomment-454419152>.

In the bitstream, it must be coded only for its first super-block, in plane order. To do so, a "coded" flag was set the first time, so that further super-blocks using the same restoration will not "code" it.

But this assumed that all super-blocks associated to a restoration unit were encoded sequentially in plane order. With parallel tile encoding, even with proper synchronization (preventing data races), this
introduces a race condition: a "stretched" restoration unit may not be coded in its first super-block, corrupting the bitstream.

To avoid the problem, expose the restoration unit only for its first super-block, by returning a `Option<&(mut) RestorationUnit>`. This also avoids the need for any synchronization (a restoration unit will never be retrieved by more than 1 tile).

At frame level, `lrf_filter_frame()` will still retrieve the correct restoration unit for each super-block, by calling `restoration_unit_by_stripe()`.

---


I submit it as an RFC, because before merging I would like to rebase and refactor my tiling branch (provide a tiled view for restoration units, since they don't need to be shared anymore) to see if it fixes the problem as I expect.

On my current tiling branch ([`tiling.116`](https://github.com/rom1v/rav1e/commits/tiling.116)), the `decode_test`s pass only either with restoration disabled, or with sequential tile encoding (replacing `par_iter_mut()` by `iter_mut()`).

@xiphmont I assume that for a given super-block, either none or all 3 planes have a restoration unit. Please tell me if this is wrong.