### PR TITLE
Handle write permissions for output.

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -334,7 +334,7 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
       "-" => Box::new(io::stdin()) as Box<dyn Read>,
       f => Box::new(File::open(&f).map_err(|e| e.context("Cannot open input file"))?) as Box<dyn Read>
     },
-    output: create_muxer(matches.value_of("OUTPUT").unwrap()),
+    output: create_muxer(matches.value_of("OUTPUT").unwrap())?,
     rec
   };
 

--- a/src/bin/muxer/ivf.rs
+++ b/src/bin/muxer/ivf.rs
@@ -5,6 +5,8 @@ use std::fs::File;
 use std::io;
 use std::io::Write;
 
+use crate::error::*;
+
 pub struct IvfMuxer {
   output: Box<dyn Write>,
 }
@@ -36,13 +38,14 @@ impl Muxer for IvfMuxer {
 }
 
 impl IvfMuxer {
-  pub fn open(path: &str) -> Box<dyn Muxer> {
+  pub fn open(path: &str) -> Result<Box<dyn Muxer>, CliError> {
+
     let ivf = IvfMuxer {
       output: match path {
         "-" => Box::new(std::io::stdout()),
-        f => Box::new(File::create(&f).unwrap())
+        f => Box::new(File::create(&f).map_err(|e| e.context("Cannot open output file"))?)
       }
     };
-    Box::new(ivf)
+    Ok(Box::new(ivf))
   }
 }

--- a/src/bin/muxer/mod.rs
+++ b/src/bin/muxer/mod.rs
@@ -25,6 +25,8 @@ use std::io;
 use std::ffi::OsStr;
 use std::path::Path;
 
+use crate::error::*;
+
 
 pub trait Muxer {
   fn write_header(
@@ -37,7 +39,7 @@ pub trait Muxer {
   fn flush(&mut self) -> io::Result<()>;
 }
 
-pub fn create_muxer(path: &str) -> Box<dyn Muxer> {
+pub fn create_muxer(path: &str) -> Result<Box<dyn Muxer>, CliError> {
   if path == "-" {
     return IvfMuxer::open(path);
   }
@@ -50,7 +52,7 @@ pub fn create_muxer(path: &str) -> Box<dyn Muxer> {
 
   match &ext[..] {
     "mp4" => {
-      Mp4Muxer::open(path)
+      Ok(Mp4Muxer::open(path))
     }
     "ivf" => {
       IvfMuxer::open(path)


### PR DESCRIPTION
When --o flag contains a path not writable to user, the result is:

```
Backtrace omitted. Run with RUST_BACKTRACE=1 to display it.
Run with RUST_BACKTRACE=full to include source snippets.

The application panicked (crashed).
  called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
in src/libcore/result.rs, line 999
thread: main

```

With patch the result is:

`error: Cannot open input file: Permission denied (os error 13)`
