### PR TITLE
Remove set_limit from the public API

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -652,10 +652,6 @@ impl<T: Pixel> Context<T> {
   pub fn get_first_pass_data(&self) -> &FirstPassData {
     &self.inner.first_pass_data
   }
-
-  pub fn set_limit(&mut self, limit: u64) {
-    self.inner.set_limit(limit);
-  }
 }
 
 
@@ -1114,8 +1110,6 @@ mod test {
   fn flush(low_lantency: bool, no_scene_detection: bool) {
     let mut ctx = setup_encoder::<u8>(64, 80, 10, 100, 8, ChromaSampling::Cs420, 150, 200, 0, low_lantency, no_scene_detection);
     let limit = 41;
-
-    ctx.set_limit(limit);
 
     for _ in  0..limit {
       let input = ctx.new_frame();

--- a/src/test_encode_decode.rs
+++ b/src/test_encode_decode.rs
@@ -61,7 +61,6 @@ pub(crate) trait TestDecoder<T: Pixel> {
       setup_encoder(w, h, speed, quantizer, bit_depth, chroma_sampling,
                     min_keyint, max_keyint, low_latency, bitrate,
                     tile_cols_log2, tile_rows_log2);
-    ctx.set_limit(limit as u64);
 
     println!("Encoding {}x{} speed {} quantizer {} bit-depth {}", w, h, speed, quantizer, bit_depth);
     #[cfg(feature="dump_ivf")]


### PR DESCRIPTION
It is not really needed and if we want to continue encoding after a flush we should use a different mean.