### PR TITLE
Fix early cast in CDEF

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -202,9 +202,8 @@ unsafe fn cdef_filter_block<T: Pixel>(
             );
         }
       }
-      let v =
-        T::cast_from(i32::cast_from(x) + ((8 + sum - (sum < 0) as i32) >> 4));
-      *ptr_out = clamp(v, T::cast_from(min), T::cast_from(max));
+      let v = i32::cast_from(x) + ((8 + sum - (sum < 0) as i32) >> 4);
+      *ptr_out = T::cast_from(clamp(v, min as i32, max as i32));
     }
   }
 }


### PR DESCRIPTION
https://beta.arewecompressedyet.com/?job=vmaf-c8ca08c77c19514d251b497900d9a24e203caa0b%402019-08-20T22%3A46%3A27.079Z&job=cdef_fix_cast%402019-08-20T22%3A47%3A09.280Z

```
   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-0.0005 |  0.0108 | -0.0075 |  -0.0009 | -0.0005 | -0.0010 |    -0.0014
```