### PR TITLE
Fix BlockRect::to_rect() calculations when x/ydec > 0.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1273,7 +1273,7 @@ impl TileSuperBlockOffset {
 
 /// Absolute offset in blocks, where a block is defined
 /// to be an N*N square where N = (1 << BLOCK_TO_PLANE_SHIFT).
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BlockOffset {
   pub x: usize,
   pub y: usize,
@@ -1281,12 +1281,12 @@ pub struct BlockOffset {
 
 /// Absolute offset in blocks inside a plane, where a block is defined
 /// to be an N*N square where N = (1 << BLOCK_TO_PLANE_SHIFT).
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PlaneBlockOffset(pub BlockOffset);
 
 /// Absolute offset in blocks inside a tile, where a block is defined
 /// to be an N*N square where N = (1 << BLOCK_TO_PLANE_SHIFT).
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TileBlockOffset(pub BlockOffset);
 
 impl BlockOffset {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -305,7 +305,7 @@ fn compute_distortion<T: Pixel>(
     let mut w_uv = (bsize.width() >> xdec) & mask;
     let mut h_uv = (bsize.height() >> ydec) & mask;
 
-    let mut area = area;
+    let mut area = Area::BlockStartingAt { bo: tile_bo.0 };
     if (w_uv == 0 || h_uv == 0) && is_chroma_block {
       w_uv = MI_SIZE;
       h_uv = MI_SIZE;
@@ -322,8 +322,8 @@ fn compute_distortion<T: Pixel>(
       for p in 1..3 {
         distortion += sse_wxh(
           &ts.input_tile.planes[p]
-            .subregion(Area::BlockStartingAt { bo: tile_bo.0 }),
-          &ts.rec.planes[p].subregion(Area::BlockStartingAt { bo: tile_bo.0 }),
+            .subregion(area),
+          &ts.rec.planes[p].subregion(area),
           w_uv,
           h_uv,
         );


### PR DESCRIPTION
Also adds unit tests, as well as a frame_block_offset function.

No change on AWCY.