### PR TITLE
Fix block importance propagation MV top left block

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1529,10 +1529,17 @@ impl<T: Pixel> ContextInner<T> {
 
               // Coordinates of the top-left corner of the block intersecting the
               // reference block from the top-left.
-              let top_left_block_x =
-                reference_x / MI_SIZE_IN_MV_UNITS * MI_SIZE_IN_MV_UNITS;
-              let top_left_block_y =
-                reference_y / MI_SIZE_IN_MV_UNITS * MI_SIZE_IN_MV_UNITS;
+              let top_left_block_x = (reference_x
+                - if reference_x < 0 { MI_SIZE_IN_MV_UNITS - 1 } else { 0 })
+                / MI_SIZE_IN_MV_UNITS
+                * MI_SIZE_IN_MV_UNITS;
+              let top_left_block_y = (reference_y
+                - if reference_y < 0 { MI_SIZE_IN_MV_UNITS - 1 } else { 0 })
+                / MI_SIZE_IN_MV_UNITS
+                * MI_SIZE_IN_MV_UNITS;
+
+              debug_assert!(reference_x >= top_left_block_x);
+              debug_assert!(reference_y >= top_left_block_y);
 
               let top_right_block_x = top_left_block_x + MI_SIZE_IN_MV_UNITS;
               let top_right_block_y = top_left_block_y;
@@ -1609,6 +1616,8 @@ impl<T: Pixel> ContextInner<T> {
           } else {
             *importance = 0.;
           }
+
+          assert!(*importance >= 0.);
         }
       }
 


### PR DESCRIPTION
[AWCY](https://beta.arewecompressedyet.com/?job=master-5ea7a15c0a7a60c37be637851f2b594a9a6b79e4&job=fix-block-imp-mv-search-2) where I set `--range full`, not sure if it affects anything.