### PR TITLE
Search all intra modes in lookahead

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -32,7 +32,7 @@ use crate::encoder::*;
 use crate::frame::*;
 use crate::metrics::calculate_frame_psnr;
 use crate::partition::*;
-use crate::predict::PredictionMode;
+use crate::predict::RAV1E_INTRA_MODES;
 use crate::rate::RCState;
 use crate::rate::FRAME_NSUBTYPES;
 use crate::rate::FRAME_SUBTYPE_I;
@@ -1806,7 +1806,6 @@ impl<T: Pixel> ContextInner<T> {
           height: IMPORTANCE_BLOCK_SIZE,
         });
 
-        // TODO: other intra prediction modes.
         let edge_buf = get_intra_edges(
           &frame.planes[0].as_region(),
           TileBlockOffset(BlockOffset { x, y }),
@@ -1819,47 +1818,55 @@ impl<T: Pixel> ContextInner<T> {
           },
           TxSize::TX_8X8,
           fi.sequence.bit_depth,
-          Some(PredictionMode::DC_PRED),
+          None,
         );
 
-        let mut plane_after_prediction_region = plane_after_prediction
-          .region_mut(Area::Rect {
-            x: (x * IMPORTANCE_BLOCK_SIZE) as isize,
-            y: (y * IMPORTANCE_BLOCK_SIZE) as isize,
-            width: IMPORTANCE_BLOCK_SIZE,
-            height: IMPORTANCE_BLOCK_SIZE,
-          });
+        let bit_depth = self.config.bit_depth;
+        let intra_mode_set = RAV1E_INTRA_MODES;
+        let intra_cost = intra_mode_set
+          .iter()
+          .map(|&luma_mode| {
+            let mut plane_after_prediction_region = plane_after_prediction
+              .region_mut(Area::Rect {
+                x: (x * IMPORTANCE_BLOCK_SIZE) as isize,
+                y: (y * IMPORTANCE_BLOCK_SIZE) as isize,
+                width: IMPORTANCE_BLOCK_SIZE,
+                height: IMPORTANCE_BLOCK_SIZE,
+              });
 
-        PredictionMode::DC_PRED.predict_intra(
-          TileRect {
-            x: x * IMPORTANCE_BLOCK_SIZE,
-            y: y * IMPORTANCE_BLOCK_SIZE,
-            width: IMPORTANCE_BLOCK_SIZE,
-            height: IMPORTANCE_BLOCK_SIZE,
-          },
-          &mut plane_after_prediction_region,
-          TxSize::TX_8X8,
-          fi.sequence.bit_depth,
-          &[], // Not used by DC_PRED.
-          0,   // Not used by DC_PRED.
-          &edge_buf,
-        );
+            luma_mode.predict_intra(
+              TileRect {
+                x: x * IMPORTANCE_BLOCK_SIZE,
+                y: y * IMPORTANCE_BLOCK_SIZE,
+                width: IMPORTANCE_BLOCK_SIZE,
+                height: IMPORTANCE_BLOCK_SIZE,
+              },
+              &mut plane_after_prediction_region,
+              TxSize::TX_8X8,
+              fi.sequence.bit_depth,
+              &[], // Not used by luma modes.
+              0,   // Not used by luma modes.
+              &edge_buf,
+            );
 
-        let plane_after_prediction_region =
-          plane_after_prediction.region(Area::Rect {
-            x: (x * IMPORTANCE_BLOCK_SIZE) as isize,
-            y: (y * IMPORTANCE_BLOCK_SIZE) as isize,
-            width: IMPORTANCE_BLOCK_SIZE,
-            height: IMPORTANCE_BLOCK_SIZE,
-          });
+            let plane_after_prediction_region =
+              plane_after_prediction.region(Area::Rect {
+                x: (x * IMPORTANCE_BLOCK_SIZE) as isize,
+                y: (y * IMPORTANCE_BLOCK_SIZE) as isize,
+                width: IMPORTANCE_BLOCK_SIZE,
+                height: IMPORTANCE_BLOCK_SIZE,
+              });
 
-        let intra_cost = get_satd(
-          &plane_org,
-          &plane_after_prediction_region,
-          IMPORTANCE_BLOCK_SIZE,
-          IMPORTANCE_BLOCK_SIZE,
-          self.config.bit_depth,
-        );
+            get_satd(
+              &plane_org,
+              &plane_after_prediction_region,
+              IMPORTANCE_BLOCK_SIZE,
+              IMPORTANCE_BLOCK_SIZE,
+              bit_depth,
+            )
+          })
+          .min()
+          .unwrap();
 
         fi.lookahead_intra_costs[y * fi.w_in_imp_b + x] = intra_cost;
       }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -479,8 +479,8 @@ fn compute_distortion_bias<T: Pixel>(
   let mean_importance = compute_mean_importance(fi, frame_bo, bsize);
 
   // Chosen based on a series of AWCY runs.
-  const FACTOR: f32 = 3.;
-  const ADDEND: f64 = 0.65;
+  const FACTOR: f32 = 0.9;
+  const ADDEND: f64 = 0.8;
 
   let bias = (mean_importance / FACTOR) as f64 + ADDEND;
   debug_assert!(bias.is_finite());

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -620,9 +620,9 @@ fn luma_chroma_mode_rdo<T: Pixel>(
       // - The values were plotted in a logarithmic 2D histogram.
       // - Based on that, the value below were chosen.
       let heuristic_sidx = match importance {
-        x if x >= 0. && x < 2. => 1,
-        x if x >= 2. && x < 4. => 0,
-        x if x >= 4. => 2,
+        x if x >= 0. && x < 1. => 1,
+        x if x >= 1. && x < 2. => 0,
+        x if x >= 2. => 2,
         _ => unreachable!(),
       };
       heuristic_sidx..=heuristic_sidx


### PR DESCRIPTION
Instead of just DC, try all of them and use the minimal intra-cost.

[AWCY on `--speed 2`](https://beta.arewecompressedyet.com/?job=speed2-2019-09-06_163944-f39b1d7&job=all-intra-modes-importance-speed2-f0.9-a0.8-2019-09-09_230607-e01baca) shows good PSNR improvement.

Since this seems to significantly shift the importance, the segment ID heuristic needs to be updated. This is what I got so far: [AWCY on default speed with the updated heuristic](https://beta.arewecompressedyet.com/?job=master-f39b1d7529575a6540d348788074dd61771047f6&job=all-intra-modes-importance-2019-09-10_164115-7bdc32d), however, as can be seen by the [AWCY on default speed of the updated heuristic vs. segment ID RDO](https://beta.arewecompressedyet.com/?job=all-intra-modes-importance-2019-09-10_164115-7bdc32d&job=all-intra-modes-importance-2019-09-10_103124-1a93398) it can be considerably improved. I guess I'll try to do this throughout my remaining time.

cc #1643 