### PR TITLE
Fix vertical partitions being coded for 4:2:2 content

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1780,7 +1780,13 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
       if split_horz { partition_types.push(PartitionType::PARTITION_HORZ); };
       if split_vert { partition_types.push(PartitionType::PARTITION_VERT); };
     } else if bsize.width_log2() == fi.min_partition_size.width_log2() + 1 {
-      partition_types.extend_from_slice(RAV1E_PARTITION_TYPES);
+      partition_types.push(PartitionType::PARTITION_NONE);
+      partition_types.push(PartitionType::PARTITION_SPLIT);
+      partition_types.push(PartitionType::PARTITION_HORZ);
+
+      if fi.sequence.chroma_sampling != ChromaSampling::Cs422 {
+        partition_types.push(PartitionType::PARTITION_VERT);
+      }
     } else {
       partition_types.push(PartitionType::PARTITION_NONE);
       partition_types.push(PartitionType::PARTITION_SPLIT);

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -280,6 +280,10 @@ impl BlockSize {
 
   pub fn largest_chroma_tx_size(self, xdec: usize, ydec: usize) -> TxSize {
     let plane_bsize = self.subsampled_size(xdec, ydec);
+    if plane_bsize == BLOCK_INVALID {
+      panic!("invalid block size for this subsampling mode");
+    }
+
     let uv_tx = max_txsize_rect_lookup[plane_bsize as usize];
 
     av1_get_coded_tx_size(uv_tx)


### PR DESCRIPTION
One branch was allowing vertical partitions to be added to the list.

Also panic with a more friendly error message instead of trying to access an array out of bounds when trying to code such an invalid partition.