### PR TITLE
CDEF RDO skip fix

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -397,7 +397,7 @@ pub fn cdef_filter_superblock<T: Pixel>(
           let out_slice = &mut out_plane.mut_slice(out_po);
           let xsize = 8 >> xdec;
           let ysize = 8 >> ydec;
-          
+
           if !skip {
             let local_pri_strength;
             let local_sec_strength;
@@ -454,8 +454,10 @@ pub fn cdef_filter_superblock<T: Pixel>(
             }
           } else {
             // we need to copy input to output
-            let in_block = in_slice.subslice((8 * bx) >> xdec, (8 * by) >> ydec);
-            let mut out_block = out_slice.subslice((8 * bx) >> xdec, (8 * by) >> ydec);
+            let in_block =
+              in_slice.subslice((8 * bx) >> xdec, (8 * by) >> ydec);
+            let mut out_block =
+              out_slice.subslice((8 * bx) >> xdec, (8 * by) >> ydec);
             for i in 0..ysize {
               for j in 0..xsize {
                 out_block[i][j] = T::cast_from(in_block[i][j]);

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -382,22 +382,23 @@ pub fn cdef_filter_superblock<T: Pixel>(
           & blocks[sbo_global.block_offset(2 * bx + 1, 2 * by)].skip
           & blocks[sbo_global.block_offset(2 * bx, 2 * by + 1)].skip
           & blocks[sbo_global.block_offset(2 * bx + 1, 2 * by + 1)].skip;
-        if !skip {
-          let dir = cdef_dirs.dir[bx][by];
-          let var = cdef_dirs.var[bx][by];
-          for p in 0..3 {
-            let out_plane = &mut out_frame.planes[p];
-            let out_po = sbo.plane_offset(&out_plane.cfg);
-            let in_plane = &in_frame.planes[p];
-            let in_po = sbo.plane_offset(&in_plane.cfg);
-            let xdec = in_plane.cfg.xdec;
-            let ydec = in_plane.cfg.ydec;
-
-            let in_stride = in_plane.cfg.stride;
-            let in_slice = &in_plane.slice(in_po);
-            let out_stride = out_plane.cfg.stride;
-            let out_slice = &mut out_plane.mut_slice(out_po);
-
+        let dir = cdef_dirs.dir[bx][by];
+        let var = cdef_dirs.var[bx][by];
+        for p in 0..3 {
+          let out_plane = &mut out_frame.planes[p];
+          let out_po = sbo.plane_offset(&out_plane.cfg);
+          let in_plane = &in_frame.planes[p];
+          let in_po = sbo.plane_offset(&in_plane.cfg);
+          let xdec = in_plane.cfg.xdec;
+          let ydec = in_plane.cfg.ydec;
+          let in_stride = in_plane.cfg.stride;
+          let in_slice = &in_plane.slice(in_po);
+          let out_stride = out_plane.cfg.stride;
+          let out_slice = &mut out_plane.mut_slice(out_po);
+          let xsize = 8 >> xdec;
+          let ysize = 8 >> ydec;
+          
+          if !skip {
             let local_pri_strength;
             let local_sec_strength;
             let mut local_damping: i32 = cdef_damping + coeff_shift;
@@ -422,9 +423,6 @@ pub fn cdef_filter_superblock<T: Pixel>(
             };
 
             unsafe {
-              let xsize = 8 >> xdec;
-              let ysize = 8 >> ydec;
-
               let PlaneConfig { ypad, xpad, .. } = in_slice.plane.cfg;
               assert!(
                 out_slice.rows_iter().len() >= ((8 * by) >> ydec) + ysize
@@ -453,6 +451,15 @@ pub fn cdef_filter_superblock<T: Pixel>(
                 ysize as isize,
                 coeff_shift as i32,
               );
+            }
+          } else {
+            // we need to copy input to output
+            let in_block = in_slice.subslice((8 * bx) >> xdec, (8 * by) >> ydec);
+            let mut out_block = out_slice.subslice((8 * bx) >> xdec, (8 * by) >> ydec);
+            for i in 0..ysize {
+              for j in 0..xsize {
+                out_block[i][j] = T::cast_from(in_block[i][j]);
+              }
             }
           }
         }

--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -609,6 +609,14 @@ impl<'a, T: Pixel> PlaneMutSlice<'a, T> {
       phantom: PhantomData,
     }
   }
+
+  pub fn subslice(&mut self, xo: usize, yo: usize) -> PlaneMutSlice<'_, T> {
+    PlaneMutSlice {
+      plane: self.plane,
+      x: self.x + xo as isize,
+      y: self.y + yo as isize
+    }
+  }
 }
 
 impl<'a, T: Pixel> Index<usize> for PlaneMutSlice<'a, T> {

--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -614,7 +614,7 @@ impl<'a, T: Pixel> PlaneMutSlice<'a, T> {
     PlaneMutSlice {
       plane: self.plane,
       x: self.x + xo as isize,
-      y: self.y + yo as isize
+      y: self.y + yo as isize,
     }
   }
 }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1587,9 +1587,6 @@ fn rdo_loop_plane_error<T: Pixel>(
 ) -> u64 {
   let sbo_0 = PlaneSuperBlockOffset(SuperBlockOffset { x: 0, y: 0 });
   let sb_blocks = if fi.sequence.use_128x128_superblock { 16 } else { 8 };
-  let in_plane = &ts.input_tile.planes[pli];
-  let test_plane = &test.planes[pli];
-  let &PlaneConfig { xdec, ydec, .. } = in_plane.plane_cfg;
   // Each direction block is 8x8 in y, potentially smaller if subsampled in chroma
   // accumulating in-frame and unpadded
   let mut err: u64 = 0;


### PR DESCRIPTION
Due to shared code, CDEF currently has a bug in RDO; skipped blocks are not copied to output, causing LRF to optimize partially on garbage blocks.