### PR TITLE
Add explicit bounds checks in txfm functions

### DIFF
--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -292,6 +292,8 @@ fn daala_fdct_ii_4<T: TxOperations>(
 }
 
 pub fn daala_fdct4<T: TxOperations>(input: &[T], output: &mut [T]) {
+  assert!(input.len() >= 4);
+  assert!(output.len() >= 4);
   let mut temp_out: [T; 4] = [T::default(); 4];
   daala_fdct_ii_4(input[0], input[1], input[2], input[3], &mut temp_out);
 
@@ -302,6 +304,9 @@ pub fn daala_fdct4<T: TxOperations>(input: &[T], output: &mut [T]) {
 }
 
 pub fn daala_fdst_vii_4<T: TxOperations>(input: &[T], output: &mut [T]) {
+  assert!(input.len() >= 4);
+  assert!(output.len() >= 4);
+
   let q0 = input[0];
   let q1 = input[1];
   let q2 = input[2];
@@ -407,6 +412,8 @@ fn daala_fdct_ii_8<T: TxOperations>(
 }
 
 pub fn daala_fdct8<T: TxOperations>(input: &[T], output: &mut [T]) {
+  assert!(input.len() >= 8);
+  assert!(output.len() >= 8);
   let mut temp_out: [T; 8] = [T::default(); 8];
   daala_fdct_ii_8(
     input[0],
@@ -486,6 +493,8 @@ fn daala_fdst_iv_8<T: TxOperations>(
 }
 
 pub fn daala_fdst8<T: TxOperations>(input: &[T], output: &mut [T]) {
+  assert!(input.len() >= 8);
+  assert!(output.len() >= 8);
   let mut temp_out: [T; 8] = [T::default(); 8];
   daala_fdst_iv_8(
     input[0],
@@ -629,6 +638,8 @@ fn daala_fdct_ii_16<T: TxOperations>(
 }
 
 fn daala_fdct16<T: TxOperations>(input: &[T], output: &mut [T]) {
+  assert!(input.len() >= 16);
+  assert!(output.len() >= 16);
   let mut temp_out: [T; 16] = [T::default(); 16];
   daala_fdct_ii_16(
     input[0],
@@ -793,6 +804,8 @@ fn daala_fdst_iv_16<T: TxOperations>(
 }
 
 fn daala_fdst16<T: TxOperations>(input: &[T], output: &mut [T]) {
+  assert!(input.len() >= 16);
+  assert!(output.len() >= 16);
   let mut temp_out: [T; 16] = [T::default(); 16];
   daala_fdst_iv_16(
     input[0],
@@ -1054,6 +1067,8 @@ fn daala_fdct_ii_32<T: TxOperations>(
 }
 
 fn daala_fdct32<T: TxOperations>(input: &[T], output: &mut [T]) {
+  assert!(input.len() >= 32);
+  assert!(output.len() >= 32);
   let mut temp_out: [T; 32] = [T::default(); 32];
   daala_fdct_ii_32(
     input[0],
@@ -1465,6 +1480,8 @@ fn daala_fdst_iv_32_asym<T: TxOperations>(
 
 #[allow(clippy::identity_op)]
 fn daala_fdct64<T: TxOperations>(input: &[T], output: &mut [T]) {
+  assert!(input.len() >= 64);
+  assert!(output.len() >= 64);
   // Use arrays to avoid ridiculous variable names
   let mut asym: [(T, T); 32] = [<(T, T)>::default(); 32];
   let mut half: [T; 32] = [T::default(); 32];

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -30,6 +30,9 @@ static SINPI_INV: [i32; 5] = [0, 1321, 2482, 3344, 3803];
 const INV_COS_BIT: usize = 12;
 
 pub fn av1_idct4(input: &[i32], output: &mut [i32], range: usize) {
+  assert!(input.len() >= 4);
+  assert!(output.len() >= 4);
+
   // stage 1
   let stg1 = [input[0], input[2], input[1], input[3]];
 
@@ -49,6 +52,9 @@ pub fn av1_idct4(input: &[i32], output: &mut [i32], range: usize) {
 }
 
 pub fn av1_iadst4(input: &[i32], output: &mut [i32], _range: usize) {
+  assert!(input.len() >= 4);
+  assert!(output.len() >= 4);
+
   let bit = 12;
 
   let x0 = input[0];
@@ -94,12 +100,16 @@ pub fn av1_iadst4(input: &[i32], output: &mut [i32], _range: usize) {
 }
 
 pub fn av1_iidentity4(input: &[i32], output: &mut [i32], _range: usize) {
-  for i in 0..4 {
-    output[i] = round_shift(SQRT2 * input[i], 12);
-  }
+  output[..4]
+    .iter_mut()
+    .zip(input[..4].iter())
+    .for_each(|(outp, inp)| *outp = round_shift(SQRT2 * *inp, 12));
 }
 
 pub fn av1_idct8(input: &[i32], output: &mut [i32], range: usize) {
+  assert!(input.len() >= 8);
+  assert!(output.len() >= 8);
+
   // call idct4
   let temp_in = [input[0], input[2], input[4], input[6]];
   let mut temp_out: [i32; 4] = [0; 4];
@@ -146,6 +156,9 @@ pub fn av1_idct8(input: &[i32], output: &mut [i32], range: usize) {
 }
 
 pub fn av1_iadst8(input: &[i32], output: &mut [i32], range: usize) {
+  assert!(input.len() >= 8);
+  assert!(output.len() >= 8);
+
   // stage 1
   let stg1 = [
     input[7], input[0], input[5], input[2], input[3], input[4], input[1],
@@ -224,12 +237,16 @@ pub fn av1_iadst8(input: &[i32], output: &mut [i32], range: usize) {
 }
 
 pub fn av1_iidentity8(input: &[i32], output: &mut [i32], _range: usize) {
-  for i in 0..8 {
-    output[i] = 2 * input[i];
-  }
+  output[..8]
+    .iter_mut()
+    .zip(input[..8].iter())
+    .for_each(|(outp, inp)| *outp = 2 * *inp);
 }
 
 fn av1_idct16(input: &[i32], output: &mut [i32], range: usize) {
+  assert!(input.len() >= 16);
+  assert!(output.len() >= 16);
+
   // call idct8
   let temp_in = [
     input[0], input[2], input[4], input[6], input[8], input[10], input[12],
@@ -324,6 +341,9 @@ fn av1_idct16(input: &[i32], output: &mut [i32], range: usize) {
 }
 
 fn av1_iadst16(input: &[i32], output: &mut [i32], range: usize) {
+  assert!(input.len() >= 16);
+  assert!(output.len() >= 16);
+
   // stage 1
   let stg1 = [
     input[15], input[0], input[13], input[2], input[11], input[4], input[9],
@@ -491,12 +511,16 @@ fn av1_iadst16(input: &[i32], output: &mut [i32], range: usize) {
 }
 
 fn av1_iidentity16(input: &[i32], output: &mut [i32], _range: usize) {
-  for i in 0..16 {
-    output[i] = round_shift(SQRT2 * 2 * input[i], 12);
-  }
+  output[..16]
+    .iter_mut()
+    .zip(input[..16].iter())
+    .for_each(|(outp, inp)| *outp = round_shift(SQRT2 * 2 * *inp, 12));
 }
 
 fn av1_idct32(input: &[i32], output: &mut [i32], range: usize) {
+  assert!(input.len() >= 32);
+  assert!(output.len() >= 32);
+
   // stage 1;
   let stg1 = [
     input[0], input[16], input[8], input[24], input[4], input[20], input[12],
@@ -794,12 +818,16 @@ fn av1_idct32(input: &[i32], output: &mut [i32], range: usize) {
 }
 
 fn av1_iidentity32(input: &[i32], output: &mut [i32], _range: usize) {
-  for i in 0..32 {
-    output[i] = input[i] * 4;
-  }
+  output[..32]
+    .iter_mut()
+    .zip(input[..32].iter())
+    .for_each(|(outp, inp)| *outp = 4 * *inp);
 }
 
 fn av1_idct64(input: &[i32], output: &mut [i32], range: usize) {
+  assert!(input.len() >= 64);
+  assert!(output.len() >= 64);
+
   // stage 1;
   let stg1 = [
     input[0], input[32], input[16], input[48], input[8], input[40], input[24],
@@ -1548,6 +1576,7 @@ mod nasm {
 
         // Transpose the input.
         // TODO: should be possible to remove changing how coeffs are written
+        assert!(input.len() >= coeff_w * coeff_h);
         for j in 0..coeff_h {
           for i in 0..coeff_w {
             coeff16.array[i * coeff_h + j] = input[j * coeff_w + i] as i16;


### PR DESCRIPTION
Provides about 2.5% overall speedup at -s1.

When manually accessing slice indices in series,
the compiler cannot determine the highest index you
are going to access, so it adds a bounds check around
every access. Many transform functions were suffering
from this. For example, our dct16 function would have
32 extra branches from this, 16 for the input array
and 16 for the output array. By adding explicit bounds
checks at the start of the function, or by using an iterator,
the compiler knows that it can elide the other bounds
checks, and you end up with 2 bounds checks per function.
This also allows the compiler to auto-vectorize the code
in these functions where it would have previously been
unable to do so.

For example, this terrible compiler concoction:
```asm
 pub fn av1_iidentity4(input: &[i32], output: &mut [i32], _range: usize) {
 push    rax
 mov     rax, rsi
 test    rsi, rsi
 je      .LBB269_1
 test    rcx, rcx
 je      .LBB269_3
 imul    esi, dword, ptr, [rdi], 5793
 add     esi, 2048
 sar     esi, 12
 mov     dword, ptr, [rdx], esi
 cmp     rax, 1
 jbe     .LBB269_6
 cmp     rcx, 2
 jb      .LBB269_9
 imul    esi, dword, ptr, [rdi, +, 4], 5793
 add     esi, 2048
 sar     esi, 12
 mov     dword, ptr, [rdx, +, 4], esi
 cmp     rax, 3
 jb      .LBB269_11
 cmp     rcx, 3
 jb      .LBB269_13
 imul    esi, dword, ptr, [rdi, +, 8], 5793
 add     esi, 2048
 sar     esi, 12
 mov     dword, ptr, [rdx, +, 8], esi
 cmp     rax, 4
 jb      .LBB269_15
 cmp     rcx, 4
 jb      .LBB269_17
 imul    eax, dword, ptr, [rdi, +, 12], 5793
 add     eax, 2048
 sar     eax, 12
 mov     dword, ptr, [rdx, +, 12], eax
 pop     rax
 ret
.LBB269_1:
 xor     esi, esi
 lea     rdi, [rip, +, .Lanon.38381e8308fb2a3452d94c1fb8d5c13e.247]
 mov     rdx, rax
 call    qword, ptr, [rip, +, _ZN4core9panicking18panic_bounds_check17h0537ade040df571eE@GOTPCREL]
 ud2
.LBB269_3:
 xor     esi, esi
 lea     rdi, [rip, +, .Lanon.38381e8308fb2a3452d94c1fb8d5c13e.248]
 mov     rdx, rcx
 call    qword, ptr, [rip, +, _ZN4core9panicking18panic_bounds_check17h0537ade040df571eE@GOTPCREL]
 ud2
.LBB269_6:
 mov     esi, 1
 lea     rdi, [rip, +, .Lanon.38381e8308fb2a3452d94c1fb8d5c13e.247]
 mov     rdx, rax
 call    qword, ptr, [rip, +, _ZN4core9panicking18panic_bounds_check17h0537ade040df571eE@GOTPCREL]
 ud2
.LBB269_9:
 mov     esi, 1
 lea     rdi, [rip, +, .Lanon.38381e8308fb2a3452d94c1fb8d5c13e.248]
 mov     rdx, rcx
 call    qword, ptr, [rip, +, _ZN4core9panicking18panic_bounds_check17h0537ade040df571eE@GOTPCREL]
 ud2
.LBB269_11:
 mov     esi, 2
 lea     rdi, [rip, +, .Lanon.38381e8308fb2a3452d94c1fb8d5c13e.247]
 mov     rdx, rax
 call    qword, ptr, [rip, +, _ZN4core9panicking18panic_bounds_check17h0537ade040df571eE@GOTPCREL]
 ud2
.LBB269_13:
 mov     esi, 2
 lea     rdi, [rip, +, .Lanon.38381e8308fb2a3452d94c1fb8d5c13e.248]
 mov     rdx, rcx
 call    qword, ptr, [rip, +, _ZN4core9panicking18panic_bounds_check17h0537ade040df571eE@GOTPCREL]
 ud2
.LBB269_15:
 mov     esi, 3
 lea     rdi, [rip, +, .Lanon.38381e8308fb2a3452d94c1fb8d5c13e.247]
 mov     rdx, rax
 call    qword, ptr, [rip, +, _ZN4core9panicking18panic_bounds_check17h0537ade040df571eE@GOTPCREL]
 ud2
.LBB269_17:
 mov     esi, 3
 lea     rdi, [rip, +, .Lanon.38381e8308fb2a3452d94c1fb8d5c13e.248]
 mov     rdx, rcx
 call    qword, ptr, [rip, +, _ZN4core9panicking18panic_bounds_check17h0537ade040df571eE@GOTPCREL]
 ud2
```

Would become this glorious vectorized assembly:
```asm
 pub fn av1_iidentity4(input: &[i32], output: &mut [i32], _range: usize) {
 push    rax
 cmp     rcx, 3
 jbe     .LBB269_3
 cmp     rsi, 4
 jb      .LBB269_2
 movdqu  xmm0, xmmword, ptr, [rdi]
 movdqa  xmm1, xmmword, ptr, [rip, +, .LCPI269_0]
 pshufd  xmm2, xmm0, 245
 pmuludq xmm0, xmm1
 pshufd  xmm0, xmm0, 232
 pmuludq xmm2, xmm1
 pshufd  xmm1, xmm2, 232
 punpckldq xmm0, xmm1
 paddd   xmm0, xmmword, ptr, [rip, +, .LCPI269_1]
 psrad   xmm0, 12
 movdqu  xmmword, ptr, [rdx], xmm0
 pop     rax
 ret
.LBB269_3:
 mov     edi, 4
 mov     rsi, rcx
 call    qword, ptr, [rip, +, _ZN4core5slice20slice_index_len_fail17h4544fc57f3d8a7a0E@GOTPCREL]
 ud2
.LBB269_2:
 mov     edi, 4
 call    qword, ptr, [rip, +, _ZN4core5slice20slice_index_len_fail17h4544fc57f3d8a7a0E@GOTPCREL]
 ud2
```