### PR TITLE
Add transform benchmarks

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -21,7 +21,7 @@ use rav1e::bench::predict::*;
 use rav1e::bench::transform::*;
 use rav1e::bench::rdo::*;
 
-use crate::transform::transform;
+use crate::transform::{forward_transforms, inverse_transforms};
 
 use criterion::*;
 use std::time::Duration;
@@ -190,5 +190,6 @@ criterion_group!{ name = me;
 
 criterion_group!(ec, ec_bench);
 
-criterion_main!(write_block, intra_prediction, cdef, cfl, me, transform, ec);
+criterion_main!(write_block, intra_prediction, cdef, cfl, me,
+  forward_transforms, inverse_transforms, ec);
 

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -12,40 +12,26 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use rav1e::bench::transform;
 
-fn bench_idct4(b: &mut Bencher, bit_depth: &usize) {
+fn init_buffers(size: usize) -> (Vec<i32>, Vec<i32>) {
   let mut ra = ChaChaRng::from_seed([0; 32]);
-  let input: [i32; 4] = ra.gen();
-  let mut output = [0i32; 4];
-  let range = bit_depth + 8;
+  let input: Vec<i32> = (0..size).map(|_| ra.gen()).collect();
+  let output = vec![0i32; size];
 
-  b.iter(|| {
-    transform::av1_idct4(&input[..], &mut output[..], range);
-  });
+  (input, output)
 }
 
 pub fn av1_idct4(c: &mut Criterion) {
-  let plain = Fun::new("plain", bench_idct4);
-  let funcs = vec![plain];
+  let (input, mut output) = init_buffers(4);
 
-  c.bench_functions("av1_idct4_8", funcs, 8);
-}
-
-fn bench_idct8(b: &mut Bencher, bit_depth: &usize) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
-  let input: [i32; 8] = ra.gen();
-  let mut output = [0i32; 8];
-  let range = bit_depth + 8;
-
-  b.iter(|| {
-    transform::av1_idct8(&input[..], &mut output[..], range);
-  });
+  c.bench_function("av1_idct4_8", move |b| b.iter(
+    || transform::av1_idct4(&input[..], &mut output[..], 16)));
 }
 
 pub fn av1_idct8(c: &mut Criterion) {
-  let plain = Fun::new("plain", bench_idct8);
-  let funcs = vec![plain];
+  let (input, mut output) = init_buffers(8);
 
-  c.bench_functions("av1_idct8_8", funcs, 8);
+  c.bench_function("av1_idct8_8", move |b| b.iter(
+    || transform::av1_idct8(&input[..], &mut output[..], 16)));
 }
 
 criterion_group!(transform, av1_idct4, av1_idct8);

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -34,4 +34,35 @@ pub fn av1_idct8(c: &mut Criterion) {
     || transform::av1_idct8(&input[..], &mut output[..], 16)));
 }
 
-criterion_group!(transform, av1_idct4, av1_idct8);
+pub fn av1_iidentity4(c: &mut Criterion) {
+  let (input, mut output) = init_buffers(4);
+
+  c.bench_function("av1_iidentity4_8", move |b| b.iter(
+    || transform::av1_iidentity4(&input[..], &mut output[..], 16)));
+}
+
+pub fn av1_iidentity8(c: &mut Criterion) {
+  let (input, mut output) = init_buffers(8);
+
+  c.bench_function("av1_iidentity8_8", move |b| b.iter(
+    || transform::av1_iidentity8(&input[..], &mut output[..], 16)));
+}
+
+pub fn av1_iadst4(c: &mut Criterion) {
+  let (input, mut output) = init_buffers(4);
+
+  c.bench_function("av1_iadst4_8", move |b| b.iter(
+    || transform::av1_iadst4(&input[..], &mut output[..], 16)));
+}
+
+pub fn av1_iadst8(c: &mut Criterion) {
+  let (input, mut output) = init_buffers(8);
+
+  c.bench_function("av1_iadst8_8", move |b| b.iter(
+    || transform::av1_iadst8(&input[..], &mut output[..], 16)));
+}
+
+criterion_group!(transform,
+  av1_idct4, av1_idct8,
+  av1_iidentity4, av1_iidentity8,
+  av1_iadst4, av1_iadst8);

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -62,7 +62,54 @@ pub fn av1_iadst8(c: &mut Criterion) {
     || transform::av1_iadst8(&input[..], &mut output[..], 16)));
 }
 
-criterion_group!(transform,
+pub fn daala_fdct4(c: &mut Criterion) {
+  let (input, mut output) = init_buffers(4);
+
+  c.bench_function("daala_fdct4", move |b| b.iter(
+    || transform::daala_fdct4(&input[..], &mut output[..])));
+}
+
+pub fn daala_fdct8(c: &mut Criterion) {
+  let (input, mut output) = init_buffers(8);
+
+  c.bench_function("daala_fdct8", move |b| b.iter(
+    || transform::daala_fdct8(&input[..], &mut output[..])));
+}
+
+pub fn fidentity4(c: &mut Criterion) {
+  let (input, mut output) = init_buffers(4);
+
+  c.bench_function("fidentity4", move |b| b.iter(
+    || transform::fidentity4(&input[..], &mut output[..])));
+}
+
+pub fn fidentity8(c: &mut Criterion) {
+  let (input, mut output) = init_buffers(8);
+
+  c.bench_function("fidentity8", move |b| b.iter(
+    || transform::fidentity8(&input[..], &mut output[..])));
+}
+
+pub fn daala_fdst_vii_4(c: &mut Criterion) {
+  let (input, mut output) = init_buffers(4);
+
+  c.bench_function("daala_fdst_vii_4", move |b| b.iter(
+    || transform::daala_fdst_vii_4(&input[..], &mut output[..])));
+}
+
+pub fn daala_fdst8(c: &mut Criterion) {
+  let (input, mut output) = init_buffers(8);
+
+  c.bench_function("daala_fdst8", move |b| b.iter(
+    || transform::daala_fdst8(&input[..], &mut output[..])));
+}
+
+criterion_group!(inverse_transforms,
   av1_idct4, av1_idct8,
   av1_iidentity4, av1_iidentity8,
   av1_iadst4, av1_iadst8);
+
+criterion_group!(forward_transforms,
+  daala_fdct4, daala_fdct8,
+  fidentity4, fidentity8,
+  daala_fdst_vii_4, daala_fdst8);

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -61,7 +61,7 @@ type TxfmFunc = dyn Fn(&[i32], &mut [i32]);
 
 use std::ops::*;
 
-trait TxOperations:
+pub trait TxOperations:
   Copy + Default + Add<Output = Self> + Sub<Output = Self>
 {
   fn tx_mul(self, _: (i32, i32)) -> Self;
@@ -291,7 +291,7 @@ fn daala_fdct_ii_4<T: TxOperations>(
   store_coeffs!(output, q0, q1, q2, q3);
 }
 
-fn daala_fdct4<T: TxOperations>(input: &[T], output: &mut [T]) {
+pub fn daala_fdct4<T: TxOperations>(input: &[T], output: &mut [T]) {
   let mut temp_out: [T; 4] = [T::default(); 4];
   daala_fdct_ii_4(input[0], input[1], input[2], input[3], &mut temp_out);
 
@@ -301,7 +301,7 @@ fn daala_fdct4<T: TxOperations>(input: &[T], output: &mut [T]) {
   output[3] = temp_out[3];
 }
 
-fn daala_fdst_vii_4<T: TxOperations>(input: &[T], output: &mut [T]) {
+pub fn daala_fdst_vii_4<T: TxOperations>(input: &[T], output: &mut [T]) {
   let q0 = input[0];
   let q1 = input[1];
   let q2 = input[2];
@@ -406,7 +406,7 @@ fn daala_fdct_ii_8<T: TxOperations>(
   output[4..8].reverse();
 }
 
-fn daala_fdct8<T: TxOperations>(input: &[T], output: &mut [T]) {
+pub fn daala_fdct8<T: TxOperations>(input: &[T], output: &mut [T]) {
   let mut temp_out: [T; 8] = [T::default(); 8];
   daala_fdct_ii_8(
     input[0],
@@ -485,7 +485,7 @@ fn daala_fdst_iv_8<T: TxOperations>(
   store_coeffs!(output, r0, r1, r2, r3, r4, r5, r6, r7);
 }
 
-fn daala_fdst8<T: TxOperations>(input: &[T], output: &mut [T]) {
+pub fn daala_fdst8<T: TxOperations>(input: &[T], output: &mut [T]) {
   let mut temp_out: [T; 8] = [T::default(); 8];
   daala_fdst_iv_8(
     input[0],
@@ -1597,11 +1597,11 @@ fn daala_fdct64<T: TxOperations>(input: &[T], output: &mut [T]) {
   reorder_4(15, 15);
 }
 
-fn fidentity4<T: TxOperations>(input: &[T], output: &mut [T]) {
+pub fn fidentity4<T: TxOperations>(input: &[T], output: &mut [T]) {
   output[..4].copy_from_slice(&input[..4]);
 }
 
-fn fidentity8<T: TxOperations>(input: &[T], output: &mut [T]) {
+pub fn fidentity8<T: TxOperations>(input: &[T], output: &mut [T]) {
   output[..8].copy_from_slice(&input[..8]);
 }
 

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -48,7 +48,7 @@ pub fn av1_idct4(input: &[i32], output: &mut [i32], range: usize) {
   output[3] = clamp_value(stg2[0] - stg2[3], range);
 }
 
-fn av1_iadst4(input: &[i32], output: &mut [i32], _range: usize) {
+pub fn av1_iadst4(input: &[i32], output: &mut [i32], _range: usize) {
   let bit = 12;
 
   let x0 = input[0];
@@ -93,7 +93,7 @@ fn av1_iadst4(input: &[i32], output: &mut [i32], _range: usize) {
   output[3] = round_shift(x3, bit);
 }
 
-fn av1_iidentity4(input: &[i32], output: &mut [i32], _range: usize) {
+pub fn av1_iidentity4(input: &[i32], output: &mut [i32], _range: usize) {
   for i in 0..4 {
     output[i] = round_shift(SQRT2 * input[i], 12);
   }
@@ -145,7 +145,7 @@ pub fn av1_idct8(input: &[i32], output: &mut [i32], range: usize) {
   output[7] = clamp_value(temp_out[0] - stg4[3], range);
 }
 
-fn av1_iadst8(input: &[i32], output: &mut [i32], range: usize) {
+pub fn av1_iadst8(input: &[i32], output: &mut [i32], range: usize) {
   // stage 1
   let stg1 = [
     input[7], input[0], input[5], input[2], input[3], input[4], input[1],
@@ -223,7 +223,7 @@ fn av1_iadst8(input: &[i32], output: &mut [i32], range: usize) {
   output[7] = -stg6[1];
 }
 
-fn av1_iidentity8(input: &[i32], output: &mut [i32], _range: usize) {
+pub fn av1_iidentity8(input: &[i32], output: &mut [i32], _range: usize) {
   for i in 0..8 {
     output[i] = 2 * input[i];
   }


### PR DESCRIPTION
Work towards #634.

Transform benchmark functions are simplified and benchmarks are added for the 4x4 and 8x8 variants of DCT, identity and ADST transforms, both forward and inverse.