### PR TITLE
api: Expose the reservoir frame delay as a settable option

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -74,6 +74,8 @@ pub struct EncoderConfig {
   pub min_key_frame_interval: u64,
   /// The *maximum* interval between two keyframes
   pub max_key_frame_interval: u64,
+  /// The number of frames over which to distribute the reservoir usage.
+  pub reservoir_frame_delay: Option<i32>,
   pub low_latency: bool,
   pub quantizer: usize,
   pub bitrate: i32,
@@ -122,6 +124,7 @@ impl EncoderConfig {
       time_base: Rational { num: 1, den: 30 },
       min_key_frame_interval: 12,
       max_key_frame_interval: 240,
+      reservoir_frame_delay: None,
       low_latency: false,
       quantizer: 100,
       bitrate: 0,
@@ -681,7 +684,8 @@ impl<T: Pixel> ContextInner<T> {
           enc.time_base.num as i64,
           enc.bitrate,
           maybe_ac_qi_max,
-          enc.max_key_frame_interval as i32
+          enc.max_key_frame_interval as i32,
+          enc.reservoir_frame_delay
         ),
         maybe_prev_log_base_q: None,
         first_pass_data: FirstPassData { frames: Vec::new() },

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -160,6 +160,13 @@ pub fn parse_cli() -> CliOptions {
         .default_value("240")
     )
     .arg(
+      Arg::with_name("RESERVOIR_FRAME_DELAY")
+        .help("Number of frames over which rate control should distribute the reservoir [default: max(240, 1.5x keyint)]\n\
+         A minimum value of 12 is enforced.")
+        .long("reservoir_frame_delay")
+        .takes_value(true)
+    )
+    .arg(
       Arg::with_name("LOW_LATENCY")
         .help("Low latency mode; disables frame reordering\n\
             Has a significant speed-to-quality trade-off")
@@ -433,6 +440,7 @@ fn parse_config(matches: &ArgMatches<'_>) -> EncoderConfig {
 
   cfg.quantizer = quantizer;
   cfg.bitrate = bitrate.checked_mul(1000).expect("Bitrate too high");
+  cfg.reservoir_frame_delay = matches.value_of("RESERVOIR_FRAME_DELAY").map(|reservior_frame_delay| reservior_frame_delay.parse().unwrap());
   cfg.show_psnr = matches.is_present("PSNR");
   cfg.pass = matches.value_of("PASS").map(|pass| pass.parse().unwrap());
   cfg.stats_file = if cfg.pass.is_some() {


### PR DESCRIPTION
There's no reason to explicitly bind this to the max keyframe interval. It's useful to, for example, set it larger than 1.5x the keyframe interval for short intervals (1-3s) to prevent bitrate starvation after larger than expected (complex) keyframes.

### Notes

* Right now the default is 1.5x the max keyframe interval. Would it be useful to set it based on some threshold of big/small keyints, or would that be too confusing?
* Is there a better option name I could use?
* This should address most of #1262 by way of letting users set this value when using small GOPs. The weird edge artifacts at high quantziers remain.
* Since it will now be user settable, we need to definitely address `log_scale` overflow ([link](https://github.com/xiph/rav1e/blob/52f0bd7fc460e3f3a137d5b48ddfc075bbc78649/src/rate.rs#L398-L399)) when implementing two pass. 
* Should we enforce a minimum of 12 still when it is user set? (**EDIT: I did this and re-pushed.**)