### PR TITLE
rate: Reset log_scale after first frame of each type

### DIFF
--- a/src/rate.rs
+++ b/src/rate.rs
@@ -754,6 +754,7 @@ impl RCState {
           f.x[1] = x;
           f.y[0] = x;
           f.y[1] = x;
+          self.log_scale[fti] = log_scale;
           // TODO: Duplicate regular P frame state for first golden P frame.
         } else {
           // Lengthen the time constant for the inter filters as we collect


### PR DESCRIPTION
This is a bug fix and aligns to rate-control in [Theora](https://git.xiph.org/?p=theora.git;a=blob;f=lib/rate.c;h=bf2b1396a17ea3c7d7ac87e8b78771f7874a4a8a;hb=HEAD#l808) and [Daala.](https://git.xiph.org/?p=daala.git;a=blob;f=src/rate.c;h=339dd56569c6b5b3b6879e860b601b7af79a651d;hb=refs/heads/master#l1123)

