### PR TITLE
Create CDEF test Sequence with correct EncoderConfig

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -533,7 +533,7 @@ mod test {
       speed_settings: SpeedSettings::from_preset(10),
       ..Default::default()
     };
-    let sequence = Sequence::new(&Default::default());
+    let sequence = Sequence::new(&config);
     let fi = FrameInvariants::new(config, sequence);
     (frame, fi)
   }


### PR DESCRIPTION
The tests were using a `Sequence` initialized with a default `EncoderConfig`, and the parameters did not correspond with the configuration passed to `FrameInvariants`.