### PR TITLE
CI: Update AppVeyor to Visual Studio 2019

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 environment:
   host: x86_64-pc-windows-msvc
@@ -14,7 +14,7 @@ matrix:
     - platform: arm64
 
 install:
-    - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+    - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
     - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
     - appveyor DownloadFile https://people.xiph.org/~tdaede/nasm-2.14.02-win64.zip -FileName nasm.zip
     - appveyor DownloadFile https://github.com/mozilla/sccache/releases/download/0.2.8/sccache-0.2.8-x86_64-pc-windows-msvc.tar.gz


### PR DESCRIPTION
Updates to the Visual Studio 2019 AppVeyor image, which contains Visual Studio 16.1.

We don't use msbuild so it shouldn't matter that much.