### PR TITLE
fix build error for cargo 1.13.0

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -51,7 +51,7 @@ impl RefType {
   }
 }
 
-use RefType::*;
+use self::RefType::*;
 
 pub const ALL_INTER_REFS: [RefType; 7] = [
   LAST_FRAME,


### PR DESCRIPTION
we will have following build error on cargo 1.13.0
this patch will fix it

$cargo build --release

   Compiling rav1e v0.1.0 (/home/thomas/codec/rav1e)
error[E0658]: imports can only refer to extern crate names passed with `--extern` on stable channel (see issue #53130)
  --> src/partition.rs:54:5
   |
25 | / pub enum RefType {
26 | |   INTRA_FRAME = 0,
27 | |   LAST_FRAME = 1,
28 | |   LAST2_FRAME = 2,
...  |
34 | |   NONE_FRAME = 8,
35 | | }
   | |_- not an extern crate passed with `--extern`
...
54 |   use RefType::*;
   |       ^^^^^^^
   |
note: this import refers to the enum defined here
  --> src/partition.rs:25:1
   |
25 | / pub enum RefType {
26 | |   INTRA_FRAME = 0,
27 | |   LAST_FRAME = 1,
28 | |   LAST2_FRAME = 2,
...  |
34 | |   NONE_FRAME = 8,
35 | | }
   | |_^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0658`.
error: Could not compile `rav1e`.