### PR TITLE
Remove reference to comparative_bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,6 @@ Run regular benchmarks with:
 cargo bench
 ```
 
-Run comparative benchmarks with:
-```
-cargo bench --features=comparative_bench
-```
-
 # Getting in Touch
 
 Come chat with us on the IRC channel #daala on Freenode! If you don't have IRC set

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -31,5 +31,4 @@ ignore = [
     "tests/aom.rs",
     # "benches/bench.rs",
     # "benches/predict.rs",
-    # "benches/comparative/predict.rs",
 ]


### PR DESCRIPTION
It had been removed to support external aom.