### PR TITLE
Replace LUTs with pattern matching in partition.rs

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -459,32 +459,12 @@ impl BlockSize {
   }
 
   pub fn is_rect_tx_allowed(self) -> bool {
-    static LUT: [u8; BlockSize::BLOCK_SIZES_ALL] = [
-      0,  // BLOCK_4X4
-      1,  // BLOCK_4X8
-      1,  // BLOCK_8X4
-      0,  // BLOCK_8X8
-      1,  // BLOCK_8X16
-      1,  // BLOCK_16X8
-      0,  // BLOCK_16X16
-      1,  // BLOCK_16X32
-      1,  // BLOCK_32X16
-      0,  // BLOCK_32X32
-      1,  // BLOCK_32X64
-      1,  // BLOCK_64X32
-      0,  // BLOCK_64X64
-      0,  // BLOCK_64X128
-      0,  // BLOCK_128X64
-      0,  // BLOCK_128X128
-      1,  // BLOCK_4X16
-      1,  // BLOCK_16X4
-      1,  // BLOCK_8X32
-      1,  // BLOCK_32X8
-      1,  // BLOCK_16X64
-      1,  // BLOCK_64X16
-    ];
-
-    LUT[self as usize] == 1
+    match self {
+      BLOCK_4X4 | BLOCK_8X8 | BLOCK_16X16 | BLOCK_32X32 |
+      BLOCK_64X64 | BLOCK_64X128 | BLOCK_128X64 | BLOCK_128X128 => false,
+      BLOCK_INVALID => unreachable!(),
+      _ => true
+    }
   }
 }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -138,12 +138,6 @@ pub enum BlockSize {
 impl BlockSize {
   pub const BLOCK_SIZES_ALL: usize = 22;
 
-  const BLOCK_SIZE_WIDTH_LOG2: [usize; BlockSize::BLOCK_SIZES_ALL] =
-    [2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 2, 4, 3, 5, 4, 6];
-
-  const BLOCK_SIZE_HEIGHT_LOG2: [usize; BlockSize::BLOCK_SIZES_ALL] =
-    [2, 3, 2, 3, 4, 3, 4, 5, 4, 5, 6, 5, 6, 7, 6, 7, 4, 2, 5, 3, 6, 4];
-
   pub fn from_width_and_height(w: usize, h: usize) -> BlockSize {
     match (w, h) {
       (4, 4) => BLOCK_4X4,
@@ -182,7 +176,15 @@ impl BlockSize {
   }
 
   pub fn width_log2(self) -> usize {
-    BlockSize::BLOCK_SIZE_WIDTH_LOG2[self as usize]
+    match self {
+      BLOCK_4X4 | BLOCK_4X8 | BLOCK_4X16 => 2,
+      BLOCK_8X4 | BLOCK_8X8 | BLOCK_8X16 | BLOCK_8X32 => 3,
+      BLOCK_16X4 | BLOCK_16X8 | BLOCK_16X16 | BLOCK_16X32 | BLOCK_16X64 => 4,
+      BLOCK_32X8 | BLOCK_32X16 | BLOCK_32X32 | BLOCK_32X64 => 5,
+      BLOCK_64X16 | BLOCK_64X32 | BLOCK_64X64 | BLOCK_64X128 => 6,
+      BLOCK_128X64 | BLOCK_128X128 => 7,
+      BLOCK_INVALID => unreachable!()
+    }
   }
 
   pub fn width_mi(self) -> usize {
@@ -194,7 +196,15 @@ impl BlockSize {
   }
 
   pub fn height_log2(self) -> usize {
-    BlockSize::BLOCK_SIZE_HEIGHT_LOG2[self as usize]
+    match self {
+      BLOCK_4X4 | BLOCK_8X4 | BLOCK_16X4 => 2,
+      BLOCK_4X8 | BLOCK_8X8 | BLOCK_16X8 | BLOCK_32X8 => 3,
+      BLOCK_4X16 | BLOCK_8X16 | BLOCK_16X16 | BLOCK_32X16 | BLOCK_64X16 => 4,
+      BLOCK_8X32 | BLOCK_16X32 | BLOCK_32X32 | BLOCK_64X32 => 5,
+      BLOCK_16X64 | BLOCK_32X64 | BLOCK_64X64 | BLOCK_128X64 => 6,
+      BLOCK_64X128 | BLOCK_128X128 => 7,
+      BLOCK_INVALID => unreachable!()
+    }
   }
 
   pub fn height_mi(self) -> usize {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -228,7 +228,6 @@ impl BlockSize {
 
   pub fn largest_uv_tx_size(self, xdec: usize, ydec: usize) -> TxSize {
     let plane_bsize = get_plane_block_size(self, xdec, ydec);
-    debug_assert!((plane_bsize as usize) < BlockSize::BLOCK_SIZES_ALL);
     let uv_tx = max_txsize_rect_lookup[plane_bsize as usize];
 
     av1_get_coded_tx_size(uv_tx)
@@ -259,203 +258,49 @@ impl BlockSize {
     (self.width() == other.width() && self.height() == other.height())
   }
 
-  #[rustfmt::skip]
-  const SUBSIZE_LOOKUP: [[BlockSize; BlockSize::BLOCK_SIZES_ALL];
-    EXT_PARTITION_TYPES] = [
-    // PARTITION_NONE
-    [
-      //                            4X4
-                                    BLOCK_4X4,
-      // 4X8,        8X4,           8X8
-      BLOCK_4X8,     BLOCK_8X4,     BLOCK_8X8,
-      // 8X16,       16X8,          16X16
-      BLOCK_8X16,    BLOCK_16X8,    BLOCK_16X16,
-      // 16X32,      32X16,         32X32
-      BLOCK_16X32,   BLOCK_32X16,   BLOCK_32X32,
-      // 32X64,      64X32,         64X64
-      BLOCK_32X64,   BLOCK_64X32,   BLOCK_64X64,
-      // 64x128,     128x64,        128x128
-      BLOCK_64X128,  BLOCK_128X64,  BLOCK_128X128,
-      // 4X16,       16X4,          8X32
-      BLOCK_4X16,    BLOCK_16X4,    BLOCK_8X32,
-      // 32X8,       16X64,         64X16
-      BLOCK_32X8,    BLOCK_16X64,   BLOCK_64X16
-    ],
-    // PARTITION_HORZ
-    [
-      //                            4X4
-                                    BLOCK_INVALID,
-      // 4X8,        8X4,           8X8
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X4,
-      // 8X16,       16X8,          16X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X8,
-      // 16X32,      32X16,         32X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_32X16,
-      // 32X64,      64X32,         64X64
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X32,
-      // 64x128,     128x64,        128x128
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_128X64,
-      // 4X16,       16X4,          8X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 32X8,       16X64,         64X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-    ],
-    // PARTITION_VERT
-    [
-      //                            4X4
-                                    BLOCK_INVALID,
-      // 4X8,        8X4,           8X8
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_4X8,
-      // 8X16,       16X8,          16X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X16,
-      // 16X32,      32X16,         32X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X32,
-      // 32X64,      64X32,         64X64
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_32X64,
-      // 64x128,     128x64,        128x128
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X128,
-      // 4X16,       16X4,          8X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 32X8,       16X64,         64X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-    ],
-    // PARTITION_SPLIT
-    [
-      //                            4X4
-                                    BLOCK_INVALID,
-      // 4X8,        8X4,           8X8
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_4X4,
-      // 8X16,       16X8,          16X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X8,
-      // 16X32,      32X16,         32X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X16,
-      // 32X64,      64X32,         64X64
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_32X32,
-      // 64x128,     128x64,        128x128
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X64,
-      // 4X16,       16X4,          8X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 32X8,       16X64,         64X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-    ],
-    // PARTITION_HORZ_A
-    [
-      //                            4X4
-                                    BLOCK_INVALID,
-      // 4X8,        8X4,           8X8
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X4,
-      // 8X16,       16X8,          16X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X8,
-      // 16X32,      32X16,         32X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_32X16,
-      // 32X64,      64X32,         64X64
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X32,
-      // 64x128,     128x64,        128x128
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_128X64,
-      // 4X16,       16X4,          8X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 32X8,       16X64,         64X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-    ],
-    // PARTITION_HORZ_B
-    [
-      //                            4X4
-                                    BLOCK_INVALID,
-      // 4X8,        8X4,           8X8
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X4,
-      // 8X16,       16X8,          16X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X8,
-      // 16X32,      32X16,         32X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_32X16,
-      // 32X64,      64X32,         64X64
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X32,
-      // 64x128,     128x64,        128x128
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_128X64,
-      // 4X16,       16X4,          8X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 32X8,       16X64,         64X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-    ],
-    // PARTITION_VERT_A
-    [
-      //                            4X4
-                                    BLOCK_INVALID,
-      // 4X8,        8X4,           8X8
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_4X8,
-      // 8X16,       16X8,          16X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X16,
-      // 16X32,      32X16,         32X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X32,
-      // 32X64,      64X32,         64X64
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_32X64,
-      // 64x128,     128x64,        128x128
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X128,
-      // 4X16,       16X4,          8X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 32X8,       16X64,         64X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-    ],
-    // PARTITION_VERT_B
-    [
-      //                            4X4
-                                    BLOCK_INVALID,
-      // 4X8,        8X4,           8X8
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_4X8,
-      // 8X16,       16X8,          16X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X16,
-      // 16X32,      32X16,         32X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X32,
-      // 32X64,      64X32,         64X64
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_32X64,
-      // 64x128,     128x64,        128x128
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X128,
-      // 4X16,       16X4,          8X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 32X8,       16X64,         64X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-    ],
-    // PARTITION_HORZ_4
-    [
-      //                            4X4
-                                    BLOCK_INVALID,
-      // 4X8,        8X4,           8X8
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 8X16,       16X8,          16X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X4,
-      // 16X32,      32X16,         32X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_32X8,
-      // 32X64,      64X32,         64X64
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X16,
-      // 64x128,     128x64,        128x128
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 4X16,       16X4,          8X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 32X8,       16X64,         64X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-    ],
-    // PARTITION_VERT_4
-    [
-      //                            4X4
-                                    BLOCK_INVALID,
-      // 4X8,        8X4,           8X8
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 8X16,       16X8,          16X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_4X16,
-      // 16X32,      32X16,         32X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X32,
-      // 32X64,      64X32,         64X64
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X64,
-      // 64x128,     128x64,        128x128
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 4X16,       16X4,          8X32
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
-      // 32X8,       16X64,         64X16
-      BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-    ]
-  ];
-
   pub fn subsize(self, partition: PartitionType) -> BlockSize {
-    BlockSize::SUBSIZE_LOOKUP[partition as usize][self as usize]
+    use PartitionType::*;
+
+    match partition {
+      PARTITION_NONE => self,
+      PARTITION_SPLIT => match self {
+        BLOCK_8X8 => BLOCK_4X4,
+        BLOCK_16X16 => BLOCK_8X8,
+        BLOCK_32X32 => BLOCK_16X16,
+        BLOCK_64X64 => BLOCK_32X32,
+        BLOCK_128X128 => BLOCK_64X64,
+        _ => BLOCK_INVALID
+      }
+      PARTITION_HORZ | PARTITION_HORZ_A | PARTITION_HORZ_B => match self {
+        BLOCK_8X8 => BLOCK_8X4,
+        BLOCK_16X16 => BLOCK_16X8,
+        BLOCK_32X32 => BLOCK_32X16,
+        BLOCK_64X64 => BLOCK_64X32,
+        BLOCK_128X128 => BLOCK_128X64,
+        _ => BLOCK_INVALID
+      },
+      PARTITION_VERT | PARTITION_VERT_A | PARTITION_VERT_B => match self {
+        BLOCK_8X8 => BLOCK_4X8,
+        BLOCK_16X16 => BLOCK_8X16,
+        BLOCK_32X32 => BLOCK_16X32,
+        BLOCK_64X64 => BLOCK_32X64,
+        BLOCK_128X128 => BLOCK_64X128,
+        _ => BLOCK_INVALID
+      },
+      PARTITION_HORZ_4 => match self {
+        BLOCK_16X16 => BLOCK_16X4,
+        BLOCK_32X32 => BLOCK_32X8,
+        BLOCK_64X64 => BLOCK_64X16,
+        _ => BLOCK_INVALID
+      },
+      PARTITION_VERT_4 => match self {
+        BLOCK_16X16 => BLOCK_4X16,
+        BLOCK_32X32 => BLOCK_8X32,
+        BLOCK_64X64 => BLOCK_16X64,
+        _ => BLOCK_INVALID
+      },
+      _ => BLOCK_INVALID
+    }
   }
 
   pub fn is_rect_tx_allowed(self) -> bool {


### PR DESCRIPTION
The goal of this change is to improve readability and conciseness. LUTs are unreadable without comments to remind the reader of what item each value is associated with (for example each block size). Pattern matching is self-documenting. There is also some redundancy with LUTs, such as multiple types of horizontal and vertical partitioning schemes using the same block size to subsize maps (compare the size of the LUT used by the `subsize()` function vs. the pattern matching alternative).