### PR TITLE
Turn off enable_filter_intra in sequence header

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -115,6 +115,7 @@ pub struct Sequence {
   // 2 - adaptive
   pub still_picture: bool,               // Video is a single frame still picture
   pub reduced_still_picture_hdr: bool,   // Use reduced header for still picture
+  pub enable_filter_intra: bool,         // enables/disables filter_intra
   pub enable_intra_edge_filter: bool,    // enables/disables corner/edge/upsampling
   pub enable_interintra_compound: bool,  // enables/disables interintra_compound
   pub enable_masked_compound: bool,      // enables/disables masked compound
@@ -197,6 +198,7 @@ impl Sequence {
       force_integer_mv: 2,
       still_picture: false,
       reduced_still_picture_hdr: false,
+      enable_filter_intra: false,
       enable_intra_edge_filter: false,
       enable_interintra_compound: false,
       enable_masked_compound: false,
@@ -1251,13 +1253,13 @@ pub fn encode_block_b<T: Pixel>(
       }
     }
     // TODO: Extra condition related to palette mode, see `read_filter_intra_mode_info` in decodemv.c
-    if luma_mode == PredictionMode::DC_PRED && bsize.width() <= 32 && bsize.height() <= 32 {
-      cw.write_use_filter_intra(w,false, bsize); // Always turn off FILTER_INTRA
+    if fi.sequence.enable_filter_intra &&
+      luma_mode == PredictionMode::DC_PRED && bsize.width() <= 32 && bsize.height() <= 32 {
+      cw.write_use_filter_intra(w,false, bsize); // turn off FILTER_INTRA
     }
   }
 
-  // write tx_size here (for now, intra frame only)
-  // TODO: Add new field tx_mode to fi, then Use the condition, fi.tx_mode == TX_MODE_SELECT
+  // write tx_size here
   if fi.tx_mode_select {
     if bsize.greater_than(BlockSize::BLOCK_4X4) && !(is_inter && skip) {
       if !is_inter {

--- a/src/header.rs
+++ b/src/header.rs
@@ -302,7 +302,7 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     }
 
     self.write_bit(seq.use_128x128_superblock)?;
-    self.write_bit(true)?; // enable filter intra
+    self.write_bit(seq.enable_filter_intra)?; // enable filter intra
     self.write_bit(seq.enable_intra_edge_filter)?;
 
     if !seq.reduced_still_picture_hdr {


### PR DESCRIPTION
So that "use_filter_intra = false" is not coded for every intra mode block.