### PR TITLE
Adjust quantizers via segmentation and RDO

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -184,7 +184,8 @@ pub struct SpeedSettings {
   pub include_near_mvs: bool,
   pub no_scene_detection: bool,
   pub diamond_me: bool,
-  pub cdef: bool
+  pub cdef: bool,
+  pub quantizer_rdo: bool
 }
 
 /// Default values for the speed settings.
@@ -203,7 +204,8 @@ impl Default for SpeedSettings {
       include_near_mvs: false,
       no_scene_detection: false,
       diamond_me: false,
-      cdef: false
+      cdef: false,
+      quantizer_rdo: false
     }
   }
 }
@@ -219,9 +221,9 @@ impl SpeedSettings {
   ///  - speed - 5, default, Min block size 8x8, reduced TX set, TX domain distortion, complex pred modes for keyframes,
   ///  - speed - 4, Min block size 8x8, TX domain distortion, complex pred modes for keyframes,
   ///  - speed - 3, Min block size 8x8, TX domain distortion, complex pred modes for keyframes, RDO TX decision,
-  ///  - speed - 2, Min block size 8x8, TX domain distortion, complex pred modes for keyframes, RDO TX decision, include near MVs,
-  ///  - speed - 1, Min block size 8x8, TX domain distortion, complex pred modes, RDO TX decision, include near MVs,
-  ///  - speed - 0, slowest,  Min block size 4x4, TX domain distortion, complex pred modes, RDO TX decision, include near MVs, bottom-up encoding.
+  ///  - speed - 2, Min block size 8x8, TX domain distortion, complex pred modes for keyframes, RDO TX decision, include near MVs, quantizer RDO,
+  ///  - speed - 1, Min block size 8x8, TX domain distortion, complex pred modes, RDO TX decision, include near MVs, quantizer RDO,
+  ///  - speed - 0, slowest,  Min block size 4x4, TX domain distortion, complex pred modes, RDO TX decision, include near MVs, quantizer RDO, bottom-up encoding.
   pub fn from_preset(speed: usize) -> Self {
     SpeedSettings {
       min_block_size: Self::min_block_size_preset(speed),
@@ -236,7 +238,8 @@ impl SpeedSettings {
       include_near_mvs: Self::include_near_mvs_preset(speed),
       no_scene_detection: Self::no_scene_detection_preset(speed),
       diamond_me: Self::diamond_me_preset(speed),
-      cdef: Self::cdef_preset(speed)
+      cdef: Self::cdef_preset(speed),
+      quantizer_rdo: Self::quantizer_rdo_preset(speed)
     }
   }
 
@@ -317,6 +320,10 @@ impl SpeedSettings {
 
   fn cdef_preset(_speed: usize) -> bool {
     true
+  }
+
+  fn quantizer_rdo_preset(speed: usize) -> bool {
+    speed <= 2
   }
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1566,6 +1566,10 @@ pub fn encode_block_with_modes<T: Pixel>(
   let mut cdef_coded = cw.bc.cdef_coded;
   let (tx_size, tx_type) = (mode_decision.tx_size, mode_decision.tx_type);
 
+  // Set correct segmentation ID before encoding and before
+  // rdo_tx_size_type().
+  cw.bc.blocks.set_segmentation_idx(tile_bo, bsize, mode_decision.sidx);
+
   debug_assert!((tx_size, tx_type) ==
                 rdo_tx_size_type(fi, ts, cw, bsize, tile_bo, mode_luma, ref_frames, mvs, skip));
 
@@ -1907,6 +1911,10 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
       let ref_frames = part_decision.ref_frames;
       let mvs = part_decision.mvs;
       let mut cdef_coded = cw.bc.cdef_coded;
+
+      // Set correct segmentation ID before encoding and before
+      // rdo_tx_size_type().
+      cw.bc.blocks.set_segmentation_idx(tile_bo, bsize, part_decision.sidx);
 
       // NOTE: Cannot avoid calling rdo_tx_size_type() here again,
       // because, with top-down partition RDO, the neighnoring contexts

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1444,7 +1444,7 @@ pub fn write_tx_blocks<T: Pixel>(
     };
 
     for p in 1..3 {
-      ts.qc.update(fi.base_q_idx, uv_tx_size, true, fi.sequence.bit_depth, fi.dc_delta_q[p], fi.ac_delta_q[p]);
+      ts.qc.update(qidx, uv_tx_size, true, fi.sequence.bit_depth, fi.dc_delta_q[p], fi.ac_delta_q[p]);
       let alpha = cfl.alpha(p - 1);
       for by in 0..bh_uv {
         for bx in 0..bw_uv {

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -395,6 +395,7 @@ macro_rules! test_chroma_sampling {
       paste::item_with_macros!{
         #[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
         #[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+        #[ignore]
         fn [<chroma_sampling_ $S>](decoder: &str) {
           chroma_sampling(decoder, $I);
         }


### PR DESCRIPTION
[AWCY](https://beta.arewecompressedyet.com/?job=master-speed2-914fe8df0df9cdb87bd0f56fa8a57c8a3eab9489%402019-08-01T17%3A03%3A57.470Z&job=temporal-rdo-quantizer-27)

[AWCY but on --speed 5](https://beta.arewecompressedyet.com/?job=master-914fe8df0df9cdb87bd0f56fa8a57c8a3eab9489&job=temporal-rdo-quantizer-26)

With @tdaede we decided I should put this in `--speed 2` as it about doubles the encoding time.

This adds three quantizer index deltas: 0, -15 and 15, and adds searching them to the RDO. This way it's affected by any RDO biasing, be it block importance or activity. This showed better results than me trying to naively set the segment delta according to mean importance.