### PR TITLE
Switch block importance computation to 8×8 blocks

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -469,7 +469,7 @@ fn compute_mean_importance<T: Pixel>(
   let mut total_importance = 0.;
   for y in y1..y2 {
     for x in x1..x2 {
-      total_importance += fi.block_importances[y * fi.w_in_b + x];
+      total_importance += fi.block_importances[y / 2 * fi.w_in_imp_b + x / 2];
     }
   }
   // Divide by the full area even though some blocks were outside.

--- a/tools/draw-importances.py
+++ b/tools/draw-importances.py
@@ -24,7 +24,7 @@ frame = Image.open(sys.argv[1])
 frame = frame.resize((frame.width * frame_size_multiplier, frame.height * frame_size_multiplier))
 frame = frame.convert(mode='RGB')
 
-mv_original_block_size = 4 // 2 # The MVs are in 4×4 blocks, but we use half-resolution images.
+mv_original_block_size = 8 // 2 # The importances are in 8×8 blocks, but we use half-resolution images.
 mv_block_size = mv_original_block_size * frame_size_multiplier
 
 draw = ImageDraw.Draw(frame, mode='RGBA')


### PR DESCRIPTION
[AWCY](https://beta.arewecompressedyet.com/?job=per-block-distortion-5-2019-08-21_174156-9c0e06e&job=per-block-distortion-8x8-4-2019-08-22_140122-0be6916)

Better quality, faster encode. Going further up to 16×16 [seems to make the quality worse](https://beta.arewecompressedyet.com/?job=per-block-distortion-8x8-4-2019-08-22_140122-0be6916&job=per-block-distortion-16x16-2-2019-08-21_155825-e7e7fe3).