### PR TITLE
capi: Expose RDO lookahead frames

### DIFF
--- a/src/capi.rs
+++ b/src/capi.rs
@@ -404,6 +404,8 @@ unsafe fn option_match(
       enc.min_key_frame_interval = value.parse().map_err(|_| ())?,
     "reservoir_frame_delay" =>
       enc.reservoir_frame_delay = Some(value.parse().map_err(|_| ())?),
+    "rdo_lookahead_frames" =>
+      enc.rdo_lookahead_frames = value.parse().map_err(|_| ())?,
     "low_latency" => enc.low_latency = value.parse().map_err(|_| ())?,
     "still_picture" => enc.still_picture = value.parse().map_err(|_| ())?,
 


### PR DESCRIPTION
This was missed in 2db1f9c81f033fcd1eb421236b52036ee74b03f2.

Maybe we should have some sort of test or checklist for API changes, since this seems to get missed often.