### PR TITLE
Fix tx size rdo

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -547,7 +547,7 @@ pub fn rdo_tx_size_type<T: Pixel>(
       tx_size.sqr() <= TxSize::TX_32X32 || tx_type == TxType::DCT_DCT
     );
 
-    tx_size = sub_tx_size_map[best_tx_size as usize];
+    tx_size = sub_tx_size_map[tx_size as usize];
     if tx_size == best_tx_size {
       break;
     };

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -547,12 +547,14 @@ pub fn rdo_tx_size_type<T: Pixel>(
       tx_size.sqr() <= TxSize::TX_32X32 || tx_type == TxType::DCT_DCT
     );
 
-    tx_size = sub_tx_size_map[tx_size as usize];
-    if tx_size == best_tx_size {
-      break;
-    };
-
+    let next_tx_size = sub_tx_size_map[tx_size as usize];
     cw.rollback(&cw_checkpoint);
+
+    if next_tx_size == tx_size {
+      break;
+    } else {
+      tx_size = next_tx_size;
+    };
   }
 
   (best_tx_size, best_tx_type)


### PR DESCRIPTION
FIx 1:  At speed 0 and 1, this fix gives gains of PSNR BD-Rate, -0.1537% and  -0.1763%, resp.
Fix 2: Enc time is slightly reduced.

[AWCY, speed 0, 1 frame](https://beta.arewecompressedyet.com/?job=ref_master_s0_psnr_1f%402019-09-06T22%3A51%3A05.284Z&job=fix2_tx_size_s0_psnr_1f%402019-09-06T23%3A16%3A16.803Z)

[AWCY, speed 1, 1 frame](https://beta.arewecompressedyet.com/?job=ref_master_s1_psnr_1f%402019-09-06T22%3A52%3A00.413Z&job=fix2_tx_size_s1_psnr_1f%402019-09-06T23%3A16%3A30.126Z)
