### PR TITLE
Public API / Doc cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
       - name: "Tests"
         script: cargo test --verbose --release --features=decode_test -- --ignored
       - name: "Bench"
-        script: cargo bench --verbose
+        script: RUSTFLAGS="--cfg rav1e_bench" cargo bench --verbose
       - name: "Doc & Clippy (linter): verifying code quality"
         script:
          - cargo doc --verbose --no-deps

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -11,14 +11,15 @@ mod predict;
 mod transform;
 mod me;
 
-use rav1e::*;
-use rav1e::cdef::cdef_filter_frame;
-use rav1e::context::*;
-use rav1e::partition::*;
-use rav1e::predict::*;
-use rav1e::rdo::rdo_cfl_alpha;
-use rav1e::rdo::RDOType;
-use rav1e::ec::*;
+use rav1e::bench::api::*;
+use rav1e::bench::encoder::*;
+use rav1e::bench::cdef::*;
+use rav1e::bench::context::*;
+use rav1e::bench::ec::*;
+use rav1e::bench::partition::*;
+use rav1e::bench::predict::*;
+use rav1e::bench::rdo::*;
+
 use crate::transform::transform;
 
 use criterion::*;
@@ -43,7 +44,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
   };
   let sequence = Sequence::new(&Default::default());
   let mut fi = FrameInvariants::<u16>::new(config, sequence);
-  let mut w = ec::WriterEncoder::new();
+  let mut w = WriterEncoder::new();
   let mut fc = CDFContext::new(fi.base_q_idx);
   let mut fb = FrameBlocks::new(fi.sb_width * 16, fi.sb_height * 16);
   let mut tb = fb.as_tile_blocks_mut();

--- a/benches/me.rs
+++ b/benches/me.rs
@@ -11,7 +11,8 @@ use criterion::*;
 use crate::partition::*;
 use crate::partition::BlockSize::*;
 use crate::plane::*;
-use rand::{ChaChaRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaChaRng;
 use rav1e::me;
 use rav1e::Pixel;
 

--- a/benches/me.rs
+++ b/benches/me.rs
@@ -8,12 +8,12 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use criterion::*;
-use crate::partition::*;
-use crate::partition::BlockSize::*;
-use crate::plane::*;
+use rav1e::bench::partition::*;
+use rav1e::bench::partition::BlockSize::*;
+use rav1e::bench::plane::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
-use rav1e::me;
+use rav1e::bench::me;
 use rav1e::Pixel;
 
 fn fill_plane<T: Pixel>(ra: &mut ChaChaRng, plane: &mut Plane<T>) {

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -8,7 +8,8 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use criterion::*;
-use rand::{ChaChaRng, Rng, RngCore, SeedableRng};
+use rand::{Rng, RngCore, SeedableRng};
+use rand_chacha::ChaChaRng;
 use rav1e::partition::BlockSize;
 use rav1e::predict::{Block4x4, Intra};
 use crate::plane::*;

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -10,10 +10,10 @@
 use criterion::*;
 use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
-use rav1e::partition::BlockSize;
-use rav1e::predict::{Block4x4, Intra};
-use crate::plane::*;
-use crate::util::*;
+use rav1e::bench::partition::BlockSize;
+use rav1e::bench::predict::{Block4x4, Intra};
+use rav1e::bench::plane::*;
+use rav1e::bench::util::*;
 
 pub const BLOCK_SIZE: BlockSize = BlockSize::BLOCK_32X32;
 

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -8,7 +8,8 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use criterion::*;
-use rand::{ChaChaRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaChaRng;
 use rav1e::transform;
 
 fn bench_idct4(b: &mut Bencher, bit_depth: &usize) {

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -10,7 +10,7 @@
 use criterion::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
-use rav1e::transform;
+use rav1e::bench::transform;
 
 fn bench_idct4(b: &mut Bencher, bit_depth: &usize) {
   let mut ra = ChaChaRng::from_seed([0; 32]);

--- a/examples/simple_encoding.rs
+++ b/examples/simple_encoding.rs
@@ -1,5 +1,6 @@
 // Encode the same tiny blank frame 30 times
 use rav1e::*;
+use rav1e::config::SpeedSettings;
 
 fn main() {
   let mut cfg = Config::default();

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,6 +10,7 @@
 use arg_enum_proc_macro::ArgEnum;
 use bitstream_io::*;
 use num_derive::*;
+use serde_derive::{Serialize, Deserialize};
 
 use crate::encoder::*;
 use crate::frame::Frame;

--- a/src/api.rs
+++ b/src/api.rs
@@ -843,14 +843,6 @@ impl<T: Pixel> ContextInner<T> {
      .as_ref().unwrap().as_ref().unwrap().clone()
   }
 
-  pub fn get_frame_count(&self) -> u64 {
-    self.frame_count
-  }
-
-  pub fn set_limit(&mut self, limit: u64) {
-    self.limit = limit;
-  }
-
   pub(crate) fn needs_more_lookahead(&self) -> bool {
     self.needs_more_frames(self.frame_count) && self.frames_processed + LOOKAHEAD_FRAMES > self.frame_q.keys().last().cloned().unwrap_or(0)
   }

--- a/src/api.rs
+++ b/src/api.rs
@@ -637,7 +637,7 @@ impl InterConfig {
   }
 }
 
-pub struct ContextInner<T: Pixel> {
+pub(crate) struct ContextInner<T: Pixel> {
   frame_count: u64,
   limit: u64,
   inter_cfg: InterConfig,

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -10,7 +10,8 @@
 use crate::muxer::{create_muxer, Muxer};
 use crate::{ColorPrimaries, MatrixCoefficients, TransferCharacteristics};
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand, Shell};
-use rav1e::*;
+use rav1e::prelude::*;
+use rav1e::version;
 use scan_fmt::scan_fmt;
 
 use std::fs::File;

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -10,7 +10,6 @@
 use crate::muxer::{create_muxer, Muxer};
 use crate::{ColorPrimaries, MatrixCoefficients, TransferCharacteristics};
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand, Shell};
-use rav1e::partition::BlockSize;
 use rav1e::*;
 
 use std::fs::File;

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -11,6 +11,7 @@ use crate::muxer::{create_muxer, Muxer};
 use crate::{ColorPrimaries, MatrixCoefficients, TransferCharacteristics};
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand, Shell};
 use rav1e::*;
+use scan_fmt::scan_fmt;
 
 use std::fs::File;
 use std::io::prelude::*;

--- a/src/bin/decoder/mod.rs
+++ b/src/bin/decoder/mod.rs
@@ -1,5 +1,5 @@
 use std::io;
-use rav1e::*;
+use rav1e::prelude::*;
 
 pub mod y4m;
 

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -1,13 +1,10 @@
 use std::io::Read;
 
-use rav1e::Rational;
 use crate::decoder::DecodeError;
 use crate::decoder::Decoder;
 use crate::decoder::VideoDetails;
-use crate::ChromaSamplePosition;
-use crate::ChromaSampling;
 use crate::Frame;
-use rav1e::*;
+use rav1e::prelude::*;
 
 impl Decoder for y4m::Decoder<'_, Box<dyn Read>> {
   fn get_video_details(&self) -> VideoDetails {

--- a/src/bin/muxer/y4m.rs
+++ b/src/bin/muxer/y4m.rs
@@ -10,9 +10,9 @@
 use crate::decoder::VideoDetails;
 use std::io::Write;
 use std::slice;
-use rav1e::*;
+use rav1e::prelude::*;
 
-pub fn write_y4m_frame<T: Pixel>(y4m_enc: &mut y4m::Encoder<'_, Box<dyn Write>>, rec: &rav1e::Frame<T>, y4m_details: VideoDetails) {
+pub fn write_y4m_frame<T: Pixel>(y4m_enc: &mut y4m::Encoder<'_, Box<dyn Write>>, rec: &Frame<T>, y4m_details: VideoDetails) {
   let pitch_y = if y4m_details.bit_depth > 8 { y4m_details.width * 2 } else { y4m_details.width };
   let chroma_sampling_period = y4m_details.chroma_sampling.sampling_period();
   let (pitch_uv, height_uv) = (

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -13,7 +13,7 @@ mod common;
 mod decoder;
 mod muxer;
 use crate::common::*;
-use rav1e::*;
+use rav1e::prelude::*;
 
 use std::io;
 use std::io::Write;

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -9,9 +9,6 @@
 
 #![deny(bare_trait_objects)]
 
-#[macro_use]
-extern crate scan_fmt;
-
 mod common;
 mod decoder;
 mod muxer;

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -327,17 +327,6 @@ pub fn cdef_sb_padded_frame_copy<T: Pixel>(
   out
 }
 
-
-pub fn cdef_empty_frame<T: Pixel, U: Pixel>(f: &Frame<T>) -> Frame<U> {
-  Frame {
-    planes: [
-      Plane::new(0, 0, f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
-      Plane::new(0, 0, f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
-      Plane::new(0, 0, f.planes[0].cfg.xdec, f.planes[0].cfg.ydec, 0, 0),
-    ]
-  }
-}
-
 // We assume in is padded, and the area we'll write out is at least as
 // large as the unpadded area of in
 // cdef_index is taken from the block context

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -11,9 +11,9 @@
 
 use crate::context::*;
 use crate::DeblockState;
-use crate::FrameInvariants;
-use crate::FrameState;
-use crate::FrameType;
+use crate::encoder::FrameInvariants;
+use crate::encoder::FrameState;
+use crate::api::FrameType;
 use crate::partition::PredictionMode::*;
 use crate::partition::RefType::*;
 use crate::plane::*;

--- a/src/entropymode.rs
+++ b/src/entropymode.rs
@@ -853,6 +853,7 @@ pub static default_cfl_alpha_cdf: [[u16; cdf_size!(CFL_ALPHABET_SIZE)];
 const SWITCHABLE_FILTERS: usize = 3;
 const SWITCHABLE_FILTER_CONTEXTS: usize = (SWITCHABLE_FILTERS + 1) * 4;
 
+#[allow(unused)]
 pub static default_switchable_interp_cdf: [[u16;
   cdf_size!(SWITCHABLE_FILTERS)];
   SWITCHABLE_FILTER_CONTEXTS] = [
@@ -912,9 +913,11 @@ pub static default_compound_mode_cdf: [[u16;
   cdf!(13046, 23214, 24505, 25942, 27435, 28442, 29330)
 ];
 
+#[allow(unused)]
 pub static default_interintra_cdf: [[u16; cdf_size!(2)]; BLOCK_SIZE_GROUPS] =
   [cdf!(16384), cdf!(26887), cdf!(27597), cdf!(30237)];
 
+#[allow(unused)]
 pub static default_interintra_mode_cdf: [[u16;
   cdf_size!(InterIntraMode::INTERINTRA_MODES as usize)];
   BLOCK_SIZE_GROUPS as usize] = [
@@ -924,6 +927,7 @@ pub static default_interintra_mode_cdf: [[u16;
   cdf!(4238, 11537, 25926)
 ];
 
+#[allow(unused)]
 pub static default_wedge_interintra_cdf: [[u16; cdf_size!(2)];
   BlockSize::BLOCK_SIZES_ALL] = [
   cdf!(16384),
@@ -950,6 +954,7 @@ pub static default_wedge_interintra_cdf: [[u16; cdf_size!(2)];
   cdf!(16384)
 ];
 
+#[allow(unused)]
 pub static default_compound_type_cdf: [[u16;
   cdf_size!(CompoundType::COMPOUND_TYPES as usize - 1)];
   BlockSize::BLOCK_SIZES_ALL as usize] = [
@@ -977,6 +982,7 @@ pub static default_compound_type_cdf: [[u16;
   cdf!(16384)
 ];
 
+#[allow(unused)]
 pub static default_wedge_idx_cdf: [[u16; cdf_size!(16)];
   BlockSize::BLOCK_SIZES_ALL] = [
   cdf!(
@@ -1069,6 +1075,7 @@ pub static default_wedge_idx_cdf: [[u16; cdf_size!(16)];
   )
 ];
 
+#[allow(unused)]
 pub static default_motion_mode_cdf: [[u16;
   cdf_size!(MotionMode::MOTION_MODES as usize)];
   BlockSize::BLOCK_SIZES_ALL as usize] = [
@@ -1096,6 +1103,7 @@ pub static default_motion_mode_cdf: [[u16;
   cdf!(29742, 31203)
 ];
 
+#[allow(unused)]
 pub static default_obmc_cdf: [[u16; cdf_size!(2)];
   BlockSize::BLOCK_SIZES_ALL] = [
   cdf!(16384),
@@ -1132,6 +1140,7 @@ pub static default_comp_ref_type_cdf: [[u16; cdf_size!(2)];
   COMP_REF_TYPE_CONTEXTS] =
   [cdf!(1198), cdf!(2070), cdf!(9166), cdf!(7499), cdf!(22475)];
 
+#[allow(unused)]
 pub static default_uni_comp_ref_cdf: [[[u16; cdf_size!(2)];
   UNIDIR_COMP_REFS - 1];
   UNI_COMP_REF_CONTEXTS] = [
@@ -1175,6 +1184,7 @@ pub static default_comp_bwdref_cdf: [[[u16; cdf_size!(2)]; BWD_REFS - 1];
   [cdf!(30606), cdf!(30489)]
 ];
 
+#[allow(unused)]
 pub static default_palette_y_size_cdf: [[u16;
   cdf_size!(PaletteSize::PALETTE_SIZES as usize)];
   PALATTE_BSIZE_CTXS] = [
@@ -1187,6 +1197,7 @@ pub static default_palette_y_size_cdf: [[u16;
   cdf!(14940, 20797, 21678, 24186, 27033, 28999)
 ];
 
+#[allow(unused)]
 pub static default_palette_uv_size_cdf: [[u16;
   cdf_size!(PaletteSize::PALETTE_SIZES as usize)];
   PALATTE_BSIZE_CTXS] = [
@@ -1199,6 +1210,7 @@ pub static default_palette_uv_size_cdf: [[u16;
   cdf!(1269, 5435, 10433, 18963, 21700, 25865)
 ];
 
+#[allow(unused)]
 pub static default_palette_y_mode_cdf: [[[u16; cdf_size!(2)];
   PALETTE_Y_MODE_CONTEXTS];
   PALATTE_BSIZE_CTXS] = [
@@ -1211,9 +1223,11 @@ pub static default_palette_y_mode_cdf: [[[u16; cdf_size!(2)];
   [cdf!(32450), cdf!(7946), cdf!(129)]
 ];
 
+#[allow(unused)]
 pub static default_palette_uv_mode_cdf: [[u16; cdf_size!(2)];
   PALETTE_UV_MODE_CONTEXTS] = [cdf!(32461), cdf!(21488)];
 
+#[allow(unused)]
 pub static default_palette_y_color_index_cdf: [[[u16;
   cdf_size!(PaletteColor::PALETTE_COLORS as usize)];
   PALETTE_COLOR_INDEX_CONTEXTS];
@@ -1269,6 +1283,7 @@ pub static default_palette_y_color_index_cdf: [[[u16;
   ]
 ];
 
+#[allow(unused)]
 pub static default_palette_uv_color_index_cdf: [[[u16;
   cdf_size!(PaletteColor::PALETTE_COLORS as usize)];
   PALETTE_COLOR_INDEX_CONTEXTS];
@@ -1324,6 +1339,7 @@ pub static default_palette_uv_color_index_cdf: [[[u16;
   ]
 ];
 
+#[allow(unused)]
 pub static default_txfm_partition_cdf: [[u16; cdf_size!(2)];
   TXFM_PARTITION_CONTEXTS] = [
   cdf!(28581),
@@ -1352,13 +1368,16 @@ pub static default_txfm_partition_cdf: [[u16; cdf_size!(2)];
 pub static default_skip_cdfs: [[u16; cdf_size!(2)]; SKIP_CONTEXTS] =
   [cdf!(31671), cdf!(16515), cdf!(4576)];
 
+#[allow(unused)]
 pub static default_skip_mode_cdfs: [[u16; cdf_size!(2)]; SKIP_MODE_CONTEXTS] =
   [cdf!(32621), cdf!(20708), cdf!(8127)];
 
+#[allow(unused)]
 pub static default_compound_idx_cdfs: [[u16; cdf_size!(2)];
   COMP_INDEX_CONTEXTS] =
   [cdf!(18244), cdf!(12865), cdf!(7053), cdf!(13259), cdf!(9334), cdf!(4644)];
 
+#[allow(unused)]
 pub static default_comp_group_idx_cdfs: [[u16; cdf_size!(2)];
   COMP_GROUP_IDX_CONTEXTS] = [
   cdf!(26607),
@@ -1369,8 +1388,10 @@ pub static default_comp_group_idx_cdfs: [[u16; cdf_size!(2)];
   cdf!(22674)
 ];
 
+#[allow(unused)]
 pub static default_intrabc_cdf: [u16; cdf_size!(2)] = cdf!(30531);
 
+#[allow(unused)]
 pub static default_filter_intra_mode_cdf: [u16;
   cdf_size!(FilterIntraMode::FILTER_INTRA_MODES as usize)] =
   cdf!(8949, 12776, 17211, 29558);
@@ -1408,6 +1429,7 @@ pub static default_wiener_restore_cdf: [u16; cdf_size!(2)] = cdf!(11570);
 
 pub static default_sgrproj_restore_cdf: [u16; cdf_size!(2)] = cdf!(16855);
 
+#[allow(unused)]
 pub static default_delta_q_cdf: [u16; cdf_size!(DELTA_Q_PROBS + 1)] =
   cdf!(28160, 32120, 32677);
 
@@ -1423,9 +1445,11 @@ pub static default_delta_lf_cdf: [u16; cdf_size!(DELTA_LF_PROBS + 1)] =
   cdf!(28160, 32120, 32677);
 
 // FIXME(someone) need real defaults here
+#[allow(unused)]
 pub static default_seg_tree_cdf: [u16; cdf_size!(MAX_SEGMENTS)] =
   cdf!(4096, 8192, 12288, 16384, 20480, 24576, 28672);
 
+#[allow(unused)]
 pub static default_segment_pred_cdf: [[u16; cdf_size!(2)];
   SEG_TEMPORAL_PRED_CTXS] =
   [cdf!(128 * 128), cdf!(128 * 128), cdf!(128 * 128)];

--- a/src/header.rs
+++ b/src/header.rs
@@ -50,6 +50,7 @@ pub enum ReferenceMode {
 }
 
 #[allow(non_camel_case_types)]
+#[allow(unused)]
 pub enum ObuType {
   OBU_SEQUENCE_HEADER = 1,
   OBU_TEMPORAL_DELIMITER = 2,
@@ -64,6 +65,7 @@ pub enum ObuType {
 
 #[derive(Clone,Copy)]
 #[allow(non_camel_case_types)]
+#[allow(unused)]
 pub enum ObuMetaType {
   OBU_META_HDR_CLL = 1,
   OBU_META_HDR_MDCV = 2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,11 +47,49 @@ mod frame;
 
 use crate::encoder::*;
 
-pub use crate::api::*;
+pub use crate::api::{Context, Config, Packet, EncoderStatus};
 pub use crate::frame::Frame;
-pub use crate::encoder::Tune;
-pub use crate::partition::BlockSize;
 pub use crate::util::{CastFromPrimitive, Pixel};
+
+pub mod prelude {
+  pub use crate::api::*;
+  pub use crate::frame::Frame;
+  pub use crate::encoder::Tune;
+  pub use crate::partition::BlockSize;
+  pub use crate::util::{CastFromPrimitive, Pixel};
+}
+
+/// Basic data structures
+pub mod data {
+  pub use crate::frame::Frame;
+  pub use crate::api::{
+    Packet, Point, Rational, FrameType, EncoderStatus
+  };
+  pub use crate::util::{CastFromPrimitive, Pixel};
+}
+
+/// Color model information
+pub mod color {
+  pub use crate::api::{
+    ChromaSamplePosition,
+    ChromaSampling,
+    ColorPrimaries,
+    TransferCharacteristics,
+    PixelRange,
+    ContentLight,
+    ColorDescription,
+    MasteringDisplay,
+    MatrixCoefficients,
+  };
+}
+
+/// Encoder configuration and settings
+pub mod config {
+  pub use crate::api::{
+    Config, EncoderConfig, SpeedSettings, PredictionModesSetting,
+  };
+}
+
 
 /// Version information
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,43 +15,43 @@
 #[macro_use]
 extern crate pretty_assertions;
 
-pub mod ec;
-pub mod partition;
-pub mod plane;
-pub mod transform;
-pub mod quantize;
-pub mod predict;
-pub mod rdo;
-pub mod rdo_tables;
+mod ec;
+mod partition;
+mod plane;
+mod transform;
+mod quantize;
+mod predict;
+mod rdo;
+mod rdo_tables;
 #[macro_use]
-pub mod util;
-pub mod context;
-pub mod entropymode;
-pub mod token_cdfs;
-pub mod deblock;
-pub mod segmentation;
-pub mod cdef;
-pub mod lrf;
-pub mod encoder;
-pub mod mc;
-pub mod me;
-pub mod metrics;
-pub mod scan_order;
-pub mod scenechange;
-pub mod rate;
-pub mod tiling;
+mod util;
+mod context;
+mod entropymode;
+mod token_cdfs;
+mod deblock;
+mod segmentation;
+mod cdef;
+mod lrf;
+mod encoder;
+mod mc;
+mod me;
+mod metrics;
+mod scan_order;
+mod scenechange;
+mod rate;
+mod tiling;
 
 mod api;
 mod header;
 mod frame;
 
-pub use crate::api::*;
-pub use crate::encoder::*;
-pub use crate::header::*;
-pub use crate::util::{CastFromPrimitive, Pixel};
+use crate::encoder::*;
 
+pub use crate::api::*;
 pub use crate::frame::Frame;
+pub use crate::encoder::Tune;
 pub use crate::partition::BlockSize;
+pub use crate::util::{CastFromPrimitive, Pixel};
 
 /// Version information
 ///
@@ -148,3 +148,18 @@ mod test_encode_decode_aom;
 #[cfg(all(test, feature="decode_test_dav1d"))]
 mod test_encode_decode_dav1d;
 
+#[cfg(rav1e_bench)]
+pub mod bench {
+  pub mod api { pub use crate::api::*; }
+  pub mod cdef { pub use crate::cdef::*; }
+  pub mod context { pub use crate::context::*; }
+  pub mod ec { pub use crate::ec::*; }
+  pub mod encoder { pub use crate::encoder::*; }
+  pub mod me { pub use crate::me::*; }
+  pub mod partition { pub use crate::partition::*; }
+  pub mod plane { pub use crate::plane::*; }
+  pub mod predict { pub use crate::predict::*; }
+  pub mod rdo { pub use crate::rdo::*; }
+  pub mod transform { pub use crate::transform::*; }
+  pub mod util { pub use crate::util::*; }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub use crate::header::*;
 pub use crate::util::{CastFromPrimitive, Pixel};
 
 pub use crate::frame::Frame;
+pub use crate::partition::BlockSize;
 
 /// Version information
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,7 @@
 #![allow(safe_extern_statics)]
 #![deny(bare_trait_objects)]
 
-#[macro_use]
-extern crate serde_derive;
-extern crate bincode;
-
-#[cfg(all(test, feature="decode_test_dav1d"))]
-extern crate dav1d_sys;
-
-#[cfg(test)]
-extern crate interpolate_name;
-
+// Override assert! and assert_eq! in tests
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -35,6 +35,7 @@ pub const RESTORE_SGRPROJ: u8 = 3;
 pub const WIENER_TAPS_MIN: [i8; 3] = [ -5, -23, -17 ];
 pub const WIENER_TAPS_MID: [i8; 3] = [ 3, -7, 15 ];
 pub const WIENER_TAPS_MAX: [i8; 3] = [ 10, 8, 46 ];
+#[allow(unused)]
 pub const WIENER_TAPS_K:   [i8; 3] = [ 1, 2, 3 ];
 pub const WIENER_BITS: usize = 7;
 

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -16,6 +16,7 @@ use crate::tiling::*;
 use crate::util::Pixel;
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+#[allow(unused)]
 pub enum FilterMode {
   REGULAR = 0,
   SMOOTH = 1,

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -42,14 +42,6 @@ pub static RAV1E_INTRA_MODES: &'static [PredictionMode] = &[
   PredictionMode::D63_PRED, */
 ];
 
-// Intra prediction modes tested at high speed levels
-#[rustfmt::skip]
-pub static RAV1E_INTRA_MODES_MINIMAL: &'static [PredictionMode] = &[
-    PredictionMode::DC_PRED,
-    PredictionMode::H_PRED,
-    PredictionMode::V_PRED
-];
-
 pub static RAV1E_INTER_MODES_MINIMAL: &'static [PredictionMode] = &[
   PredictionMode::NEARESTMV
 ];
@@ -92,12 +84,14 @@ const NEED_LEFT: u8 = 1 << 1;
 const NEED_ABOVE: u8 = 1 << 2;
 const NEED_ABOVERIGHT: u8 = 1 << 3;
 const NEED_ABOVELEFT: u8 = 1 << 4;
+#[allow(unused)]
 const NEED_BOTTOMLEFT: u8 = 1 << 5;
 
 /*const INTRA_EDGE_FILT: usize = 3;
 const INTRA_EDGE_TAPS: usize = 5;
 const MAX_UPSAMPLE_SZ: usize = 16;*/
 
+#[allow(unused)]
 pub static extend_modes: [u8; INTRA_MODES] = [
   NEED_ABOVE | NEED_LEFT,                  // DC
   NEED_ABOVE,                              // V

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -579,7 +579,7 @@ impl RCState {
   }
 
   // TODO: Separate quantizers for Cb and Cr.
-  pub fn select_qi<T: Pixel>(
+  pub(crate) fn select_qi<T: Pixel>(
     &self, ctx: &ContextInner<T>, fti: usize, maybe_prev_log_base_q: Option<i64>
   ) -> QuantizerParameters {
     // Is rate control active?

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -22,7 +22,9 @@ pub const FRAME_NSUBTYPES: usize = 4;
 
 pub const FRAME_SUBTYPE_I: usize = 0;
 pub const FRAME_SUBTYPE_P: usize = 1;
+#[allow(unused)]
 pub const FRAME_SUBTYPE_B0: usize = 2;
+#[allow(unused)]
 pub const FRAME_SUBTYPE_B1: usize = 3;
 pub const FRAME_SUBTYPE_SEF: usize = 4;
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -40,6 +40,7 @@ use std::cmp;
 use std::vec::Vec;
 use crate::partition::PartitionType::*;
 use arrayvec::*;
+use serde_derive::{Serialize, Deserialize};
 
 #[derive(Copy,Clone,PartialEq)]
 pub enum RDOType {

--- a/src/rdo_tables.rs
+++ b/src/rdo_tables.rs
@@ -1,9 +1,11 @@
 
 pub const RDO_NUM_BINS: usize =  50;
+#[allow(unused)]
 pub const RDO_MAX_BIN: usize = 10000;
 pub const RATE_EST_MAX_BIN: usize = 100_000;
 pub const RDO_QUANT_BINS: usize = 8;
 pub const RDO_QUANT_DIV: usize = 256/RDO_QUANT_BINS;
+#[allow(unused)]
 pub const RDO_BIN_SIZE: u64 = (RDO_MAX_BIN / RDO_NUM_BINS) as u64;
 pub const RATE_EST_BIN_SIZE: u64 = (RATE_EST_MAX_BIN / RDO_NUM_BINS) as u64;
 

--- a/src/test_encode_decode.rs
+++ b/src/test_encode_decode.rs
@@ -7,7 +7,9 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use super::*;
+use crate::*;
+use crate::color::ChromaSampling;
+use crate::config::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::sync::Arc;

--- a/src/tiling/plane_region.rs
+++ b/src/tiling/plane_region.rs
@@ -179,7 +179,7 @@ macro_rules! plane_region_common {
       ///
       /// # Example
       ///
-      /// ```
+      /// ``` ignore
       /// # use rav1e::tiling::*;
       /// # fn f(region: &PlaneRegion<'_, u16>) {
       /// // a subregion from (10, 8) to the end of the region
@@ -187,7 +187,7 @@ macro_rules! plane_region_common {
       /// # }
       /// ```
       ///
-      /// ```
+      /// ``` ignore
       /// # use rav1e::context::*;
       /// # use rav1e::tiling::*;
       /// # fn f(region: &PlaneRegion<'_, u16>) {
@@ -313,7 +313,7 @@ impl<'a, T: Pixel> PlaneRegionMut<'a, T> {
   ///
   /// # Example
   ///
-  /// ```
+  /// ``` ignore
   /// # use rav1e::tiling::*;
   /// # fn f(region: &mut PlaneRegionMut<'_, u16>) {
   /// // a mutable subregion from (10, 8) having size (32, 32)
@@ -321,7 +321,7 @@ impl<'a, T: Pixel> PlaneRegionMut<'a, T> {
   /// # }
   /// ```
   ///
-  /// ```
+  /// ``` ignore
   /// # use rav1e::context::*;
   /// # use rav1e::tiling::*;
   /// # fn f(region: &mut PlaneRegionMut<'_, u16>) {

--- a/src/tiling/plane_region.rs
+++ b/src/tiling/plane_region.rs
@@ -37,19 +37,19 @@ impl Rect {
   }
 }
 
-/// Structure to describe a rectangle area in several ways
-///
-/// To retrieve a subregion from a region, we need to provide the subregion
-/// bounds, relative to its parent region. The subregion must always be included
-/// in its parent region.
-///
-/// For that purpose, we could just use a rectangle (x, y, width, height), but
-/// this would be too cumbersome to use in practice. For example, we often need
-/// to pass a subregion from an offset, using the same bottom-right corner as
-/// its parent, or to pass a subregion expressed in block offset instead of
-/// pixel offset.
-///
-/// Area provides a flexible way to describe a subregion.
+// Structure to describe a rectangle area in several ways
+//
+// To retrieve a subregion from a region, we need to provide the subregion
+// bounds, relative to its parent region. The subregion must always be included
+// in its parent region.
+//
+// For that purpose, we could just use a rectangle (x, y, width, height), but
+// this would be too cumbersome to use in practice. For example, we often need
+// to pass a subregion from an offset, using the same bottom-right corner as
+// its parent, or to pass a subregion expressed in block offset instead of
+// pixel offset.
+//
+// Area provides a flexible way to describe a subregion.
 #[derive(Debug, Clone, Copy)]
 pub enum Area {
   /// A well-defined rectangle
@@ -171,31 +171,31 @@ macro_rules! plane_region_common {
         }
       }
 
-      /// Return a view to a subregion of the plane
-      ///
-      /// The subregion must be included in (i.e. must not exceed) this region.
-      ///
-      /// It is described by an `Area`, relative to this region.
-      ///
-      /// # Example
-      ///
-      /// ``` ignore
-      /// # use rav1e::tiling::*;
-      /// # fn f(region: &PlaneRegion<'_, u16>) {
-      /// // a subregion from (10, 8) to the end of the region
-      /// let subregion = region.subregion(Area::StartingAt { x: 10, y: 8 });
-      /// # }
-      /// ```
-      ///
-      /// ``` ignore
-      /// # use rav1e::context::*;
-      /// # use rav1e::tiling::*;
-      /// # fn f(region: &PlaneRegion<'_, u16>) {
-      /// // a subregion from the top-left of block (2, 3) having size (64, 64)
-      /// let bo = BlockOffset { x: 2, y: 3 };
-      /// let subregion = region.subregion(Area::BlockRect { bo, width: 64, height: 64 });
-      /// # }
-      /// ```
+      // Return a view to a subregion of the plane
+      //
+      // The subregion must be included in (i.e. must not exceed) this region.
+      //
+      // It is described by an `Area`, relative to this region.
+      //
+      // # Example
+      //
+      // ``` ignore
+      // # use rav1e::tiling::*;
+      // # fn f(region: &PlaneRegion<'_, u16>) {
+      // // a subregion from (10, 8) to the end of the region
+      // let subregion = region.subregion(Area::StartingAt { x: 10, y: 8 });
+      // # }
+      // ```
+      //
+      // ``` ignore
+      // # use rav1e::context::*;
+      // # use rav1e::tiling::*;
+      // # fn f(region: &PlaneRegion<'_, u16>) {
+      // // a subregion from the top-left of block (2, 3) having size (64, 64)
+      // let bo = BlockOffset { x: 2, y: 3 };
+      // let subregion = region.subregion(Area::BlockRect { bo, width: 64, height: 64 });
+      // # }
+      // ```
       #[inline(always)]
       pub fn subregion(&self, area: Area) -> PlaneRegion<'_, T> {
         let rect = area.to_rect(
@@ -305,31 +305,31 @@ impl<'a, T: Pixel> PlaneRegionMut<'a, T> {
     }
   }
 
-  /// Return a mutable view to a subregion of the plane
-  ///
-  /// The subregion must be included in (i.e. must not exceed) this region.
-  ///
-  /// It is described by an `Area`, relative to this region.
-  ///
-  /// # Example
-  ///
-  /// ``` ignore
-  /// # use rav1e::tiling::*;
-  /// # fn f(region: &mut PlaneRegionMut<'_, u16>) {
-  /// // a mutable subregion from (10, 8) having size (32, 32)
-  /// let subregion = region.subregion_mut(Area::Rect { x: 10, y: 8, width: 32, height: 32 });
-  /// # }
-  /// ```
-  ///
-  /// ``` ignore
-  /// # use rav1e::context::*;
-  /// # use rav1e::tiling::*;
-  /// # fn f(region: &mut PlaneRegionMut<'_, u16>) {
-  /// // a mutable subregion from the top-left of block (2, 3) to the end of the region
-  /// let bo = BlockOffset { x: 2, y: 3 };
-  /// let subregion = region.subregion_mut(Area::BlockStartingAt { bo });
-  /// # }
-  /// ```
+  // Return a mutable view to a subregion of the plane
+  //
+  // The subregion must be included in (i.e. must not exceed) this region.
+  //
+  // It is described by an `Area`, relative to this region.
+  //
+  // # Example
+  //
+  // ``` ignore
+  // # use rav1e::tiling::*;
+  // # fn f(region: &mut PlaneRegionMut<'_, u16>) {
+  // // a mutable subregion from (10, 8) having size (32, 32)
+  // let subregion = region.subregion_mut(Area::Rect { x: 10, y: 8, width: 32, height: 32 });
+  // # }
+  // ```
+  //
+  // ``` ignore
+  // # use rav1e::context::*;
+  // # use rav1e::tiling::*;
+  // # fn f(region: &mut PlaneRegionMut<'_, u16>) {
+  // // a mutable subregion from the top-left of block (2, 3) to the end of the region
+  // let bo = BlockOffset { x: 2, y: 3 };
+  // let subregion = region.subregion_mut(Area::BlockStartingAt { bo });
+  // # }
+  // ```
   #[inline(always)]
   pub fn subregion_mut(&mut self, area: Area) -> PlaneRegionMut<'_, T> {
     let rect = area.to_rect(

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,10 +27,7 @@ pub struct Align32;
 
 /// A 16 byte aligned array.
 /// # Examples
-/// ```
-/// extern crate rav1e;
-/// use rav1e::util::*;
-///
+/// ``` ignore
 /// let mut x: AlignedArray<[i16; 64 * 64]> = AlignedArray([0; 64 * 64]);
 /// assert!(x.array.as_ptr() as usize % 16 == 0);
 ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,15 +25,15 @@ macro_rules! cdf_size {
 #[repr(align(32))]
 pub struct Align32;
 
-/// A 16 byte aligned array.
-/// # Examples
-/// ``` ignore
-/// let mut x: AlignedArray<[i16; 64 * 64]> = AlignedArray([0; 64 * 64]);
-/// assert!(x.array.as_ptr() as usize % 16 == 0);
-///
-/// let mut x: AlignedArray<[i16; 64 * 64]> = UninitializedAlignedArray();
-/// assert!(x.array.as_ptr() as usize % 16 == 0);
-/// ```
+// A 16 byte aligned array.
+// # Examples
+// ```
+// let mut x: AlignedArray<[i16; 64 * 64]> = AlignedArray([0; 64 * 64]);
+// assert!(x.array.as_ptr() as usize % 16 == 0);
+//
+// let mut x: AlignedArray<[i16; 64 * 64]> = UninitializedAlignedArray();
+// assert!(x.array.as_ptr() as usize % 16 == 0);
+// ```
 pub struct AlignedArray<ARRAY>
 {
   _alignment: [Align32; 0],

--- a/src/util.rs
+++ b/src/util.rs
@@ -52,6 +52,10 @@ pub fn UninitializedAlignedArray<ARRAY>() -> AlignedArray<ARRAY> {
 
 #[test]
 fn sanity() {
+  fn is_aligned<T>(ptr: *const T, n: usize) -> bool {
+    ((ptr as usize) & ((1 << n) - 1)) == 0
+  }
+
   let a: AlignedArray<_> = AlignedArray([0u8; 3]);
   assert!(is_aligned(a.array.as_ptr(), 4));
 }
@@ -80,11 +84,6 @@ impl Fixed for usize {
   fn align_power_of_two_and_shift(&self, n: usize) -> usize {
     (self + (1 << n) - 1) >> n
   }
-}
-
-/// Check alignment.
-pub fn is_aligned<T>(ptr: *const T, n: usize) -> bool {
-  ((ptr as usize) & ((1 << n) - 1)) == 0
 }
 
 pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {


### PR DESCRIPTION
Use `cargo doc --open` to see the difference.

Would probably make sense to group all the configuration structs in some way e.g. all the color definition structs in a `color` module.