### PR TITLE
rate: Do not enable frame drops by default

### DIFF
--- a/src/rate.rs
+++ b/src/rate.rs
@@ -537,8 +537,7 @@ impl RCState {
       target_bitrate,
       reservoir_frame_delay,
       maybe_ac_qi_max,
-      // By default, enforce hard buffer constraints.
-      drop_frames: true,
+      drop_frames: false,
       cap_overflow: true,
       cap_underflow: false,
       // TODO: Support multiple passes.


### PR DESCRIPTION
It wasn't supposed to be enabled, and we don't handle it correctly.