### PR TITLE
Disable intra tx partition

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -635,7 +635,8 @@ impl<T: Pixel> FrameInvariants<T> {
       fi.ref_frames[i] = 0;
     }
 
-    fi.tx_mode_select = fi.config.speed_settings.rdo_tx_decision;
+    // Until has_tr() and has_bl() is fixed to use partition info, disable intra tx partition
+    fi.tx_mode_select = false;
 
     fi
   }

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -32,14 +32,12 @@ pub static RAV1E_INTRA_MODES: &'static [PredictionMode] = &[
   PredictionMode::SMOOTH_H_PRED,
   PredictionMode::SMOOTH_V_PRED,
   PredictionMode::PAETH_PRED,
-  // Disable directional intra prediction AGAIN, since it cause failure
-  // with intra tx partitioning depth = 2
-  /* PredictionMode::D45_PRED,
+  PredictionMode::D45_PRED,
   PredictionMode::D135_PRED,
   PredictionMode::D117_PRED,
   PredictionMode::D153_PRED,
   PredictionMode::D207_PRED,
-  PredictionMode::D63_PRED, */
+  PredictionMode::D63_PRED,
 ];
 
 pub static RAV1E_INTER_MODES_MINIMAL: &'static [PredictionMode] = &[


### PR DESCRIPTION
    Disable transform partition for intra mode block
    
    Until the two functons has_tr() and has_bl() is fixed to use partition type info
    or add new two separate versions, disable intra tx partition.
    
    Our existing has_tr() and has_bl() have been shared by both mvref and intra prediction uses,
    and it works if partition size == tx block size.
    However, it can fail if multiple tx blocks exist in a partition, due to missing logic
    to decide the availability of top right and bottom left pixels based on partition type.
    
    Then, enable the disabled directional intra prediction
    since it works if no tx partition is done.