### PR TITLE
Fix tile rows count in bitstream

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -630,7 +630,7 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
       self.write_bit(false);
     }
 
-    let rows_ones = ti.tile_rows_log2 - ti.min_tile_cols_log2;
+    let rows_ones = ti.tile_rows_log2 - ti.min_tile_rows_log2;
     for _ in 0..rows_ones {
       self.write_bit(true);
     }


### PR DESCRIPTION
The number of ones to write the number of tile _rows_ in the bitstream
was incorrectly computed from the minimum tile _columns_.

The bug remained undetected because unless the video is larger than
MAX_TILE_WIDTH or bigger than MAX_TILE_AREA:

    min_tile_rows_log2 = min_tile_cols_log2 = 0