### PR TITLE
Optimize tile.rs::tile_log2()

### DIFF
--- a/src/tiling/tiler.rs
+++ b/src/tiling/tiler.rs
@@ -111,11 +111,10 @@ impl TilingInfo {
   ///
   /// <https://aomediacodec.github.io/av1-spec/#tile-size-calculation-function>
   fn tile_log2(blk_size: usize, target: usize) -> usize {
-    let mut k = 0;
-    while (blk_size << k) < target {
-      k += 1;
-    }
-    k
+    debug_assert!(blk_size != 0 && target > blk_size &&
+      blk_size.ilog() == (blk_size - 1).ilog() + 1 && // Block size is a power of 2
+      target.ilog() == (target - 1).ilog() + 1); // Target is a power of 2
+    if target <= blk_size { 0 } else { target.ilog() - blk_size.ilog() }
   }
 
   #[inline(always)]


### PR DESCRIPTION
Not that useful since tile computation is only done once as far as I know, but this turns `tile_log2()` into a one-liner, and in test benchmarks it is several times faster.