### PR TITLE
Do not run benchmarks on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
       - name: "Tests"
         script: cargo test --verbose --release --features=decode_test -- --ignored
       - name: "Bench"
-        script: cargo bench --features=bench --verbose
+        script: cargo bench --features=bench --no-run --verbose
       - name: "Doc & Clippy (linter): verifying code quality"
         script:
          - cargo doc --verbose --no-deps


### PR DESCRIPTION
As far as I can tell, we are not using CI benchmark results and they may be unreliable. With this change, they will still be built and return compilation errors, but they will not run on Travis.