### PR TITLE
rdo: do not force SGR if CDEF is disabled

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1497,7 +1497,7 @@ pub fn rdo_loop_decision<T: Pixel>(tile_sbo: TileSuperBlockOffset, fi: &FrameInv
           let rate = cw.count_lrf_switchable(w, &ts.restoration.as_const(), current_lrf, pli);
           let frame_bo = ts.to_frame_super_block_offset(tile_sbo).block_offset(0, 0);
           let cost = compute_rd_cost(fi, frame_bo, BlockSize::BLOCK_64X64, rate, err);
-          if best_cost[pli] < 0. || cost < best_cost[pli] {
+          if (fi.sequence.enable_cdef && best_cost[pli] < 0.) || cost < best_cost[pli] {
             best_cost[pli] = cost;
             best_lrf[pli] = current_lrf;
             lrf_change = true;


### PR DESCRIPTION
No change in metrics in the normal case:
https://beta.arewecompressedyet.com/?job=master-8b5936e33ea49a9320a13b0ef0103956684340e1&job=cdef-cost-fix%402019-08-07T05%3A48%3A17.300Z

With CDEF completely disabled and this fix, we see a ~3% regression in metrics (as opposed to > 80%):
https://beta.arewecompressedyet.com/?job=master-8b5936e33ea49a9320a13b0ef0103956684340e1&job=cdef-disabled%402019-08-07T04%3A20%3A03.200Z

Fixes #1399