### PR TITLE
Rate-control: double trial encodes for I and P frames

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -858,7 +858,15 @@ impl<T: Pixel> ContextInner<T> {
           let fi = self.frame_invariants.get_mut(&cur_idx).unwrap();
           fi.set_quantizers(&qps);
 
-          if self.rc_state.needs_trial_encode(fti) {
+          let trials = if !self.rc_state.needs_trial_encode(fti) {
+            0
+          } else if fti > 1 {
+            1
+          } else {
+            2
+          };
+          for _ in 0..trials {
+            let fi = self.frame_invariants.get_mut(&cur_idx).unwrap();
             let mut fs = FrameState::new_with_frame(fi, frame.clone());
             let data = encode_frame(fi, &mut fs);
             self.rc_state.record_trial_encode(


### PR DESCRIPTION
Validating with objective-1-fast, after the second trial there is no statistically significant bias in the scale of initial frames for each type. Subsequent I and P frames also have no significant bias in scale prediction; B0 and B1 type frames are biased from the scale prediction on the order of 5% and 3%.

```python
from scipy import stats
stats.ttest_1samp(data, 0)
```

Initial frames:

frame type  | p-value
--|--
I  | 0.805331
P  | 0.096869
B0 | 0.329777
B1 | 0.037461

Subsequent frames:

frame type  | p-value
--|--
I  | 0.785931
P  | 0.993957
B0 | 0.000010
B1 | 0.000038