### PR TITLE
Misc Context improvements

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -722,12 +722,12 @@ impl<T: Pixel> Context<T> {
   /// let frame = ctx.new_frame();
   /// ```
   #[inline]
-  pub fn new_frame(&self) -> Arc<Frame<T>> {
-    Arc::new(Frame::new(
+  pub fn new_frame(&self) -> Frame<T> {
+    Frame::new(
       self.config.width,
       self.config.height,
       self.config.chroma_sampling,
-    ))
+    )
   }
 
   /// Sends the frame for encoding.
@@ -888,7 +888,7 @@ impl<T: Pixel> Context<T> {
   ///
   /// fn encode_frames(
   ///     ctx: &mut Context<u8>,
-  ///     mut frames: impl Iterator<Item=Arc<Frame<u8>>>
+  ///     mut frames: impl Iterator<Item=Frame<u8>>
   /// ) -> Result<(), EncoderStatus> {
   ///     // This is a slightly contrived example, intended to showcase the
   ///     // various statuses that can be returned from receive_packet().
@@ -911,7 +911,7 @@ impl<T: Pixel> Context<T> {
   ///                 // The encoder has requested additional frames. Push the
   ///                 // next frame in, or flush the encoder if there are no
   ///                 // frames left (on None).
-  ///                 ctx.send_frame(frames.next())?;
+  ///                 ctx.send_frame(frames.next().map(Arc::new))?;
   ///             },
   ///             Err(EncoderStatus::EnoughData) => {
   ///                 // Since we aren't trying to push frames after flushing,
@@ -2367,7 +2367,7 @@ mod test {
   }
 
   fn send_test_frame<T: Pixel>(ctx: &mut Context<T>, content_value: T) {
-    let mut input = Arc::try_unwrap(ctx.new_frame()).unwrap();
+    let mut input = ctx.new_frame();
     fill_frame_const(&mut input, content_value);
     let _ = ctx.send_frame(Arc::new(input));
   }

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -15,7 +15,6 @@ use interpolate_name::interpolate_test;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::collections::VecDeque;
-use std::sync::Arc;
 
 #[cfg(all(test, feature = "decode_test"))]
 mod aom;
@@ -44,9 +43,9 @@ pub(crate) fn read_frame_batch<T: Pixel>(
 ) {
   for _ in 0..limit {
     let mut input = ctx.new_frame();
-    fill_frame(ra, Arc::get_mut(&mut input).unwrap());
+    fill_frame(ra, &mut input);
 
-    let _ = ctx.send_frame(Some(input));
+    let _ = ctx.send_frame(input);
   }
 
   ctx.flush();


### PR DESCRIPTION
Split off of #1587 and based on that since it affects the new docs a little. The first two commits are from there, so ignore them.

- adds `#[inline]` to `Context` methods;
- adds `IntoFrame` for `Frame` without an `Arc`;
- switches `Context::new_frame()` to return `Frame` without `Arc`.