### PR TITLE
Allow rectangular partition at leaf nodes of topdown partition search

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -208,13 +208,17 @@ impl SpeedSettings {
   /// This preset is set this way because 8x8 with reduced TX set is faster but with equivalent
   /// or better quality compared to 16x16 or 32x32 (to which reduced TX set does not apply).
   fn min_block_size_preset(speed: usize) -> BlockSize {
-    if speed == 0 {
-      BlockSize::BLOCK_4X4
-    } else if speed <= 8 {
-      BlockSize::BLOCK_8X8
-    } else {
-      BlockSize::BLOCK_64X64
-    }
+    let min_block_size =
+      if speed == 0 {
+        BlockSize::BLOCK_4X4
+      } else if speed <= 8 {
+        BlockSize::BLOCK_8X8
+      } else {
+        BlockSize::BLOCK_64X64
+      };
+    // Topdown search checks min_block_size for PARTITION_SPLIT only, so min_block_size must be square.
+    assert!(min_block_size.is_sqr());
+    min_block_size
   }
 
   /// Multiref is enabled automatically if low_latency is false,


### PR DESCRIPTION
speed 5, (encoding time increase 14%~1%) [AWCY](https://beta.arewecompressedyet.com/?job=master-ef7a66a2ff710352d8fd0048c67048158c2e28ff&job=rect_part_leaf_s5%402019-04-30T20%3A05%3A35.283Z)

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -1.4529 | -1.9177 | -1.8769 |  -1.4698 | -1.3873 | -1.3750 |    -1.6576 |

speed 1, 5 frames, (encoding time increase 44%~11%) [AWCY](https://beta.arewecompressedyet.com/?job=test_rect_part_inside_16x16_or_smaller_s1_5f%402019-04-29T23%3A55%3A48.318Z&job=master-ef7a66a2_s1_5f%402019-04-29T23%3A20%3A33.601Z)

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -1.3921 | -2.0810 | -1.5809 |  -1.4713 | -1.2711 | -1.2584 |    -1.7207 |