### PR TITLE
Add max_line_length into .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ indent_style = space
 # understand that the line is complete and can be considered as a line.
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 79
 
 [*.md]
 # Trailing whitespace may have a special meaning. For example, two spaces at the


### PR DESCRIPTION
This isn't "standard" but is supported by a range of editors. For me in nvim it makes comment reflow automatically work at the correct 79 characters instead of the default 100 which is very convenient.