### PR TITLE
quantize: Bring back the very slightly smaller inter biasing

### DIFF
--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -241,9 +241,12 @@ impl QuantizationContext {
     // post-deadzoning.
     //
     // [1] https://people.xiph.org/~jm/notes/theoretical_results.pdf
-    self.dc_offset = self.dc_quant as i32 * 109 / 256;
-    self.ac_offset0 = self.ac_quant as i32 * 98 / 256;
-    self.ac_offset1 = self.ac_quant as i32 * 109 / 256;
+    self.dc_offset =
+      self.dc_quant as i32 * (if is_intra { 109 } else { 108 }) / 256;
+    self.ac_offset0 =
+      self.ac_quant as i32 * (if is_intra { 98 } else { 97 }) / 256;
+    self.ac_offset1 =
+      self.ac_quant as i32 * (if is_intra { 109 } else { 108 }) / 256;
     self.ac_offset_eob =
       self.ac_quant as i32 * (if is_intra { 88 } else { 44 }) / 256;
   }


### PR DESCRIPTION
I had originally merged them since they were only 1/256 different, but it seems it actually does make a difference.

AWCY Link: https://beta.arewecompressedyet.com/?job=master-cc170c2a17675aae6fdcfd12ecc97eaeba90b974&job=deadzoning1%402019-09-02T14%3A31%3A02.785Z

Based on that AWCY link, do you guys think it's worth bringing them back / merging this PR?