### PR TITLE
Set Y4M pixel range to limited from CLI

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -30,6 +30,7 @@ pub struct CliOptions {
   pub io: EncoderIO,
   pub enc: EncoderConfig,
   pub limit: usize,
+  pub color_range_specified: bool,
   pub skip: usize,
   pub verbose: bool,
   pub threads: usize,
@@ -334,6 +335,9 @@ pub fn parse_cli() -> CliOptions {
     io,
     enc: parse_config(&matches),
     limit: matches.value_of("LIMIT").unwrap().parse().unwrap(),
+    // Use `occurrences_of()` because `is_present()` is always true
+    // if a parameter has a default value.
+    color_range_specified: matches.occurrences_of("PIXEL_RANGE") > 0,
     skip: matches.value_of("SKIP").unwrap().parse().unwrap(),
     verbose: matches.is_present("VERBOSE"),
     threads,

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -162,6 +162,13 @@ fn main() {
   cli.enc.bit_depth = video_info.bit_depth;
   cli.enc.chroma_sampling = video_info.chroma_sampling;
   cli.enc.chroma_sample_position = video_info.chroma_sample_position;
+
+  // If no pixel range is specified via CLI, assume limited,
+  // as it is the default for the Y4M format.
+  if cli.enc.pixel_range == PixelRange::Unspecified {
+    cli.enc.pixel_range = PixelRange::Limited;
+  }
+
   cli.enc.time_base = video_info.time_base;
   let cfg = Config {
     enc: cli.enc,

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -165,7 +165,7 @@ fn main() {
 
   // If no pixel range is specified via CLI, assume limited,
   // as it is the default for the Y4M format.
-  if cli.enc.pixel_range == PixelRange::Unspecified {
+  if !cli.color_range_specified {
     cli.enc.pixel_range = PixelRange::Limited;
   }
 


### PR DESCRIPTION
Attempt to fix #1341. I don't think the `y4m` crate is parsing range in the header, so simply use the default value of limited.