### PR TITLE
Revert "Use integral images in the self guided filter (#1396)"

### DIFF
--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -303,7 +303,7 @@ impl<T: Pixel> Plane<T> {
   }
 
   #[inline]
-  pub fn row_range(&self, x: isize, y: isize) -> Range<usize> {
+  fn row_range(&self, x: isize, y: isize) -> Range<usize> {
     debug_assert!(self.cfg.yorigin as isize + y >= 0);
     debug_assert!(self.cfg.xorigin as isize + x >= 0);
     let base_y = (self.cfg.yorigin as isize + y) as usize;


### PR DESCRIPTION
This reverts commit 16ea18ea6eaf3f0e8549a6804ebb45ea37f659fb.

AWCY shows this commit changing stats. It should not.