### PR TITLE
Make Sequence::sb_size[_log2]() const fn

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -290,8 +290,8 @@ impl Sequence {
   }
 
   #[inline(always)]
-  pub fn sb_size_log2(&self) -> usize {
-    if self.use_128x128_superblock { 7 } else { 6 }
+  pub const fn sb_size_log2(&self) -> usize {
+    6 + (self.use_128x128_superblock as usize)
   }
 }
 


### PR DESCRIPTION
Work towards #1464.

The same cannot be done with corresponding `FrameInvariants` functions, because trait bounds other than `Sized` are not supported with `const fn` currently (`FrameInvariants` has a `Pixel` bound).