### PR TITLE
Enable loop restoration filter for 4:4:4 input

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -217,8 +217,7 @@ impl Sequence {
       enable_warped_motion: false,
       enable_superres: false,
       enable_cdef: config.speed_settings.cdef && config.chroma_sampling != ChromaSampling::Cs422,
-      enable_restoration: config.chroma_sampling != ChromaSampling::Cs422 &&
-        config.chroma_sampling != ChromaSampling::Cs444, // FIXME: not working yet
+      enable_restoration: config.chroma_sampling != ChromaSampling::Cs422,
       operating_points_cnt_minus_1: 0,
       operating_point_idc,
       display_model_info_present_flag: false,


### PR DESCRIPTION
I re-tested it and it works with `nyan.y4m` converted to 4:4:4. If decoding tests succeed in CI I assume it is working. There are still desyncs when enabling it with 4:2:2, including out-of-bounds memory access in the self-guided filter and further desyncs causing decoding errors.