### PR TITLE
Enforce a lower bound of 1. Fixes #1211.

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -353,6 +353,10 @@ fn parse_config(matches: &ArgMatches<'_>) -> EncoderConfig {
     }
 
     // Validate arguments
+    if max_interval < 1 {
+      panic!("Keyframe interval must be greater than 0");
+    }
+
     if speed > 10 {
       panic!("Speed must be between 0-10");
     } else if min_interval > max_interval {


### PR DESCRIPTION
cargo run -- nyan.y4m -I 0 --output test.ivf
    Finished dev [optimized + debuginfo] target(s) in 0.43s
     Running `target/debug/rav1e nyan.y4m -I 0 --output test.ivf`
thread 'main' panicked at 'Keyframe interval must be greater than 0', src/bin/common.rs:357:7