### PR TITLE
rustfmt: Use fn_args_layout instead of fn_args_density

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,7 +3,7 @@
 max_width = 79
 comment_width = 79
 force_explicit_abi = false
-fn_args_density = "Compressed"
+fn_args_layout = "Compressed"
 use_small_heuristics = "Max"
 match_arm_blocks = false
 reorder_imports = true


### PR DESCRIPTION
This was renamed here: https://github.com/rust-lang/rustfmt/commit/e6b60a40d50c8905d8ef8696943c686947f905d7