### PR TITLE
Fix get_sad() arguments order

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -757,8 +757,8 @@ pub fn rdo_mode_decision<T: Pixel>(
             get_sad(
               &plane_org,
               &plane_ref,
-              tx_size.height(),
               tx_size.width(),
+              tx_size.height(),
               fi.sequence.bit_depth
             )
           )


### PR DESCRIPTION
Commit 3d8c463c5bbbb2f69c1c8b388bc3efad0de66cc5 reversed the width and height parameters of `get_sad()`. Reverse the arguments for one missing call.