### PR TITLE
Tune temporal RDO constants

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -482,7 +482,7 @@ fn compute_distortion_bias<T: Pixel>(
 
   // Chosen based on a series of AWCY runs.
   const FACTOR: f32 = 3.;
-  const ADDEND: f64 = 0.8;
+  const ADDEND: f64 = 0.65;
 
   let bias = (mean_importance / FACTOR) as f64 + ADDEND;
   debug_assert!(bias.is_finite());

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -24,9 +24,9 @@ pub fn segmentation_optimize<T: Pixel>(
   // We don't change the values between frames.
   fs.segmentation.update_data = fi.primary_ref_frame == PRIMARY_REF_NONE;
 
-  // A series of AWCY runs with deltas 10, 13, 15, 17, 20 showed this to be
-  // the optimal one.
-  const TEMPORAL_RDO_QI_DELTA: i16 = 15;
+  // A series of AWCY runs with deltas 13, 15, 17, 18, 19, 20, 21, 22, 23
+  // showed this to be the optimal one.
+  const TEMPORAL_RDO_QI_DELTA: i16 = 21;
 
   // Fill in 3 slots with 0, delta, -delta. The slot IDs are also used in
   // luma_chroma_mode_rdo() so if you change things here make sure to check


### PR DESCRIPTION
[AWCY](https://beta.arewecompressedyet.com/?job=tune-rdo-coeffs-2-q15-f3-a0.8-2019-08-26_225010-d31741f&job=tune-rdo-coeffs-2-q21-f3-a0.65-2019-08-27_130909-d31741f)

[AWCY on `--speed 2`](https://beta.arewecompressedyet.com/?job=tune-rdo-coeffs-2-q15-f3-a0.8-speed2-2019-08-28_101943-d31741f&job=tune-rdo-coeffs-2-q21-f3-a0.65-speed2-2019-08-28_102019-d31741f)