### PR TITLE
Document the rest of the owl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ capi = []
 dump_lookahead_data = ["byteorder", "image"]
 
 [dependencies]
-arg_enum_proc_macro = "0.2"
+arg_enum_proc_macro = "0.3"
 bitstream-io = "0.8"
 clap = { version = "2", optional = true, default-features = false }
 libc = "0.2"

--- a/src/api/color.rs
+++ b/src/api/color.rs
@@ -210,8 +210,11 @@ impl Default for MatrixCoefficients {
 /// Signal the content color description
 #[derive(Copy, Clone, Debug)]
 pub struct ColorDescription {
+  /// Color primaries.
   pub color_primaries: ColorPrimaries,
+  /// Transfer charasteristics.
   pub transfer_characteristics: TransferCharacteristics,
+  /// Matrix coefficients.
   pub matrix_coefficients: MatrixCoefficients,
 }
 

--- a/src/api/color.rs
+++ b/src/api/color.rs
@@ -251,7 +251,7 @@ pub struct ContentLight {
 /// fixed-point values.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
-pub struct Point {
+pub struct ChromaticityPoint {
   /// The X coordinate.
   pub x: u16,
   /// The Y coordinate.
@@ -265,9 +265,9 @@ pub struct Point {
 pub struct MasteringDisplay {
   /// Chromaticity coordinates in Red, Green, Blue order
   /// expressed as 0.16 fixed-point
-  pub primaries: [Point; 3],
+  pub primaries: [ChromaticityPoint; 3],
   /// Chromaticity coordinates expressed as 0.16 fixed-point
-  pub white_point: Point,
+  pub white_point: ChromaticityPoint,
   /// 24.8 fixed-point maximum luminance in candelas per square meter
   pub max_luminance: u32,
   /// 18.14 fixed-point minimum luminance in candelas per square meter

--- a/src/api/color.rs
+++ b/src/api/color.rs
@@ -247,11 +247,14 @@ pub struct ContentLight {
   pub max_frame_average_light_level: u16,
 }
 
-/// Chromaticity coordinates expressed as 0.16 fixed-point values
+/// Chromaticity coordinates as defined by CIE 1931, expressed as 0.16
+/// fixed-point values.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct Point {
+  /// The X coordinate.
   pub x: u16,
+  /// The Y coordinate.
   pub y: u16,
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -216,28 +216,45 @@ impl EncoderConfig {
   }
 }
 
-/// Contains all the speed settings
+/// Contains the speed settings.
 #[derive(Clone, Copy, Debug)]
 pub struct SpeedSettings {
+  /// Minimum block size.
+  ///
+  /// Must be a square block size, so e.g. 8×4 isn't allowed here.
   pub min_block_size: BlockSize,
+  /// Enables inter-frames to have multiple reference frames.
   pub multiref: bool,
+  /// Enables fast deblocking filter.
   pub fast_deblock: bool,
+  /// Enables reduced transform set.
   pub reduced_tx_set: bool,
+  /// Enables using transform-domain distortion instead of pixel-domain.
   pub tx_domain_distortion: bool,
+  /// Enables using transform-domain rate estimation.
   pub tx_domain_rate: bool,
+  /// Enables bottom-up encoding, rather than top-down.
   pub encode_bottomup: bool,
+  /// Enables searching transform size and type with RDO.
   pub rdo_tx_decision: bool,
+  /// Prediction modes to search.
   pub prediction_modes: PredictionModesSetting,
+  /// Enables searching near motion vectors during RDO.
   pub include_near_mvs: bool,
+  /// Disables scene-cut detection.
   pub no_scene_detection: bool,
+  /// Enables diamond motion vector search rather than full search.
   pub diamond_me: bool,
+  /// Enables CDEF.
   pub cdef: bool,
+  /// Enables searching for the optimal segment ID (quantizer delta) with RDO.
+  ///
+  /// When disabled, the segment ID is chosen heuristically.
   pub quantizer_rdo: bool,
-  /// Use satd instead of sad for subpel search
+  /// Use SATD instead of SAD for subpixel search.
   pub use_satd_subpel: bool,
 }
 
-/// Default values for the speed settings.
 impl Default for SpeedSettings {
   fn default() -> Self {
     SpeedSettings {
@@ -262,18 +279,19 @@ impl Default for SpeedSettings {
 
 impl SpeedSettings {
   /// Set the speed setting according to a numeric speed preset.
-  /// The speed settings vary depending on speed value from 0 to 10:
-  ///  - speed - 10, fastest, Min block size 64x64, TX domain distortion, fast deblock, no scenechange detection,
-  ///  - speed - 9, Min block size 64x64, TX domain distortion, fast deblock,
-  ///  - speed - 8, Min block size 8x8, reduced TX set, TX domain distortion, fast deblock,
-  ///  - speed - 7, Min block size 8x8, reduced TX set, TX domain distortion,
-  ///  - speed - 6, Min block size 8x8, reduced TX set, TX domain distortion,
-  ///  - speed - 5, default, Min block size 8x8, reduced TX set, TX domain distortion, complex pred modes for keyframes,
-  ///  - speed - 4, Min block size 8x8, TX domain distortion, complex pred modes for keyframes,
-  ///  - speed - 3, Min block size 8x8, TX domain distortion, complex pred modes for keyframes, RDO TX decision,
-  ///  - speed - 2, Min block size 8x8, TX domain distortion, complex pred modes for keyframes, RDO TX decision, include near MVs, quantizer RDO,
-  ///  - speed - 1, Min block size 8x8, TX domain distortion, complex pred modes, RDO TX decision, include near MVs, quantizer RDO,
-  ///  - speed - 0, slowest,  Min block size 4x4, TX domain distortion, complex pred modes, RDO TX decision, include near MVs, quantizer RDO, bottom-up encoding.
+  ///
+  /// The speed settings vary depending on speed value from 0 to 10.
+  /// - 10 (fastest): min block size 64x64, TX domain distortion, fast deblock, no scenechange detection.
+  /// - 9: min block size 64x64, TX domain distortion, fast deblock.
+  /// - 8: min block size 8x8, reduced TX set, TX domain distortion, fast deblock.
+  /// - 7: min block size 8x8, reduced TX set, TX domain distortion.
+  /// - 6: min block size 8x8, reduced TX set, TX domain distortion.
+  /// - 5 (default): min block size 8x8, reduced TX set, TX domain distortion, complex pred modes for keyframes.
+  /// - 4: min block size 8x8, TX domain distortion, complex pred modes for keyframes.
+  /// - 3: min block size 8x8, TX domain distortion, complex pred modes for keyframes, RDO TX decision.
+  /// - 2: min block size 8x8, TX domain distortion, complex pred modes for keyframes, RDO TX decision, include near MVs, quantizer RDO.
+  /// - 1: min block size 8x8, TX domain distortion, complex pred modes, RDO TX decision, include near MVs, quantizer RDO.
+  /// - 0 (slowest): min block size 4x4, TX domain distortion, complex pred modes, RDO TX decision, include near MVs, quantizer RDO, bottom-up encoding.
   pub fn from_preset(speed: usize) -> Self {
     SpeedSettings {
       min_block_size: Self::min_block_size_preset(speed),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -43,22 +43,28 @@ use std::sync::Arc;
 use std::{cmp, fmt, io};
 
 // TODO: use the num crate?
+/// A rational number.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct Rational {
+  /// Numerator.
   pub num: u64,
+  /// Denominator.
   pub den: u64,
 }
 
 impl Rational {
+  /// Creates a rational number from the given numerator and denominator.
   pub fn new(num: u64, den: u64) -> Self {
     Rational { num, den }
   }
 
+  /// Returns a rational number that is the reciprocal of the given one.
   pub fn from_reciprocal(reciprocal: Self) -> Self {
     Rational { num: reciprocal.den, den: reciprocal.num }
   }
 
+  /// Returns the rational number as a floating-point number.
   pub fn as_f64(self) -> f64 {
     self.num as f64 / self.den as f64
   }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,6 +6,7 @@
 // obtain it at www.aomedia.org/license/software. If the Alliance for Open
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+#![deny(missing_docs)]
 
 /// Color model information
 pub mod color;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -70,60 +70,92 @@ impl Rational {
   }
 }
 
-/// Encoder Settings impacting the bitstream produced
+/// Encoder settings which impact the produced bitstream.
 #[derive(Clone, Debug)]
 pub struct EncoderConfig {
   // output size
+  /// Width of the frames in pixels.
   pub width: usize,
+  /// Height of the frames in pixels.
   pub height: usize,
 
   // data format and ancillary color information
+  /// Bit depth.
   pub bit_depth: usize,
+  /// Chroma subsampling.
   pub chroma_sampling: ChromaSampling,
+  /// Chroma sample position.
   pub chroma_sample_position: ChromaSamplePosition,
+  /// Pixel value range.
   pub pixel_range: PixelRange,
+  /// Content color description (primaries, transfer characteristics, matrix).
   pub color_description: Option<ColorDescription>,
+  /// HDR mastering display parameters.
   pub mastering_display: Option<MasteringDisplay>,
+  /// HDR content light parameters.
   pub content_light: Option<ContentLight>,
 
-  /// Still picture mode flag
+  /// Still picture mode flag.
   pub still_picture: bool,
 
   // encoder configuration
+  /// Target CPU feature level.
   pub cpu_feature_level: CpuFeatureLevel,
+  /// Video time base.
   pub time_base: Rational,
   /// The *minimum* interval between two keyframes
   pub min_key_frame_interval: u64,
   /// The *maximum* interval between two keyframes
   pub max_key_frame_interval: u64,
   /// The number of temporal units over which to distribute the reservoir
-  ///  usage.
+  /// usage.
   pub reservoir_frame_delay: Option<i32>,
+  /// Flag to enable low latency mode.
+  ///
+  /// In this mode the frame reordering is disabled.
   pub low_latency: bool,
+  /// The base quantizer to use.
   pub quantizer: usize,
   /// The minimum allowed base quantizer to use in bitrate mode.
   pub min_quantizer: u8,
+  /// The target bitrate for the bitrate mode.
   pub bitrate: i32,
+  /// Metric to tune the quality for.
   pub tune: Tune,
   /// Number of tiles horizontally. Must be a power of two.
-  /// Overridden by the tiles parameter, if present.
+  ///
+  /// Overridden by [`tiles`], if present.
+  ///
+  /// [`tiles`]: #structfield.tiles
   pub tile_cols: usize,
   /// Number of tiles vertically. Must be a power of two.
-  /// Overridden by the tiles parameter, if present.
+  ///
+  /// Overridden by [`tiles`], if present.
+  ///
+  /// [`tiles`]: #structfield.tiles
   pub tile_rows: usize,
-  /// Total number of tiles desired. Encoder will try to optimally split
-  /// to reach this number of tiles, rounded up. Overrides
-  /// tile_cols and tile_rows parameters.
+  /// Total number of tiles desired.
+  ///
+  /// Encoder will try to optimally split to reach this number of tiles,
+  /// rounded up. Overrides [`tile_cols`] and [`tile_rows`].
+  ///
+  /// [`tile_cols`]: #structfield.tile_cols
+  /// [`tile_rows`]: #structfield.tile_rows
   pub tiles: usize,
-  /// Number of frames to read ahead for RDO lookahead computation.
+  /// Number of frames to read ahead for the RDO lookahead computation.
   pub rdo_lookahead_frames: u64,
+  /// Settings which affect the enconding speed vs. quality trade-off.
   pub speed_settings: SpeedSettings,
+  /// If enabled, computes the PSNR values and stores them in [`Packet`].
+  ///
+  /// [`Packet`]: struct.Packet.html#structfield.psnr
   pub show_psnr: bool,
+  /// Enables dumping of internal RDO training data.
   pub train_rdo: bool,
 }
 
-/// Default preset for EncoderConfig: it is a balance between quality and speed.
-/// See [`with_speed_preset()`]
+/// Default preset for EncoderConfig: it is a balance between quality and
+/// speed. See [`with_speed_preset()`].
 ///
 /// [`with_speed_preset()`]: struct.EncoderConfig.html#method.with_speed_preset
 impl Default for EncoderConfig {
@@ -134,9 +166,10 @@ impl Default for EncoderConfig {
 }
 
 impl EncoderConfig {
-  /// This is a preset which provides default settings according to a speed value in the specific range 0-10.
-  /// For each speed value it is having different preset. See [`from_preset()`].
-  /// If the input value is greater than 10, it will result in the same settings of 10.
+  /// This is a preset which provides default settings according to a speed
+  /// value in the specific range 0–10. Each speed value corresponds to a
+  /// different preset. See [`from_preset()`]. If the input value is greater
+  /// than 10, it will result in the same settings as 10.
   ///
   /// [`from_preset()`]: struct.SpeedSettings.html#method.from_preset
   pub fn with_speed_preset(speed: usize) -> Self {
@@ -175,6 +208,9 @@ impl EncoderConfig {
     }
   }
 
+  /// Returns the video frame rate computed from [`time_base`].
+  ///
+  /// [`time_base`]: #structfield.time_base
   pub fn frame_rate(&self) -> f64 {
     Rational::from_reciprocal(self.time_base).as_f64()
   }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -7,6 +7,7 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+/// Color model information
 pub mod color;
 
 pub use color::*;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -770,7 +770,16 @@ impl<T: Pixel> fmt::Display for Packet<T> {
   }
 }
 
+/// Types which can be converted into frames.
+///
+/// This trait is used in [`Context::send_frame`] to allow for passing in
+/// frames with optional frame parameters and optionally frames wrapped in
+/// `Arc` (to allow for zero-copy, since the encoder uses frames in `Arc`
+/// internally).
+///
+/// [`Context::send_frame`]: struct.Context.html#method.send_frame
 pub trait IntoFrame<T: Pixel> {
+  /// Converts the type into a tuple of frame and parameters.
   fn into(self) -> (Option<Arc<Frame<T>>>, Option<FrameParameters>);
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -438,9 +438,10 @@ pub enum PredictionModesSetting {
   ComplexAll,
 }
 
-/// Contains all the encoder configuration
+/// Contains the encoder configuration.
 #[derive(Clone, Debug, Default)]
 pub struct Config {
+  /// Settings which impact the produced bitstream.
   pub enc: EncoderConfig,
   /// The number of threads in the threadpool.
   pub threads: usize,
@@ -451,6 +452,21 @@ fn check_tile_log2(n: usize) -> bool {
 }
 
 impl Config {
+  /// Creates a [`Context`] with this configuration.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use rav1e::prelude::*;
+  ///
+  /// # fn main() -> Result<(), EncoderStatus> {
+  /// let cfg = Config::default();
+  /// let ctx: Context<u8> = cfg.new_context()?;
+  /// # Ok(())
+  /// # }
+  /// ```
+  ///
+  /// [`Context`]: struct.Context.html
   pub fn new_context<T: Pixel>(&self) -> Result<Context<T>, EncoderStatus> {
     assert!(
       8 * std::mem::size_of::<T>() >= self.enc.bit_depth,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -399,13 +399,18 @@ impl SpeedSettings {
   }
 }
 
+/// Possible types of a frame.
 #[allow(dead_code, non_camel_case_types)]
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 #[repr(C)]
 pub enum FrameType {
+  /// Key frame.
   KEY,
+  /// Inter-frame.
   INTER,
+  /// Intra-only frame.
   INTRA_ONLY,
+  /// Switching frame.
   SWITCH,
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -426,10 +426,15 @@ impl fmt::Display for FrameType {
   }
 }
 
+/// Prediction modes to search.
 #[derive(Clone, Copy, Debug, PartialOrd, PartialEq, FromPrimitive)]
 pub enum PredictionModesSetting {
+  /// Only simple prediction modes.
   Simple,
+  /// Search all prediction modes on key frames and simple modes on other
+  /// frames.
   ComplexKeyframes,
+  /// Search all prediction modes on all frames.
   ComplexAll,
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -712,8 +712,8 @@ pub enum EncoderStatus {
   NeedMoreData,
   /// There are enough frames in the queue.
   ///
-  /// May be emitted by [`Context::send_frame()`] when the input queue is
-  /// constrained.
+  /// May be emitted by [`Context::send_frame()`] when trying to send a frame
+  /// after the encoder has been flushed.
   ///
   /// [`Context::send_frame()`]: struct.Context.html#method.send_frame
   EnoughData,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -737,8 +737,14 @@ pub enum EncoderStatus {
   NotReady,
 }
 
+/// Represents a packet.
+///
+/// A packet contains one shown frame together with zero or more additional
+/// frames.
 pub struct Packet<T: Pixel> {
+  /// The packet data.
   pub data: Vec<u8>,
+  /// The reconstruction of the shown frame.
   pub rec: Option<Frame<T>>,
   /// The number of the input frame corresponding to the one shown frame in the
   /// TU stored in this packet. Since AV1 does not explicitly reorder frames,
@@ -746,8 +752,9 @@ pub struct Packet<T: Pixel> {
   // TODO: When we want to add VFR support, we will need a more explicit time
   // stamp here.
   pub input_frameno: u64,
+  /// Type of the shown frame.
   pub frame_type: FrameType,
-  /// PSNR for Y, U, and V planes
+  /// PSNR for Y, U, and V planes for the shown frame.
   pub psnr: Option<(f64, f64, f64)>,
 }
 

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -485,20 +485,20 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
         .expect("Cannot parse the mastering display option");
       Some(MasteringDisplay {
         primaries: [
-          Point {
+          ChromaticityPoint {
             x: (r_x * ((1 << 16) as f64)).round() as u16,
             y: (r_y * ((1 << 16) as f64)).round() as u16,
           },
-          Point {
+          ChromaticityPoint {
             x: (g_x * ((1 << 16) as f64)).round() as u16,
             y: (g_y * ((1 << 16) as f64)).round() as u16,
           },
-          Point {
+          ChromaticityPoint {
             x: (b_x * ((1 << 16) as f64)).round() as u16,
             y: (b_y * ((1 << 16) as f64)).round() as u16,
           },
         ],
-        white_point: Point {
+        white_point: ChromaticityPoint {
           x: (wp_x * ((1 << 16) as f64)).round() as u16,
           y: (wp_y * ((1 << 16) as f64)).round() as u16,
         },

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -4,6 +4,7 @@
 //! encoder written in [Rust](https://rust-lang.org)
 //!
 //! This is the C-compatible API
+#![deny(missing_docs)]
 
 use std::slice;
 use std::sync::Arc;

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -251,6 +251,7 @@ pub unsafe extern fn rav1e_data_unref(data: *mut Data) {
   }
 }
 
+/// Create a RaConfig filled with default parameters.
 #[no_mangle]
 pub unsafe extern fn rav1e_config_default() -> *mut Config {
   let cfg = rav1e::Config { enc: rav1e::EncoderConfig::default(), threads: 0 };
@@ -381,6 +382,7 @@ pub unsafe extern fn rav1e_config_set_mastering_display(
   }
 }
 
+/// Free the RaConfig.
 #[no_mangle]
 pub unsafe extern fn rav1e_config_unref(cfg: *mut Config) {
   if !cfg.is_null() {
@@ -518,6 +520,7 @@ pub unsafe extern fn rav1e_context_new(cfg: *const Config) -> *mut Context {
   }
 }
 
+/// Free the RaContext.
 #[no_mangle]
 pub unsafe extern fn rav1e_context_unref(ctx: *mut Context) {
   if !ctx.is_null() {
@@ -541,6 +544,7 @@ pub unsafe extern fn rav1e_frame_new(ctx: *const Context) -> *mut Frame {
   Box::into_raw(frame)
 }
 
+/// Free the RaFrame.
 #[no_mangle]
 pub unsafe extern fn rav1e_frame_unref(frame: *mut Frame) {
   if !frame.is_null() {
@@ -665,7 +669,7 @@ pub unsafe extern fn rav1e_last_status(ctx: *const Context) -> EncoderStatus {
   (*ctx).last_err.into()
 }
 
-/// Return a string matching the EncooderStatus variant.
+/// Return a string matching the EncoderStatus variant.
 #[no_mangle]
 pub unsafe extern fn rav1e_status_to_str(
   status: EncoderStatus,
@@ -711,6 +715,7 @@ pub unsafe extern fn rav1e_receive_packet(
   ret.into()
 }
 
+/// Free the RaPacket.
 #[no_mangle]
 pub unsafe extern fn rav1e_packet_unref(pkt: *mut Packet) {
   if !pkt.is_null() {

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -57,28 +57,35 @@ pub struct Frame {
   frame_type: FrameTypeOverride,
 }
 
+/// Status that can be returned by encoder functions.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, FromPrimitive)]
 pub enum EncoderStatus {
-  /// Normal operation
+  /// Normal operation.
   Success = 0,
-  /// The encoder needs more data to produce an output Packet
-  /// May be emitted by `Context::receive_packet`  when frame reordering is enabled.
+  /// The encoder needs more data to produce an output packet.
+  ///
+  /// May be emitted by `rav1e_receive_packet` when frame reordering is
+  /// enabled.
   NeedMoreData,
-  /// There are enough Frames queue
-  /// May be emitted by `Context::send_frame` when the input queue is constrained
+  /// There are enough frames in the queue.
+  ///
+  /// May be emitted by `rav1e_send_frame` when trying to send a frame after
+  /// the encoder has been flushed.
   EnoughData,
-  /// The encoder already produced the number of frames requested
-  /// May be emitted by `Context::receive_packet` after a flush request had been processed
-  /// or the frame limit had been reached.
+  /// The encoder has already produced the number of frames requested.
+  ///
+  /// May be emitted by `rav1e_receive_packet` after a flush request had been
+  /// processed or the frame limit had been reached.
   LimitReached,
-  /// A Frame had been encoded but not emitted yet
+  /// A Frame had been encoded but not emitted yet.
   Encoded,
-  /// Generic fatal error
+  /// Generic fatal error.
   Failure = -1,
   /// A frame was encoded in the first pass of a 2-pass encode, but its stats
-  /// data was not retrieved with rav1e_twopass_out(), or not enough stats data was
-  /// provided in the second pass of a 2-pass encode to encode the next frame.
+  /// data was not retrieved with `rav1e_twopass_out`, or not enough stats data
+  /// was provided in the second pass of a 2-pass encode to encode the next
+  /// frame.
   NotReady = -2,
 }
 

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -359,15 +359,17 @@ pub unsafe extern fn rav1e_config_set_content_light(
 
 /// Set the mastering display information for HDR10 streams.
 ///
-/// primaries and white_point arguments are RaPoint, containing 0.16 fixed point values.
+/// primaries and white_point arguments are RaChromaticityPoint, containing 0.16 fixed point
+/// values.
 /// max_luminance is a 24.8 fixed point value.
 /// min_luminance is a 18.14 fixed point value.
 ///
 /// Returns a negative value on error or 0.
 #[no_mangle]
 pub unsafe extern fn rav1e_config_set_mastering_display(
-  cfg: *mut Config, primaries: [rav1e::Point; 3], white_point: rav1e::Point,
-  max_luminance: u32, min_luminance: u32,
+  cfg: *mut Config, primaries: [rav1e::ChromaticityPoint; 3],
+  white_point: rav1e::ChromaticityPoint, max_luminance: u32,
+  min_luminance: u32,
 ) -> c_int {
   (*cfg).cfg.enc.mastering_display = Some(rav1e::MasteringDisplay {
     primaries,

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -41,12 +41,17 @@ pub struct FrameParameters {
   pub frame_type_override: FrameTypeOverride,
 }
 
+/// One video frame.
 #[derive(Debug, Clone)]
 pub struct Frame<T: Pixel> {
+  /// Planes constituting the frame.
   pub planes: [Plane<T>; 3],
 }
 
 impl<T: Pixel> Frame<T> {
+  /// Creates a new frame with the given parameters.
+  ///
+  /// Allocates data for the planes.
   pub fn new(
     width: usize, height: usize, chroma_sampling: ChromaSampling,
   ) -> Self {

--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -20,15 +20,29 @@ use crate::util::*;
 /// Plane-specific configuration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlaneConfig {
+  /// Data stride.
   pub stride: usize,
+  /// Allocated height in pixels.
   pub alloc_height: usize,
+  /// Width in pixels.
   pub width: usize,
+  /// Height in pixels.
   pub height: usize,
+  /// Decimator along the X axis.
+  ///
+  /// For example, for chroma planes in a 4:2:0 configuration this would be 1.
   pub xdec: usize,
+  /// Decimator along the Y axis.
+  ///
+  /// For example, for chroma planes in a 4:2:0 configuration this would be 1.
   pub ydec: usize,
+  /// Number of padding pixels on the right.
   pub xpad: usize,
+  /// Number of padding pixels on the bottom.
   pub ypad: usize,
+  /// X where the data starts.
   pub xorigin: usize,
+  /// Y where the data starts.
   pub yorigin: usize,
 }
 

--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -147,11 +147,13 @@ impl<T: Pixel> PlaneData<T> {
   }
 }
 
-/// Plane abstraction
+/// One data plane of a frame.
 ///
+/// For example, a plane can be a Y luma plane or a U or V chroma plane.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Plane<T: Pixel> {
   pub(crate) data: PlaneData<T>,
+  /// Plane configuration.
   pub cfg: PlaneConfig,
 }
 
@@ -209,6 +211,7 @@ impl<T: Pixel> Plane<T> {
   /// Stride alignment in bytes.
   const STRIDE_ALIGNMENT_LOG2: usize = 5;
 
+  /// Allocates and returns a new plane.
   pub fn new(
     width: usize, height: usize, xdec: usize, ydec: usize, xpad: usize,
     ypad: usize,
@@ -344,19 +347,23 @@ impl<T: Pixel> Plane<T> {
     base..base + width
   }
 
+  /// Returns the pixel at the given coordinates.
   pub fn p(&self, x: usize, y: usize) -> T {
     self.data[self.index(x, y)]
   }
 
+  /// Returns plane data starting from the origin.
   pub fn data_origin(&self) -> &[T] {
     &self.data[self.index(0, 0)..]
   }
 
+  /// Returns mutable plane data starting from the origin.
   pub fn data_origin_mut(&mut self) -> &mut [T] {
     let i = self.index(0, 0);
     &mut self.data[i..]
   }
 
+  /// Copies data into the plane from a pixel array.
   pub fn copy_from_raw_u8(
     &mut self, source: &[u8], source_stride: usize, source_bytewidth: usize,
   ) {
@@ -420,7 +427,7 @@ impl<T: Pixel> Plane<T> {
     }
   }
 
-  /// Iterates over the pixels in the `Plane`, skipping the padding.
+  /// Iterates over the pixels in the plane, skipping the padding.
   pub fn iter(&self) -> PlaneIter<'_, T> {
     PlaneIter::new(self)
   }

--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -433,6 +433,7 @@ impl<T: Pixel> Plane<T> {
   }
 }
 
+/// Iterator over plane pixels, skipping padding.
 #[derive(Debug)]
 pub struct PlaneIter<'a, T: Pixel> {
   plane: &'a Plane<T>,
@@ -441,6 +442,7 @@ pub struct PlaneIter<'a, T: Pixel> {
 }
 
 impl<'a, T: Pixel> PlaneIter<'a, T> {
+  /// Creates a new iterator.
   pub fn new(plane: &'a Plane<T>) -> Self {
     Self { plane, y: 0, x: 0 }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub use crate::api::{Config, Context, EncoderStatus, Packet};
 pub use crate::frame::Frame;
 pub use crate::util::{CastFromPrimitive, Pixel};
 
+/// Commonly used types and traits.
 pub mod prelude {
   pub use crate::api::*;
   pub use crate::encoder::Tune;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,9 @@ pub mod prelude {
 
 /// Basic data structures
 pub mod data {
-  pub use crate::api::{EncoderStatus, FrameType, Packet, Point, Rational};
+  pub use crate::api::{
+    ChromaticityPoint, EncoderStatus, FrameType, Packet, Rational,
+  };
   pub use crate::frame::Frame;
   pub use crate::frame::FrameParameters;
   pub use crate::util::{CastFromPrimitive, Pixel, PixelType};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ use crate::encoder::*;
 
 pub use crate::api::{Config, Context, EncoderStatus, Packet};
 pub use crate::frame::Frame;
-pub use crate::util::{CastFromPrimitive, Pixel};
+pub use crate::util::{CastFromPrimitive, Pixel, PixelType};
 
 /// Commonly used types and traits.
 pub mod prelude {
@@ -69,7 +69,7 @@ pub mod prelude {
   pub use crate::frame::Plane;
   pub use crate::frame::PlaneConfig;
   pub use crate::partition::BlockSize;
-  pub use crate::util::{CastFromPrimitive, Pixel};
+  pub use crate::util::{CastFromPrimitive, Pixel, PixelType};
 }
 
 /// Basic data structures
@@ -77,7 +77,7 @@ pub mod data {
   pub use crate::api::{EncoderStatus, FrameType, Packet, Point, Rational};
   pub use crate::frame::Frame;
   pub use crate::frame::FrameParameters;
-  pub use crate::util::{CastFromPrimitive, Pixel};
+  pub use crate::util::{CastFromPrimitive, Pixel, PixelType};
 }
 
 pub use crate::api::color;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,7 @@ pub mod config {
 /// let v2 = Version::parse(&short).unwrap();
 ///
 /// assert_eq!(v1, v2);
-///```
-///
+/// ```
 pub mod version {
   /// Major version component
   ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,37 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+//! rav1e is an [AV1] video encoder.
+//!
+//! ## Overview
+//!
+//! rav1e is an experimental encoder. It is designed to eventually cover all
+//! use cases, though in its current form it is most suitable for cases where
+//! libaom (the reference encoder) is too slow.
+//!
+//! ## Features
+//!
+//! * Intra and inter frames
+//! * 64x64 superblocks
+//! * 4x4 to 64x64 RDO-selected square and 2:1/1:2 rectangular blocks
+//! * DC, H, V, Paeth, smooth, and a subset of directional prediction modes
+//! * DCT, ADST and identity transforms (up to 64x64, 16x16 and 32x32
+//!   respectively)
+//! * 8-, 10- and 12-bit depth color
+//! * 4:2:0 (full support), 4:2:2 and 4:4:4 (limited) chroma sampling
+//! * Variable speed settings
+//! * Near real-time encoding at high speed levels
+//!
+//! ## Usage
+//!
+//! Encoding is done through the [`Context`] struct. Examples on
+//! [`Context::receive_packet`] show how to create a [`Context`], send frames
+//! into it and receive packets of encoded data.
+//!
+//! [AV1]: https://aomediacodec.github.io/av1-spec/av1-spec.pdf
+//! [`Context`]: struct.Context.html
+//! [`Context::receive_packet`]: struct.Context.html#method.receive_packet
+
 #![allow(safe_extern_statics)]
 #![deny(bare_trait_objects)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,7 @@ pub mod data {
   pub use crate::util::{CastFromPrimitive, Pixel};
 }
 
-/// Color model information
-pub mod color {
-  pub use crate::api::color::*;
-}
+pub use crate::api::color;
 
 /// Encoder configuration and settings
 pub mod config {

--- a/src/util.rs
+++ b/src/util.rs
@@ -125,8 +125,11 @@ impl_cast_from_primitive!(i16 => { i8, i16, i32, i64, isize });
 impl_cast_from_primitive!(i32 => { u32, u64, usize });
 impl_cast_from_primitive!(i32 => { i8, i16, i32, i64, isize });
 
+/// Types that can be used as pixel types.
 pub enum PixelType {
+  /// 8 bits per pixel, stored in a `u8`.
   U8,
+  /// 10 or 12 bits per pixel, stored in a `u16`.
   U16,
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -96,7 +96,9 @@ pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
   }
 }
 
+/// Trait for casting between primitive types.
 pub trait CastFromPrimitive<T>: Copy + 'static {
+  /// Casts the given value into `Self`.
   fn cast_from(v: T) -> Self;
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -133,6 +133,7 @@ pub enum PixelType {
   U16,
 }
 
+/// A type that can be used as a pixel type.
 pub trait Pixel:
   PrimInt
   + Into<u32>
@@ -155,8 +156,12 @@ pub trait Pixel:
   + Sync
   + 'static
 {
+  /// Returns a [`PixelType`] variant corresponding to this type.
+  ///
+  /// [`PixelType`]: enum.PixelType.html
   fn type_enum() -> PixelType;
 
+  /// Converts stride in pixels to stride in bytes.
   fn to_asm_stride(in_stride: usize) -> isize {
     (in_stride * size_of::<Self>()) as isize
   }


### PR DESCRIPTION
Closes #1076, closes #1078, closes #1484, closes #1349, closes #1219.

Adds `#![deny(missing_docs)]` to capi and `src/api/mod.rs`.