### PR TITLE
Disable self-guided filter when CDEF is disabled

### DIFF
--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -1012,6 +1012,8 @@ impl RestorationState {
                                    &mut out.planes[pli]);
             },
             RestorationFilter::Sgrproj{set, xqd} => {
+              if !fi.sequence.enable_cdef { continue; }
+
               sgrproj_stripe_filter(set, xqd, fi,
                                     crop_w - x,
                                     (crop_h as isize - stripe_start_y) as usize,


### PR DESCRIPTION
This leads to about -73% to BD rate when CDEF is not used (at `-s 10`).

This should be reverted when #1399 is fixed.