### PR TITLE
Map an input maximum keyframe interval of 0 to "infinity" (u64::MAX)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -209,6 +209,17 @@ impl EncoderConfig {
     }
   }
 
+  /// Sets the minimum and maximum keyframe interval, handling special cases as needed.
+  pub fn set_key_frame_interval(
+    &mut self, min_interval: u64, max_interval: u64,
+  ) {
+    self.min_key_frame_interval = min_interval;
+
+    // Map an input value of 0 to an infinite interval
+    self.max_key_frame_interval =
+      if max_interval == 0 { std::u64::MAX } else { max_interval };
+  }
+
   /// Returns the video frame rate computed from [`time_base`].
   ///
   /// [`time_base`]: #structfield.time_base

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -165,7 +165,7 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
     )
     .arg(
       Arg::with_name("KEYFRAME_INTERVAL")
-        .help("Maximum interval between keyframes")
+        .help("Maximum interval between keyframes. When set to 0, disables fixed-interval keyframes.")
         .short("I")
         .long("keyint")
         .takes_value(true)
@@ -419,11 +419,6 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
       min_interval = min_interval.min(max_interval);
     }
 
-    // Validate arguments
-    if max_interval < 1 {
-      panic!("Keyframe interval must be greater than 0");
-    }
-
     if speed > 10 {
       panic!("Speed must be between 0-10");
     } else if min_interval > max_interval {
@@ -444,8 +439,7 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
       .unwrap_or_default();
 
     let mut cfg = EncoderConfig::with_speed_preset(speed);
-    cfg.min_key_frame_interval = min_interval;
-    cfg.max_key_frame_interval = max_interval;
+    cfg.set_key_frame_interval(min_interval, max_interval);
 
     cfg.pixel_range =
       matches.value_of("PIXEL_RANGE").unwrap().parse().unwrap_or_default();

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -445,10 +445,16 @@ unsafe fn option_match(
     "bitrate" => enc.bitrate = value.parse().map_err(|_| ())?,
 
     "key_frame_interval" => {
-      enc.max_key_frame_interval = value.parse().map_err(|_| ())?
+      enc.set_key_frame_interval(
+        enc.min_key_frame_interval,
+        value.parse().map_err(|_| ())?,
+      );
     }
     "min_key_frame_interval" => {
-      enc.min_key_frame_interval = value.parse().map_err(|_| ())?
+      enc.set_key_frame_interval(
+        value.parse().map_err(|_| ())?,
+        enc.max_key_frame_interval,
+      );
     }
     "reservoir_frame_delay" => {
       enc.reservoir_frame_delay = Some(value.parse().map_err(|_| ())?)


### PR DESCRIPTION
Opening this for discussion.

The goal of this PR is to provide a simple interface to set an infinite keyframe interval (i.e. keyframes inserted only on scene changes), as opposed to having users pass the maximum value of an unsigned 64-bit value themselves.

The alternative solution would be to add a new option that overrides the keyframe interval values provided, but in order to support this through the C API a new encoder config parameter would be needed, so overall it seems unnecessarily complex to me.

In order to avoid duplicating logic between the C API and the CLI, a function is added to the encoder config. It takes both minimum and maximum keyframe interval values in case we want to map more special cases in the future (e.g. auto interval when the minimum interval input value is 0).