### PR TITLE
Fix and enable non-4:2:0 inter frames (excluding sub-8x8 blocks)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -507,12 +507,7 @@ impl Config {
 
     // FIXME: inter unsupported with 4:2:2 and 4:4:4 chroma sampling
     let chroma_sampling = config.chroma_sampling;
-    let keyframe_only = chroma_sampling == ChromaSampling::Cs444 ||
-      chroma_sampling == ChromaSampling::Cs422;
-    if keyframe_only {
-      config.max_key_frame_interval = 1;
-      config.min_key_frame_interval = 1;
-    }
+
     // FIXME: tx partition for intra not supported for chroma 422
     if chroma_sampling == ChromaSampling::Cs422 {
       config.speed_settings.rdo_tx_decision = false;

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -385,10 +385,8 @@ fn chroma_sampling(decoder: &str, cs: ChromaSampling) {
   let w = 64;
   let h = 80;
 
-  // TODO: bump keyint when inter is supported
-
   let mut dec = get_decoder::<u8>(decoder, w as usize, h as usize);
-  dec.encode_decode(w, h, speed, quantizer, limit, 8, cs, 1, 1, true, 0, 0, 0);
+  dec.encode_decode(w, h, speed, quantizer, limit, 8, cs, 15, 15, true, 0, 0, 0);
 }
 
 macro_rules! test_chroma_sampling {


### PR DESCRIPTION
Some work towards #970.

This also explicitly disables blocks of size under 8x8 for non-4:2:0 inter frames via ugly condition sets in the `encoder.rs` partitioning functions.