### PR TITLE
Change min block size for speed 1 from 8x8 to 4x4

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -327,7 +327,7 @@ impl SpeedSettings {
   /// This preset is set this way because 8x8 with reduced TX set is faster but with equivalent
   /// or better quality compared to 16x16 or 32x32 (to which reduced TX set does not apply).
   fn min_block_size_preset(speed: usize) -> BlockSize {
-    let min_block_size = if speed == 0 {
+    let min_block_size = if speed <= 1 {
       BlockSize::BLOCK_4X4
     } else if speed <= 8 {
       BlockSize::BLOCK_8X8


### PR DESCRIPTION
[AWCY results showing the change from master at speed 1](https://beta.arewecompressedyet.com/?job=master-2b20894d_s1%402019-08-21T16%3A10%3A31.334Z&job=test_s1_min_blk_4x4%402019-08-21T16%3A17%3A33.625Z)