### PR TITLE
Add --tiles option to automatically assign tiles.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -76,8 +76,15 @@ pub struct EncoderConfig {
   pub quantizer: usize,
   pub bitrate: i32,
   pub tune: Tune,
+  /// log2(tile columns). If tiles is also specified, this acts
+  /// as a minimum.
   pub tile_cols_log2: usize,
+  /// log2(tile rows). If tiles is also specified, this acts
+  /// as a minimum.
   pub tile_rows_log2: usize,
+  /// Number of tiles desired. The video is split automatically so that
+  /// it contains at least this many tiles.
+  pub tiles: usize,
   pub speed_settings: SpeedSettings,
   /// `None` for one-pass encode. `Some(1)` or `Some(2)` for two-pass encoding.
   pub pass: Option<u8>,
@@ -126,6 +133,7 @@ impl EncoderConfig {
       tune: Tune::default(),
       tile_cols_log2: 0,
       tile_rows_log2: 0,
+      tiles: 0,
       speed_settings: SpeedSettings::from_preset(speed),
       pass: None,
       show_psnr: false,

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -186,6 +186,14 @@ pub fn parse_cli() -> CliOptions {
         .takes_value(true)
         .default_value("0")
     )
+    .arg(
+      Arg::with_name("TILES")
+        .help("Number of tiles. Tile-cols and tile-rows are overridden\n\
+               so that the video has at least this many tiles.")
+        .long("tiles")
+        .takes_value(true)
+        .default_value("0")
+    )
     // MASTERING
     .arg(
       Arg::with_name("PIXEL_RANGE")
@@ -446,6 +454,8 @@ fn parse_config(matches: &ArgMatches<'_>) -> EncoderConfig {
 
   cfg.tile_cols_log2 = matches.value_of("TILE_COLS_LOG2").unwrap().parse().unwrap();
   cfg.tile_rows_log2 = matches.value_of("TILE_ROWS_LOG2").unwrap().parse().unwrap();
+
+  cfg.tiles = matches.value_of("TILES").unwrap().parse().unwrap();
 
   if cfg.tile_cols_log2 > 6 || cfg.tile_rows_log2 > 6 {
     panic!("Log2 of tile columns and rows may not be greater than 6");


### PR DESCRIPTION
Use a simple algorithm that greedily splits, longer direction first.