### PR TITLE
Do not call twice compute_lookahead_data on the flushing action

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -313,7 +313,6 @@ impl<T: Pixel> Context<T> {
       }
       self.inner.limit = Some(self.inner.frame_count);
       self.is_flushing = true;
-      self.inner.compute_lookahead_data();
     } else if self.is_flushing {
       return Err(EncoderStatus::EnoughData);
     }


### PR DESCRIPTION
The inner `send_frame()` would call it even in that case.