### PR TITLE
Added Copyright message.

### DIFF
--- a/ivf/src/lib.rs
+++ b/ivf/src/lib.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
+// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 /// Simple ivf muxer
 ///
 use bitstream_io::{BitReader, BitWriter, LittleEndian};

--- a/src/bin/decoder/mod.rs
+++ b/src/bin/decoder/mod.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
+// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 use rav1e::prelude::*;
 use std::io;
 

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
+// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 use std::io::Read;
 
 use crate::decoder::DecodeError;

--- a/src/bin/error.rs
+++ b/src/bin/error.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
+// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 use std::error::Error;
 
 #[derive(Debug, Error)]

--- a/src/bin/muxer/ivf.rs
+++ b/src/bin/muxer/ivf.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
+// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 use super::Muxer;
 use ivf::*;
 use rav1e::prelude::*;

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
+// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 //! # C API for rav1e
 //!
 //! [rav1e](https://github.com/xiph/rav1e/) is an [AV1](https://aomediacodec.github.io/av1-spec/)

--- a/src/rdo_tables.rs
+++ b/src/rdo_tables.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
+// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 pub const RDO_NUM_BINS: usize = 50;
 #[allow(unused)]
 pub const RDO_MAX_BIN: usize = 10000;


### PR DESCRIPTION
These files lack a Copyright message:

build.rs
examples/simple_encoding.rs
ivf/src/lib.rs
crates/avformat-sys/build.rs
src/bin/error.rs
crates/avformat-sys/src/lib.rs
crates/nasm_rs/src/lib.rs
src/bin/decoder/mod.rs
src/bin/decoder/y4m.rs
src/bin/muxer/ivf.rs

Unsure if these should be updated as well...