### PR TITLE
Convert some Vecs in RDO to ArrayVecs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ scan_fmt = { version = "0.1.3", optional = true }
 ivf = { path = "ivf/", optional = true }
 rayon = "1.0"
 bincode = "=1.0.1"
+arrayvec = "0.4.10"
 
 [target.'cfg(target_arch = "x86_64")'.build-dependencies]
 nasm-rs = { git = "https://github.com/tdaede/nasm-rs", branch="msvc-OUT", optional = true }


### PR DESCRIPTION
These are fixed size and stack allocated rather than malloc()'ed,
hopefully improving speed and reducing memory fragmentation.

Vecs that are passed across functions have not been converted.