### PR TITLE
Cleanup travis and reduce the amount cached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,37 +18,32 @@ addons:
       - libvulkan-dev
 before_install:
   - export BUILD_DIR="$TRAVIS_HOME/.build"
+  - export DEPS_DIR="$TRAVIS_HOME/.local"
   - mkdir -p "$BUILD_DIR"
+  - mkdir -p "$DEPS_DIR/bin"
+  - mkdir -p "$DEPS_DIR/lib/pkgconfig"
+  - export PATH="$PATH:$DEPS_DIR/bin"
+  - export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$DEPS_DIR/lib/pkgconfig:$DEPS_DIR/lib/x86_64-linux-gnu/pkgconfig"
+  - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEPS_DIR/lib:$DEPS_DIR/lib/x86_64-linux-gnu"
   - pip3 install meson
   - bash "$TRAVIS_BUILD_DIR/.travis/install-sccache.sh"
-  - export PATH="$PATH:$BUILD_DIR/sccache"
   - export RUSTC_WRAPPER=sccache
   - export SCCACHE_CACHE_SIZE=500M
   - export SCCACHE_DIR="$TRAVIS_HOME/.cache/sccache"
   - sccache --version
   - bash "$TRAVIS_BUILD_DIR/.travis/install-nasm.sh"
-  - export PATH="$PATH:$BUILD_DIR/nasm/bin"
-  - export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BUILD_DIR/nasm/lib/pkgconfig"
-  - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$BUILD_DIR/nasm/lib"
   - nasm --version
   - bash "$TRAVIS_BUILD_DIR/.travis/install-kcov.sh"
-  - export PATH="$PATH:$BUILD_DIR/kcov/bin"
   - kcov --version
   - bash "$TRAVIS_BUILD_DIR/.travis/install-aom.sh"
-  - export PATH="$PATH:$BUILD_DIR/aom/bin"
-  - export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BUILD_DIR/aom/lib/pkgconfig"
-  - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$BUILD_DIR/aom/lib"
-  - which aomenc
+  - aomenc --help | grep "AV1 Encoder"
   - bash "$TRAVIS_BUILD_DIR/.travis/install-dav1d.sh"
-  - export PATH="$PATH:$BUILD_DIR/dav1d/bin"
-  - export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BUILD_DIR/dav1d/lib/x86_64-linux-gnu/pkgconfig"
-  - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$BUILD_DIR/dav1d/lib/x86_64-linux-gnu"
   - dav1d --version
   - cd "$TRAVIS_BUILD_DIR"
 cache:
-  cargo: true
   directories:
-    - $TRAVIS_HOME/.build
+    - $TRAVIS_HOME/.cache/sccache
+    - $TRAVIS_HOME/.local
 
 after_script:
   - sccache -s

--- a/.travis/install-aom.sh
+++ b/.travis/install-aom.sh
@@ -3,17 +3,13 @@ set -ex
 
 AOM_VERSION="1.0.0-errata1"
 
-if [[ "$("$BUILD_DIR/aom/bin/aomenc" --help)" != *"AV1 Encoder $AOM_VERSION"* ]]; then
-  # Remove any old versions that might exist from the cache
-  rm -rf "$BUILD_DIR/aom"
-
-  mkdir -p "$BUILD_DIR/aom"
+if [[ "$(aomenc --help)" != *"AV1 Encoder $AOM_VERSION"* ]]; then
   git clone --depth 1 -b "v$AOM_VERSION" https://aomedia.googlesource.com/aom "aom-$AOM_VERSION"
   cd "aom-$AOM_VERSION"
   rm -rf CMakeCache.txt CMakeFiles
   mkdir -p .build
   cd .build
-  cmake -GNinja .. -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=0 -DENABLE_DOCS=0 -DCONFIG_LOWBITDEPTH=1 -DCMAKE_INSTALL_PREFIX="$BUILD_DIR/aom" -DCONFIG_PIC=1
+  cmake -GNinja .. -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=0 -DENABLE_DOCS=0 -DCONFIG_LOWBITDEPTH=1 -DCMAKE_INSTALL_PREFIX="$DEPS_DIR" -DCONFIG_PIC=1
   ninja && ninja install
 else
   echo "Using cached directory."

--- a/.travis/install-dav1d.sh
+++ b/.travis/install-dav1d.sh
@@ -3,22 +3,15 @@ set -ex
 
 DAV1D_VERSION="0.4.0"
 
-# needed to check if dav1d exists and is the right version
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$BUILD_DIR/dav1d/lib/x86_64-linux-gnu"
-
 # dav1d prints the version number to stderr
-if [ "$("$BUILD_DIR/dav1d/bin/dav1d" --version 2>&1 > /dev/null)" != "$DAV1D_VERSION" ]; then
-  # Remove any old versions that might exist from the cache
-  rm -rf "$BUILD_DIR/dav1d"
-
-  mkdir -p "$BUILD_DIR/dav1d"
+if [ "$(dav1d --version 2>&1 > /dev/null)" != "$DAV1D_VERSION" ]; then
   curl -L "https://code.videolan.org/videolan/dav1d/-/archive/$DAV1D_VERSION/dav1d-$DAV1D_VERSION.tar.gz" | tar xz
   cd "dav1d-$DAV1D_VERSION"
   # Tell meson where to look for nasm, because it doesn't respect our $PATH
-  export NASM_PATH="$BUILD_DIR/nasm/bin/nasm"
+  export NASM_PATH="$DEPS_DIR/bin/nasm"
   export NASM_PATH="${NASM_PATH//'/'/'\/'}"
   sed -i "s/nasm = find_program('nasm')/nasm = find_program(['nasm', '$NASM_PATH'])/g" meson.build
-  meson build --buildtype release --prefix "$BUILD_DIR/dav1d"
+  meson build --buildtype release --prefix "$DEPS_DIR"
   ninja -C build install
 else
   echo "Using cached directory."

--- a/.travis/install-kcov.sh
+++ b/.travis/install-kcov.sh
@@ -3,15 +3,11 @@ set -ex
 
 KCOV_VERSION="36"
 
-if [ "$("$BUILD_DIR/kcov/bin/kcov" --version)" != "kcov $KCOV_VERSION" ]; then
-  # Remove any old versions that might exist from the cache
-  rm -rf "$BUILD_DIR/kcov"
-
-  mkdir -p "$BUILD_DIR/kcov"
+if [ "$(kcov --version)" != "kcov $KCOV_VERSION" ]; then
   curl -L "https://github.com/SimonKagstrom/kcov/archive/v$KCOV_VERSION.tar.gz" | tar xz
   cd "kcov-$KCOV_VERSION"
   mkdir .build && cd .build
-  cmake -GNinja -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .. -DCMAKE_INSTALL_PREFIX="$BUILD_DIR/kcov" && ninja && ninja install
+  cmake -GNinja -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .. -DCMAKE_INSTALL_PREFIX="$DEPS_DIR" && ninja && ninja install
 else
   echo "Using cached directory."
 fi

--- a/.travis/install-nasm.sh
+++ b/.travis/install-nasm.sh
@@ -3,14 +3,10 @@ set -ex
 
 NASM_VERSION="2.14"
 
-if [[ "$("$BUILD_DIR/nasm/bin/nasm" --version)" != "NASM version $NASM_VERSION"* ]]; then
-  # Remove any old versions that might exist from the cache
-  rm -rf "$BUILD_DIR/nasm"
-
-  mkdir -p "$BUILD_DIR/nasm"
+if [[ "$(nasm --version)" != "NASM version $NASM_VERSION"* ]]; then
   curl -L "https://download.videolan.org/contrib/nasm/nasm-$NASM_VERSION.tar.gz" | tar xz
   cd "nasm-$NASM_VERSION"
-  ./configure CC='sccache gcc' --prefix="$BUILD_DIR/nasm" && make -j2 && make install
+  ./configure CC='sccache gcc' --prefix="$DEPS_DIR" && make -j2 && make install
 else
   echo "Using cached directory."
 fi

--- a/.travis/install-sccache.sh
+++ b/.travis/install-sccache.sh
@@ -3,13 +3,9 @@ set -ex
 
 SCCACHE_VERSION="0.2.10"
 
-if [ "$("$BUILD_DIR/sccache/sccache" --version)" != "sccache $SCCACHE_VERSION" ]; then
-  # Remove any old versions that might exist from the cache
-  rm -rf "$BUILD_DIR/sccache"
-  mkdir -p "$BUILD_DIR/sccache"
-
+if [ "$(sccache --version)" != "sccache $SCCACHE_VERSION" ]; then
   curl -L "https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz" | tar xz
-  mv "sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl/sccache" "$BUILD_DIR/sccache/sccache"
+  mv -f "sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl/sccache" "$DEPS_DIR/bin/sccache"
 else
   echo "Using cached directory."
 fi


### PR DESCRIPTION
The Minimum Rustc Version jobs were hanging due to taking too long to extract the cache. It appears that the overall cache size was over 14GB. This PR reduces the amount of files cached in order to attempt to relieve this issue, down to 1.2GB. Travis will now only cache the built binaries for dependencies we build ourselves, and only cache the sccache directory, instead of the target directory. These changes show significant speedups for the longer-running jobs (10% on average, but 50% on the Minimum Rustc job).