### PR TITLE
Fix build for tests non-x86_64

### DIFF
--- a/src/ec.rs
+++ b/src/ec.rs
@@ -1043,6 +1043,7 @@ mod test {
     assert_eq!(r.symbol(&cdf), 2);
   }
 
+  #[cfg(target_arch = "x86_64")]
   #[test]
   fn update_cdf_4_sse2() {
     let mut cdf = [7296, 3819, 1616, 0, 0];


### PR DESCRIPTION
Test for `update_cdf_4_sse2` fails since the method under test cannot be found.