### PR TITLE
Initial temporal RDO implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,13 @@ quick_test = []
 desync_finder = []
 bench = []
 
+# Enables debug dumping of lookahead computation results, specifically:
+# - i-qres.png: quarter-resolution luma planes,
+# - i-hres.png: half-resolution luma planes,
+# - i-mvs.bin: motion vectors,
+# - i-imps.bin: block importances.
+dump_lookahead_data = ["byteorder", "image"]
+
 [dependencies]
 arg_enum_proc_macro = "0.1.1"
 bitstream-io = "0.8"
@@ -48,6 +55,8 @@ bincode = "1.1"
 arrayvec = "0.4.10"
 better-panic = "0.1"
 err-derive = "0.1"
+image = { version = "0.21.2", optional = true }
+byteorder = { version = "1.3.2", optional = true }
 
 [build-dependencies]
 nasm-rs = { version = "0.1", path = "crates/nasm_rs/", optional = true }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1192,7 +1192,8 @@ impl<T: Pixel> ContextInner<T> {
           cdfs: fs.cdfs,
           // TODO: can we set MVs here? We can probably even compute these MVs
           // right now instead of in encode_tile?
-          frame_mvs: fs.frame_mvs
+          frame_mvs: fs.frame_mvs,
+          output_frameno: self.next_lookahead_output_frameno - 1
         });
         for i in 0..(REF_FRAMES as usize) {
           if (fi.refresh_frame_flags & (1 << i)) != 0 {
@@ -1280,7 +1281,8 @@ impl<T: Pixel> ContextInner<T> {
         input_hres: fs.input_hres,
         input_qres: fs.input_qres,
         cdfs: fs.cdfs,
-        frame_mvs: fs.frame_mvs
+        frame_mvs: fs.frame_mvs,
+        output_frameno: self.next_lookahead_output_frameno - 1
       });
       for i in 0..(REF_FRAMES as usize) {
         if (fi.refresh_frame_flags & (1 << i)) != 0 {
@@ -1401,7 +1403,7 @@ impl<T: Pixel> ContextInner<T> {
           // TODO avoid the clone by having rec Arc.
           let rec = if fi.show_frame { Some(fs.rec.clone()) } else { None };
 
-          update_rec_buffer(fi, fs);
+          update_rec_buffer(self.output_frameno, fi, fs);
 
           // Copy persistent fields into subsequent FrameInvariants.
           let rec_buffer = fi.rec_buffer.clone();

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,8 +10,10 @@
 use arg_enum_proc_macro::ArgEnum;
 use bitstream_io::*;
 use num_derive::*;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde_derive::{Deserialize, Serialize};
 
+use crate::context::{FrameBlocks, SuperBlockOffset};
 use crate::encoder::*;
 use crate::frame::Frame;
 use crate::metrics::calculate_frame_psnr;
@@ -1133,6 +1135,158 @@ impl<T: Pixel> ContextInner<T> {
     while self.set_frame_properties(self.next_lookahead_output_frameno).is_ok()
     {
       self.next_lookahead_output_frameno += 1;
+
+      // Compute the lookahead motion vectors.
+      let fi = self
+        .frame_invariants
+        .get_mut(&(self.next_lookahead_output_frameno - 1))
+        .unwrap();
+
+      // We're only interested in valid frames which are not
+      // show-existing-frame. Those two don't modify the rec_buffer so there's
+      // no need to do anything special about it either, it'll propagate on its
+      // own.
+      if fi.invalid || fi.show_existing_frame {
+        continue;
+      }
+
+      let frame = self.frame_q[&fi.input_frameno].as_ref().unwrap();
+
+      // TODO: some of this work, like downsampling, could be reused in the
+      // actual encoding.
+      let mut fs = FrameState::new_with_frame(fi, frame.clone());
+      fs.input_hres.downsample_from(&frame.planes[0]);
+      fs.input_hres.pad(fi.width, fi.height);
+      fs.input_qres.downsample_from(&fs.input_hres);
+      fs.input_qres.pad(fi.width, fi.height);
+
+      #[cfg(feature = "dump_lookahead_data")]
+      {
+        let plane = &fs.input_qres;
+        image::GrayImage::from_fn(
+          plane.cfg.width as u32,
+          plane.cfg.height as u32,
+          |x, y| image::Luma([plane.p(x as usize, y as usize).as_()])
+        )
+        .save(format!("{}-qres.png", fi.input_frameno))
+        .unwrap();
+        let plane = &fs.input_hres;
+        image::GrayImage::from_fn(
+          plane.cfg.width as u32,
+          plane.cfg.height as u32,
+          |x, y| image::Luma([plane.p(x as usize, y as usize).as_()])
+        )
+        .save(format!("{}-hres.png", fi.input_frameno))
+        .unwrap();
+      }
+
+      // Do not modify the next output frame's FrameInvariants.
+      if self.output_frameno == self.next_lookahead_output_frameno - 1 {
+        // We do want to propagate the lookahead_rec_buffer though.
+        let rfs = Arc::new(ReferenceFrame {
+          order_hint: fi.order_hint,
+          // Use the original frame contents.
+          frame: (&**frame).clone(), // TODO: get rid of the frame data clone.
+          input_hres: fs.input_hres,
+          input_qres: fs.input_qres,
+          cdfs: fs.cdfs,
+          // TODO: can we set MVs here? We can probably even compute these MVs
+          // right now instead of in encode_tile?
+          frame_mvs: fs.frame_mvs
+        });
+        for i in 0..(REF_FRAMES as usize) {
+          if (fi.refresh_frame_flags & (1 << i)) != 0 {
+            fi.lookahead_rec_buffer.frames[i] = Some(Arc::clone(&rfs));
+            fi.lookahead_rec_buffer.deblock[i] = fs.deblock;
+          }
+        }
+
+        continue;
+      }
+
+      // Our lookahead_rec_buffer should be filled with correct original frame
+      // data from the previous frames. Copy it into rec_buffer because that's
+      // what the MV search uses. During the actual encoding rec_buffer is
+      // overwritten with its correct values anyway.
+      fi.rec_buffer = fi.lookahead_rec_buffer.clone();
+
+      // TODO: as in the encoding code, key frames will have no references.
+      // However, for block importance purposes we want key frames to act as
+      // P-frames in this instance.
+      //
+      // Compute the motion vectors.
+      let mut blocks = FrameBlocks::new(fi.w_in_b, fi.h_in_b);
+
+      fi.tiling
+        .tile_iter_mut(&mut fs, &mut blocks)
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .for_each(|mut ctx| {
+          let ts = &mut ctx.ts;
+
+          // Compute the quarter-resolution motion vectors.
+          let tile_pmvs = build_coarse_pmvs(fi, ts);
+
+          // Compute the half-resolution motion vectors.
+          for sby in 0..ts.sb_height {
+            for sbx in 0..ts.sb_width {
+              let tile_sbo = SuperBlockOffset { x: sbx, y: sby };
+              build_half_res_pmvs(fi, ts, tile_sbo, &tile_pmvs);
+            }
+          }
+        });
+
+      #[cfg(feature = "dump_lookahead_data")]
+      {
+        use crate::partition::RefType::*;
+
+        let second_ref_frame = if !self.inter_cfg.multiref {
+          LAST_FRAME // make second_ref_frame match first
+        } else if fi.idx_in_group_output == 0 {
+          LAST2_FRAME
+        } else {
+          ALTREF_FRAME
+        };
+
+        // Use the default index, it corresponds to the last P-frame or to the
+        // backwards lower reference (so the closest previous frame).
+        let index = if second_ref_frame.to_index() != 0 { 0 } else { 1 };
+
+        let mvs = &fs.frame_mvs[index];
+        use byteorder::{NativeEndian, WriteBytesExt};
+        let mut buf = vec![];
+        buf.write_u64::<NativeEndian>(mvs.rows as u64).unwrap();
+        buf.write_u64::<NativeEndian>(mvs.cols as u64).unwrap();
+        for y in 0..mvs.rows {
+          for x in 0..mvs.cols {
+            let mv = mvs[y][x];
+            buf.write_i16::<NativeEndian>(mv.row).unwrap();
+            buf.write_i16::<NativeEndian>(mv.col).unwrap();
+          }
+        }
+        ::std::fs::write(format!("{}-mvs.bin", fi.input_frameno), buf)
+          .unwrap();
+      }
+
+      // Set lookahead_rec_buffer on this FrameInvariants for future
+      // FrameInvariants to pick it up.
+      let rfs = Arc::new(ReferenceFrame {
+        order_hint: fi.order_hint,
+        // Use the original frame contents.
+        frame: (&**frame).clone(), // TODO: get rid of the frame data clone.
+        input_hres: fs.input_hres,
+        input_qres: fs.input_qres,
+        cdfs: fs.cdfs,
+        frame_mvs: fs.frame_mvs
+      });
+      for i in 0..(REF_FRAMES as usize) {
+        if (fi.refresh_frame_flags & (1 << i)) != 0 {
+          fi.lookahead_rec_buffer.frames[i] = Some(Arc::clone(&rfs));
+          fi.lookahead_rec_buffer.deblock[i] = fs.deblock;
+        }
+      }
+    }
+
     }
   }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1191,7 +1191,7 @@ impl<T: Pixel> ContextInner<T> {
         let rfs = Arc::new(ReferenceFrame {
           order_hint: fi.order_hint,
           // Use the original frame contents.
-          frame: (&**frame).clone(), // TODO: get rid of the frame data clone.
+          frame: frame.clone(),
           input_hres: fs.input_hres,
           input_qres: fs.input_qres,
           cdfs: fs.cdfs,
@@ -1282,7 +1282,7 @@ impl<T: Pixel> ContextInner<T> {
       let rfs = Arc::new(ReferenceFrame {
         order_hint: fi.order_hint,
         // Use the original frame contents.
-        frame: (&**frame).clone(), // TODO: get rid of the frame data clone.
+        frame: frame.clone(),
         input_hres: fs.input_hres,
         input_qres: fs.input_qres,
         cdfs: fs.cdfs,

--- a/src/api.rs
+++ b/src/api.rs
@@ -1236,6 +1236,9 @@ impl<T: Pixel> ContextInner<T> {
           }
         });
 
+      // Save the motion vectors to FrameInvariants.
+      fi.lookahead_mvs = fs.frame_mvs.clone().into_boxed_slice();
+
       #[cfg(feature = "dump_lookahead_data")]
       {
         use crate::partition::RefType::*;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -495,6 +495,10 @@ pub struct FrameInvariants<T: Pixel> {
   /// `rec_buffer` contains the current frame's reference frames and
   /// `lookahead_rec_buffer` contains the next frame's reference frames.
   pub lookahead_rec_buffer: ReferenceFramesSet<T>,
+  /// Future importance values for each 4×4 block. That is, a value indicating
+  /// how much future frames depend on the block (for example, via
+  /// inter-prediction).
+  pub block_importances: Box<[f32]>,
 }
 
 pub(crate) fn pos_to_lvl(pos: u64, pyramid_depth: u64) -> u64 {
@@ -628,6 +632,7 @@ impl<T: Pixel> FrameInvariants<T> {
         vec.into_boxed_slice()
       },
       lookahead_rec_buffer: ReferenceFramesSet::new(),
+      block_importances: vec![0.; w_in_b * h_in_b].into_boxed_slice(),
     }
   }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1620,7 +1620,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
       let w: &mut W = if cw.bc.cdef_coded {w_post_cdef} else {w_pre_cdef};
       let tell = w.tell_frac();
       cw.write_partition(w, tile_bo, PartitionType::PARTITION_NONE, bsize);
-      compute_rd_cost(fi, w.tell_frac() - tell, 0)
+      compute_rd_cost(fi, ts.to_frame_block_offset(tile_bo), bsize, w.tell_frac() - tell, 0)
     } else {
       0.0
     };
@@ -1687,7 +1687,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
         let w: &mut W = if cw.bc.cdef_coded { w_post_cdef } else { w_pre_cdef };
         let tell = w.tell_frac();
         cw.write_partition(w, tile_bo, partition, bsize);
-        rd_cost = compute_rd_cost(fi, w.tell_frac() - tell, 0);
+        rd_cost = compute_rd_cost(fi, ts.to_frame_block_offset(tile_bo), bsize, w.tell_frac() - tell, 0);
       }
 
       let four_partitions = [

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -485,6 +485,9 @@ pub struct FrameInvariants<T: Pixel> {
   /// should be ignored. Invalid frames occur when a subgop is prematurely
   /// ended, for example, by a key frame or the end of the video.
   pub invalid: bool,
+  /// Motion vectors to the _original_ reference frames (not reconstructed).
+  /// Used for lookahead purposes.
+  pub lookahead_mvs: Box<[FrameMotionVectors]>,
   /// The lookahead version of `rec_buffer`, used for storing and propagating
   /// the original reference frames (rather than reconstructed ones). The
   /// lookahead uses both `rec_buffer` and `lookahead_rec_buffer`, where
@@ -616,6 +619,13 @@ impl<T: Pixel> FrameInvariants<T> {
       tx_mode_select : false,
       default_filter: FilterMode::REGULAR,
       invalid: false,
+      lookahead_mvs: {
+        let mut vec = Vec::with_capacity(REF_FRAMES);
+        for _ in 0..REF_FRAMES {
+          vec.push(FrameMotionVectors::new(w_in_b, h_in_b));
+        }
+        vec.into_boxed_slice()
+      },
       lookahead_rec_buffer: ReferenceFramesSet::new(),
     }
   }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -495,6 +495,9 @@ pub struct FrameInvariants<T: Pixel> {
   /// `rec_buffer` contains the current frame's reference frames and
   /// `lookahead_rec_buffer` contains the next frame's reference frames.
   pub lookahead_rec_buffer: ReferenceFramesSet<T>,
+  /// Intra prediction cost estimations for each 4×4 block. Used for block
+  /// importance computation.
+  pub lookahead_intra_costs: Box<[u32]>,
   /// Future importance values for each 4×4 block. That is, a value indicating
   /// how much future frames depend on the block (for example, via
   /// inter-prediction).
@@ -632,6 +635,7 @@ impl<T: Pixel> FrameInvariants<T> {
         vec.into_boxed_slice()
       },
       lookahead_rec_buffer: ReferenceFramesSet::new(),
+      lookahead_intra_costs: vec![0; w_in_b * h_in_b].into_boxed_slice(),
       block_importances: vec![0.; w_in_b * h_in_b].into_boxed_slice(),
     }
   }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -54,7 +54,7 @@ const MAX_NUM_OPERATING_POINTS: usize = MAX_NUM_TEMPORAL_LAYERS * MAX_NUM_SPATIA
 #[derive(Debug, Clone)]
 pub struct ReferenceFrame<T: Pixel> {
   pub order_hint: u32,
-  pub frame: Frame<T>,
+  pub frame: Arc<Frame<T>>,
   pub input_hres: Plane<T>,
   pub input_qres: Plane<T>,
   pub cdfs: CDFContext,
@@ -2359,7 +2359,7 @@ pub fn update_rec_buffer<T: Pixel>(
   let rfs = Arc::new(
     ReferenceFrame {
       order_hint: fi.order_hint,
-      frame: fs.rec,
+      frame: Arc::new(fs.rec),
       input_hres: fs.input_hres,
       input_qres: fs.input_qres,
       cdfs: fs.cdfs,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1991,7 +1991,7 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
 }
 
 #[inline(always)]
-fn build_coarse_pmvs<T: Pixel>(fi: &FrameInvariants<T>, ts: &TileStateMut<'_, T>) -> Vec<[Option<MotionVector>; REF_FRAMES]> {
+pub(crate) fn build_coarse_pmvs<T: Pixel>(fi: &FrameInvariants<T>, ts: &TileStateMut<'_, T>) -> Vec<[Option<MotionVector>; REF_FRAMES]> {
   assert!(!fi.sequence.use_128x128_superblock);
   if ts.mi_width >= 16 && ts.mi_height >= 16 {
     let mut frame_pmvs = Vec::with_capacity(ts.sb_width * ts.sb_height);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -59,6 +59,7 @@ pub struct ReferenceFrame<T: Pixel> {
   pub input_qres: Plane<T>,
   pub cdfs: CDFContext,
   pub frame_mvs: Vec<FrameMotionVectors>,
+  pub output_frameno: u64,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -2347,7 +2348,9 @@ pub fn encode_frame<T: Pixel>(
   packet
 }
 
-pub fn update_rec_buffer<T: Pixel>(fi: &mut FrameInvariants<T>, fs: FrameState<T>) {
+pub fn update_rec_buffer<T: Pixel>(
+  output_frameno: u64, fi: &mut FrameInvariants<T>, fs: FrameState<T>
+) {
   let rfs = Arc::new(
     ReferenceFrame {
       order_hint: fi.order_hint,
@@ -2356,6 +2359,7 @@ pub fn update_rec_buffer<T: Pixel>(fi: &mut FrameInvariants<T>, fs: FrameState<T
       input_qres: fs.input_qres,
       cdfs: fs.cdfs,
       frame_mvs: fs.frame_mvs,
+      output_frameno,
     }
   );
   for i in 0..(REF_FRAMES as usize) {

--- a/tools/draw-importances.py
+++ b/tools/draw-importances.py
@@ -1,0 +1,49 @@
+import struct
+import sys
+from os.path import splitext
+import numpy as np
+from PIL import Image, ImageDraw
+from matplotlib import pyplot as plt
+
+
+# Renders block importances output by ContextInner::compute_lookahead_data().
+# Usage: draw-importances.py <i-hres.png> <i-imps.bin>
+#        will output i-imps.png.
+
+
+with open(sys.argv[2], 'rb') as f:
+    contents = f.read()
+
+rows, cols = struct.unpack('qq', contents[:16])
+imps = np.frombuffer(contents[16:], dtype=np.float32).reshape((rows, cols))
+max_imp = np.max(imps)
+
+frame_size_multiplier = 4
+
+frame = Image.open(sys.argv[1])
+frame = frame.resize((frame.width * frame_size_multiplier, frame.height * frame_size_multiplier))
+frame = frame.convert(mode='RGB')
+
+mv_original_block_size = 4 // 2 # The MVs are in 4×4 blocks, but we use half-resolution images.
+mv_block_size = mv_original_block_size * frame_size_multiplier
+
+draw = ImageDraw.Draw(frame, mode='RGBA')
+
+# Draw the grid.
+for i in range(0, frame.width, mv_block_size):
+    draw.line(((i, 0), (i, frame.height)), fill=(0, 0, 0, 255))
+for i in range(0, frame.height, mv_block_size):
+    draw.line(((0, i), (frame.width, i)), fill=(0, 0, 0, 255))
+
+# Draw the importances.
+if max_imp > 0:
+    for y in range(rows):
+        for x in range(cols):
+            imp = imps[y, x]
+            top_left = (x * mv_block_size, y * mv_block_size)
+            bottom_right = (top_left[0] + mv_block_size, top_left[1] + mv_block_size)
+            draw.rectangle((top_left, bottom_right), fill=(int(imp / max_imp * 255), 0, 0, 128))
+
+fig = plt.figure(figsize=(frame.width, frame.height), dpi=1)
+fig.figimage(frame, cmap='gray')
+plt.savefig(splitext(sys.argv[2])[0] + '.png', bbox_inches='tight')

--- a/tools/draw-mvs.py
+++ b/tools/draw-mvs.py
@@ -1,0 +1,60 @@
+import struct
+import sys
+import numpy as np
+from PIL import Image, ImageDraw
+from matplotlib import pyplot as plt
+
+
+# Renders motion vectors output by ContextInner::compute_lookahead_data().
+# Requires *-hres.png and *-mvs.bin files.
+# Usage: draw-mvs.py <number>
+#        will read i-hres.png and i-mvs.bin for i in [0; number) and output i-mvs.png.
+
+
+def draw_mvs(prefix):
+    with open(prefix + '-mvs.bin', 'rb') as f:
+        contents = f.read()
+
+    rows, cols = struct.unpack('qq', contents[:16])
+    mvs = np.frombuffer(contents[16:], dtype=np.short).reshape((rows, cols, 2))
+
+    frame_size_multiplier = 4
+
+    frame = Image.open(prefix + '-hres.png')
+    frame = frame.resize((frame.width * frame_size_multiplier, frame.height * frame_size_multiplier))
+
+    mv_original_block_size = 4 // 2 # The MVs are in 4×4 blocks, but we use half-resolution images.
+    mv_subsampling = 8 # The MVs currently computed are the same in 8×8 blocks.
+    mv_units_per_pixel = 8 # MVs are in 8ths of a pixel.
+    mvs = mvs[::mv_subsampling, ::mv_subsampling]
+    rows = rows // mv_subsampling
+    cols = cols // mv_subsampling
+    mv_block_size = mv_original_block_size * frame_size_multiplier * mv_subsampling
+
+    draw = ImageDraw.Draw(frame)
+
+    # Draw the grid.
+    for i in range(0, frame.width, mv_block_size):
+        draw.line(((i, 0), (i, frame.height)))
+    for i in range(0, frame.height, mv_block_size):
+        draw.line(((0, i), (frame.width, i)))
+
+    # Draw the motion vectors.
+    for y in range(rows):
+        for x in range(cols):
+            mv = mvs[y, x]
+            start = (x * mv_block_size + mv_block_size // 2,
+                     y * mv_block_size + mv_block_size // 2)
+            end = (mv[1] * frame_size_multiplier // mv_units_per_pixel + start[0],
+                   mv[0] * frame_size_multiplier // mv_units_per_pixel + start[1])
+            draw.line((start, end), fill=255)
+
+    fig = plt.figure(figsize=(frame.width, frame.height), dpi=1)
+    fig.figimage(frame, cmap='gray')
+    plt.savefig(prefix + '-mvs.png', bbox_inches='tight')
+    plt.close(fig)
+
+
+for prefix in range(1, int(sys.argv[1])):
+    print(prefix)
+    draw_mvs(str(prefix))


### PR DESCRIPTION
This PR adds original-frame motion vector computation in lookahead, and block importance computation in lookahead, which is heavily based on x264's MBTree, as described in [this paper](https://pdfs.semanticscholar.org/032f/1ab7d9db385780a02eb2d579af8303b266d2.pdf). Additionally, the distortion is biased in the RD-cost computation according to the computed block importance. [Three-way AWCY](https://beta.arewecompressedyet.com/?job=master-5de2d05cbdc78af88402ee3d7b74261cb11c90ad&job=lookahead-mv-3-16-2019-07-23_131331-dbb9d2f&job=lookahead-mv-3-16-INVERTED-2019-07-23_131446-8df6d94) (original; this PR; this PR with inverted bias to show that it works).

The block importance computation is far from final. For instance, right now it only uses half-res MVs and a single intra prediction mode.

Two new Python scripts are included to visualize the computed MVs and block importances respectively, which are dumped when the corresponding flag is set in `compute_lookahead_data()`.

Things that might be desirable to do with this PR before merging:
- Add tests for the computed MVs and block importance values. An actual real clip with, say, two subgops worth of frames would be very valuable for this, but I guess it can be done on random pixels with a set seed?
- Play with the constants (`4` and `0.8` in the RD-cost biasing, lookahead frame queue size, etc.). However it's not really worth it to spend too much time on this until the block importance computation is closer to being finalized, and until we can affect the actual quantizers.
- ~~Hide `WRITE_DEBUG_FILES` behind a feature or something because it pulls two extra dependencies.~~
- Make a speed setting to enable or disable the block importance computation because it could take a while, especially later on when full MVs are employed.