### PR TITLE
Use the log crate instead of eprintln! statements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ autobins = false
 [features]
 decode_test = ["aom-sys"]
 decode_test_dav1d = ["dav1d-sys"]
-binaries = ["ivf", "y4m", "clap", "scan_fmt"]
+binaries = ["ivf", "y4m", "clap", "scan_fmt", "pretty_env_logger"]
 default = ["binaries", "nasm", "signal_support"]
 nasm = ["nasm-rs"]
 signal_support = ["signal-hook"]
@@ -56,6 +56,8 @@ better-panic = "0.1"
 err-derive = "0.1"
 image = { version = "0.22.1", optional = true }
 byteorder = { version = "1.3.2", optional = true }
+log = "0.4"
+pretty_env_logger = { version = "0.3", optional = true }
 
 [build-dependencies]
 nasm-rs = { version = "0.1", path = "crates/nasm_rs/", optional = true }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2413,16 +2413,16 @@ mod test {
       loop {
         match ctx.receive_packet() {
           Ok(_) => {
-            eprintln!("Packet Received {}/{}", count, limit);
+            debug!("Packet Received {}/{}", count, limit);
             count += 1;
           }
           Err(EncoderStatus::EnoughData) => {
-            eprintln!("{:?}", EncoderStatus::EnoughData);
+            debug!("{:?}", EncoderStatus::EnoughData);
 
             break 'out;
           }
           Err(e) => {
-            eprintln!("{:?}", e);
+            debug!("{:?}", e);
             break;
           }
         }
@@ -2466,16 +2466,16 @@ mod test {
       loop {
         match ctx.receive_packet() {
           Ok(_) => {
-            eprintln!("Packet Received {}/{}", count, limit);
+            debug!("Packet Received {}/{}", count, limit);
             count += 1;
           }
           Err(EncoderStatus::EnoughData) => {
-            eprintln!("{:?}", EncoderStatus::EnoughData);
+            debug!("{:?}", EncoderStatus::EnoughData);
 
             break 'out;
           }
           Err(e) => {
-            eprintln!("{:?}", e);
+            debug!("{:?}", e);
             break;
           }
         }

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -402,7 +402,7 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
   }
 
   let mut cfg = if let Some(settings) = matches.value_of("SPEED_TEST") {
-    eprintln!("Running in speed test mode--ignoring other settings");
+    info!("Running in speed test mode--ignoring other settings");
     let mut cfg = EncoderConfig::default();
     settings
       .split_whitespace()

--- a/src/bin/error.rs
+++ b/src/bin/error.rs
@@ -33,10 +33,10 @@ impl ToError for std::num::ParseIntError {
 }
 
 pub fn print_error(e: &dyn Error) {
-  eprintln!("error: {}", e);
+  error!("{}", e);
   let mut cause = e.source();
   while let Some(e) = cause {
-    eprintln!("caused by: {}", e);
+    error!("Caused by: {}", e);
     cause = e.source();
   }
 }

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -28,12 +28,12 @@ use rav1e::prelude::*;
 use crate::decoder::Decoder;
 use crate::decoder::VideoDetails;
 use crate::muxer::*;
+use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::io::Seek;
 use std::io::Write;
 use std::sync::Arc;
-use std::env;
 
 struct Source<D: Decoder> {
   limit: usize,

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -11,6 +11,8 @@
 
 #[macro_use]
 extern crate err_derive;
+#[macro_use]
+extern crate log;
 
 mod common;
 mod decoder;
@@ -31,6 +33,7 @@ use std::io::Read;
 use std::io::Seek;
 use std::io::Write;
 use std::sync::Arc;
+use std::env;
 
 struct Source<D: Decoder> {
   limit: usize,
@@ -208,25 +211,38 @@ fn do_encode<T: Pixel, D: Decoder>(
     for frame in frame_info {
       progress.add_frame(frame);
       if verbose {
-        eprintln!("{} - {}", frame, progress);
+        info!("{} - {}", frame, progress);
       } else {
+        // Print a one-line progress indicator that overrides itself with every update
         eprint!("\r{}                    ", progress);
       };
     }
 
     output.flush().unwrap();
   }
-  eprint!("\n{}\n", progress.print_summary());
+  if !verbose {
+    // Clear out the temporary progress indicator
+    eprint!("\r");
+  }
+  progress.print_summary();
   Ok(())
 }
 
 fn main() {
   better_panic::install();
+  init_logger();
 
   match run() {
     Ok(()) => {}
     Err(e) => error::print_error(&e),
   }
+}
+
+fn init_logger() {
+  if env::var("RUST_LOG").is_err() {
+    env::set_var("RUST_LOG", "info");
+  }
+  pretty_env_logger::init();
 }
 
 fn run() -> Result<(), error::CliError> {
@@ -266,7 +282,7 @@ fn run() -> Result<(), error::CliError> {
   cli.enc.time_base = video_info.time_base;
   let cfg = Config { enc: cli.enc, threads: cli.threads };
 
-  eprintln!(
+  info!(
     "{}x{} @ {}/{} fps",
     video_info.width,
     video_info.height,
@@ -303,7 +319,7 @@ fn run() -> Result<(), error::CliError> {
             std::process::exit(128 + sig);
           }
           e.store(true, Ordering::SeqCst);
-          eprintln!("\rExit requested, flushing.\n");
+          info!("\rExit requested, flushing.\n");
         })
         .expect("Cannot register the signal hooks");
       }

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -136,12 +136,12 @@ impl ProgressInfo {
       return 0;
     }
     self
-        .frame_info
-        .iter()
-        .filter(|frame| frame.frame_type == frame_type)
-        .map(|frame| frame.size)
-        .sum::<usize>()
-        / count
+      .frame_info
+      .iter()
+      .filter(|frame| frame.frame_type == frame_type)
+      .map(|frame| frame.size)
+      .sum::<usize>()
+      / count
   }
 
   pub fn print_summary(&self) {
@@ -170,14 +170,14 @@ impl ProgressInfo {
   fn print_video_psnr(&self) {
     info!("----------");
     let psnr_y =
-        self.frame_info.iter().map(|fi| fi.psnr.unwrap().0).sum::<f64>()
-            / self.frame_info.len() as f64;
+      self.frame_info.iter().map(|fi| fi.psnr.unwrap().0).sum::<f64>()
+        / self.frame_info.len() as f64;
     let psnr_u =
-        self.frame_info.iter().map(|fi| fi.psnr.unwrap().1).sum::<f64>()
-            / self.frame_info.len() as f64;
+      self.frame_info.iter().map(|fi| fi.psnr.unwrap().1).sum::<f64>()
+        / self.frame_info.len() as f64;
     let psnr_v =
-        self.frame_info.iter().map(|fi| fi.psnr.unwrap().2).sum::<f64>()
-            / self.frame_info.len() as f64;
+      self.frame_info.iter().map(|fi| fi.psnr.unwrap().2).sum::<f64>()
+        / self.frame_info.len() as f64;
     info!(
       "Mean PSNR: Y: {:.4}  Cb: {:.4}  Cr: {:.4}  Avg: {:.4}",
       psnr_y,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1933,7 +1933,6 @@ impl FieldMap {
   /// Print the field the address belong to
   fn lookup(&self, addr: usize) {
     for (name, start, end) in &self.map {
-      // eprintln!("{} {} {} val {}", name, start, end, addr);
       if addr >= *start && addr < *end {
         println!(" CDF {}", name);
         println!();

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2781,7 +2781,7 @@ fn encode_tile_group<T: Pixel>(
   }
 
   if fi.config.train_rdo {
-    eprintln!("train rdo");
+    info!("Training RDO");
     for rdo_tracker in &rdo_trackers {
       fs.t.merge_in(&rdo_tracker);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@
 #[macro_use]
 extern crate pretty_assertions;
 
+#[macro_use]
+extern crate log;
+
 #[cfg(any(cargo_c, feature = "capi"))]
 pub mod capi;
 


### PR DESCRIPTION
Split from #1620

The log level can be toggled using the RUST_LOG
environment variable, e.g. set to `RUST_LOG=debug`
for local debugging. This also enables us to add
e.g. debug! statements throughout the crate that
we wouldn't want users to see in production, but
would generally be useful to a rav1e developer.