### PR TITLE
Increase min scan_fmt version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde_derive = "1.0"
 serde_json = { version = "1.0", optional = true }
 dav1d-sys = { version = "0.2", optional = true }
 aom-sys = { version = "0.1.2", optional = true }
-scan_fmt = { version = "0.2", optional = true }
+scan_fmt = { version = "0.2.3", optional = true }
 ivf = { version = "0.1", path = "ivf/", optional = true }
 avformat-sys = { version = "0.1", path = "crates/avformat-sys/", optional = true }
 rayon = "1.0"


### PR DESCRIPTION
Some users on IRC were seeing build failures solved by
a cargo update.