### PR TITLE
Tune temporal RDO coefficients

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -39,7 +39,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::{cmp, fmt, io};
 
-const RDO_LOOKAHEAD_FRAMES: u64 = 10;
+const RDO_LOOKAHEAD_FRAMES: u64 = 40;
 
 // TODO: use the num crate?
 #[derive(Clone, Copy, Debug)]

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -373,8 +373,8 @@ pub fn compute_rd_cost<T: Pixel>(
   // Divide by the full area even though some blocks were outside.
   mean_importance /= (bsize.width_mi() * bsize.height_mi()) as f32;
 
-  // Chosen empirically so the bias ends up being around 1.
-  const FACTOR: f32 = 4.;
+  // Chosen based on a series of AWCY runs.
+  const FACTOR: f32 = 3.;
   const ADDEND: f64 = 0.8;
 
   let bias = (mean_importance / FACTOR) as f64 + ADDEND;


### PR DESCRIPTION
So I have a better baseline for segmentation.

[AWCY](https://beta.arewecompressedyet.com/?job=master-c0990b3336e6e37691f65c6f17f62448322d6e4d&job=tune-rdo-coeffs-f3-a0.8-l40)

[AWCY between master, optimal coeffs with 10 lookahead, optimal coeffs with 40 lookahead (this PR)](https://beta.arewecompressedyet.com/?job=master-c0990b3336e6e37691f65c6f17f62448322d6e4d&job=tune-rdo-coeffs-f3-a0.8-l10&job=tune-rdo-coeffs-f3-a0.8-l40)

As per [a big number of AWCY runs](https://beta.arewecompressedyet.com/?job=master-c0990b3336e6e37691f65c6f17f62448322d6e4d&job=tune-rdo-coeffs-f2-a0.5-l10&job=tune-rdo-coeffs-f2-a0.6-l10&job=tune-rdo-coeffs-f2-a0.4-l10&job=tune-rdo-coeffs-f3-a0.6-l10&job=tune-rdo-coeffs-f3-a0.5-l10&job=tune-rdo-coeffs-f3-a0.4-l10&job=tune-rdo-coeffs-f2-a0.5-l40&job=tune-rdo-coeffs-f2-a0.6-l40&job=tune-rdo-coeffs-f2-a0.4-l40&job=tune-rdo-coeffs-f3-a0.4-l40&job=tune-rdo-coeffs-f3-a0.5-l40&job=tune-rdo-coeffs-f3-a0.6-l40&job=tune-rdo-coeffs-f2-a0.7-l10&job=tune-rdo-coeffs-f2-a0.8-l10&job=tune-rdo-coeffs-f3-a0.7-l10&job=tune-rdo-coeffs-f3-a0.8-l10&job=tune-rdo-coeffs-f2-a0.7-l40&job=tune-rdo-coeffs-f2-a0.8-l40&job=tune-rdo-coeffs-f3-a0.7-l40&job=tune-rdo-coeffs-f3-a0.8-l40&job=tune-rdo-coeffs-f4-a0.8-l40&job=tune-rdo-coeffs-f4-a0.7-l40&job=tune-rdo-coeffs-f3-a0.9-l10&job=tune-rdo-coeffs-f3-a1-l10&job=tune-rdo-coeffs-f4-a0.9-l10) which I can't even link in its entirety because AWCY ran out of alphabet letters. Warning: this link destroys browsers.

Factor 3 and addend 0.8 end up being the best for both lookahead frames settings. Notably, increasing addend helps with `red_kayak` which is the main clip that tanks everything on lower addends (even when other clips improve).