### PR TITLE
Change ilog() return type to usize

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -39,10 +39,8 @@ use arg_enum_proc_macro::ArgEnum;
 use bitstream_io::{BitWriter, BigEndian};
 use bincode::{serialize, deserialize};
 use rayon::iter::*;
-use std;
 use std::{fmt, io, mem};
-use std::io::Write;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::sync::Arc;
 use std::fs::File;
 use arrayvec::*;
@@ -2095,7 +2093,7 @@ fn encode_tile_group<T: Pixel>(fi: &FrameInvariants<T>, fs: &mut FrameState<T>) 
   fs.cdfs = cdfs[idx_max];
   fs.cdfs.reset_counts();
 
-  let max_tile_size_bytes = ((max_len as u32).ilog() + 7) / 8;
+  let max_tile_size_bytes = ((max_len.ilog() + 7) / 8) as u32;
   debug_assert!(max_tile_size_bytes > 0 && max_tile_size_bytes <= 4);
   fs.max_tile_size_bytes = max_tile_size_bytes;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -165,8 +165,8 @@ impl_cast_from_pixel_to_primitive!(i32);
 impl_cast_from_pixel_to_primitive!(u32);
 
 pub trait ILog: PrimInt {
-  fn ilog(self) -> Self {
-    Self::from(size_of::<Self>() * 8 - self.leading_zeros() as usize).unwrap()
+  fn ilog(self) -> usize {
+    size_of::<Self>() * 8 - self.leading_zeros() as usize
   }
 }
 


### PR DESCRIPTION
Thanks to @tterribe for pointing out the usually unnecessary conversion.