### PR TITLE
Clean up subsampled block size and chroma transform size functions

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -168,38 +168,6 @@ pub static sub_tx_size_map: [TxSize; TxSize::TX_SIZES_ALL] = [
   TX_32X16,  // TX_64X16
 ];
 
-static ss_size_lookup: [[[BlockSize; 2]; 2]; BlockSize::BLOCK_SIZES_ALL] = [
-  //  ss_x == 0    ss_x == 0        ss_x == 1      ss_x == 1
-  //  ss_y == 0    ss_y == 1        ss_y == 0      ss_y == 1
-  [  [ BLOCK_4X4, BLOCK_4X4 ], [BLOCK_4X4, BLOCK_4X4 ] ],
-  [  [ BLOCK_4X8, BLOCK_4X4 ], [BLOCK_4X4, BLOCK_4X4 ] ],
-  [  [ BLOCK_8X4, BLOCK_4X4 ], [BLOCK_4X4, BLOCK_4X4 ] ],
-  [  [ BLOCK_8X8, BLOCK_8X4 ], [BLOCK_4X8, BLOCK_4X4 ] ],
-  [  [ BLOCK_8X16, BLOCK_8X8 ], [BLOCK_4X16, BLOCK_4X8 ] ],
-  [  [ BLOCK_16X8, BLOCK_16X4 ], [BLOCK_8X8, BLOCK_8X4 ] ],
-  [  [ BLOCK_16X16, BLOCK_16X8 ], [BLOCK_8X16, BLOCK_8X8 ] ],
-  [  [ BLOCK_16X32, BLOCK_16X16 ], [BLOCK_8X32, BLOCK_8X16 ] ],
-  [  [ BLOCK_32X16, BLOCK_32X8 ], [BLOCK_16X16, BLOCK_16X8 ] ],
-  [  [ BLOCK_32X32, BLOCK_32X16 ], [BLOCK_16X32, BLOCK_16X16 ] ],
-  [  [ BLOCK_32X64, BLOCK_32X32 ], [BLOCK_16X64, BLOCK_16X32 ] ],
-  [  [ BLOCK_64X32, BLOCK_64X16 ], [BLOCK_32X32, BLOCK_32X16 ] ],
-  [  [ BLOCK_64X64, BLOCK_64X32 ], [BLOCK_32X64, BLOCK_32X32 ] ],
-  [  [ BLOCK_64X128, BLOCK_64X64 ], [ BLOCK_INVALID, BLOCK_32X64 ] ],
-  [  [ BLOCK_128X64, BLOCK_INVALID ], [ BLOCK_64X64, BLOCK_64X32 ] ],
-  [  [ BLOCK_128X128, BLOCK_128X64 ], [ BLOCK_64X128, BLOCK_64X64 ] ],
-  [  [ BLOCK_4X16, BLOCK_4X8 ], [BLOCK_4X16, BLOCK_4X8 ] ],
-  [  [ BLOCK_16X4, BLOCK_16X4 ], [BLOCK_8X4, BLOCK_8X4 ] ],
-  [  [ BLOCK_8X32, BLOCK_8X16 ], [BLOCK_INVALID, BLOCK_4X16 ] ],
-  [  [ BLOCK_32X8, BLOCK_INVALID ], [BLOCK_16X8, BLOCK_16X4 ] ],
-  [  [ BLOCK_16X64, BLOCK_16X32 ], [BLOCK_INVALID, BLOCK_8X32 ] ],
-  [  [ BLOCK_64X16, BLOCK_INVALID ], [BLOCK_32X16, BLOCK_32X8 ] ]
-];
-
-pub fn get_plane_block_size(bsize: BlockSize, subsampling_x: usize, subsampling_y: usize)
-    -> BlockSize {
-  ss_size_lookup[bsize as usize][subsampling_x][subsampling_y]
-}
-
 // Generates 4 bit field in which each bit set to 1 represents
 // a blocksize partition  1111 means we split 64x64, 32x32, 16x16
 // and 8x8.  1000 means we just split the 64x64 to 32x32
@@ -1538,7 +1506,7 @@ impl<'a> BlockContext<'a> {
       let plane_bsize = if plane == 0 {
         bsize
       } else {
-        get_plane_block_size(bsize, xdec2, ydec2)
+        bsize.subsampled_size(xdec2, ydec2)
       };
       let bw = plane_bsize.width_mi();
       let bh = plane_bsize.height_mi();

--- a/src/context.rs
+++ b/src/context.rs
@@ -1797,17 +1797,12 @@ macro_rules! symbol_with_update {
 }
 
 pub fn av1_get_coded_tx_size(tx_size: TxSize) -> TxSize {
-  if tx_size == TX_64X64 || tx_size == TX_64X32 || tx_size == TX_32X64 {
-    return TX_32X32
+  match tx_size {
+    TX_64X64 | TX_64X32 | TX_32X64 => TX_32X32,
+    TX_16X64 => TX_16X32,
+    TX_64X16 => TX_32X16,
+    _ => tx_size
   }
-  if tx_size == TX_16X64 {
-    return TX_16X32
-  }
-  if tx_size == TX_64X16 {
-    return TX_32X16
-  }
-
-  tx_size
 }
 
 #[derive(Clone)]

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -129,7 +129,7 @@ fn deblock_size<T: Pixel>(
     let (txsize, prev_txsize) = if pli==0 {
       (block.txsize, prev_block.txsize)
     } else {
-      (block.bsize.largest_uv_tx_size(xdec, ydec), prev_block.bsize.largest_uv_tx_size(xdec, ydec))
+      (block.bsize.largest_chroma_tx_size(xdec, ydec), prev_block.bsize.largest_chroma_tx_size(xdec, ydec))
     };
     let (tx_n, prev_tx_n) = if vertical {
       (cmp::max(txsize.width_mi(), 1), cmp::max(prev_txsize.width_mi(), 1))
@@ -1030,7 +1030,7 @@ fn filter_v_edge<T: Pixel>(
   pli: usize, bd: usize, xdec: usize, ydec: usize
 ) {
   let block = &blocks[bo];
-  let txsize = if pli==0 { block.txsize } else { block.bsize.largest_uv_tx_size(xdec, ydec) };
+  let txsize = if pli==0 { block.txsize } else { block.bsize.largest_chroma_tx_size(xdec, ydec) };
   let tx_edge = bo.x >> xdec & (txsize.width_mi() - 1) == 0;
   if tx_edge {
     let prev_block = deblock_left(blocks, bo, p);
@@ -1068,7 +1068,7 @@ fn sse_v_edge<T: Pixel>(
   tally: &mut [i64; MAX_LOOP_FILTER + 2], pli: usize, bd: usize, xdec: usize, ydec: usize
 ) {
   let block = &blocks[bo];
-  let txsize = if pli==0 { block.txsize } else { block.bsize.largest_uv_tx_size(xdec, ydec) };
+  let txsize = if pli==0 { block.txsize } else { block.bsize.largest_chroma_tx_size(xdec, ydec) };
   let tx_edge = bo.x >> xdec & (txsize.width_mi() - 1) == 0;
   if tx_edge {
     let prev_block = deblock_left(blocks, bo, rec_plane);
@@ -1135,7 +1135,7 @@ fn filter_h_edge<T: Pixel>(
   pli: usize, bd: usize, xdec: usize, ydec: usize
 ) {
   let block = &blocks[bo];
-  let txsize = if pli==0 { block.txsize } else { block.bsize.largest_uv_tx_size(xdec, ydec) };
+  let txsize = if pli==0 { block.txsize } else { block.bsize.largest_chroma_tx_size(xdec, ydec) };
   let tx_edge = bo.y >> ydec & (txsize.height_mi() - 1) == 0;
   if tx_edge {
     let prev_block = deblock_up(blocks, bo, p);
@@ -1173,7 +1173,7 @@ fn sse_h_edge<T: Pixel>(
   tally: &mut [i64; MAX_LOOP_FILTER + 2], pli: usize, bd: usize, xdec: usize, ydec: usize
 ) {
   let block = &blocks[bo];
-  let txsize = if pli==0 { block.txsize } else { block.bsize.largest_uv_tx_size(xdec, ydec) };
+  let txsize = if pli==0 { block.txsize } else { block.bsize.largest_chroma_tx_size(xdec, ydec) };
   let tx_edge = bo.y >> ydec & (txsize.height_mi() - 1) == 0;
   if tx_edge {
     let prev_block = deblock_up(blocks, bo, rec_plane);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1354,7 +1354,7 @@ pub fn write_tx_blocks<T: Pixel>(
 
   if luma_only { return tx_dist };
 
-  let uv_tx_size = bsize.largest_uv_tx_size(xdec, ydec);
+  let uv_tx_size = bsize.largest_chroma_tx_size(xdec, ydec);
 
   let mut bw_uv = (bw * tx_size.width_mi()) >> xdec;
   let mut bh_uv = (bh * tx_size.height_mi()) >> ydec;
@@ -1443,7 +1443,7 @@ pub fn write_tx_tree<T: Pixel>(
 
   if luma_only { return tx_dist };
 
-  let uv_tx_size = bsize.largest_uv_tx_size(xdec, ydec);
+  let uv_tx_size = bsize.largest_chroma_tx_size(xdec, ydec);
 
   let mut bw_uv = (bw * tx_size.width_mi()) >> xdec;
   let mut bh_uv = (bh * tx_size.height_mi()) >> ydec;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1010,7 +1010,7 @@ pub fn motion_compensate<T: Pixel>(
   let luma_tile_rect = ts.tile_rect();
   for p in 0..num_planes {
     let plane_bsize = if p == 0 { bsize }
-    else { get_plane_block_size(bsize, u_xdec, u_ydec) };
+    else { bsize.subsampled_size(u_xdec, u_ydec) };
 
     let rec = &mut ts.rec.planes[p];
     let po = tile_bo.plane_offset(&rec.plane_cfg);
@@ -1278,7 +1278,7 @@ pub fn luma_ac<T: Pixel>(
   ac: &mut [i16], ts: &mut TileStateMut<'_, T>, tile_bo: BlockOffset, bsize: BlockSize
 ) {
   let PlaneConfig { xdec, ydec, .. } = ts.input.planes[1].cfg;
-  let plane_bsize = get_plane_block_size(bsize, xdec, ydec);
+  let plane_bsize = bsize.subsampled_size(xdec, ydec);
   let bo = if bsize.is_sub8x8(xdec, ydec) {
     let offset = bsize.sub8x8_offset(xdec, ydec);
     tile_bo.with_offset(offset.0, offset.1)
@@ -1367,7 +1367,7 @@ pub fn write_tx_blocks<T: Pixel>(
   bw_uv /= uv_tx_size.width_mi();
   bh_uv /= uv_tx_size.height_mi();
 
-  let plane_bsize = get_plane_block_size(bsize, xdec, ydec);
+  let plane_bsize = bsize.subsampled_size(xdec, ydec);
 
   if chroma_mode.is_cfl() {
     luma_ac(&mut ac.array, ts, tile_bo, bsize);
@@ -1456,7 +1456,7 @@ pub fn write_tx_tree<T: Pixel>(
   bw_uv /= uv_tx_size.width_mi();
   bh_uv /= uv_tx_size.height_mi();
 
-  let plane_bsize = get_plane_block_size(bsize, xdec, ydec);
+  let plane_bsize = bsize.subsampled_size(xdec, ydec);
 
   if bw_uv > 0 && bh_uv > 0 {
     // TODO: Disable these asserts temporarilly, since chroma_sampling_422_aom and chroma_sampling_444_aom

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -236,8 +236,52 @@ impl BlockSize {
     }
   }
 
+  /// Source: Subsampled_Size (AV1 specification section 5.11.38)
+  pub fn subsampled_size(self, xdec: usize, ydec: usize) -> BlockSize {
+    match (xdec, ydec) {
+      (0, 0) /* 4:4:4 */ => self,
+      (1, 0) /* 4:2:2 */ => match self {
+        BLOCK_4X4 | BLOCK_8X4 => BLOCK_4X4,
+        BLOCK_8X8 => BLOCK_4X8,
+        BLOCK_16X4 => BLOCK_8X4,
+        BLOCK_16X8 => BLOCK_8X8,
+        BLOCK_16X16 => BLOCK_8X16,
+        BLOCK_32X8 => BLOCK_16X8,
+        BLOCK_32X16 => BLOCK_16X16,
+        BLOCK_32X32 => BLOCK_16X32,
+        BLOCK_64X16 => BLOCK_32X16,
+        BLOCK_64X32 => BLOCK_32X32,
+        BLOCK_64X64 => BLOCK_32X64,
+        BLOCK_128X64 => BLOCK_64X64,
+        BLOCK_128X128 => BLOCK_64X128,
+        _ => BLOCK_INVALID
+      },
+      (1, 1) /* 4:2:0 */ => match self {
+        BLOCK_4X4 | BLOCK_4X8 | BLOCK_8X4 | BLOCK_8X8 => BLOCK_4X4,
+        BLOCK_4X16 | BLOCK_8X16 => BLOCK_4X8,
+        BLOCK_8X32 => BLOCK_4X16,
+        BLOCK_16X4 | BLOCK_16X8 => BLOCK_8X4,
+        BLOCK_16X16 => BLOCK_8X8,
+        BLOCK_16X32 => BLOCK_8X16,
+        BLOCK_16X64 => BLOCK_8X32,
+        BLOCK_32X8 => BLOCK_16X4,
+        BLOCK_32X16 => BLOCK_16X8,
+        BLOCK_32X32 => BLOCK_16X16,
+        BLOCK_32X64 => BLOCK_16X32,
+        BLOCK_64X16 => BLOCK_32X8,
+        BLOCK_64X32 => BLOCK_32X16,
+        BLOCK_64X64 => BLOCK_32X32,
+        BLOCK_64X128 => BLOCK_32X64,
+        BLOCK_128X64 => BLOCK_64X32,
+        BLOCK_128X128 => BLOCK_64X64,
+        _ => BLOCK_INVALID
+      },
+      _ => unreachable!()
+    }
+  }
+
   pub fn largest_chroma_tx_size(self, xdec: usize, ydec: usize) -> TxSize {
-    let plane_bsize = get_plane_block_size(self, xdec, ydec);
+    let plane_bsize = self.subsampled_size(xdec, ydec);
     let uv_tx = max_txsize_rect_lookup[plane_bsize as usize];
 
     av1_get_coded_tx_size(uv_tx)

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -236,7 +236,7 @@ impl BlockSize {
     }
   }
 
-  pub fn largest_uv_tx_size(self, xdec: usize, ydec: usize) -> TxSize {
+  pub fn largest_chroma_tx_size(self, xdec: usize, ydec: usize) -> TxSize {
     let plane_bsize = get_plane_block_size(self, xdec, ydec);
     let uv_tx = max_txsize_rect_lookup[plane_bsize as usize];
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -902,7 +902,7 @@ pub fn rdo_cfl_alpha<T: Pixel>(
   ts: &mut TileStateMut<'_, T>, tile_bo: BlockOffset, bsize: BlockSize, bit_depth: usize
 ) -> Option<CFLParams> {
   let PlaneConfig { xdec, ydec, .. } = ts.input.planes[1].cfg;
-  let uv_tx_size = bsize.largest_uv_tx_size(xdec, ydec);
+  let uv_tx_size = bsize.largest_chroma_tx_size(xdec, ydec);
 
   let mut ac: AlignedArray<[i16; 32 * 32]> = UninitializedAlignedArray();
   luma_ac(&mut ac.array, ts, tile_bo, bsize);


### PR DESCRIPTION
Requesting @ycho for review as the last person who touched this code, but if someone else wants to review please go ahead.

I found the format of the `Subsampled_Size` table (which is equivalent to `ss_size_lookup`) to be difficult to read, and there is unnecessary data for subsampling in the vertical but not horizontal direction (which does not correspond to any supported color space). It is replaced here with pattern matching. It is a bit longer than the LUT but more readable in my opinion.

There were also some errors in the `ss_size_lookup` tables, mostly block sizes that should be invalid that were not marked as such in 4:2:2. I used the specification as reference for this conversion.