### PR TITLE
Resolve unused code warnings on non-x86

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod deblock;
 mod encoder;
 mod entropymode;
 mod lrf;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod lrf_simd;
 mod mc;
 mod me;

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -18,6 +18,7 @@ use crate::frame::PlaneConfig;
 use crate::frame::PlaneMutSlice;
 use crate::frame::PlaneOffset;
 use crate::frame::PlaneSlice;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use crate::lrf_simd::*;
 use crate::util::clamp;
 use crate::util::CastFromPrimitive;


### PR DESCRIPTION
The LRF SIMD module is effectively empty on non-x86 targets.