### PR TITLE
Fix submit_awcy.py with empty -prefix

### DIFF
--- a/tools/submit_awcy.py
+++ b/tools/submit_awcy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/tools/submit_awcy.py
+++ b/tools/submit_awcy.py
@@ -50,7 +50,7 @@ args = parser.parse_args()
 
 if args.branch is None:
     try:
-        args.branch = subprocess.check_output('git symbolic-ref -q --short HEAD',shell=True).strip()
+        args.branch = subprocess.check_output('git symbolic-ref -q --short HEAD',shell=True).strip().decode('utf-8')
     except:
         args.branch = None
 


### PR DESCRIPTION
Decode the output of subprocess, otherwise it's a bytes and you can't concatenate that with a string below.