### PR TITLE
Enhanced CLI stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ image = { version = "0.22.1", optional = true }
 byteorder = { version = "1.3.2", optional = true }
 log = "0.4"
 pretty_env_logger = { version = "0.3", optional = true }
+itertools = "0.8"
 
 [build-dependencies]
 nasm-rs = { version = "0.1", path = "crates/nasm_rs/", optional = true }

--- a/src/api/color.rs
+++ b/src/api/color.rs
@@ -9,6 +9,7 @@
 
 use arg_enum_proc_macro::ArgEnum;
 use num_derive::FromPrimitive;
+use std::fmt;
 
 /// Sample position for subsampled chroma
 #[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
@@ -42,6 +43,21 @@ pub enum ChromaSampling {
   Cs444,
   /// Monochrome.
   Cs400,
+}
+
+impl fmt::Display for ChromaSampling {
+  fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    write!(
+      f,
+      "{}",
+      match self {
+        ChromaSampling::Cs420 => "4:2:0",
+        ChromaSampling::Cs422 => "4:2:2",
+        ChromaSampling::Cs444 => "4:4:4",
+        ChromaSampling::Cs400 => "Monochrome",
+      }
+    )
+  }
 }
 
 impl Default for ChromaSampling {

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -1,16 +1,21 @@
+use rav1e::data::EncoderStats;
 use rav1e::prelude::*;
 use rav1e::{Packet, Pixel};
 use std::fmt;
 use std::time::Instant;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct FrameSummary {
-  // Frame size in bytes
+  /// Frame size in bytes
   pub size: usize,
   pub input_frameno: u64,
   pub frame_type: FrameType,
-  // PSNR for Y, U, and V planes
+  /// PSNR for Y, U, and V planes
   pub psnr: Option<(f64, f64, f64)>,
+  /// QP selected for the frame.
+  pub qp: u8,
+  /// Block-level encoding stats for the frame
+  pub enc_stats: EncoderStats,
 }
 
 impl<T: Pixel> From<Packet<T>> for FrameSummary {
@@ -20,6 +25,8 @@ impl<T: Pixel> From<Packet<T>> for FrameSummary {
       input_frameno: packet.input_frameno,
       frame_type: packet.frame_type,
       psnr: packet.psnr,
+      qp: packet.qp,
+      enc_stats: packet.enc_stats,
     }
   }
 }
@@ -144,13 +151,175 @@ impl ProgressInfo {
       / count
   }
 
-  pub fn print_summary(&self) {
+  fn get_frame_type_avg_qp(&self, frame_type: FrameType) -> f32 {
+    let count = self.get_frame_type_count(frame_type);
+    if count == 0 {
+      return 0.;
+    }
+    self
+      .frame_info
+      .iter()
+      .filter(|frame| frame.frame_type == frame_type)
+      .map(|frame| frame.qp as f32)
+      .sum::<f32>()
+      / count as f32
+  }
+
+  fn get_block_count_by_frame_type(&self, frame_type: FrameType) -> usize {
+    self
+      .frame_info
+      .iter()
+      .filter(|frame| frame.frame_type == frame_type)
+      .map(|frame| frame.enc_stats.block_size_counts.values().sum::<usize>())
+      .sum()
+  }
+
+  fn get_tx_count_by_frame_type(&self, frame_type: FrameType) -> usize {
+    self
+      .frame_info
+      .iter()
+      .filter(|frame| frame.frame_type == frame_type)
+      .map(|frame| frame.enc_stats.tx_type_counts.values().sum::<usize>())
+      .sum()
+  }
+
+  fn get_bsize_pct_by_frame_type(
+    &self, bsize: BlockSize, frame_type: FrameType,
+  ) -> f32 {
+    let count = self.get_block_count_by_frame_type(frame_type);
+    if count == 0 {
+      return 0.;
+    }
+    self
+      .frame_info
+      .iter()
+      .filter(|frame| frame.frame_type == frame_type)
+      .map(|frame| {
+        frame.enc_stats.block_size_counts.get(&bsize).copied().unwrap_or(0)
+      })
+      .sum::<usize>() as f32
+      / count as f32
+      * 100.
+  }
+
+  fn get_skip_pct_by_frame_type(&self, frame_type: FrameType) -> f32 {
+    let count = self.get_block_count_by_frame_type(frame_type);
+    if count == 0 {
+      return 0.;
+    }
+    self
+      .frame_info
+      .iter()
+      .filter(|frame| frame.frame_type == frame_type)
+      .map(|frame| frame.enc_stats.skip_block_count)
+      .sum::<usize>() as f32
+      / count as f32
+      * 100.
+  }
+
+  fn get_txtype_pct_by_frame_type(
+    &self, txtype: TxType, frame_type: FrameType,
+  ) -> f32 {
+    let count = self.get_tx_count_by_frame_type(frame_type);
+    if count == 0 {
+      return 0.;
+    }
+    self
+      .frame_info
+      .iter()
+      .filter(|frame| frame.frame_type == frame_type)
+      .map(|frame| {
+        frame.enc_stats.tx_type_counts.get(&txtype).copied().unwrap_or(0)
+      })
+      .sum::<usize>() as f32
+      / count as f32
+      * 100.
+  }
+
+  fn get_luma_pred_count_by_frame_type(&self, frame_type: FrameType) -> usize {
+    self
+      .frame_info
+      .iter()
+      .filter(|frame| frame.frame_type == frame_type)
+      .map(|frame| {
+        frame.enc_stats.luma_pred_mode_counts.values().sum::<usize>()
+      })
+      .sum()
+  }
+
+  fn get_chroma_pred_count_by_frame_type(
+    &self, frame_type: FrameType,
+  ) -> usize {
+    self
+      .frame_info
+      .iter()
+      .filter(|frame| frame.frame_type == frame_type)
+      .map(|frame| {
+        frame.enc_stats.chroma_pred_mode_counts.values().sum::<usize>()
+      })
+      .sum()
+  }
+
+  fn get_luma_pred_mode_pct_by_frame_type(
+    &self, pred_mode: PredictionMode, frame_type: FrameType,
+  ) -> f32 {
+    let count = self.get_luma_pred_count_by_frame_type(frame_type);
+    if count == 0 {
+      return 0.;
+    }
+    self
+      .frame_info
+      .iter()
+      .filter(|frame| frame.frame_type == frame_type)
+      .map(|frame| {
+        frame
+          .enc_stats
+          .luma_pred_mode_counts
+          .get(&pred_mode)
+          .copied()
+          .unwrap_or(0)
+      })
+      .sum::<usize>() as f32
+      / count as f32
+      * 100.
+  }
+
+  fn get_chroma_pred_mode_pct_by_frame_type(
+    &self, pred_mode: PredictionMode, frame_type: FrameType,
+  ) -> f32 {
+    let count = self.get_chroma_pred_count_by_frame_type(frame_type);
+    if count == 0 {
+      return 0.;
+    }
+    self
+      .frame_info
+      .iter()
+      .filter(|frame| frame.frame_type == frame_type)
+      .map(|frame| {
+        frame
+          .enc_stats
+          .chroma_pred_mode_counts
+          .get(&pred_mode)
+          .copied()
+          .unwrap_or(0)
+      })
+      .sum::<usize>() as f32
+      / count as f32
+      * 100.
+  }
+
+  pub fn print_summary(&self, verbose: bool) {
     info!("{}", self);
     info!("----------");
     self.print_frame_type_summary(FrameType::KEY);
     self.print_frame_type_summary(FrameType::INTER);
     self.print_frame_type_summary(FrameType::INTRA_ONLY);
     self.print_frame_type_summary(FrameType::SWITCH);
+    if verbose {
+      self.print_block_type_summary();
+      self.print_transform_type_summary();
+      self.print_prediction_modes_summary();
+    }
     if self.show_psnr {
       self.print_video_psnr();
     }
@@ -159,10 +328,12 @@ impl ProgressInfo {
   fn print_frame_type_summary(&self, frame_type: FrameType) {
     let count = self.get_frame_type_count(frame_type);
     let size = self.get_frame_type_avg_size(frame_type);
+    let avg_qp = self.get_frame_type_avg_qp(frame_type);
     info!(
-      "{:17} {:>6}    avg size: {:>7} B",
+      "{:17} {:>6} | avg QP: {:6.2} | avg size: {:>7} B",
       format!("{}:", frame_type),
       count,
+      avg_qp,
       size
     );
   }
@@ -185,6 +356,227 @@ impl ProgressInfo {
       psnr_v,
       (psnr_y + psnr_u + psnr_v) / 3.0
     )
+  }
+
+  fn print_block_type_summary(&self) {
+    self.print_block_type_summary_for_frame_type(FrameType::KEY, 'I');
+    self.print_block_type_summary_for_frame_type(FrameType::INTER, 'P');
+  }
+
+  fn print_block_type_summary_for_frame_type(
+    &self, frame_type: FrameType, type_label: char,
+  ) {
+    info!("----------");
+    info!(
+      "bsize {}: {:>6} {:>6} {:>6} {:>6} {:>6} {:>6}",
+      type_label, "x128", "x64", "x32", "x16", "x8", "x4"
+    );
+    info!(
+      "   128x: {:>5.1}% {:>5.1}%                              {}",
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_128X128, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_128X64, frame_type),
+      if frame_type == FrameType::INTER {
+        format!("skip: {:>5.1}%", self.get_skip_pct_by_frame_type(frame_type))
+      } else {
+        String::new()
+      }
+    );
+    info!(
+      "    64x: {:>5.1}% {:>5.1}% {:>5.1}% {:>5.1}%",
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_64X128, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_64X64, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_64X32, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_64X16, frame_type),
+    );
+    info!(
+      "    32x:        {:>5.1}% {:>5.1}% {:>5.1}% {:>5.1}%",
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_32X64, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_32X32, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_32X16, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_32X8, frame_type),
+    );
+    info!(
+      "    16x:        {:>5.1}% {:>5.1}% {:>5.1}% {:>5.1}% {:>5.1}%",
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_16X64, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_16X32, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_16X16, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_16X8, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_16X4, frame_type),
+    );
+    info!(
+      "     8x:               {:>5.1}% {:>5.1}% {:>5.1}% {:>5.1}%",
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_8X32, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_8X16, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_8X8, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_8X4, frame_type),
+    );
+    info!(
+      "     4x:                      {:>5.1}% {:>5.1}% {:>5.1}%",
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_4X16, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_4X8, frame_type),
+      self.get_bsize_pct_by_frame_type(BlockSize::BLOCK_4X4, frame_type),
+    );
+  }
+
+  fn print_transform_type_summary(&self) {
+    info!("----------");
+    self.print_transform_type_summary_by_frame_type(FrameType::KEY, 'I');
+    self.print_transform_type_summary_by_frame_type(FrameType::INTER, 'P');
+  }
+
+  fn print_transform_type_summary_by_frame_type(
+    &self, frame_type: FrameType, type_label: char,
+  ) {
+    info!(
+      "txtypes {}: DCT_DCT: {:.1}% | ADST_DCT: {:.1}% | DCT_ADST: {:.1}% | ADST_ADST: {:.1}%",
+      type_label,
+      self.get_txtype_pct_by_frame_type(TxType::DCT_DCT, frame_type),
+      self.get_txtype_pct_by_frame_type(TxType::ADST_DCT, frame_type),
+      self.get_txtype_pct_by_frame_type(TxType::DCT_ADST, frame_type),
+      self.get_txtype_pct_by_frame_type(TxType::ADST_ADST, frame_type)
+    );
+    info!(
+      "           IDTX: {:.1}% | V_DCT: {:.1}% | H_DCT: {:.1}%",
+      self.get_txtype_pct_by_frame_type(TxType::IDTX, frame_type),
+      self.get_txtype_pct_by_frame_type(TxType::V_DCT, frame_type),
+      self.get_txtype_pct_by_frame_type(TxType::H_DCT, frame_type),
+    )
+  }
+
+  fn print_prediction_modes_summary(&self) {
+    info!("----------");
+    self.print_luma_prediction_mode_summary_by_frame_type(FrameType::KEY, 'I');
+    self
+      .print_chroma_prediction_mode_summary_by_frame_type(FrameType::KEY, 'I');
+    info!("----------");
+    self
+      .print_luma_prediction_mode_summary_by_frame_type(FrameType::INTER, 'P');
+    self.print_chroma_prediction_mode_summary_by_frame_type(
+      FrameType::INTER,
+      'P',
+    );
+  }
+
+  fn print_luma_prediction_mode_summary_by_frame_type(
+    &self, frame_type: FrameType, type_label: char,
+  ) {
+    if frame_type == FrameType::KEY {
+      info!(
+        "y modes {}: DC: {:.1}% | V: {:.1}% | H: {:.1}% | Paeth: {:.1}%",
+        type_label,
+        self.get_luma_pred_mode_pct_by_frame_type(
+          PredictionMode::DC_PRED,
+          frame_type
+        ),
+        self.get_luma_pred_mode_pct_by_frame_type(
+          PredictionMode::V_PRED,
+          frame_type
+        ),
+        self.get_luma_pred_mode_pct_by_frame_type(
+          PredictionMode::H_PRED,
+          frame_type
+        ),
+        self.get_luma_pred_mode_pct_by_frame_type(
+          PredictionMode::PAETH_PRED,
+          frame_type
+        ),
+      );
+      info!(
+        "           Smooth: {:.1}% | Smooth V: {:.1}% | Smooth H: {:.1}%",
+        self.get_luma_pred_mode_pct_by_frame_type(
+          PredictionMode::SMOOTH_PRED,
+          frame_type
+        ),
+        self.get_luma_pred_mode_pct_by_frame_type(
+          PredictionMode::SMOOTH_V_PRED,
+          frame_type
+        ),
+        self.get_luma_pred_mode_pct_by_frame_type(
+          PredictionMode::SMOOTH_H_PRED,
+          frame_type
+        ),
+      );
+      info!(
+      "        D: 45: {:.1}% | 63: {:.1}% | 117: {:.1}% | 135: {:.1}% | 153: {:.1}% | 207: {:.1}%",
+      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D45_PRED, frame_type),
+      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D63_PRED, frame_type),
+      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D117_PRED, frame_type),
+      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D135_PRED, frame_type),
+      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D153_PRED, frame_type),
+      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D207_PRED, frame_type),
+    );
+    } else if frame_type == FrameType::INTER {
+      info!(
+        "y modes {}: Nearest: {:.1}% | Near0: {:.1}% | Near1: {:.1}% | NearNear: {:.1}%",
+        type_label,
+        self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::NEARESTMV, frame_type),
+        self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::NEAR0MV, frame_type),
+        self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::NEAR1MV, frame_type),
+        self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::NEAR_NEARMV, frame_type),
+      );
+      info!("           New: {:.1}% | NewNew: {:.1}% | NearestNearest: {:.1}% | GlobalGlobal: {:.1}%",
+            self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::NEWMV, frame_type),
+            self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::NEW_NEWMV, frame_type),
+            self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::NEAREST_NEARESTMV, frame_type),
+            self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::GLOBAL_GLOBALMV, frame_type),);
+    }
+  }
+
+  fn print_chroma_prediction_mode_summary_by_frame_type(
+    &self, frame_type: FrameType, type_label: char,
+  ) {
+    if frame_type == FrameType::KEY {
+      info!(
+        "uv modes {}: DC: {:.1}% | V: {:.1}% | H: {:.1}% | Paeth: {:.1}%",
+        type_label,
+        self.get_chroma_pred_mode_pct_by_frame_type(
+          PredictionMode::DC_PRED,
+          frame_type
+        ),
+        self.get_chroma_pred_mode_pct_by_frame_type(
+          PredictionMode::V_PRED,
+          frame_type
+        ),
+        self.get_chroma_pred_mode_pct_by_frame_type(
+          PredictionMode::H_PRED,
+          frame_type
+        ),
+        self.get_chroma_pred_mode_pct_by_frame_type(
+          PredictionMode::PAETH_PRED,
+          frame_type
+        ),
+      );
+      info!(
+        "            Smooth: {:.1}% | Smooth V: {:.1}% | Smooth H: {:.1}% | UV CFL: {:.1}%",
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::SMOOTH_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::SMOOTH_V_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::SMOOTH_H_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::UV_CFL_PRED, frame_type),
+      );
+      info!(
+        "         D: 45: {:.1}% | 63: {:.1}% | 117: {:.1}% | 135: {:.1}% | 153: {:.1}% | 207: {:.1}%",
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D45_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D63_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D117_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D135_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D153_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D207_PRED, frame_type),
+      );
+    } else if frame_type == FrameType::INTER {
+      info!(
+        "uv modes {}: Nearest: {:.1}% | Near0: {:.1}% | Near1: {:.1}% | NearNear: {:.1}%",
+        type_label,
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::NEARESTMV, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::NEAR0MV, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::NEAR1MV, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::NEAR_NEARMV, frame_type),
+      );
+      info!("            New: {:.1}% | NewNew: {:.1}% | NearestNearest: {:.1}% | GlobalGlobal: {:.1}%",
+            self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::NEWMV, frame_type),
+            self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::NEW_NEWMV, frame_type),
+            self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::NEAREST_NEARESTMV, frame_type),
+            self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::GLOBAL_GLOBALMV, frame_type),);
+    }
   }
 }
 

--- a/src/cpu_features.rs
+++ b/src/cpu_features.rs
@@ -14,9 +14,10 @@ pub use x86::*;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86 {
+  use arg_enum_proc_macro::ArgEnum;
   use std::env;
 
-  #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd)]
+  #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, ArgEnum)]
   pub enum CpuFeatureLevel {
     NATIVE,
     AVX2,
@@ -61,7 +62,9 @@ mod x86 {
 
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 mod native {
-  #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd)]
+  use arg_enum_proc_macro::ArgEnum;
+
+  #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, ArgEnum)]
   pub enum CpuFeatureLevel {
     NATIVE,
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ mod recon_intra;
 mod scan_order;
 mod scenechange;
 mod segmentation;
+mod stats;
 mod tiling;
 mod token_cdfs;
 
@@ -99,6 +100,8 @@ pub mod prelude {
   pub use crate::frame::Plane;
   pub use crate::frame::PlaneConfig;
   pub use crate::partition::BlockSize;
+  pub use crate::predict::PredictionMode;
+  pub use crate::transform::TxType;
   pub use crate::util::{CastFromPrimitive, Pixel, PixelType};
 }
 
@@ -109,6 +112,7 @@ pub mod data {
   };
   pub use crate::frame::Frame;
   pub use crate::frame::FrameParameters;
+  pub use crate::stats::EncoderStats;
   pub use crate::util::{CastFromPrimitive, Pixel, PixelType};
 }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -56,6 +56,7 @@ impl RefType {
 }
 
 use self::RefType::*;
+use std::fmt;
 
 pub const ALL_INTER_REFS: [RefType; 7] = [
   LAST_FRAME,
@@ -372,6 +373,40 @@ impl BlockSize {
       BLOCK_INVALID => unreachable!(),
       _ => true,
     }
+  }
+}
+
+impl fmt::Display for BlockSize {
+  fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    write!(
+      f,
+      "{}",
+      match self {
+        BlockSize::BLOCK_4X4 => "4x4",
+        BlockSize::BLOCK_4X8 => "4x8",
+        BlockSize::BLOCK_8X4 => "8x4",
+        BlockSize::BLOCK_8X8 => "8x8",
+        BlockSize::BLOCK_8X16 => "8x16",
+        BlockSize::BLOCK_16X8 => "16x8",
+        BlockSize::BLOCK_16X16 => "16x16",
+        BlockSize::BLOCK_16X32 => "16x32",
+        BlockSize::BLOCK_32X16 => "32x16",
+        BlockSize::BLOCK_32X32 => "32x32",
+        BlockSize::BLOCK_32X64 => "32x64",
+        BlockSize::BLOCK_64X32 => "64x32",
+        BlockSize::BLOCK_64X64 => "64x64",
+        BlockSize::BLOCK_64X128 => "64x128",
+        BlockSize::BLOCK_128X64 => "128x64",
+        BlockSize::BLOCK_128X128 => "128x128",
+        BlockSize::BLOCK_4X16 => "4x16",
+        BlockSize::BLOCK_16X4 => "16x4",
+        BlockSize::BLOCK_8X32 => "8x32",
+        BlockSize::BLOCK_32X8 => "32x8",
+        BlockSize::BLOCK_16X64 => "16x64",
+        BlockSize::BLOCK_64X16 => "64x16",
+        BlockSize::BLOCK_INVALID => "Invalid",
+      }
+    )
   }
 }
 

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -58,7 +58,7 @@ pub static RAV1E_INTER_COMPOUND_MODES: &[PredictionMode] = &[
   PredictionMode::NEAR_NEARMV,
 ];
 
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub enum PredictionMode {
   DC_PRED,     // Average of above and left pixels
   V_PRED,      // Vertical

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -673,6 +673,7 @@ fn luma_chroma_mode_rdo<T: Pixel>(
           &mv_stack,
           rdo_type,
           need_recon_pixel,
+          false,
         );
 
         let rate = wr.tell_frac() - tell;
@@ -1149,6 +1150,7 @@ pub fn rdo_mode_decision<T: Pixel>(
         &Vec::new(),
         rdo_type,
         true, // For CFL, luma should be always reconstructed.
+        false,
       );
 
       let rate = wr.tell_frac() - tell;
@@ -1555,6 +1557,7 @@ pub fn rdo_partition_decision<T: Pixel, W: Writer>(
             offset,
             &mode_decision,
             rdo_type,
+            false,
           );
           child_modes.push(mode_decision);
         }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,59 @@
+use crate::partition::BlockSize;
+use crate::prelude::PredictionMode;
+use crate::transform::TxType;
+use std::collections::BTreeMap;
+use std::ops::{Add, AddAssign};
+
+#[derive(Debug, Clone)]
+pub struct EncoderStats {
+  /// Stores counts of each block size used in this frame
+  pub block_size_counts: BTreeMap<BlockSize, usize>,
+  /// Stores the number of skip blocks used in this frame
+  pub skip_block_count: usize,
+  /// Stores counts of each transform type used in this frame
+  pub tx_type_counts: BTreeMap<TxType, usize>,
+  /// Stores counts of each prediction mode used for luma in this frame
+  pub luma_pred_mode_counts: BTreeMap<PredictionMode, usize>,
+  /// Stores counts of each prediction mode used in this frame
+  pub chroma_pred_mode_counts: BTreeMap<PredictionMode, usize>,
+}
+
+impl Default for EncoderStats {
+  fn default() -> Self {
+    EncoderStats {
+      block_size_counts: BTreeMap::new(),
+      skip_block_count: 0,
+      tx_type_counts: BTreeMap::new(),
+      luma_pred_mode_counts: BTreeMap::new(),
+      chroma_pred_mode_counts: BTreeMap::new(),
+    }
+  }
+}
+
+impl Add<&Self> for EncoderStats {
+  type Output = Self;
+
+  fn add(self, rhs: &EncoderStats) -> Self::Output {
+    let mut lhs = self;
+    lhs += rhs;
+    lhs
+  }
+}
+
+impl AddAssign<&Self> for EncoderStats {
+  fn add_assign(&mut self, rhs: &EncoderStats) {
+    rhs.block_size_counts.iter().for_each(|(&k, &v)| {
+      *self.block_size_counts.entry(k).or_insert(0) += v;
+    });
+    rhs.chroma_pred_mode_counts.iter().for_each(|(&k, &v)| {
+      *self.chroma_pred_mode_counts.entry(k).or_insert(0) += v;
+    });
+    rhs.luma_pred_mode_counts.iter().for_each(|(&k, &v)| {
+      *self.luma_pred_mode_counts.entry(k).or_insert(0) += v;
+    });
+    rhs.tx_type_counts.iter().for_each(|(&k, &v)| {
+      *self.tx_type_counts.entry(k).or_insert(0) += v;
+    });
+    self.skip_block_count += rhs.skip_block_count;
+  }
+}

--- a/src/tiling/tile_state.rs
+++ b/src/tiling/tile_state.rs
@@ -18,6 +18,7 @@ use crate::lrf::{
 };
 use crate::quantize::*;
 use crate::rdo::*;
+use crate::stats::EncoderStats;
 use crate::util::*;
 
 /// Tiled view of FrameState
@@ -66,6 +67,8 @@ pub struct TileStateMut<'a, T: Pixel> {
   pub stripe_filter_buffer: IntegralImageBuffer,
   // Used in sgrproj_solve().
   pub solve_buffer: IntegralImageBuffer,
+
+  pub enc_stats: EncoderStats,
 }
 
 impl<'a, T: Pixel> TileStateMut<'a, T> {
@@ -131,6 +134,7 @@ impl<'a, T: Pixel> TileStateMut<'a, T> {
         STRIPE_FILTER_INTEGRAL_IMAGE_SIZE,
       ),
       solve_buffer: IntegralImageBuffer::zeroed(SOLVE_INTEGRAL_IMAGE_SIZE),
+      enc_stats: EncoderStats::default(),
     }
   }
 

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -41,7 +41,7 @@ static INV_SQRT2: i32 = 2896; // 2^12 / sqrt(2)
 
 pub const TX_TYPES: usize = 16;
 
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
 #[repr(C)]
 pub enum TxType {
   DCT_DCT = 0,   // DCT  in both horizontal and vertical
@@ -63,7 +63,7 @@ pub enum TxType {
 }
 
 /// Transform Size
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 #[repr(C)]
 pub enum TxSize {
   TX_4X4,


### PR DESCRIPTION
Closes #1595

Example of verbose output:
```
[INFO  rav1e] Using y4m decoder: 1280x720p @ 60/1 fps, 4:2:0, 8-bit
[INFO  rav1e] CPU Feature Level: AVX2
[INFO  rav1e] Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual tiles=0 tile_rows=0 tile_cols=0 rdo_lookahead_frames=40 min_block_size=4x4 multiref=true fast_deblock=false reduced_tx_set=false tx_domain_distortion=true tx_domain_rate=false encode_bottomup=true rdo_tx_decision=true prediction_modes=Complex-All include_near_mvs=true no_scene_detection=false diamond_me=true cdef=true quantizer_rdo=true use_satd_subpel=true
[INFO  rav1e] Input Frame 0 - Key frame - 59872 bytes - encoded 1 frames, 0.003 fps, 28738.56 Kb/s
[INFO  rav1e] Input Frame 1 - Inter frame - 27367 bytes - encoded 2 frames, 0.003 fps, 20937.36 Kb/s
...
[INFO  rav1e] Input Frame 59 - Inter frame - 2068 bytes - encoded 60 frames, 0.011 fps, 3265.33 Kb/s
[INFO  rav1e::stats] ----------
[INFO  rav1e::stats] Key frame:             1 | avg QP:  79.00 | avg size:   59872 B
[INFO  rav1e::stats] Inter frame:          59 | avg QP: 117.29 | avg size:    5903 B
[INFO  rav1e::stats] Intra only frame:      0 | avg QP:   0.00 | avg size:       0 B
[INFO  rav1e::stats] Switching frame:       0 | avg QP:   0.00 | avg size:       0 B
[INFO  rav1e::stats] ----------
[INFO  rav1e::stats] bsize I:   x128    x64    x32    x16     x8     x4
[INFO  rav1e::stats]    128x:   0.0%   0.0%                              
[INFO  rav1e::stats]     64x:   0.0%   0.0%   0.4%   0.0%
[INFO  rav1e::stats]     32x:          0.3%   0.1%   1.5%   0.0%
[INFO  rav1e::stats]     16x:          0.0%   1.3%   1.1%   6.5%   0.0%
[INFO  rav1e::stats]      8x:                 0.0%   5.6%   6.8%  21.4%
[INFO  rav1e::stats]      4x:                        0.0%  20.8%  34.1%
[INFO  rav1e::stats] ----------
[INFO  rav1e::stats] bsize P:   x128    x64    x32    x16     x8     x4
[INFO  rav1e::stats]    128x:   0.0%   0.0%                              skip:  98.2%
[INFO  rav1e::stats]     64x:   0.0%   0.1%   0.7%   0.0%
[INFO  rav1e::stats]     32x:          0.7%   0.6%   2.7%   0.0%
[INFO  rav1e::stats]     16x:          0.0%   2.6%   3.2%   9.1%   0.0%
[INFO  rav1e::stats]      8x:                 0.0%   7.9%  12.6%  19.2%
[INFO  rav1e::stats]      4x:                        0.0%  16.3%  24.3%
[INFO  rav1e::stats] ----------
[INFO  rav1e::stats] txtypes I: DCT_DCT: 43.6% | ADST_DCT: 10.6% | DCT_ADST: 16.5% | ADST_ADST: 26.7%
[INFO  rav1e::stats]            IDTX: 0.3% | V_DCT: 0.5% | H_DCT: 1.7%
[INFO  rav1e::stats] txtypes P: DCT_DCT: 98.9% | ADST_DCT: 0.4% | DCT_ADST: 0.3% | ADST_ADST: 0.2%
[INFO  rav1e::stats]            IDTX: 0.0% | V_DCT: 0.0% | H_DCT: 0.1%
[INFO  rav1e::stats] ----------
[INFO  rav1e::stats] y modes I: DC: 18.3% | V: 3.0% | H: 20.1% | Paeth: 3.3%
[INFO  rav1e::stats]            Smooth: 25.0% | Smooth V: 6.7% | Smooth H: 5.8%
[INFO  rav1e::stats]         D: 45: 0.5% | 63: 1.7% | 117: 1.3% | 135: 2.1% | 153: 10.0% | 207: 2.3%
[INFO  rav1e::stats] uv modes I: DC: 23.8% | V: 2.7% | H: 19.0% | Paeth: 3.0%
[INFO  rav1e::stats]             Smooth: 21.7% | Smooth V: 5.4% | Smooth H: 4.3% | UV CFL: 4.3%
[INFO  rav1e::stats]          D: 45: 0.4% | 63: 1.4% | 117: 1.1% | 135: 1.8% | 153: 9.1% | 207: 2.0%
[INFO  rav1e::stats] ----------
[INFO  rav1e::stats] y modes P: Nearest: 64.0% | Near0: 12.7% | Near1: 0.1% | NearNear: 1.6%
[INFO  rav1e::stats]            New: 5.5% | NewNew: 0.8% | NearestNearest: 14.6% | GlobalGlobal: 0.0%
[INFO  rav1e::stats] uv modes P: Nearest: 64.0% | Near0: 12.7% | Near1: 0.1% | NearNear: 1.6%
[INFO  rav1e::stats]             New: 5.5% | NewNew: 0.8% | NearestNearest: 14.6% | GlobalGlobal: 0.0%
```

Non-verbose output:
```
[INFO  rav1e] Using y4m decoder: 640x360p @ 25/1 fps, 4:2:0, 8-bit
[INFO  rav1e] CPU Feature Level: AVX2
[INFO  rav1e] encoded 3/3 frames, 0.766 fps, 1886.33 Kb/s, est. size: 0.03 MB, est. time: 0 s      
[INFO  rav1e::stats] ----------
[INFO  rav1e::stats] Key frame:             1 | avg QP:  79.00 | avg size:   26893 B
[INFO  rav1e::stats] Inter frame:           2 | avg QP: 117.00 | avg size:     701 B
[INFO  rav1e::stats] Intra only frame:      0 | avg QP:   0.00 | avg size:       0 B
[INFO  rav1e::stats] Switching frame:       0 | avg QP:   0.00 | avg size:       0 B
```