### PR TITLE
Expose the Frame Override API in the C API

### DIFF
--- a/src/capi.rs
+++ b/src/capi.rs
@@ -21,6 +21,14 @@ use num_traits::cast::FromPrimitive;
 
 use crate::prelude as rav1e;
 
+type PixelRange = rav1e::PixelRange;
+type ChromaSamplePosition = rav1e::ChromaSamplePosition;
+type ChromaSampling = rav1e::ChromaSampling;
+type MatrixCoefficients = rav1e::MatrixCoefficients;
+type ColorPrimaries = rav1e::ColorPrimaries;
+type TransferCharacteristics = rav1e::TransferCharacteristics;
+type Rational = rav1e::Rational;
+
 /// Raw video Frame
 ///
 /// It can be allocated throught rav1e_frame_new(), populated using rav1e_frame_fill_plane()
@@ -220,14 +228,6 @@ pub unsafe extern fn rav1e_data_unref(data: *mut Data) {
     let _ = Vec::from_raw_parts(data.data as *mut u8, data.len as usize, data.len as usize);
   }
 }
-
-type PixelRange = rav1e::PixelRange;
-type ChromaSamplePosition = rav1e::ChromaSamplePosition;
-type ChromaSampling = rav1e::ChromaSampling;
-type MatrixCoefficients = rav1e::MatrixCoefficients;
-type ColorPrimaries = rav1e::ColorPrimaries;
-type TransferCharacteristics = rav1e::TransferCharacteristics;
-type Rational = rav1e::Rational;
 
 #[no_mangle]
 pub unsafe extern fn rav1e_config_default() -> *mut Config {

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -7,6 +7,8 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use num_derive::FromPrimitive;
+
 use crate::util::*;
 use crate::api::ChromaSampling;
 use crate::context::SB_SIZE;
@@ -23,7 +25,8 @@ const FRAME_MARGIN: usize = 16 + SUBPEL_FILTER_SIZE;
 /// Override the frame type decision
 ///
 /// Only certain frame types can be selected.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
+#[repr(C)]
 pub enum FrameTypeOverride {
   /// Do not force any decision.
   No,


### PR DESCRIPTION
Tested and seems to work (on Linux).

In particular, someone needs to double check my `Box` usage in the commit `
Switch RaFrame to a struct with an internal enum`. I am not confident I did that right.

CC: @nox (since he isn't listed 