### PR TITLE
cdef: pick strength based on quantizer

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -24,7 +24,7 @@ pub struct CdefDirections {
 }
 
 pub const CDEF_VERY_LARGE: u16 = 30000;
-pub const CDEF_SEC_STRENGTHS: u8 = 4;
+pub(crate) const CDEF_SEC_STRENGTHS: u8 = 4;
 
 // Instead of dividing by n between 2 and 8, we multiply by 3*5*7*8/n.
 // The output is then 840 times larger, but we don't care for finding

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -24,7 +24,7 @@ pub struct CdefDirections {
 }
 
 pub const CDEF_VERY_LARGE: u16 = 30000;
-const CDEF_SEC_STRENGTHS: u8 = 4;
+pub const CDEF_SEC_STRENGTHS: u8 = 4;
 
 // Instead of dividing by n between 2 and 8, we multiply by 3*5*7*8/n.
 // The output is then 840 times larger, but we don't care for finding

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -762,11 +762,6 @@ impl<T: Pixel> FrameInvariants<T> {
 
   pub fn set_quantizers(&mut self, qps: &QuantizerParameters) {
     self.base_q_idx = qps.ac_qi[0];
-    if self.frame_type != FrameType::KEY {
-      self.cdef_bits = 0;
-    } else {
-      self.cdef_bits = 0;
-    }
     let base_q_idx = self.base_q_idx as i32;
     for pi in 0..3 {
       debug_assert!(qps.dc_qi[pi] as i32 - base_q_idx >= -128);
@@ -783,17 +778,17 @@ impl<T: Pixel> FrameInvariants<T> {
     let q = bexp64(qps.log_target_q as i64 + q57(QSCALE)) as f32;
     /* These coefficients were trained on libaom. */
     if !self.intra_only {
-        let predicted_y_f1 = clamp((-q * q * 0.00000235939456_f32 + q * 0.0068615186_f32 + 0.02709886_f32).round() as i32, 0, 15);
-        let predicted_y_f2 = clamp((-q * q * 0.000000576297339_f32 + q * 0.00139933452_f32 + 0.03831067_f32).round() as i32, 0, 3);
-        let predicted_uv_f1 = clamp((-q * q * 0.000000709506878_f32 + q * 0.00346288458_f32 + 0.00887099_f32).round() as i32, 0, 15);
-        let predicted_uv_f2 = clamp((q * q * 0.000000238740853_f32 + q * 0.000282235851_f32 + 0.05576307_f32).round() as i32, 0, 3);
+        let predicted_y_f1 = clamp((-q * q * 0.0000023593946_f32 + q * 0.0068615186_f32 + 0.02709886_f32).round() as i32, 0, 15);
+        let predicted_y_f2 = clamp((-q * q * 0.00000057629734_f32 + q * 0.0013993345_f32 + 0.03831067_f32).round() as i32, 0, 3);
+        let predicted_uv_f1 = clamp((-q * q * 0.0000007095069_f32 + q * 0.0034628846_f32 + 0.00887099_f32).round() as i32, 0, 15);
+        let predicted_uv_f2 = clamp((q * q * 0.00000023874085_f32 + q * 0.00028223585_f32 + 0.05576307_f32).round() as i32, 0, 3);
         self.cdef_y_strengths[0] = (predicted_y_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_y_f2) as u8;
         self.cdef_uv_strengths[0] = (predicted_uv_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_uv_f2) as u8;
     } else {
-        let predicted_y_f1 = clamp((q * q * 0.00000337319739_f32 + q * 0.0080705937_f32 + 0.0187634_f32).round() as i32, 0, 15);
-        let predicted_y_f2 = clamp((-q * q * -0.00000291673427_f32 + q * 0.00277986238_f32 + 0.0079405_f32).round() as i32, 0, 3);
-        let predicted_uv_f1 = clamp((-q * q * 0.0000130790995_f32 + q * 0.0128924046_f32 - 0.00748388_f32).round() as i32, 0, 15);
-        let predicted_uv_f2 = clamp((q * q * 0.00000326517829_f32 + q * 0.000355201832_f32 + 0.00228092_f32).round() as i32, 0, 3);
+        let predicted_y_f1 = clamp((q * q * 0.0000033731974_f32 + q * 0.008070594_f32 + 0.0187634_f32).round() as i32, 0, 15);
+        let predicted_y_f2 = clamp((-q * q * -0.00000291673427_f32 + q * 0.0027798624_f32 + 0.0079405_f32).round() as i32, 0, 3);
+        let predicted_uv_f1 = clamp((-q * q * 0.0000130790995_f32 + q * 0.012892405_f32 - 0.00748388_f32).round() as i32, 0, 15);
+        let predicted_uv_f2 = clamp((q * q * 0.0000032651783_f32 + q * 0.00035520183_f32 + 0.00228092_f32).round() as i32, 0, 3);
         self.cdef_y_strengths[0] = (predicted_y_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_y_f2) as u8;
         self.cdef_uv_strengths[0] = (predicted_uv_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_uv_f2) as u8;
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -786,7 +786,7 @@ impl<T: Pixel> FrameInvariants<T> {
         self.cdef_uv_strengths[0] = (predicted_uv_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_uv_f2) as u8;
     } else {
         let predicted_y_f1 = clamp((q * q * 0.0000033731974_f32 + q * 0.008070594_f32 + 0.0187634_f32).round() as i32, 0, 15);
-        let predicted_y_f2 = clamp((-q * q * -0.00000291673427_f32 + q * 0.0027798624_f32 + 0.0079405_f32).round() as i32, 0, 3);
+        let predicted_y_f2 = clamp((-q * q * -0.0000029167343_f32 + q * 0.0027798624_f32 + 0.0079405_f32).round() as i32, 0, 3);
         let predicted_uv_f1 = clamp((-q * q * 0.0000130790995_f32 + q * 0.012892405_f32 - 0.00748388_f32).round() as i32, 0, 15);
         let predicted_uv_f2 = clamp((q * q * 0.0000032651783_f32 + q * 0.00035520183_f32 + 0.00228092_f32).round() as i32, 0, 3);
         self.cdef_y_strengths[0] = (predicted_y_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_y_f2) as u8;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -471,7 +471,6 @@ pub struct FrameInvariants<T: Pixel> {
   pub dc_delta_q: [i8; 3],
   pub ac_delta_q: [i8; 3],
   pub lambda: f64,
-  pub log_target_q: i64,
   pub me_lambda: f64,
   pub me_range_scale: u8,
   pub use_tx_domain_distortion: bool,
@@ -610,7 +609,6 @@ impl<T: Pixel> FrameInvariants<T> {
       dc_delta_q: [0; 3],
       ac_delta_q: [0; 3],
       lambda: 0.0,
-      log_target_q: 0,
       me_lambda: 0.0,
       me_range_scale: 1,
       use_tx_domain_distortion,
@@ -780,10 +778,9 @@ impl<T: Pixel> FrameInvariants<T> {
     }
     self.lambda =
       qps.lambda * ((1 << (2 * (self.sequence.bit_depth - 8))) as f64);
-    self.log_target_q = qps.log_target_q;
     self.me_lambda = self.lambda.sqrt();
 
-    let q = bexp64(self.log_target_q as i64 + q57(QSCALE)) as f32;
+    let q = bexp64(qps.log_target_q as i64 + q57(QSCALE)) as f32;
     /* These coefficients were trained on libaom. */
     if !self.intra_only {
         let predicted_y_f1 = clamp((-q * q * 0.00000235939456_f32 + q * 0.0068615186_f32 + 0.02709886_f32).round() as i32, 0, 15);

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -47,7 +47,7 @@ const TWOPASS_PACKET_SZ: usize = 8;
 const SEF_BITS: i64 = 24;
 
 // The scale of AV1 quantizer tables (relative to the pixel domain), i.e., Q3.
-const QSCALE: i32 = 3;
+pub const QSCALE: i32 = 3;
 
 // We clamp the actual I and B frame delays to a minimum of 10 to work
 //  within the range of values where later incrementing the delay works as
@@ -92,7 +92,7 @@ fn ilog64(v: i64) -> i32 {
 
 // Convert an integer into a Q57 fixed-point fraction.
 // The integer must be in the range -64 to 63, inclusive.
-const fn q57(v: i32) -> i64 {
+pub const fn q57(v: i32) -> i64 {
   // TODO: Add assert if it ever becomes possible to do in a const function.
   (v as i64) << 57
 }
@@ -116,7 +116,7 @@ const ATANH_LOG2: &[i64; 32] = &[
 // input: a log base 2 in Q57 format.
 // output: a 64 bit integer in Q0 (no fraction).
 // TODO: Mark const once we can use local variables in a const function.
-fn bexp64(logq57: i64) -> i64 {
+pub fn bexp64(logq57: i64) -> i64 {
   let ipart = (logq57 >> 57) as i32;
   if ipart < 0 {
     return 0;

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -47,7 +47,7 @@ const TWOPASS_PACKET_SZ: usize = 8;
 const SEF_BITS: i64 = 24;
 
 // The scale of AV1 quantizer tables (relative to the pixel domain), i.e., Q3.
-pub const QSCALE: i32 = 3;
+pub(crate) const QSCALE: i32 = 3;
 
 // We clamp the actual I and B frame delays to a minimum of 10 to work
 //  within the range of values where later incrementing the delay works as
@@ -92,7 +92,7 @@ fn ilog64(v: i64) -> i32 {
 
 // Convert an integer into a Q57 fixed-point fraction.
 // The integer must be in the range -64 to 63, inclusive.
-pub const fn q57(v: i32) -> i64 {
+pub(crate) const fn q57(v: i32) -> i64 {
   // TODO: Add assert if it ever becomes possible to do in a const function.
   (v as i64) << 57
 }
@@ -116,7 +116,7 @@ const ATANH_LOG2: &[i64; 32] = &[
 // input: a log base 2 in Q57 format.
 // output: a 64 bit integer in Q0 (no fraction).
 // TODO: Mark const once we can use local variables in a const function.
-pub fn bexp64(logq57: i64) -> i64 {
+pub(crate) fn bexp64(logq57: i64) -> i64 {
   let ipart = (logq57 >> 57) as i32;
   if ipart < 0 {
     return 0;


### PR DESCRIPTION
|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.3890 | -0.7035 | -1.2771 |  -0.1636 | -0.0987 | -0.0441 |    -0.1748 |

~4-6% faster encoding time for low QP.

https://beta.arewecompressedyet.com/?job=master-7f7209e95861e4d15211cb465f1d49dbef86029e&job=rav1e-cdef-from-q-squash%402019-07-03T04%3A00%3A41.134Z