### PR TITLE
Remove input chroma sampling restriction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cargo cinstall --release
 
 ## Compressing video
 
-Input videos must be in y4m format and have 4:2:0 chroma subsampling.
+Input videos must be in y4m format.
 
 ```sh
 cargo run --release --bin rav1e -- input.y4m -o output.ivf

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cargo cinstall --release
 
 ## Compressing video
 
-Input videos must be in y4m format.
+Input videos must be in y4m format. The monochrome color format is not supported.
 
 ```sh
 cargo run --release --bin rav1e -- input.y4m -o output.ivf


### PR DESCRIPTION
All sampling formats are supported (though not fully for non-4:2:0 as mentioned above).