### PR TITLE
Do not use NeedMoreData to signal that a frame had been encoded

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -550,6 +550,8 @@ pub enum EncoderStatus {
   /// May be emitted by `Context::receive_packet` after a flush request had been processed
   /// or the frame limit had been reached.
   LimitReached,
+  /// A Frame had been encoded but not emitted yet
+  Encoded,
   /// Generic fatal error
   Failure,
 }
@@ -880,7 +882,7 @@ impl<T: Pixel> ContextInner<T> {
             let fi = fi.clone();
             self.finalize_packet(rec, &fi)
           } else {
-            Err(EncoderStatus::NeedMoreData)
+            Err(EncoderStatus::Encoded)
           }
         } else {
           Err(EncoderStatus::NeedMoreData)

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -88,6 +88,7 @@ fn process_frame<T: Pixel, D: Decoder>(
     Err(EncoderStatus::Failure) => {
       panic!("Failed to encode video");
     }
+    Err(EncoderStatus::Encoded) => {}
   }
   Some(frame_summaries)
 }


### PR DESCRIPTION
This avoids some confusion @dwbuiten reported some time ago. (yet another cherry-pick from the segment-threading set)

(crav1e will be updated accordingly)