### PR TITLE
Give an intuitive error message if the Rust version is too old

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: rust
 rust:
+  # This should reference the earliest supported rustc version
+  # and should match the version number in build.rs
   - 1.36.0
+  - stable
 env:
   - RUST_BACKTRACE=1
 addons:
@@ -44,6 +47,9 @@ cache:
 after_script:
 - sccache -s
 
+# Run the tests on both the minimum and latest supported Rust version
+script: cargo test --verbose --release --features=decode_test -- --ignored
+
 jobs:
   include:
       - name: "Build & Coveralls"
@@ -52,8 +58,6 @@ jobs:
          - kcov --version
          - RUSTFLAGS="-C link-dead-code" cargo build --features=decode_test,quick_test --tests --verbose
          - travis_wait cargo kcov -v --coveralls --no-clean-rebuild -- --verify --exclude-pattern=$HOME/.cargo,aom_build,.h,test
-      - name: "Tests"
-        script: cargo test --verbose --release --features=decode_test -- --ignored
       - name: "Bench"
         script: cargo bench --features=bench --no-run --verbose
       - name: "Doc & Clippy (linter): verifying code quality"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ byteorder = { version = "1.3.2", optional = true }
 [build-dependencies]
 nasm-rs = { version = "0.1", path = "crates/nasm_rs/", optional = true }
 vergen = "3"
+rustc_version = "0.2"
 
 [target.'cfg(unix)'.build-dependencies]
 pkg-config = "0.3.12"

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,8 @@
 use std::env;
 use std::fs;
 use std::path::Path;
+use rustc_version::{version, Version};
+use std::process::exit;
 
 #[allow(dead_code)]
 fn rerun_dir<P: AsRef<Path>>(dir: P) {
@@ -57,8 +59,19 @@ fn build_nasm_files() {
   rerun_dir("src/ext/x86");
 }
 
+fn rustc_version_check() {
+    // This should match the version in .travis.yml
+    const REQUIRED_VERSION: &str = "1.36.0";
+    if version().unwrap() < Version::parse(REQUIRED_VERSION).unwrap() {
+        eprintln!("rav1e requires rustc >= {}.", REQUIRED_VERSION);
+        exit(1);
+    }
+}
+
 #[allow(unused_variables)]
 fn main() {
+    rustc_version_check();
+
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     // let env = env::var("CARGO_CFG_TARGET_ENV").unwrap();


### PR DESCRIPTION
The addition of a minimum Rust version also means we should
test against both the minimum version and the latest stable
version in .travis.yml. This MR adds the CI tests against the
latest stable, and mentions that the minimum version in .travis.yml
should match the minimum version in build.rs.