### PR TITLE
Fix excessive memory usage issue in lookahead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.35.0
+  - 1.36.0
 env:
   - RUST_BACKTRACE=1
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.36.0
+  - 1.35.0
 env:
   - RUST_BACKTRACE=1
 addons:

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1782,13 +1782,13 @@ impl<T: Pixel> ContextInner<T> {
     if cur_input_frameno == 0 {
       return;
     }
-    for i in self.frame_q.keys().next().cloned().unwrap_or(0)..cur_input_frameno {
+    for i in 0..cur_input_frameno {
       self.frame_q.remove(&i);
     }
     if self.output_frameno < 2 {
       return;
     }
-    for i in self.frame_invariants.keys().next().cloned().unwrap_or(0)..(self.output_frameno - 1) {
+    for i in 0..(self.output_frameno - 1) {
       self.frame_invariants.remove(&i);
       self.gop_output_frameno_start.remove(&i);
       self.gop_input_frameno_start.remove(&i);


### PR DESCRIPTION
The lookahead would read all frames in the video into memory
before processing any of them. This would lead to huge amounts of
memory usage on longer videos.

Fixes #1523.