### PR TITLE
Un-break reservoir constraints

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -173,7 +173,7 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
     )
     .arg(
       Arg::with_name("RESERVOIR_FRAME_DELAY")
-        .help("Number of frames over which rate control should distribute the reservoir [default: max(240, 1.5x keyint)]\n\
+        .help("Number of frames over which rate control should distribute the reservoir [default: min(240, 1.5x keyint)]\n\
          A minimum value of 12 is enforced.")
         .long("reservoir-frame-delay")
         .alias("reservoir_frame_delay")

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -627,7 +627,7 @@ impl RCState {
     let reservoir_frame_delay = if maybe_reservoir_frame_delay.is_some() {
       maybe_reservoir_frame_delay.unwrap().max(12)
     } else {
-      ((max_key_frame_interval.checked_mul(3)?) >> 1).max(240)
+      ((max_key_frame_interval.checked_mul(3)?) >> 1).min(240)
     };
     // TODO: What are the limits on these?
     let npixels = (frame_width as i64) * (frame_height as i64);

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -616,17 +616,19 @@ impl RCState {
     ac_qi_min: u8, max_key_frame_interval: i32,
     maybe_reservoir_frame_delay: Option<i32>,
   ) -> Option<RCState> {
-    // The default buffer size is set equal to 1.5x the keyframe interval.
-    // We enforce a minimum of 12 and a maximum of 240.
+    // The default buffer size is set equal to 1.5x the keyframe interval, or 240
+    //  frames; whichsever is smaller.
+    // For user set values, we enforce a minimum of 12.
     // The interval is short enough to allow reaction, but long enough to allow
     //  looking into the next GOP (avoiding the case where the last frames
     //  before an I-frame get starved), in most cases.
     // The 12 frame minimum gives us some chance to distribute bit estimation
     //  errors in the worst case.
-    let reservoir_frame_delay = maybe_reservoir_frame_delay
-      .unwrap_or(max_key_frame_interval.checked_mul(3)? >> 1)
-      .max(12)
-      .min(240);
+    let reservoir_frame_delay = if maybe_reservoir_frame_delay.is_some() {
+      maybe_reservoir_frame_delay.unwrap().max(12)
+    } else {
+      ((max_key_frame_interval.checked_mul(3)?) >> 1).max(240)
+    };
     // TODO: What are the limits on these?
     let npixels = (frame_width as i64) * (frame_height as i64);
     // Insane framerates or frame sizes mean insane bitrates.

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -617,7 +617,7 @@ impl RCState {
     maybe_reservoir_frame_delay: Option<i32>,
   ) -> Option<RCState> {
     // The default buffer size is set equal to 1.5x the keyframe interval, or 240
-    //  frames; whichsever is smaller, with a minimum of 12.
+    //  frames; whichever is smaller, with a minimum of 12.
     // For user set values, we enforce a minimum of 12.
     // The interval is short enough to allow reaction, but long enough to allow
     //  looking into the next GOP (avoiding the case where the last frames

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -617,18 +617,20 @@ impl RCState {
     maybe_reservoir_frame_delay: Option<i32>,
   ) -> Option<RCState> {
     // The default buffer size is set equal to 1.5x the keyframe interval, or 240
-    //  frames; whichsever is smaller.
+    //  frames; whichsever is smaller, with a minimum of 12.
     // For user set values, we enforce a minimum of 12.
     // The interval is short enough to allow reaction, but long enough to allow
     //  looking into the next GOP (avoiding the case where the last frames
     //  before an I-frame get starved), in most cases.
     // The 12 frame minimum gives us some chance to distribute bit estimation
     //  errors in the worst case.
-    let reservoir_frame_delay = if maybe_reservoir_frame_delay.is_some() {
-      maybe_reservoir_frame_delay.unwrap().max(12)
+    let reservoir_frame_delay = if let Some(rfd) = maybe_reservoir_frame_delay
+    {
+      rfd
     } else {
       ((max_key_frame_interval.checked_mul(3)?) >> 1).min(240)
-    };
+    }
+    .max(12);
     // TODO: What are the limits on these?
     let npixels = (frame_width as i64) * (frame_height as i64);
     // Insane framerates or frame sizes mean insane bitrates.


### PR DESCRIPTION
The previous fix (#1637) was incorrect and removes part of the entire point of exposing it as an API (I should know... I added it). Capping to 240 makes no sense for user input... it make about as much sense as capping VBV buffer and maxrate in H.264. Maybe I want a 30 second frame reservoir. Maybe my frame rate isn't 24. This is also important for 2-pass, because with a capped reservori delay, 2nd pass could only hae the option of "240 frames or less" or "the whole file", which is not sufficient.

This PR reverts that change and makes the code match what the comment actually says (and what was actually asked for by @tdaede in #1324), as well as enforces a minimum of 12 for the default too.

#1637 was merged without any of the people who actually wrote this part of the code looking at it, which is not ideal. It was submitted in the middle of the night (for my timezone) and merged before I even got to a PC this morning.