### PR TITLE
Use same-level primary references for levels up to 2.

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -692,7 +692,7 @@ impl<T: Pixel> FrameInvariants<T> {
     let ref_in_previous_group = LAST3_FRAME;
 
     // reuse probability estimates from previous frames only in top level frames
-    fi.primary_ref_frame = if fi.pyramid_level > 0 {
+    fi.primary_ref_frame = if fi.pyramid_level > 2 {
       PRIMARY_REF_NONE
     } else {
       (ref_in_previous_group.to_index()) as u32


### PR DESCRIPTION
master-98f4d66d1fc5456a4b3178c8694fb2d03d44504a -> level_2_primary_ref@2019-07-09T01:46:21.426Z

|   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|-|-|-|-|-|-|-|
| -2.4867 | -2.4091 | -2.4374 |  -2.4710 | -2.5525 | -2.5742 |    -2.6157 |

https://beta.arewecompressedyet.com/?job=level_2_primary_ref%402019-07-09T01%3A46%3A21.426Z&job=master-98f4d66d1fc5456a4b3178c8694fb2d03d44504a