### PR TITLE
Fix chroma subsampling with odd luma sizes.

### DIFF
--- a/src/api/color.rs
+++ b/src/api/color.rs
@@ -51,14 +51,29 @@ impl Default for ChromaSampling {
 }
 
 impl ChromaSampling {
-  /// Provide the sampling period in the horizontal and vertical axes.
-  pub fn sampling_period(self) -> (usize, usize) {
+  /// Provides the amount to right shift the luma plane dimensions to get the
+  ///  chroma plane dimensions.
+  /// Only values 0 or 1 are ever returned.
+  /// The plane dimensions must also be rounded up to accomodate odd luma plane
+  ///  sizes.
+  /// Cs400 returns None, as there are no chroma planes.
+  pub fn get_decimation(&self) -> Option<(usize, usize)> {
     use self::ChromaSampling::*;
     match self {
-      Cs420 => (2, 2),
-      Cs422 => (2, 1),
-      Cs444 => (1, 1),
-      Cs400 => (2, 2)
+      Cs420 => Some((1, 1)),
+      Cs422 => Some((1, 0)),
+      Cs444 => Some((0, 0)),
+      Cs400 => None,
+    }
+  }
+
+  pub fn get_chroma_dimensions(&self, luma_width: usize, luma_height: usize)
+   -> (usize, usize) {
+    if let Some((ss_x, ss_y)) = self.get_decimation() {
+      ((luma_width + ss_x) >> ss_x, (luma_height + ss_y) >> ss_y)
+    }
+    else {
+      (0, 0)
     }
   }
 }

--- a/src/api/color.rs
+++ b/src/api/color.rs
@@ -57,7 +57,7 @@ impl ChromaSampling {
   /// The plane dimensions must also be rounded up to accomodate odd luma plane
   ///  sizes.
   /// Cs400 returns None, as there are no chroma planes.
-  pub fn get_decimation(&self) -> Option<(usize, usize)> {
+  pub fn get_decimation(self) -> Option<(usize, usize)> {
     use self::ChromaSampling::*;
     match self {
       Cs420 => Some((1, 1)),
@@ -67,7 +67,7 @@ impl ChromaSampling {
     }
   }
 
-  pub fn get_chroma_dimensions(&self, luma_width: usize, luma_height: usize)
+  pub fn get_chroma_dimensions(self, luma_width: usize, luma_height: usize)
    -> (usize, usize) {
     if let Some((ss_x, ss_y)) = self.get_decimation() {
       ((luma_width + ss_x) >> ss_x, (luma_height + ss_y) >> ss_y)

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -32,17 +32,18 @@ impl Decoder for y4m::Decoder<'_, Box<dyn Read>> {
       .map(|frame| {
         let mut f: Frame<T> = Frame::new(cfg.width, cfg.height, cfg.chroma_sampling);
 
-        let (chroma_period, _) = cfg.chroma_sampling.sampling_period();
+        let (chroma_width, _) = cfg.chroma_sampling
+         .get_chroma_dimensions(cfg.width, cfg.height);
 
         f.planes[0].copy_from_raw_u8(frame.get_y_plane(), cfg.width * bytes, bytes);
         f.planes[1].copy_from_raw_u8(
           frame.get_u_plane(),
-          cfg.width * bytes / chroma_period,
+          chroma_width * bytes,
           bytes
         );
         f.planes[2].copy_from_raw_u8(
           frame.get_v_plane(),
-          cfg.width * bytes / chroma_period,
+          chroma_width * bytes,
           bytes
         );
         f

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -52,14 +52,12 @@ impl<T: Pixel> Frame<T> {
     let luma_height = height.align_power_of_two(3);
     let luma_padding = SB_SIZE + FRAME_MARGIN;
 
-    let (chroma_sampling_period_x, chroma_sampling_period_y) =
-      chroma_sampling.sampling_period();
-    let chroma_width = luma_width / chroma_sampling_period_x;
-    let chroma_height = luma_height / chroma_sampling_period_y;
-    let chroma_padding_x = luma_padding / chroma_sampling_period_x;
-    let chroma_padding_y = luma_padding / chroma_sampling_period_y;
-    let chroma_decimation_x = chroma_sampling_period_x - 1;
-    let chroma_decimation_y = chroma_sampling_period_y - 1;
+    let (chroma_decimation_x, chroma_decimation_y) =
+     chroma_sampling.get_decimation().unwrap_or((0, 0));
+    let (chroma_width, chroma_height) = chroma_sampling
+     .get_chroma_dimensions(luma_width, luma_height);
+    let chroma_padding_x = luma_padding >> chroma_decimation_x;
+    let chroma_padding_y = luma_padding >> chroma_decimation_y;
 
     Frame {
       planes: [

--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -256,8 +256,8 @@ impl<T: Pixel> Plane<T> {
     let yorigin = self.cfg.yorigin;
     let stride = self.cfg.stride;
     let alloc_height = self.cfg.alloc_height;
-    let width = w >> self.cfg.xdec;
-    let height = h >> self.cfg.ydec;
+    let width = w + self.cfg.xdec >> self.cfg.xdec;
+    let height = h + self.cfg.ydec >> self.cfg.ydec;
 
     if xorigin > 0 {
       for y in 0..height {

--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -256,8 +256,8 @@ impl<T: Pixel> Plane<T> {
     let yorigin = self.cfg.yorigin;
     let stride = self.cfg.stride;
     let alloc_height = self.cfg.alloc_height;
-    let width = w + self.cfg.xdec >> self.cfg.xdec;
-    let height = h + self.cfg.ydec >> self.cfg.ydec;
+    let width = (w + self.cfg.xdec) >> self.cfg.xdec;
+    let height = (h + self.cfg.ydec) >> self.cfg.ydec;
 
     if xorigin > 0 {
       for y in 0..height {


### PR DESCRIPTION
```
None of the existing input/output code was accounting for odd luma
 sizes when subsampling chroma correctly.
This replaces the previous sampling_period() API, which encouraged
 divisions and was used incorrectly everywhere it was invoked, with
 a get_chroma_dimensions() API.
Since this is what everyone was doing after calling
 sampling_period() anyway, we can now implement the logic once,
 correctly, in a central place.

There is still an API for getting the chroma decimation shifts,
 since these are used internally in by our Planes and tiling logic.
But we now use an API that actually returns the shifts
 (gauranteeing that the decimation can be expressed in terms of
 shifts, instead of blindly converting by subtracting 1 from the
 period), and correctly identifies that there is no sensible return
 value for Cs400.

Cs400 still will not work, because as soon as we try to copy the
 frame data out of the y4m buffers, we'll call chunks() with a
 chunk size of 0 (on a slice of size 0), which will panic!().
But we do not support Cs400 yet anyway.
The requisite special cases can be added in a future patch by
 whoever tries to get it to work.
```