### PR TITLE
[WIP] Bias RDO  based on activity

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1235,7 +1235,7 @@ pub fn encode_tx_block<T: Pixel>(
     w.add_bits_frac(estimated_rate as u32);
   }
   let bias =
-    compute_distortion_bias(fi, ts.to_frame_block_offset(tile_bo), bsize);
+    compute_distortion_bias(fi, ts.to_frame_block_offset(tile_bo), bsize, p);
   (has_coeff, RawDistortion::new(tx_dist) * bias * fi.dist_scale[p])
 }
 


### PR DESCRIPTION
Biasing the distortion based on activity measured using activity calculated in #1263.
The scale for the distortion bias will be computed empirically to produce encodes of the same file size as without activity bias.

The plan is to use Newton-Raphson Method to compute the scale which minimizes MSE of file size as compared to encodes without any activity bias.
```
s' = s - (MSE/f'(s))
where f : s -> file_size
```
