### PR TITLE
Extract Config validation into a function

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -43,7 +43,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
     speed_settings: SpeedSettings::from_preset(10),
     ..Default::default()
   };
-  let sequence = Sequence::new(&Default::default()).unwrap();
+  let sequence = Sequence::new(&Default::default());
   let mut fi = FrameInvariants::<u16>::new(config, sequence);
   let mut w = WriterEncoder::new();
   let mut fc = CDFContext::new(fi.base_q_idx);
@@ -128,7 +128,7 @@ fn cdef_frame_bench(b: &mut Bencher, width: usize, height: usize) {
     speed_settings: SpeedSettings::from_preset(10),
     ..Default::default()
   };
-  let sequence = Sequence::new(&Default::default()).unwrap();
+  let sequence = Sequence::new(&Default::default());
   let fi = FrameInvariants::<u16>::new(config, sequence);
   let fb = FrameBlocks::new(fi.sb_width * 16, fi.sb_height * 16);
   let mut fs = FrameState::new(&fi);
@@ -156,7 +156,7 @@ fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
     speed_settings: SpeedSettings::from_preset(10),
     ..Default::default()
   };
-  let sequence = Sequence::new(&Default::default()).unwrap();
+  let sequence = Sequence::new(&Default::default());
   let fi = FrameInvariants::<u16>::new(config, sequence);
   let mut fs = FrameState::new(&fi);
   let mut ts = fs.as_tile_state_mut();

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18,6 +18,7 @@ pub use color::*;
 
 use arrayvec::ArrayVec;
 use bitstream_io::*;
+use err_derive::Error;
 use itertools::Itertools;
 use num_derive::*;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -791,7 +792,7 @@ pub struct Context<T: Pixel> {
 /// Status that can be returned by [`Context`] functions.
 ///
 /// [`Context`]: struct.Context.html
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Error)]
 pub enum EncoderStatus {
   /// The encoder needs more data to produce an output packet.
   ///
@@ -799,6 +800,7 @@ pub enum EncoderStatus {
   /// enabled.
   ///
   /// [`Context::receive_packet()`]: struct.Context.html#method.receive_packet
+  #[error(display = "need more data")]
   NeedMoreData,
   /// There are enough frames in the queue.
   ///
@@ -806,6 +808,7 @@ pub enum EncoderStatus {
   /// after the encoder has been flushed.
   ///
   /// [`Context::send_frame()`]: struct.Context.html#method.send_frame
+  #[error(display = "enough data")]
   EnoughData,
   /// The encoder has already produced the number of frames requested.
   ///
@@ -813,10 +816,13 @@ pub enum EncoderStatus {
   /// been processed or the frame limit had been reached.
   ///
   /// [`Context::receive_packet()`]: struct.Context.html#method.receive_packet
+  #[error(display = "limit reached")]
   LimitReached,
   /// A frame had been encoded but not emitted yet.
+  #[error(display = "encoded")]
   Encoded,
   /// Generic fatal error.
+  #[error(display = "failure")]
   Failure,
   /// A frame was encoded in the first pass of a 2-pass encode, but its stats
   /// data was not retrieved with [`Context::twopass_out()`], or not enough
@@ -824,6 +830,7 @@ pub enum EncoderStatus {
   /// the next frame.
   ///
   /// [`Context::twopass_out()`]: struct.Context.html#method.twopass_out
+  #[error(display = "not ready")]
   NotReady,
 }
 

--- a/src/bin/error.rs
+++ b/src/bin/error.rs
@@ -6,6 +6,8 @@ pub enum CliError {
   Io { msg: String, io: std::io::Error },
   #[error(display = "{}: {:?}", msg, status)]
   Enc { msg: String, status: rav1e::EncoderStatus },
+  #[error(display = "{}: {}", msg, status)]
+  Config { msg: String, status: rav1e::InvalidConfig },
   #[error(display = "Cannot parse option `{}`: {}", opt, err)]
   ParseInt { opt: String, err: std::num::ParseIntError },
 }
@@ -23,6 +25,12 @@ impl ToError for std::io::Error {
 impl ToError for rav1e::EncoderStatus {
   fn context(self, msg: &str) -> CliError {
     CliError::Enc { msg: msg.to_owned(), status: self }
+  }
+}
+
+impl ToError for rav1e::InvalidConfig {
+  fn context(self, msg: &str) -> CliError {
+    CliError::Config { msg: msg.to_owned(), status: self }
   }
 }
 

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -671,7 +671,7 @@ mod test {
       speed_settings: SpeedSettings::from_preset(10),
       ..Default::default()
     };
-    let sequence = Sequence::new(&config).unwrap();
+    let sequence = Sequence::new(&config);
     let fi = FrameInvariants::new(config, sequence);
     (frame, fi)
   }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -160,12 +160,11 @@ pub struct Sequence {
 }
 
 impl Sequence {
-  pub fn new(config: &EncoderConfig) -> Option<Sequence> {
+  pub fn new(config: &EncoderConfig) -> Sequence {
     let width_bits = 32 - (config.width as u32).leading_zeros();
     let height_bits = 32 - (config.height as u32).leading_zeros();
-    if width_bits > 16 || height_bits > 16 {
-      return None;
-    }
+    assert!(width_bits <= 16);
+    assert!(height_bits <= 16);
 
     let profile = if config.bit_depth == 12
       || config.chroma_sampling == ChromaSampling::Cs422
@@ -188,7 +187,7 @@ impl Sequence {
       tier[i] = 0;
     }
 
-    Some(Sequence {
+    Sequence {
       profile,
       num_bits_width: width_bits,
       num_bits_height: height_bits,
@@ -232,7 +231,7 @@ impl Sequence {
       tier,
       film_grain_params_present: false,
       separate_uv_delta_q: true,
-    })
+    }
   }
 
   pub fn get_relative_dist(&self, a: u32, b: u32) -> i32 {
@@ -311,7 +310,7 @@ impl Sequence {
 
 impl Default for Sequence {
   fn default() -> Self {
-    Sequence::new(&EncoderConfig::default()).unwrap()
+    Sequence::new(&EncoderConfig::default())
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ mod header;
 
 use crate::encoder::*;
 
-pub use crate::api::{Config, Context, EncoderStatus, Packet};
+pub use crate::api::{Config, Context, EncoderStatus, InvalidConfig, Packet};
 pub use crate::frame::Frame;
 pub use crate::util::{CastFromPrimitive, Pixel, PixelType};
 
@@ -121,7 +121,8 @@ pub use crate::api::color;
 /// Encoder configuration and settings
 pub mod config {
   pub use crate::api::{
-    Config, EncoderConfig, PredictionModesSetting, SpeedSettings,
+    Config, EncoderConfig, InvalidConfig, PredictionModesSetting,
+    SpeedSettings,
   };
 }
 

--- a/src/tiling/tiler.rs
+++ b/src/tiling/tiler.rs
@@ -311,7 +311,7 @@ pub mod test {
       chroma_sampling,
       ..Default::default()
     };
-    let mut sequence = Sequence::new(&config).unwrap();
+    let mut sequence = Sequence::new(&config);
     // These tests are all assuming SB-sized LRUs, so set that.
     sequence.enable_large_lru = false;
     FrameInvariants::new(config, sequence)


### PR DESCRIPTION
Please comment on the design.

- I have to store the maximal values to print them, unfortunately; I reported an issue into `err-derive` about this: https://gitlab.com/torkleyy/err-derive/issues/5
- Do we want to expose this in the C API somehow?
- Do we want to clearly expose all the min/max values as public constants or something?
- The hidden variant is added so that it's possible for us to add more variants without it being a breaking change (as more checks are added for example).
- Error is implemented for `EncoderStatus` so that it's possible to convert it to `Box<dyn Error>` (see doctests).

I don't _particularly_ like the magic number checks instead of checked operations, but on the other hand it results in clear range guarantees (rather than "we changed the order of operations in this update and suddenly this config value is no longer allowed").