### PR TITLE
Fix order of x and y in sgr solve

### DIFF
--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -663,8 +663,8 @@ pub fn sgrproj_solve<T: Pixel>(set: u8, fi: &FrameInvariants<T>,
     }
 
     for yi in 0..cdef_h {
-      let u = i32::cast_from(cdeffed.p(yi,xi)) << SGRPROJ_RST_BITS;
-      let s = i32::cast_from(input.p(yi,xi)) << SGRPROJ_RST_BITS;
+      let u = i32::cast_from(cdeffed.p(xi,yi)) << SGRPROJ_RST_BITS;
+      let s = i32::cast_from(input.p(xi,yi)) << SGRPROJ_RST_BITS;
       let f2 = f_r2[yi] as i32 - u;
       let f1 = f_r1[yi] as i32 - u;
       h[0][0] += f2 as f64 * f2 as f64;


### PR DESCRIPTION
```
   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-0.1518 | -0.1329 | -0.1283 |  -0.1500 | -0.2130 | -0.1771 |    -0.1877
```
https://beta.arewecompressedyet.com/?job=master-dc15476cb8a3d552488e9138dc0585d775a13749&job=lrf_banish_the_triangle%402019-07-18T19%3A45%3A33.819Z