### PR TITLE
Optimize chroma quantizer offsets for subset3

### DIFF
--- a/src/rate.rs
+++ b/src/rate.rs
@@ -435,10 +435,9 @@ const Q57_SQUARE_EXP_SCALE: f64 =
 
 // Daala style log-offset for chroma quantizers
 fn chroma_offset(log_target_q: i64) -> (i64, i64) {
-    let blog64_40 = 0xAA4_D3C2_5E68_DC58i64;
-    let x = log_target_q.max(0).min(blog64_40);
-    // m = (blog64(16) - blog64(5)) / blog64(40)
-    let y = 1291i64 * (x >> 12);
+    let x = log_target_q.max(0);
+    // Gradient 0.266 optimized for CIEDE2000+PSNR on subset3
+    let y = (x >> 2) + (x >> 6);
     // blog64(7) - blog64(4); blog64(5) - blog64(4)
     (0x19D_5D9F_D501_0B37 - y, 0xA4_D3C2_5E68_DC58 - y)
 }


### PR DESCRIPTION
PSNR and CIEDE2000 rate distortion curves were collected for [subset3](https://media.xiph.org/video/derf/), sampled at `--quality [5, 21, ..., 245]` for chroma quantization gradients in the range `10...25`(Q6), using a training binary built from https://github.com/barrbrain/rav1e/commit/uv-delta-q-train and flags `--tune Psnr -s 4`.
![BD-rates for CIEDE2000 and PSNR from subset3](https://user-images.githubusercontent.com/220594/57133559-1f7d8d80-6dde-11e9-9e25-b134799913f3.png)

BD-rates were derived with an anchor of 24 in Q6, the CIEDE2000-optimal point for the lower half of the quality range. CIEDE 2000 was initially targeted exclusively but this ends up significantly harming luma-only BD-rates (+5%) for minor gains (-1%). Y-PSNR is the most structurally similar to CIEDE 2000 among the luma-only metrics. We trade the marginal gains in CIEDE 2000 for greater losses in Y-PSNR by targeting the sum of their BD-rates. A gradient was found that yielded the minimum sum of BD-rates for PNSR and CIEDE2000, 17 in Q6.
![BD-rate per gradient in Q6](https://user-images.githubusercontent.com/220594/57134248-83a15100-6de0-11e9-861c-b8a72f969d0f.png)

The search was repeated with 100 iterations of dropping out 20% of the image set. The mean of these was 17 with a standard deviation of 0.08 in Q6.
![Distribution of optimal gradients](https://user-images.githubusercontent.com/220594/57135357-1a234180-6de4-11e9-9a2a-69d34a14076a.png)

For details of the analysis and the data, see the note book in [gist.github.com/9d541d809d1d664460b5ce5c00a57948](https://nbviewer.jupyter.org/gist/barrbrain/9d541d809d1d664460b5ce5c00a57948/Chroma%20quantizer%20balance.ipynb).

AWCY results for [objective-1-fast at default speed](https://beta.arewecompressedyet.com/?job=master-c4886a38f0a8bba7c0377375eb8a4e564518cd0e&job=uv-delta-q-optim%402019-05-03T11%3A50%3A10.046Z):

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -1.1897 |  6.9317 |  6.6597 |  -1.4446 | -1.1497 | -1.2336 |     0.9731 |

<details>

|                                                       Video |    PSNR | PSNR HVS |    SSIM | CIEDE 2000 |  PSNR Cb |  PSNR Cr |   APSNR | APSNR Cb | APSNR Cr | MS SSIM |    VMAF |
|                                                        ---: |    ---: |     ---: |    ---: |       ---: |     ---: |     ---: |    ---: |     ---: |     ---: |    ---: |    ---: |
|                                           DOTA2_60f_420.y4m | -1.2463 |  -1.7981 | -1.3664 |     2.6698 |   7.6524 |   6.6120 | -1.2327 |   7.7043 |   6.7578 | -1.6225 | -1.1758 |
|                             KristenAndSara_1280x720_60f.y4m | -0.7340 |  -1.0284 | -0.8038 |     1.4825 |   8.7565 |   8.5828 | -0.7312 |   8.7747 |   8.6415 | -0.7270 | -0.3505 |
|                                       MINECRAFT_60f_420.y4m | -0.8168 |  -1.0256 | -0.9730 |     2.4027 |  11.5860 |   8.8807 | -0.8281 |  11.6117 |   8.9856 | -0.9933 | -1.6517 |
|             Netflix_Aerial_1920x1080_60fps_8bit_420_60f.y4m | -1.6770 |  -2.1363 | -1.5600 |     1.0463 |  13.5266 |  15.6122 | -1.6689 |  13.4848 |  15.5672 | -1.6781 | -0.5241 |
|               Netflix_Boat_1920x1080_60fps_8bit_420_60f.y4m | -0.9288 |  -1.1462 | -0.8208 |     1.6651 |  10.6688 |  11.3187 | -0.9168 |  10.6718 |  11.3691 | -0.8987 | -0.1911 |
|          Netflix_Crosswalk_1920x1080_60fps_8bit_420_60f.y4m | -0.6234 |  -0.8427 | -0.6307 |     1.0812 |   4.6611 |   3.9754 | -0.6389 |   4.7535 |   4.0876 | -0.8035 | -0.7178 |
|          Netflix_DrivingPOV_1280x720_60fps_8bit_420_60f.y4m | -0.9836 |  -1.3174 | -0.5673 |     1.7513 |  10.7572 |   8.9555 | -0.9594 |  10.7767 |   9.0262 | -0.6181 | -1.4120 |
|         Netflix_FoodMarket_1920x1080_60fps_8bit_420_60f.y4m | -1.3099 |  -1.5673 | -1.2215 |     0.5477 |   6.9102 |   5.6994 | -1.2947 |   6.9660 |   5.7049 | -1.3441 | -2.8559 |
|        Netflix_PierSeaside_1920x1080_60fps_8bit_420_60f.y4m | -2.1904 |  -2.2593 | -2.2793 |     0.3964 |   7.4633 |   7.7214 | -2.1568 |   7.6052 |   7.8828 | -2.2831 | -1.2517 |
|       Netflix_RollerCoaster_1280x720_60fps_8bit_420_60f.y4m | -1.6285 |  -1.9127 | -1.2312 |     1.8233 |   6.1853 |   7.3872 | -1.6359 |   6.3449 |   7.5398 | -1.3480 | -1.0466 |
| Netflix_SquareAndTimelapse_1920x1080_60fps_8bit_420_60f.y4m | -0.9737 |  -1.1464 | -0.9051 |     1.6469 |   8.8541 |   8.0102 | -0.9742 |   8.9245 |   8.1288 | -0.9552 | -0.7825 |
|         Netflix_TunnelFlag_1920x1080_60fps_8bit_420_60f.y4m | -0.6911 |  -0.8460 | -0.5755 |     2.1955 |  10.2264 |   8.1191 | -0.6768 |  10.2878 |   8.1600 | -0.6626 |  0.0714 |
|                                       STARCRAFT_60f_420.y4m | -0.9484 |  -1.0995 | -0.8896 |     1.6903 |   8.6958 |   9.7911 | -0.9465 |   8.7164 |   9.7744 | -1.0339 | -2.4971 |
|                                         aspen_1080p_60f.y4m | -0.9179 |  -1.1613 | -0.6325 |     0.1693 |   6.5080 |  10.7645 | -0.9093 |   6.5361 |  10.7806 | -0.8702 | -1.2418 |
|                                       blue_sky_360p_60f.y4m | -2.3969 |  -2.3116 | -2.1940 |     1.1078 |   9.4673 |  11.6960 | -2.2810 |   9.8308 |  11.8982 | -2.2502 | -1.5178 |
|                                             dark70p_60f.y4m | -3.4944 |  -4.2740 | -3.2611 |    -7.4516 | -13.1982 | -12.3307 | -3.3991 |  -9.8244 |  -9.8242 | -3.8849 | -3.6769 |
|                              ducks_take_off_1080p50_60f.y4m | -2.6466 |  -4.2545 | -2.6490 |    -0.2560 |   4.8989 |   9.8371 | -2.6779 |   5.2194 |  10.0305 | -3.1317 | -2.9705 |
|                                      gipsrestat720p_60f.y4m | -0.5360 |  -0.8569 | -0.6348 |     1.7484 |  10.1294 |  11.3230 | -0.5341 |  10.1306 |  11.3610 | -0.6500 |  0.5651 |
|                                         kirland360p_60f.y4m | -0.6159 |  -0.8222 | -0.5117 |     0.4522 |   0.3334 |   3.6616 | -0.6978 |   0.2520 |   3.5789 | -0.6279 |  0.4544 |
|                                        life_1080p30_60f.y4m | -0.9812 |  -1.1659 | -0.9782 |     0.5271 |   5.2903 |   5.1757 | -0.9828 |   5.3076 |   5.4048 | -1.0025 | -0.5275 |
|                                          niklas360p_60f.y4m | -1.6728 |  -1.5371 | -1.8010 |     0.6230 |   6.2720 |   4.5182 | -1.5948 |   6.5485 |   5.0320 | -1.3270 | -1.8904 |
|                                      red_kayak_360p_60f.y4m | -0.3412 |  -0.4497 | -0.4595 |     1.2977 |   7.7089 |   1.7827 | -0.3742 |   8.0168 |   2.2574 | -0.2412 | -0.4670 |
|                                   rush_hour_1080p25_60f.y4m | -1.1673 |  -1.4818 | -1.4170 |     2.0864 |   7.6277 |   3.3380 | -1.1610 |   7.6589 |   3.5009 | -1.5973 | -0.6585 |
|                                     shields_640x360_60f.y4m | -2.0554 |  -2.5136 | -2.0465 |     0.1528 |   8.3213 |   6.4457 | -2.0205 |   8.3283 |   6.3253 | -2.0188 | -2.4414 |
|                                   speed_bag_640x360_60f.y4m | -0.4886 |  -0.5414 | -0.4090 |     2.3697 |   6.0266 |   7.9484 | -0.4393 |   6.1086 |   8.1589 | -0.4537 | -0.6053 |
|                                  thaloundeskmtg360p_60f.y4m | -0.7698 |  -0.8664 | -0.5850 |    -0.0810 |   2.4793 |   1.6117 | -0.6128 |   2.4449 |   1.5435 | -0.4691 |  1.1238 |
|                                touchdown_pass_1080p_60f.y4m | -0.7779 |  -0.8217 | -0.7810 |     0.9217 |  11.4230 |   7.0397 | -0.7878 |  11.4231 |   7.1892 | -0.7047 | -0.4156 |
|                                   vidyo1_720p_60fps_60f.y4m | -1.0018 |  -1.1350 | -0.7160 |     1.1197 |   8.1606 |   5.8266 | -0.9989 |   8.1630 |   5.8497 | -0.7547 | -0.8819 |
|                                   vidyo4_720p_60fps_60f.y4m | -0.8438 |  -0.8596 | -0.7959 |     2.2072 |   8.7551 |   9.1925 | -0.8420 |   8.7836 |   9.2537 | -0.9239 | -0.3807 |
|                                           wikipedia_420.y4m | -0.2312 |  -0.1595 | -0.7941 |     1.8006 |   1.8049 |   1.2936 | -0.2324 |   1.8964 |   1.2848 | -1.1311 |  0.8682 |

</details>