### PR TITLE
Disable non-square partition for topdown partition search

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2454,14 +2454,6 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
       if split_vert {
         partition_types.push(PartitionType::PARTITION_VERT);
       };
-    } else if bsize.width_log2() == fi.min_partition_size.width_log2() + 1 {
-      partition_types.push(PartitionType::PARTITION_NONE);
-      partition_types.push(PartitionType::PARTITION_SPLIT);
-      partition_types.push(PartitionType::PARTITION_HORZ);
-
-      if fi.sequence.chroma_sampling != ChromaSampling::Cs422 {
-        partition_types.push(PartitionType::PARTITION_VERT);
-      }
     } else {
       partition_types.push(PartitionType::PARTITION_NONE);
       partition_types.push(PartitionType::PARTITION_SPLIT);


### PR DESCRIPTION
Related to #1612

Reverting c4886a38f0a8bba7c0377375eb8a4e564518cd0e

This causes coding loss by 1.29% at speed1, 1 fame, --tune psnr,
with reduced encoding time by 10%~40%.