### PR TITLE
Fix documentation for speed levels 9 and 10

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -336,8 +336,8 @@ impl SpeedSettings {
   /// Set the speed setting according to a numeric speed preset.
   ///
   /// The speed settings vary depending on speed value from 0 to 10.
-  /// - 10 (fastest): min block size 64x64, TX domain distortion, fast deblock, no scenechange detection.
-  /// - 9: min block size 64x64, TX domain distortion, fast deblock.
+  /// - 10 (fastest): min block size 64x64, reduced TX set, TX domain distortion, fast deblock, no scenechange detection.
+  /// - 9: min block size 64x64, reduced TX set, TX domain distortion, fast deblock.
   /// - 8: min block size 8x8, reduced TX set, TX domain distortion, fast deblock.
   /// - 7: min block size 8x8, reduced TX set, TX domain distortion.
   /// - 6: min block size 8x8, reduced TX set, TX domain distortion.

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -129,9 +129,9 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
         .long_help("Speed level (0 is best quality, 10 is fastest)\n\
         Speeds 10 and 0 are extremes and are generally not recommended\n\
         - 10 (fastest):\n\
-        Min block size 64x64, TX domain distortion, fast deblock, no scenechange detection\n\
+        Min block size 64x64, reduced TX set, TX domain distortion, fast deblock, no scenechange detection\n\
         - 9:\n\
-        Min block size 64x64, TX domain distortion, fast deblock\n\
+        Min block size 64x64, reduced TX set, TX domain distortion, fast deblock\n\
         - 8:\n\
         Min block size 8x8, reduced TX set, TX domain distortion, fast deblock\n\
         - 7:\n\


### PR DESCRIPTION
The speed settings had reduced TX set enabled, but it was not
documented as such.