### PR TITLE
API: Expose minimum quantizer option

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -81,6 +81,8 @@ pub struct EncoderConfig {
   pub reservoir_frame_delay: Option<i32>,
   pub low_latency: bool,
   pub quantizer: usize,
+  /// The minimum allowed base quantizer to use in bitrate mode.
+  pub min_quantizer: u8,
   pub bitrate: i32,
   pub tune: Tune,
   pub tile_cols_log2: usize,
@@ -127,6 +129,7 @@ impl EncoderConfig {
       time_base: Rational { num: 1, den: 30 },
       min_key_frame_interval: 12,
       max_key_frame_interval: 240,
+      min_quantizer: 0,
       reservoir_frame_delay: None,
       low_latency: false,
       quantizer: 100,
@@ -816,6 +819,7 @@ impl<T: Pixel> ContextInner<T> {
           enc.time_base.num as i64,
           enc.bitrate,
           maybe_ac_qi_max,
+          enc.min_quantizer,
           enc.max_key_frame_interval as i32,
           enc.reservoir_frame_delay
         ),

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -110,6 +110,12 @@ pub fn parse_cli() -> CliOptions {
         .takes_value(true)
     )
     .arg(
+      Arg::with_name("MINQP")
+        .help("Minimum quantizer (0-255) to use in bitrate mode [default: 0]")
+        .long("min_quantizer")
+        .takes_value(true)
+    )
+    .arg(
       Arg::with_name("BITRATE")
         .help("Bitrate (kbps)")
         .short("b")
@@ -445,6 +451,7 @@ fn parse_config(matches: &ArgMatches<'_>) -> EncoderConfig {
   };
 
   cfg.quantizer = quantizer;
+  cfg.min_quantizer = matches.value_of("MINQP").unwrap().parse().unwrap_or(0);
   cfg.bitrate = bitrate.checked_mul(1000).expect("Bitrate too high");
   cfg.reservoir_frame_delay = matches.value_of("RESERVOIR_FRAME_DELAY").map(|reservior_frame_delay| reservior_frame_delay.parse().unwrap());
   cfg.show_psnr = matches.is_present("PSNR");


### PR DESCRIPTION
This is useful for 1-pass ABR to stop it from going totally nuts on some clips that have, for example, hard black cuts.

@tterribe needs to confirm im not doing something stupid here.