### PR TITLE
Deduplicate tiling configuration validation and adjustment

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -154,6 +154,10 @@ impl EncoderConfig {
       train_rdo: false
     }
   }
+
+  pub fn frame_rate(&self) -> f64 {
+    Rational::from_reciprocal(self.time_base).as_f64()
+  }
 }
 
 /// Contains all the speed settings

--- a/src/api.rs
+++ b/src/api.rs
@@ -43,6 +43,17 @@ impl Rational {
   pub fn new(num: u64, den: u64) -> Self {
     Rational { num, den }
   }
+
+  pub fn from_reciprocal(reciprocal: Self) -> Self {
+    Rational {
+      num: reciprocal.den,
+      den: reciprocal.num,
+    }
+  }
+
+  pub fn as_f64(self) -> f64 {
+    self.num as f64 / self.den as f64
+  }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -513,11 +513,13 @@ impl<T: Pixel> FrameInvariants<T> {
 
     let w_in_b = 2 * config.width.align_power_of_two_and_shift(3); // MiCols, ((width+7)/8)<<3 >> MI_SIZE_LOG2
     let h_in_b = 2 * config.height.align_power_of_two_and_shift(3); // MiRows, ((height+7)/8)<<3 >> MI_SIZE_LOG2
+    let frame_rate = config.frame_rate();
 
     let mut tiling = TilingInfo::from_target_tiles(
       sequence.sb_size_log2(),
       config.width,
       config.height,
+      frame_rate,
       config.tile_cols_log2,
       config.tile_rows_log2
     );
@@ -531,6 +533,7 @@ impl<T: Pixel> FrameInvariants<T> {
           sequence.sb_size_log2(),
           config.width,
           config.height,
+          frame_rate,
           tile_cols_log2,
           tile_rows_log2
         );

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -514,18 +514,6 @@ impl<T: Pixel> FrameInvariants<T> {
     let w_in_b = 2 * config.width.align_power_of_two_and_shift(3); // MiCols, ((width+7)/8)<<3 >> MI_SIZE_LOG2
     let h_in_b = 2 * config.height.align_power_of_two_and_shift(3); // MiRows, ((height+7)/8)<<3 >> MI_SIZE_LOG2
 
-    let frame_rate = (config.time_base.den / config.time_base.num) as usize;
-    let min_tile_cols = (config.width - 1) / 4096;
-    // The minimum number of tiles is determined based on the following requirements:
-    // - A tile cannot be wider than 4096 pixels
-    // - A tile cannot be larger than 4096x2304 pixels
-    // - The tile size * the frame rate * a temporal ratio cannot exceed a given fixed rate
-    //   corresponding to 4K60 resolution with a 1.1 ratio.
-    let min_tiles = 1 + min_tile_cols.max(
-      (config.width * config.height) / (4096 * 2304)).max(
-      (config.width * config.height * frame_rate) / (4096_f64 * 2176_f64 * 60_f64 * 1.1) as usize
-    );
-
     let mut tiling = TilingInfo::from_target_tiles(
       sequence.sb_size_log2(),
       config.width,
@@ -534,13 +522,9 @@ impl<T: Pixel> FrameInvariants<T> {
       config.tile_rows_log2
     );
 
-    if config.tiles > 0 || tiling.rows * tiling.cols < min_tiles {
-      // If a number of automatically-assigned tiles is specified,
-      // start with the bare minimum number of tile rows and columns.
-      // Otherwise, the tile assignment is triggered because we need
-      // to add more tiles than the number set in the configuration.
-      let mut tile_rows_log2 = if config.tiles == 0 { config.tile_rows_log2 } else { 0 };
-      let mut tile_cols_log2 = if config.tiles == 0 { config.tile_cols_log2 } else { min_tile_cols };
+    if config.tiles > 0 {
+      let mut tile_rows_log2 = 0;
+      let mut tile_cols_log2 = 0;
       while (tile_rows_log2 < tiling.max_tile_rows_log2) || (tile_cols_log2 < tiling.max_tile_cols_log2) {
 
         tiling = TilingInfo::from_target_tiles(
@@ -551,10 +535,7 @@ impl<T: Pixel> FrameInvariants<T> {
           tile_rows_log2
         );
 
-        if tiling.rows * tiling.cols >= config.tiles &&
-          tiling.rows * tiling.cols >= min_tiles {
-            break;
-        }
+        if tiling.rows * tiling.cols >= config.tiles { break };
 
         if ((tiling.tile_height_sb >= tiling.tile_width_sb) &&
             (tiling.tile_rows_log2 < tiling.max_tile_rows_log2))

--- a/src/tiling/tiler.rs
+++ b/src/tiling/tiler.rs
@@ -19,6 +19,7 @@ pub const MAX_TILE_WIDTH: usize = 4096;
 pub const MAX_TILE_AREA: usize = 4096 * 2304;
 pub const MAX_TILE_COLS: usize = 64;
 pub const MAX_TILE_ROWS: usize = 64;
+pub const MAX_TILE_RATE: f64 = 4096f64 * 2176f64 * 60f64 * 1.1;
 
 /// Tiling information
 ///
@@ -49,6 +50,7 @@ impl TilingInfo {
     sb_size_log2: usize,
     frame_width: usize,
     frame_height: usize,
+    frame_rate: f64,
     tile_cols_log2: usize,
     tile_rows_log2: usize,
   ) -> Self {
@@ -71,7 +73,9 @@ impl TilingInfo {
     let max_tile_rows_log2 = Self::tile_log2(1, sb_rows.min(MAX_TILE_ROWS));
 
     let min_tiles_log2 = min_tile_cols_log2
-      .max(Self::tile_log2(max_tile_area_sb, sb_cols * sb_rows));
+      .max(Self::tile_log2(max_tile_area_sb, sb_cols * sb_rows))
+      .max((((frame_width * frame_height) as f64 * frame_rate
+        / MAX_TILE_RATE + 0.5) as usize).ilog());
 
     let tile_cols_log2 =
       tile_cols_log2.max(min_tile_cols_log2).min(max_tile_cols_log2);
@@ -212,33 +216,34 @@ pub mod test {
   fn test_tiling_info_from_tile_count() {
     let sb_size_log2 = 6;
     let (width, height) = (160, 144);
+    let frame_rate = 25f64;
 
-    let ti = TilingInfo::from_target_tiles(sb_size_log2, width, height, 0, 0);
+    let ti = TilingInfo::from_target_tiles(sb_size_log2, width, height, frame_rate, 0, 0);
     assert_eq!(1, ti.cols);
     assert_eq!(1, ti.rows);
     assert_eq!(3, ti.tile_width_sb);
     assert_eq!(3, ti.tile_height_sb);
 
-    let ti = TilingInfo::from_target_tiles(sb_size_log2, width, height, 1, 1);
+    let ti = TilingInfo::from_target_tiles(sb_size_log2, width, height, frame_rate, 1, 1);
     assert_eq!(2, ti.cols);
     assert_eq!(2, ti.rows);
     assert_eq!(2, ti.tile_width_sb);
     assert_eq!(2, ti.tile_height_sb);
 
-    let ti = TilingInfo::from_target_tiles(sb_size_log2, width, height, 2, 2);
+    let ti = TilingInfo::from_target_tiles(sb_size_log2, width, height, frame_rate, 2, 2);
     assert_eq!(3, ti.cols);
     assert_eq!(3, ti.rows);
     assert_eq!(1, ti.tile_width_sb);
     assert_eq!(1, ti.tile_height_sb);
 
     // cannot split more than superblocks
-    let ti = TilingInfo::from_target_tiles(sb_size_log2, width, height, 10, 8);
+    let ti = TilingInfo::from_target_tiles(sb_size_log2, width, height, frame_rate, 10, 8);
     assert_eq!(3, ti.cols);
     assert_eq!(3, ti.rows);
     assert_eq!(1, ti.tile_width_sb);
     assert_eq!(1, ti.tile_height_sb);
 
-    let ti = TilingInfo::from_target_tiles(sb_size_log2, 1024, 1024, 0, 0);
+    let ti = TilingInfo::from_target_tiles(sb_size_log2, 1024, 1024, frame_rate, 0, 0);
     assert_eq!(1, ti.cols);
     assert_eq!(1, ti.rows);
     assert_eq!(16, ti.tile_width_sb);
@@ -270,10 +275,11 @@ pub mod test {
     let mut fs = FrameState::new(&fi);
     // frame size 160x144, 40x36 in 4x4-blocks
     let mut fb = FrameBlocks::new(fi.w_in_b, fi.h_in_b);
+    let frame_rate = fi.config.frame_rate();
 
     {
       // 2x2 tiles
-      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, 1, 1);
+      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, frame_rate, 1, 1);
       let mut iter = ti.tile_iter_mut(&mut fs, &mut fb);
       assert_eq!(4, iter.len());
       assert!(iter.next().is_some());
@@ -289,7 +295,7 @@ pub mod test {
 
     {
       // 4x4 tiles requested, will actually get 3x3 tiles
-      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, 2, 2);
+      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, frame_rate, 2, 2);
       let mut iter = ti.tile_iter_mut(&mut fs, &mut fb);
       assert_eq!(9, iter.len());
       assert!(iter.next().is_some());
@@ -329,7 +335,7 @@ pub mod test {
     let mut fb = FrameBlocks::new(fi.w_in_b, fi.h_in_b);
 
     // 4x4 tiles requested, will actually get 3x3 tiles
-    let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, 2, 2);
+    let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, fi.config.frame_rate(), 2, 2);
     let iter = ti.tile_iter_mut(&mut fs, &mut fb);
     let tile_states = iter.map(|ctx| ctx.ts).collect::<Vec<_>>();
 
@@ -400,7 +406,7 @@ pub mod test {
     let mut fb = FrameBlocks::new(fi.w_in_b, fi.h_in_b);
 
     // 4x4 tiles requested, will actually get 3x3 tiles
-    let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, 2, 2);
+    let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, fi.config.frame_rate(), 2, 2);
     let iter = ti.tile_iter_mut(&mut fs, &mut fb);
     let tbs = iter.map(|ctx| ctx.tb).collect::<Vec<_>>();
 
@@ -433,7 +439,7 @@ pub mod test {
 
     {
       // 4x4 tiles requested, will actually get 3x3 tiles
-      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, 2, 2);
+      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, fi.config.frame_rate(), 2, 2);
       let iter = ti.tile_iter_mut(&mut fs, &mut fb);
       let mut tile_states = iter.map(|ctx| ctx.ts).collect::<Vec<_>>();
 
@@ -490,7 +496,7 @@ pub mod test {
     let fi = create_frame_invariants(64, 80, ChromaSampling::Cs420);
     let mut fs = FrameState::new(&fi);
     let mut fb = FrameBlocks::new(fi.w_in_b, fi.h_in_b);
-    let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, 2, 2);
+    let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, fi.config.frame_rate(), 2, 2);
     let iter = ti.tile_iter_mut(&mut fs, &mut fb);
     let mut tile_states = iter.map(|ctx| ctx.ts).collect::<Vec<_>>();
 
@@ -523,7 +529,7 @@ pub mod test {
 
     {
       // 2x2 tiles, each one containing 2×2 restoration units (1 super-block per restoration unit)
-      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, 1, 1);
+      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, fi.config.frame_rate(), 1, 1);
       let iter = ti.tile_iter_mut(&mut fs, &mut fb);
       let mut tile_states = iter.map(|ctx| ctx.ts).collect::<Vec<_>>();
 
@@ -578,7 +584,7 @@ pub mod test {
 
     {
       // 4x4 tiles requested, will actually get 3x3 tiles
-      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, 2, 2);
+      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, fi.config.frame_rate(), 2, 2);
       let iter = ti.tile_iter_mut(&mut fs, &mut fb);
       let mut tile_states = iter.map(|ctx| ctx.ts).collect::<Vec<_>>();
 
@@ -615,7 +621,7 @@ pub mod test {
 
     {
       // 4x4 tiles requested, will actually get 3x3 tiles
-      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, 2, 2);
+      let ti = TilingInfo::from_target_tiles(fi.sb_size_log2(), fi.width, fi.height, fi.config.frame_rate(), 2, 2);
       let iter = ti.tile_iter_mut(&mut fs, &mut fb);
       let mut tbs = iter.map(|ctx| ctx.tb).collect::<Vec<_>>();
 


### PR DESCRIPTION
This reverts commit 95c773470fdb6bd0e6126e85ae834bdec72494bf and adds a rate restriction to the `TilingInfo` constructor.

Fixes #1451.