### PR TITLE
Update Gitlab CI script with stages similar to Travis

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,76 +1,164 @@
 variables:
-    CARGO_HOME: $CI_PROJECT_DIR/.cargo
-    DOCKER_IMAGE_TAG: '1.36'
+  CARGO_HOME: $CI_PROJECT_DIR/.cargo
+  LATEST_IMAGE_TAG: '1.37'
+  MINIMUM_IMAGE_TAG: '1.36'
 
 stages:
-    - build
-    - lint
-    - test
-    - bench
-    - doc
+  - check
+  - lint
+  - build
+  - test
+  - doc
 
 cache:
-    paths:
-        - $CARGO_HOME
-    key: global-cache
+  paths:
+    - $CARGO_HOME
+  key: rav1e-${CI_COMMIT_REF_SLUG}
 
 before_script:
-    - ls target/ || true
-    - ls $CARGO_HOME || true
-    - rustc --version
-    - cargo --version
-    - cargo clippy --version
-    #- kcov --version
+  - ls target/ || true
+  - ls $CARGO_HOME || true
+  - rustc --version
+  - nasm --version
+  - aomenc --help | grep 'AOMedia Project AV1 Encoder'
+  - dav1d --version
+  - kcov --version
 
-image: registry.gitlab.xiph.org/xiph/rav1e-docker/rust-rav1e:$DOCKER_IMAGE_TAG
+image: registry.gitlab.xiph.org/xiph/rav1e-docker/rust-rav1e:$LATEST_IMAGE_TAG
 
-rav1e build:
-    stage: build
-    tags:
-        - docker
-        - alpine
-    script:
-        #- cargo install --force cargo-kcov
-        - RUSTFLAGS="-C link-dead-code" cargo build --features=decode_test,quick_test --tests --verbose
-        #- cargo kcov -v --no-clean-rebuild -- --verify --exclude-pattern=$HOME/.cargo,aom_build,.h,test
-    artifacts:
-        paths:
-            - target/
-        expire_in: 2 hours
+Latest Stable Rustc:
+  stage: check
+  tags:
+    - docker
+    - alpine
+  script:
+    - cargo check --features=decode_test,decode_test_dav1d,quick_test --tests
+  artifacts:
+    paths:
+      - target/
+      - Cargo.lock
+    expire_in: 4 hours
 
-rav1e test:
-    stage: test
-    tags:
-        - docker
-        - alpine
-    script:
-        - cargo test --verbose --release --features=decode_test,check_asm -- --ignored
+Minimum Rustc:
+  image: registry.gitlab.xiph.org/xiph/rav1e-docker/rust-rav1e:$MINIMUM_IMAGE_TAG
+  stage: check
+  tags:
+    - docker
+    - alpine
+  script:
+    - cargo check --features=decode_test,decode_test_dav1d,quick_test --tests
 
-rav1e benchmark:
-    stage: bench
-    tags:
-        - docker
-        - alpine
-    script:
-        - cargo bench --features=bench --verbose
+No Default Features:
+  stage: check
+  tags:
+    - docker
+    - alpine
+  script:
+    - cargo check --no-default-features
 
-rav1e lint:
-    stage: lint
-    tags:
-        - docker
-        - alpine
-    script:
-        - cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment -A clippy::cognitive_complexity -A clippy::needless_range_loop -A clippy::too_many_arguments -A clippy::verbose_bit_mask -A clippy::unreadable_literal -A clippy::many_single_char_names --verbose
-    allow_failure: true
+CAPI and Debugging Features:
+  stage: check
+  tags:
+    - docker
+    - alpine
+  script:
+    - cargo check --features=capi,dump_lookahead_data
 
-rav1e generate docs:
-    stage: doc
-    tags:
-        - docker
-        - alpine
-    script:
-        - cargo doc --verbose --no-deps
-    artifacts:
-        paths:
-            - target/doc/
-        expire_in: 1 week
+Compile Benchmarks:
+  stage: check
+  tags:
+    - docker
+    - alpine
+  script:
+    - cargo check --features=bench --benches
+
+Clippy Lints:
+  stage: lint
+  dependencies:
+    - Latest Stable Rustc
+  tags:
+    - docker
+    - alpine
+  script:
+    - touch src/lib.rs # Ensure cargo re-checks rav1e, since we ran `cargo check` earlier
+    - >-
+      cargo clippy -- -D warnings -A clippy::cast_lossless -A clippy::cast_ptr_alignment
+      -A clippy::cognitive_complexity -A clippy::needless_range_loop -A clippy::too_many_arguments
+      -A clippy::verbose_bit_mask -A clippy::unreadable_literal -A clippy::many_single_char_names
+
+Code Styles:
+  stage: lint
+  tags:
+    - docker
+    - alpine
+  script:
+    - cargo fmt -- --check
+
+Build rav1e:
+  stage: build
+  dependencies:
+    - Latest Stable Rustc
+  tags:
+    - docker
+    - alpine
+  script:
+    - RUSTFLAGS="-C link-dead-code" cargo build --features=decode_test,decode_test_dav1d,quick_test --tests
+  artifacts:
+    paths:
+      - target/
+      - Cargo.lock
+    expire_in: 4 hours
+
+Coveralls Tests:
+  stage: test
+  dependencies:
+    - Build rav1e
+  tags:
+    - docker
+    - alpine
+  variables:
+    CI_NAME: Gitlab
+    CI_BUILD_NUMBER: "$CI_PIPELINE_ID"
+    CI_BUILD_URL: "$CI_PIPELINE_URL"
+    CI_BRANCH: "$CI_COMMIT_REF_NAME"
+    CI_PULL_REQUEST: "$CI_MERGE_REQUEST_ID"
+    # This is named "Travis", but it also allows cargo-kcov to use a repo_token to push to Coveralls
+    TRAVIS_JOB_ID: ""
+  script:
+    # Currently not pushing to coveralls. Add `--coveralls` to the first half when ready to enable.
+    # Requires TRAVIS_JOB_ID to be set to coveralls repo_token (via Gitlab secrets) first.
+    - cargo kcov -v --no-clean-rebuild -- --verify --exclude-pattern="$HOME/.cargo,aom_build,.h,test"
+
+Slow Tests (aom):
+  stage: test
+  dependencies:
+    - Latest Stable Rustc
+  tags:
+    - docker
+    - alpine
+  script:
+    - cargo test --release --features=decode_test --color=always -- --color=always --ignored
+
+Slow Tests (dav1d):
+  stage: test
+  dependencies:
+    - Latest Stable Rustc
+  tags:
+    - docker
+    - alpine
+  script:
+    - cargo test --release --features=decode_test_dav1d --color=always -- --color=always --ignored
+
+Generate Docs:
+  stage: doc
+  dependencies:
+    - Latest Stable Rustc
+  tags:
+    - docker
+    - alpine
+  script:
+    - cargo doc --no-deps
+  artifacts:
+    paths:
+      - target/doc/
+    expire_in: 1 week


### PR DESCRIPTION
This is more optimized than the travis script, because Gitlab:
- Allows us to use a custom docker image which already has all our dependencies
- Runs the build in stages, allowing us to reuse the results from one stage in a future stage or fail fast