### PR TITLE
Fix for #1601, #1611 and #1629 and possibly #1608

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3603,7 +3603,8 @@ impl<'a> ContextWriter<'a> {
     if !fi.allow_intrabc {
       // TODO: also disallow if lossless
       let rp = &mut rs.planes[pli];
-      if let Some(filter) = rp.restoration_unit(sbo).map(|ru| ru.filter) {
+      if let Some(filter) = rp.restoration_unit(sbo, true).map(|ru| ru.filter)
+      {
         match filter {
           RestorationFilter::None => match rp.rp_cfg.lrf_type {
             RESTORE_WIENER => {

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -574,9 +574,8 @@ macro_rules! test_chroma_sampling {
 
 test_chroma_sampling! {(420, ChromaSampling::Cs420), (422, ChromaSampling::Cs422), (444, ChromaSampling::Cs444)}
 
-// FIXME: #1601
-//#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
-//#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
 fn tile_encoding_with_stretched_restoration_units(decoder: &str) {
   let limit = 5;
   let w = 256;

--- a/src/tiling/tiler.rs
+++ b/src/tiling/tiler.rs
@@ -312,8 +312,7 @@ pub mod test {
       ..Default::default()
     };
     let mut sequence = Sequence::new(&config).unwrap();
-    // FIXME: #1601
-    // smallest possible tiles smaller than smallest possible LRUs
+    // These tests are all assuming SB-sized LRUs, so set that.
     sequence.enable_large_lru = false;
     FrameInvariants::new(config, sequence)
   }


### PR DESCRIPTION
This patch set attempts to both improve cooperation between LRF and
tiling setup, but also eliminate several illegal configurations.

The patch strategy is to consistently eliminate evaluation of
'stretch' superblocks in RDO of LRUs for the loop restoration filter.
This primarily affects the case where a tile consists of
primarily/exclusively SBs that belong to an LRU stretched from some
other tile.