### PR TITLE
Add full-resolution 16×16 MV search to lookahead

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1154,10 +1154,28 @@ impl<T: Pixel> ContextInner<T> {
         let tile_pmvs = build_coarse_pmvs(fi, ts);
 
         // Compute the half-resolution motion vectors.
+        let mut half_res_pmvs = Vec::with_capacity(ts.sb_height * ts.sb_width);
+
         for sby in 0..ts.sb_height {
           for sbx in 0..ts.sb_width {
-            let tile_sbo = TileSuperBlockOffset(SuperBlockOffset { x: sbx, y: sby });
-            build_half_res_pmvs(fi, ts, tile_sbo, &tile_pmvs);
+            let tile_sbo =
+              TileSuperBlockOffset(SuperBlockOffset { x: sbx, y: sby });
+            half_res_pmvs
+              .push(build_half_res_pmvs(fi, ts, tile_sbo, &tile_pmvs));
+          }
+        }
+
+        // Compute the full-resolution motion vectors.
+        for sby in 0..ts.sb_height {
+          for sbx in 0..ts.sb_width {
+            let tile_sbo =
+              TileSuperBlockOffset(SuperBlockOffset { x: sbx, y: sby });
+            build_full_res_pmvs(
+              fi,
+              ts,
+              tile_sbo,
+              &half_res_pmvs,
+            );
           }
         }
       });

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2352,7 +2352,10 @@ pub(crate) fn build_full_res_pmvs<T: Pixel>(
               // ┗━━━━━━━┷━━━━━━━┻━━━━━━━┷━━━━━━━┛
               //
               // Each search receives all covering and adjacent motion vectors
-              // as candidates.
+              // as candidates. Additionally, the middle two rows of blocks
+              // also receive the 32×32 motion vectors from neighboring 64×64
+              // blocks, even though not directly adjacent; same with middle
+              // two columns.
               let covering_half_res = match (x, y) {
                 (0..=1, 0..=1) => (half_res_pmvs_this_block[1][r]),
                 (2..=3, 0..=1) => (half_res_pmvs_this_block[2][r]),
@@ -2364,10 +2367,10 @@ pub(crate) fn build_full_res_pmvs<T: Pixel>(
               let (vertical_candidate_1, vertical_candidate_2) = match (x, y) {
                 (0..=1, 0) => (pmvs_n[0][r], pmvs_n[3][r]),
                 (2..=3, 0) => (pmvs_n[0][r], pmvs_n[4][r]),
-                (0..=1, 1) => (None, half_res_pmvs_this_block[3][r]),
-                (2..=3, 1) => (None, half_res_pmvs_this_block[4][r]),
-                (0..=1, 2) => (None, half_res_pmvs_this_block[1][r]),
-                (2..=3, 2) => (None, half_res_pmvs_this_block[2][r]),
+                (0..=1, 1) => (pmvs_n[3][r], half_res_pmvs_this_block[3][r]),
+                (2..=3, 1) => (pmvs_n[4][r], half_res_pmvs_this_block[4][r]),
+                (0..=1, 2) => (pmvs_s[1][r], half_res_pmvs_this_block[1][r]),
+                (2..=3, 2) => (pmvs_s[2][r], half_res_pmvs_this_block[2][r]),
                 (0..=1, 3) => (pmvs_s[0][r], pmvs_s[1][r]),
                 (2..=3, 3) => (pmvs_s[0][r], pmvs_s[2][r]),
                 _ => unreachable!(),
@@ -2377,10 +2380,10 @@ pub(crate) fn build_full_res_pmvs<T: Pixel>(
                 match (x, y) {
                   (0, 0..=1) => (pmvs_w[0][r], pmvs_w[2][r]),
                   (0, 2..=3) => (pmvs_w[0][r], pmvs_w[4][r]),
-                  (1, 0..=1) => (None, half_res_pmvs_this_block[2][r]),
-                  (1, 2..=3) => (None, half_res_pmvs_this_block[4][r]),
-                  (2, 0..=1) => (None, half_res_pmvs_this_block[1][r]),
-                  (2, 2..=3) => (None, half_res_pmvs_this_block[3][r]),
+                  (1, 0..=1) => (pmvs_w[2][r], half_res_pmvs_this_block[2][r]),
+                  (1, 2..=3) => (pmvs_w[4][r], half_res_pmvs_this_block[4][r]),
+                  (2, 0..=1) => (pmvs_e[1][r], half_res_pmvs_this_block[1][r]),
+                  (2, 2..=3) => (pmvs_e[3][r], half_res_pmvs_this_block[3][r]),
                   (3, 0..=1) => (pmvs_e[0][r], pmvs_e[2][r]),
                   (3, 2..=3) => (pmvs_e[0][r], pmvs_e[4][r]),
                   _ => unreachable!(),

--- a/tools/draw-mvs.py
+++ b/tools/draw-mvs.py
@@ -24,7 +24,7 @@ def draw_mvs(prefix):
     frame = frame.resize((frame.width * frame_size_multiplier, frame.height * frame_size_multiplier))
 
     mv_original_block_size = 4 // 2 # The MVs are in 4×4 blocks, but we use half-resolution images.
-    mv_subsampling = 8 # The MVs currently computed are the same in 8×8 blocks.
+    mv_subsampling = 4 # The MVs currently computed are the same in 4×4 blocks.
     mv_units_per_pixel = 8 # MVs are in 8ths of a pixel.
     mvs = mvs[::mv_subsampling, ::mv_subsampling]
     rows = rows // mv_subsampling


### PR DESCRIPTION
Bonus: cool Unicode box drawing character diagrams.

I don't like how there's `motion_estimation` and `estimate_motion`, but `estimate_motion` had a big precedent: `estimate_motion_ss2` and `estimate_motion_ss4`.

[AWCY](https://beta.arewecompressedyet.com/?job=master-e0d9e789f49207b95e12b35309fbf27737e9886c&job=lookahead-full-res-mvs-7-2019-08-09_124236-e6fdc6f), two individual AWCYs in the commit messages.

This is [very slightly worse](https://beta.arewecompressedyet.com/?job=lookahead-full-res-mvs-5-2019-08-08_180621-0c26826&job=lookahead-full-res-mvs-7-2019-08-09_124236-e6fdc6f) than a previous version I had with candidates that made slightly less sense. I mean, I could just throw all MVs I have there as candidates, but is this the correct approach to take?