### PR TITLE
Fixes #1292

### DIFF
--- a/src/test_encode_decode/aom.rs
+++ b/src/test_encode_decode/aom.rs
@@ -10,7 +10,7 @@
 
 use super::*;
 use std::marker::PhantomData;
-use std::{mem, ptr, slice};
+use std::{mem::MaybeUninit, ptr, slice};
 use std::collections::VecDeque;
 use std::ffi::CStr;
 use crate::util::Pixel;
@@ -27,7 +27,7 @@ impl<T: Pixel> TestDecoder<T> for AomDecoder<T> {
   fn setup_decoder(w: usize, h: usize) -> Self {
     unsafe {
       let interface = aom_codec_av1_dx();
-      let mut dec: aom_codec_ctx = mem::uninitialized();
+      let mut dec: aom_codec_ctx = MaybeUninit::uninit().assume_init();
       let cfg = aom_codec_dec_cfg_t {
         threads: 1,
         w: w as u32,

--- a/src/test_encode_decode/dav1d.rs
+++ b/src/test_encode_decode/dav1d.rs
@@ -9,7 +9,7 @@
 
 use super::*;
 use std::marker::PhantomData;
-use std::{mem, ptr, slice};
+use std::{mem::MaybeUninit, ptr, slice};
 use std::collections::VecDeque;
 use crate::util::{Pixel, CastFromPrimitive};
 use crate::test_encode_decode::{compare_plane, TestDecoder, DecodeResult};
@@ -24,8 +24,8 @@ pub(crate) struct Dav1dDecoder<T: Pixel> {
 impl<T: Pixel> TestDecoder<T> for Dav1dDecoder<T> {
   fn setup_decoder(_w: usize, _h: usize) -> Self {
     unsafe {
-      let mut settings = mem::uninitialized();
-      let mut dec: Dav1dDecoder<T> = mem::uninitialized();
+      let mut settings = MaybeUninit::init().assume_init();
+      let mut dec: Dav1dDecoder<T> = MaybeUninit::init().assume_init();
 
       dav1d_default_settings(&mut settings);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,9 +8,8 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use num_traits::*;
-use std::mem;
-use std::mem::size_of;
 use std::fmt::{Debug, Display};
+use std::mem::{size_of, MaybeUninit};
 
 //TODO: Nice to have (although I wasn't able to find a way to do it yet in rust): zero-fill arrays that are
 // shorter than required.  Need const fn (Rust Issue #24111) or const generics (Rust RFC #2000)
@@ -47,7 +46,7 @@ pub const fn AlignedArray<ARRAY>(array: ARRAY) -> AlignedArray<ARRAY> {
 
 #[allow(non_snake_case)]
 pub fn UninitializedAlignedArray<ARRAY>() -> AlignedArray<ARRAY> {
-  AlignedArray(unsafe { mem::uninitialized() })
+  AlignedArray(unsafe { MaybeUninit::uninit().assume_init() })
 }
 
 #[test]


### PR DESCRIPTION
Both `cargo test` and `cargo build` were run without errors.