### PR TITLE
Don't parallelize coarse motion estimation

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -458,8 +458,6 @@ pub struct Config {
   pub threads: usize
 }
 
-const MAX_USABLE_THREADS: usize = 4;
-
 impl Config {
   pub fn new_context<T: Pixel>(&self) -> Context<T> {
     assert!(8 * std::mem::size_of::<T>() >= self.enc.bit_depth, "The Pixel u{} does not match the Config bit_depth {}",
@@ -473,13 +471,7 @@ impl Config {
       None
     };
 
-    let threads = if self.threads == 0 {
-      rayon::current_num_threads().min(MAX_USABLE_THREADS)
-    } else {
-      self.threads
-    };
-
-    let pool = rayon::ThreadPoolBuilder::new().num_threads(threads).build().unwrap();
+    let pool = rayon::ThreadPoolBuilder::new().num_threads(self.threads).build().unwrap();
 
     Context {
       inner: ContextInner {


### PR DESCRIPTION
This fine-grained parallelization caused performance drop with parallel tile encoding.

Here is an example with 8 tiles, not parallelizing gives a speed up of ~1.24x.

**Before:**

```
$ time target/release/rav1e \
    --tile-cols-log2 2 \
    --tile-rows-log2 1 \
    Netflix_Crosswalk_1920x1080_60fps_8bit_420_60f.y4m \
    -o video.ivf
1920x1080 @ 60/1 fps
encoded 60 frames, 0.403 fps, 3950.45 Kb/s
Key Frames:      1    avg size:   46692 B
Inter:          59    avg size:    7779 B
Intra Only:      0    avg size:       0 B
Switch:          0    avg size:       0 B

real    2m28,724s
user    11m17,732s
sys     0m4,482s
```

**After:**

```
$ time target/release/rav1e \
    --tile-cols-log2 2 \
    --tile-rows-log2 1 \
    Netflix_Crosswalk_1920x1080_60fps_8bit_420_60f.y4m \
    -o video.ivf
1920x1080 @ 60/1 fps
encoded 60 frames, 0.503 fps, 3950.45 Kb/s
Key Frames:      1    avg size:   46692 B
Inter:          59    avg size:    7779 B
Intra Only:      0    avg size:       0 B
Switch:          0    avg size:       0 B

real    1m59,275s
user    13m0,328s
sys     0m0,428s
```