### PR TITLE
Enable the Clippy's "type_complexity" lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,4 @@ jobs:
          - cargo doc --verbose --no-deps
          - rustup component add clippy
          - cargo clippy --version
-         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::cognitive_complexity -A clippy::needless_range_loop -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::verbose_bit_mask --verbose
+         - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::cognitive_complexity -A clippy::needless_range_loop -A clippy::too_many_arguments -A clippy::verbose_bit_mask --verbose

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1492,7 +1492,9 @@ fn av1_idct64(input: &[i32], output: &mut [i32], range: usize) {
   output[63] = clamp_value(stg10[0] - stg10[63], range);
 }
 
-static INV_TXFM_FNS: [[fn(&[i32], &mut [i32], usize); 5]; 4] = [
+type InvTxfmFn = fn(input: &[i32], output: &mut [i32], range: usize);
+
+static INV_TXFM_FNS: [[InvTxfmFn; 5]; 4] = [
   [av1_idct4, av1_idct8, av1_idct16, av1_idct32, av1_idct64],
   [av1_iadst4, av1_iadst8, av1_iadst16, |_, _, _| unimplemented!(), |_, _, _| unimplemented!()],
   [


### PR DESCRIPTION
This PR enables the [type_complexity](https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity) lint, and fixes all warnings caused by it.