### PR TITLE
Implement Default for Sequence and FrameInvariants

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -295,6 +295,12 @@ impl Sequence {
   }
 }
 
+impl Default for Sequence {
+  fn default() -> Self {
+    Sequence::new(&EncoderConfig::default())
+  }
+}
+
 #[derive(Debug)]
 pub struct FrameState<T: Pixel> {
   pub sb_size_log2: usize,
@@ -808,6 +814,12 @@ impl<T: Pixel> FrameInvariants<T> {
   #[inline(always)]
   pub fn sb_size_log2(&self) -> usize {
     self.sequence.sb_size_log2()
+  }
+}
+
+impl<T: Pixel> Default for FrameInvariants<T> {
+  fn default() -> Self {
+    FrameInvariants::new(EncoderConfig::default(), Sequence::default())
   }
 }
 


### PR DESCRIPTION
`EncoderConfig` has a `Default` implementation to support tests, so this simply propagates its implementation to allow initializing a test `Sequence` or `FrameInvariants` in one line.

Since tests seem to use non-default resolutions, I have not changed them.