### PR TITLE
Fix refactor of subsampled motion estimation

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2141,10 +2141,17 @@ fn encode_tile<T: Pixel>(
                 fi, fs, BlockSize::BLOCK_32X32, r, sbo.block_offset(8, 8), &[Some(pmv), pmv_e, pmv_s], i
               );
 
-              for k in 1..5 {
-                if let Some(mv) = pmvs[k][r] {
-                  save_block_motion(fs, fi.w_in_b, fi.h_in_b, BlockSize::BLOCK_32X32, sbo.block_offset(0, 0), i, mv);
-                }
+              if let Some(mv) = pmvs[1][r] {
+                save_block_motion(fs, fi.w_in_b, fi.h_in_b, BlockSize::BLOCK_32X32, sbo.block_offset(0, 0), i, mv);
+              }
+              if let Some(mv) = pmvs[2][r] {
+                save_block_motion(fs, fi.w_in_b, fi.h_in_b, BlockSize::BLOCK_32X32, sbo.block_offset(8, 0), i, mv);
+              }
+              if let Some(mv) = pmvs[3][r] {
+                save_block_motion(fs, fi.w_in_b, fi.h_in_b, BlockSize::BLOCK_32X32, sbo.block_offset(0, 8), i, mv);
+              }
+              if let Some(mv) = pmvs[4][r] {
+                save_block_motion(fs, fi.w_in_b, fi.h_in_b, BlockSize::BLOCK_32X32, sbo.block_offset(8, 8), i, mv);
               }
             }
           }


### PR DESCRIPTION
In commit 1d39058af520661010798241de6029477371e395, I didn't notice that the offsets were different for each `save_block_motion()` call.

As a result, objective quality results [decreased](https://beta.arewecompressedyet.com/?job=master-cd3ef475ba6a2a7d9832e78dbc296f64e6e7a859&job=master-3c2aebf88ab6f1218f87f37527861afb2547ef6b):

```
  PSNR | PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000
0.3851 |  0.3281 |  0.3225 |   0.3801 | 0.3967 |  0.3853 |     0.3381
```

I launched a AWCY job, there is no objective quality difference now: 

```
  PSNR | PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000
0.0000 |  0.0000 |  0.0000 |   0.0000 | 0.0000 |  0.0000 |     0.0000
```
https://beta.arewecompressedyet.com/?job=master-cd3ef475ba6a2a7d9832e78dbc296f64e6e7a859&job=fix_subme%402019-04-18T00%3A11%3A17.903Z