### PR TITLE
Add newtypes for {Plane,Tile}{Super,}BlockOffset

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -63,7 +63,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
 
   b.iter(|| {
     for &mode in RAV1E_INTRA_MODES {
-      let sbo = SuperBlockOffset { x: sbx, y: sby };
+      let sbo = TileSuperBlockOffset(SuperBlockOffset { x: sbx, y: sby });
       for p in 1..3 {
         ts.qc.update(fi.base_q_idx, tx_size, mode.is_intra(), 8, fi.dc_delta_q[p], fi.ac_delta_q[p]);
         for by in 0..8 {
@@ -75,7 +75,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
               continue;
             };
             let bo = sbo.block_offset(bx, by);
-            let tx_bo = BlockOffset { x: bo.x + bx, y: bo.y + by };
+            let tx_bo = TileBlockOffset(BlockOffset { x: bo.0.x + bx, y: bo.0.y + by });
             let po = tx_bo.plane_offset(&ts.input.planes[p].cfg);
             encode_tx_block(
               &mut fi,
@@ -151,7 +151,7 @@ fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
   let fi = FrameInvariants::<u16>::new(config, sequence);
   let mut fs = FrameState::new(&fi);
   let mut ts = fs.as_tile_state_mut();
-  let offset = BlockOffset { x: 1, y: 1 };
+  let offset = TileBlockOffset(BlockOffset { x: 1, y: 1 });
   b.iter(|| rdo_cfl_alpha(&mut ts, offset, bsize, fi.sequence.bit_depth))
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -17,7 +17,7 @@ use num_derive::*;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde_derive::{Deserialize, Serialize};
 
-use crate::context::{FrameBlocks, SuperBlockOffset, MI_SIZE};
+use crate::context::{FrameBlocks, TileSuperBlockOffset, SuperBlockOffset, MI_SIZE};
 use crate::dist::get_satd;
 use crate::encoder::*;
 use crate::frame::*;
@@ -1156,7 +1156,7 @@ impl<T: Pixel> ContextInner<T> {
         // Compute the half-resolution motion vectors.
         for sby in 0..ts.sb_height {
           for sbx in 0..ts.sb_width {
-            let tile_sbo = SuperBlockOffset { x: sbx, y: sby };
+            let tile_sbo = TileSuperBlockOffset(SuperBlockOffset { x: sbx, y: sby });
             build_half_res_pmvs(fi, ts, tile_sbo, &tile_pmvs);
           }
         }
@@ -1242,7 +1242,7 @@ impl<T: Pixel> ContextInner<T> {
         // TODO: other intra prediction modes.
         let edge_buf = get_intra_edges(
           &frame.planes[0].as_region(),
-          BlockOffset{ x, y },
+          TileBlockOffset(BlockOffset{ x, y }),
           0, 0, BlockSize::BLOCK_4X4,
           PlaneOffset {
             x: x as isize * MI_SIZE as isize,

--- a/src/recon_intra.rs
+++ b/src/recon_intra.rs
@@ -166,7 +166,7 @@ pub fn get_has_tr_table(/*partition: PartitionType, */bsize: BlockSize) -> &'sta
 }
 
 pub fn has_top_right(/*const AV1_COMMON *cm,*/
-                         bsize: BlockSize, partition_bo: BlockOffset,
+                         bsize: BlockSize, partition_bo: TileBlockOffset,
                          top_available: bool, right_available: bool,
                          tx_size: TxSize,
                          row_off: usize, col_off: usize, ss_x: usize, _ss_y: usize) -> bool {
@@ -176,8 +176,8 @@ pub fn has_top_right(/*const AV1_COMMON *cm,*/
   let plane_bw_unit = (bw_unit >> ss_x).max(1);
   let top_right_count_unit = tx_size.width_mi();
 
-  let mi_col = partition_bo.x;
-  let mi_row = partition_bo.y;
+  let mi_col = partition_bo.0.x;
+  let mi_row = partition_bo.0.y;
 
   if row_off > 0 {  // Just need to check if enough pixels on the right.
     // 128x128 SB is not supported yet by rav1e
@@ -355,7 +355,7 @@ pub fn get_has_bl_table(/*partition: PartitionType, */bsize: BlockSize) -> &'sta
 }
 
 pub fn has_bottom_left(/*const AV1_COMMON *cm,*/
-                         bsize: BlockSize, partition_bo: BlockOffset,
+                         bsize: BlockSize, partition_bo: TileBlockOffset,
                          bottom_available: bool, left_available: bool,
                          tx_size: TxSize,
                          row_off: usize, col_off: usize, _ss_x: usize, ss_y: usize) -> bool {
@@ -392,8 +392,8 @@ pub fn has_bottom_left(/*const AV1_COMMON *cm,*/
     let plane_bh_unit = (bh_unit >> ss_y).max(1);
     let bottom_left_count_unit = tx_size.height_mi();
 
-    let mi_col = partition_bo.x;
-    let mi_row = partition_bo.y;
+    let mi_col = partition_bo.0.x;
+    let mi_row = partition_bo.0.y;
 
     // All bottom-left pixels are in the left block, which is already available.
     if row_off + bottom_left_count_unit < plane_bh_unit { return true };

--- a/src/tiling/plane_region.rs
+++ b/src/tiling/plane_region.rs
@@ -232,7 +232,7 @@ macro_rules! plane_region_common {
       }
 
       #[inline(always)]
-      pub fn to_frame_block_offset(&self, tile_bo: BlockOffset) -> BlockOffset {
+      pub fn to_frame_block_offset(&self, tile_bo: TileBlockOffset) -> PlaneBlockOffset {
         debug_assert!(self.rect.x >= 0);
         debug_assert!(self.rect.y >= 0);
         let PlaneConfig { xdec, ydec, .. } = self.plane_cfg;
@@ -240,18 +240,18 @@ macro_rules! plane_region_common {
         debug_assert!(self.rect.y as usize % (MI_SIZE >> ydec) == 0);
         let bx = self.rect.x as usize >> MI_SIZE_LOG2 - xdec;
         let by = self.rect.y as usize >> MI_SIZE_LOG2 - ydec;
-        BlockOffset {
-          x: bx + tile_bo.x,
-          y: by + tile_bo.y,
-        }
+        PlaneBlockOffset(BlockOffset {
+          x: bx + tile_bo.0.x,
+          y: by + tile_bo.0.y,
+        })
       }
 
       #[inline(always)]
       pub fn to_frame_super_block_offset(
         &self,
-        tile_sbo: SuperBlockOffset,
+        tile_sbo: TileSuperBlockOffset,
         sb_size_log2: usize
-      ) -> SuperBlockOffset {
+      ) -> PlaneSuperBlockOffset {
         debug_assert!(sb_size_log2 == 6 || sb_size_log2 == 7);
         debug_assert!(self.rect.x >= 0);
         debug_assert!(self.rect.y >= 0);
@@ -260,10 +260,10 @@ macro_rules! plane_region_common {
         debug_assert!(self.rect.y as usize % (1 << sb_size_log2 - ydec) == 0);
         let sbx = self.rect.x as usize >> sb_size_log2 - xdec;
         let sby = self.rect.y as usize >> sb_size_log2 - ydec;
-        SuperBlockOffset {
-          x: sbx + tile_sbo.x,
-          y: sby + tile_sbo.y,
-        }
+        PlaneSuperBlockOffset(SuperBlockOffset {
+          x: sbx + tile_sbo.0.x,
+          y: sby + tile_sbo.0.y,
+        })
       }
     }
 

--- a/src/tiling/tile.rs
+++ b/src/tiling/tile.rs
@@ -46,37 +46,37 @@ impl TileRect {
   #[inline(always)]
   pub fn to_frame_block_offset(
     &self,
-    tile_bo: BlockOffset,
+    tile_bo: TileBlockOffset,
     xdec: usize,
     ydec: usize,
-  ) -> BlockOffset {
+  ) -> PlaneBlockOffset {
     debug_assert!(self.x as usize % (MI_SIZE >> xdec) == 0);
     debug_assert!(self.y as usize % (MI_SIZE >> ydec) == 0);
     let bx = self.x >> (MI_SIZE_LOG2 - xdec);
     let by = self.y >> (MI_SIZE_LOG2 - ydec);
-    BlockOffset {
-      x: bx + tile_bo.x,
-      y: by + tile_bo.y,
-    }
+    PlaneBlockOffset(BlockOffset {
+      x: bx + tile_bo.0.x,
+      y: by + tile_bo.0.y,
+    })
   }
 
   #[inline(always)]
   pub fn to_frame_super_block_offset(
     &self,
-    tile_sbo: SuperBlockOffset,
+    tile_sbo: TileSuperBlockOffset,
     sb_size_log2: usize,
     xdec: usize,
     ydec: usize,
-  ) -> SuperBlockOffset {
+  ) -> PlaneSuperBlockOffset {
     debug_assert!(sb_size_log2 == 6 || sb_size_log2 == 7);
     debug_assert!(self.x as usize % (1 << (sb_size_log2 - xdec)) == 0);
     debug_assert!(self.y as usize % (1 << (sb_size_log2 - ydec)) == 0);
     let sbx = self.x as usize >> (sb_size_log2 - xdec);
     let sby = self.y as usize >> (sb_size_log2 - ydec);
-    SuperBlockOffset {
-      x: sbx + tile_sbo.x,
-      y: sby + tile_sbo.y,
-    }
+    PlaneSuperBlockOffset(SuperBlockOffset {
+      x: sbx + tile_sbo.0.x,
+      y: sby + tile_sbo.0.y,
+    })
   }
 }
 

--- a/src/tiling/tile_blocks.rs
+++ b/src/tiling/tile_blocks.rs
@@ -93,22 +93,22 @@ macro_rules! tile_blocks_common {
       }
 
       #[inline(always)]
-      pub fn above_of(&self, bo: BlockOffset) -> &Block {
-        &self[bo.y - 1][bo.x]
+      pub fn above_of(&self, bo: TileBlockOffset) -> &Block {
+        &self[bo.0.y - 1][bo.0.x]
       }
 
       #[inline(always)]
-      pub fn left_of(&self, bo: BlockOffset) -> &Block {
-        &self[bo.y][bo.x - 1]
+      pub fn left_of(&self, bo: TileBlockOffset) -> &Block {
+        &self[bo.0.y][bo.0.x - 1]
       }
 
       #[inline(always)]
-      pub fn above_left_of(&self, bo: BlockOffset) -> &Block {
-        &self[bo.y - 1][bo.x - 1]
+      pub fn above_left_of(&self, bo: TileBlockOffset) -> &Block {
+        &self[bo.0.y - 1][bo.0.x - 1]
       }
 
-      pub fn get_cdef(&self, sbo: SuperBlockOffset) -> u8 {
-        let bo = sbo.block_offset(0, 0);
+      pub fn get_cdef(&self, sbo: TileSuperBlockOffset) -> u8 {
+        let bo = sbo.block_offset(0, 0).0;
         self[bo.y][bo.x].cdef_index
       }
     }
@@ -128,12 +128,12 @@ macro_rules! tile_blocks_common {
       }
     }
 
-    // for convenience, also index by BlockOffset
-    impl Index<BlockOffset> for $name<'_> {
+    // for convenience, also index by TileBlockOffset
+    impl Index<TileBlockOffset> for $name<'_> {
       type Output = Block;
       #[inline(always)]
-      fn index(&self, bo: BlockOffset) -> &Self::Output {
-        &self[bo.y][bo.x]
+      fn index(&self, bo: TileBlockOffset) -> &Self::Output {
+        &self[bo.0.y][bo.0.x]
       }
     }
   }
@@ -158,7 +158,7 @@ impl TileBlocksMut<'_> {
   }
 
   #[inline(always)]
-  pub fn for_each<F>(&mut self, bo: BlockOffset, bsize: BlockSize, f: F)
+  pub fn for_each<F>(&mut self, bo: TileBlockOffset, bsize: BlockSize, f: F)
   where
     F: Fn(&mut Block) -> (),
   {
@@ -166,7 +166,7 @@ impl TileBlocksMut<'_> {
     let bh = bsize.height_mi();
     for y in 0..bh {
       for x in 0..bw {
-        f(&mut self[bo.y + y as usize][bo.x + x as usize]);
+        f(&mut self[bo.0.y + y as usize][bo.0.x + x as usize]);
       }
     }
   }
@@ -174,7 +174,7 @@ impl TileBlocksMut<'_> {
   #[inline(always)]
   pub fn set_mode(
     &mut self,
-    bo: BlockOffset,
+    bo: TileBlockOffset,
     bsize: BlockSize,
     mode: PredictionMode,
   ) {
@@ -182,7 +182,7 @@ impl TileBlocksMut<'_> {
   }
 
   #[inline(always)]
-  pub fn set_block_size(&mut self, bo: BlockOffset, bsize: BlockSize) {
+  pub fn set_block_size(&mut self, bo: TileBlockOffset, bsize: BlockSize) {
     let n4_w = bsize.width_mi();
     let n4_h = bsize.height_mi();
     self.for_each(bo, bsize, |block| {
@@ -195,7 +195,7 @@ impl TileBlocksMut<'_> {
   #[inline(always)]
   pub fn set_tx_size(
     &mut self,
-    bo: BlockOffset,
+    bo: TileBlockOffset,
     bsize: BlockSize,
     tx_size: TxSize,
   ) {
@@ -203,14 +203,14 @@ impl TileBlocksMut<'_> {
   }
 
   #[inline(always)]
-  pub fn set_skip(&mut self, bo: BlockOffset, bsize: BlockSize, skip: bool) {
+  pub fn set_skip(&mut self, bo: TileBlockOffset, bsize: BlockSize, skip: bool) {
     self.for_each(bo, bsize, |block| block.skip = skip);
   }
 
   #[inline(always)]
   pub fn set_segmentation_idx(
     &mut self,
-    bo: BlockOffset,
+    bo: TileBlockOffset,
     bsize: BlockSize,
     idx: u8,
   ) {
@@ -220,7 +220,7 @@ impl TileBlocksMut<'_> {
   #[inline(always)]
   pub fn set_ref_frames(
     &mut self,
-    bo: BlockOffset,
+    bo: TileBlockOffset,
     bsize: BlockSize,
     r: [RefType; 2],
   ) {
@@ -230,7 +230,7 @@ impl TileBlocksMut<'_> {
   #[inline(always)]
   pub fn set_motion_vectors(
     &mut self,
-    bo: BlockOffset,
+    bo: TileBlockOffset,
     bsize: BlockSize,
     mvs: [MotionVector; 2],
   ) {
@@ -238,8 +238,8 @@ impl TileBlocksMut<'_> {
   }
 
   #[inline(always)]
-  pub fn set_cdef(&mut self, sbo: SuperBlockOffset, cdef_index: u8) {
-    let bo = sbo.block_offset(0, 0);
+  pub fn set_cdef(&mut self, sbo: TileSuperBlockOffset, cdef_index: u8) {
+    let bo = sbo.block_offset(0, 0).0;
     // Checkme: Is 16 still the right block unit for 128x128 superblocks?
     let bw = cmp::min(bo.x + MIB_SIZE, self.cols);
     let bh = cmp::min(bo.y + MIB_SIZE, self.rows);
@@ -262,9 +262,9 @@ impl IndexMut<usize> for TileBlocksMut<'_> {
   }
 }
 
-impl IndexMut<BlockOffset> for TileBlocksMut<'_> {
+impl IndexMut<TileBlockOffset> for TileBlocksMut<'_> {
   #[inline(always)]
-  fn index_mut(&mut self, bo: BlockOffset) -> &mut Self::Output {
-    &mut self[bo.y][bo.x]
+  fn index_mut(&mut self, bo: TileBlockOffset) -> &mut Self::Output {
+    &mut self[bo.0.y][bo.0.x]
   }
 }

--- a/src/tiling/tile_state.rs
+++ b/src/tiling/tile_state.rs
@@ -38,7 +38,7 @@ use crate::util::*;
 /// frame-wise once the tile views vanish (e.g. for deblocking).
 #[derive(Debug)]
 pub struct TileStateMut<'a, T: Pixel> {
-  pub sbo: SuperBlockOffset,
+  pub sbo: PlaneSuperBlockOffset,
   pub sb_size_log2: usize,
   pub sb_width: usize,
   pub sb_height: usize,
@@ -62,7 +62,7 @@ pub struct TileStateMut<'a, T: Pixel> {
 impl<'a, T: Pixel> TileStateMut<'a, T> {
   pub fn new(
     fs: &'a mut FrameState<T>,
-    sbo: SuperBlockOffset,
+    sbo: PlaneSuperBlockOffset,
     sb_size_log2: usize,
     width: usize,
     height: usize,
@@ -70,8 +70,8 @@ impl<'a, T: Pixel> TileStateMut<'a, T> {
     debug_assert!(width % MI_SIZE == 0, "Tile width must be a multiple of MI_SIZE");
     debug_assert!(height % MI_SIZE == 0, "Tile width must be a multiple of MI_SIZE");
     let luma_rect = TileRect {
-      x: sbo.x << sb_size_log2,
-      y: sbo.y << sb_size_log2,
+      x: sbo.0.x << sb_size_log2,
+      y: sbo.0.y << sb_size_log2,
       width,
       height,
     };
@@ -106,8 +106,8 @@ impl<'a, T: Pixel> TileStateMut<'a, T> {
         .map(|fmvs| {
           TileMotionVectorsMut::new(
             fmvs,
-            sbo.x << (sb_size_log2 - MI_SIZE_LOG2),
-            sbo.y << (sb_size_log2 - MI_SIZE_LOG2),
+            sbo.0.x << (sb_size_log2 - MI_SIZE_LOG2),
+            sbo.0.y << (sb_size_log2 - MI_SIZE_LOG2),
             width >> MI_SIZE_LOG2,
             height >> MI_SIZE_LOG2,
           )
@@ -120,28 +120,28 @@ impl<'a, T: Pixel> TileStateMut<'a, T> {
   #[inline(always)]
   pub fn tile_rect(&self) -> TileRect {
     TileRect {
-      x: self.sbo.x << self.sb_size_log2,
-      y: self.sbo.y << self.sb_size_log2,
+      x: self.sbo.0.x << self.sb_size_log2,
+      y: self.sbo.0.y << self.sb_size_log2,
       width: self.width,
       height: self.height,
     }
   }
 
   #[inline(always)]
-  pub fn to_frame_block_offset(&self, tile_bo: BlockOffset) -> BlockOffset {
-    let bx = self.sbo.x << (self.sb_size_log2 - MI_SIZE_LOG2);
-    let by = self.sbo.y << (self.sb_size_log2 - MI_SIZE_LOG2);
-    BlockOffset {
-      x: bx + tile_bo.x,
-      y: by + tile_bo.y,
-    }
+  pub fn to_frame_block_offset(&self, tile_bo: TileBlockOffset) -> PlaneBlockOffset {
+    let bx = self.sbo.0.x << (self.sb_size_log2 - MI_SIZE_LOG2);
+    let by = self.sbo.0.y << (self.sb_size_log2 - MI_SIZE_LOG2);
+    PlaneBlockOffset(BlockOffset {
+      x: bx + tile_bo.0.x,
+      y: by + tile_bo.0.y,
+    })
   }
 
   #[inline(always)]
-  pub fn to_frame_super_block_offset(&self, tile_sbo: SuperBlockOffset) -> SuperBlockOffset {
-    SuperBlockOffset {
-      x: self.sbo.x + tile_sbo.x,
-      y: self.sbo.y + tile_sbo.y,
-    }
+  pub fn to_frame_super_block_offset(&self, tile_sbo: TileSuperBlockOffset) -> PlaneSuperBlockOffset {
+    PlaneSuperBlockOffset(SuperBlockOffset {
+      x: self.sbo.0.x + tile_sbo.0.x,
+      y: self.sbo.0.y + tile_sbo.0.y,
+    })
   }
 }

--- a/src/tiling/tiler.rs
+++ b/src/tiling/tiler.rs
@@ -176,12 +176,12 @@ impl<'a, 'b, T: Pixel> Iterator for TileContextIterMut<'a, 'b, T> {
       let ctx = TileContextMut {
         ts: {
           let fs = unsafe { &mut *self.fs };
-          let sbo = SuperBlockOffset {
+          let sbo = PlaneSuperBlockOffset(SuperBlockOffset {
             x: tile_col * self.ti.tile_width_sb,
             y: tile_row * self.ti.tile_height_sb,
-          };
-          let x = sbo.x << self.ti.sb_size_log2;
-          let y = sbo.y << self.ti.sb_size_log2;
+          });
+          let x = sbo.0.x << self.ti.sb_size_log2;
+          let y = sbo.0.y << self.ti.sb_size_log2;
           let tile_width = self.ti.tile_width_sb << self.ti.sb_size_log2;
           let tile_height = self.ti.tile_height_sb << self.ti.sb_size_log2;
           let width = tile_width.min(self.ti.frame_width - x);


### PR DESCRIPTION
Helps ensure type safety. `Plane` offsets are relative to the plane, and `Tile` offsets are relative to the tile, with methods on `TileState` providing conversions.

This is an idea I had ever since I bumped into this while implementing mean block importance computation in `compute_rd_cost()`. While I would like to say that error would've been entirely prevented had this been in-place, it wouldn't, because in that code I extracted raw `.x` and `.y` anyway. However, I clearly needed the frame block offset and I could've figured it out by looking at the type names.

[AWCY just in case (all zeros)](https://beta.arewecompressedyet.com/?job=block-offset-refactor&job=master-52074d09a3563fe7c2ea0730c13ec919052b847c)