### PR TITLE
Bias distortion per-block rather than with mean

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2126,13 +2126,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
       let w: &mut W = if cw.bc.cdef_coded { w_post_cdef } else { w_pre_cdef };
       let tell = w.tell_frac();
       cw.write_partition(w, tile_bo, PartitionType::PARTITION_NONE, bsize);
-      compute_rd_cost(
-        fi,
-        ts.to_frame_block_offset(tile_bo),
-        bsize,
-        w.tell_frac() - tell,
-        0,
-      )
+      compute_rd_cost(fi, w.tell_frac() - tell, 0)
     } else {
       0.0
     };
@@ -2225,13 +2219,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
           if cw.bc.cdef_coded { w_post_cdef } else { w_pre_cdef };
         let tell = w.tell_frac();
         cw.write_partition(w, tile_bo, partition, bsize);
-        rd_cost = compute_rd_cost(
-          fi,
-          ts.to_frame_block_offset(tile_bo),
-          bsize,
-          w.tell_frac() - tell,
-          0,
-        );
+        rd_cost = compute_rd_cost(fi, w.tell_frac() - tell, 0);
       }
 
       let four_partitions = [


### PR DESCRIPTION
[AWCY](https://beta.arewecompressedyet.com/?job=master-db0da3c97efb269cb23571f2c1f68afdf1ad9813&job=per-block-distortion-4-2019-08-21_141456-89544e8)

Previously the distortion was computed for a given block, then biased with the mean importance of this block. Now the distortion is biased granularly as it is computed which allows the biasing to be more accurate (as importance is computed on a small block size basis).