### PR TITLE
Provide a mean to dump and restore the encoder config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ bench = []
 check_asm = []
 capi = []
 tracing = ["rust_hawktracer"]
+serialize = ["serde"]
 
 # Enables debug dumping of lookahead computation results, specifically:
 # - i-qres.png: quarter-resolution luma planes,
@@ -61,12 +62,12 @@ num-traits = "0.2"
 num-derive = "0.3"
 paste = "0.1"
 noop_proc_macro = "0.2.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
 dav1d-sys = { version = "0.2", optional = true }
 aom-sys = { version = "0.1.3", optional = true }
 scan_fmt = { version = "0.2.3", optional = true }
 ivf = { version = "0.1", path = "ivf/", optional = true }
 rayon = "1.0"
-bincode = { version = "1.1", optional = true }
 arrayvec = "0.5"
 better-panic = { version = "0.2", optional = true }
 err-derive = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ bench = []
 check_asm = []
 capi = []
 tracing = ["rust_hawktracer"]
-serialize = ["serde"]
+serialize = ["serde", "toml"]
 
 # Enables debug dumping of lookahead computation results, specifically:
 # - i-qres.png: quarter-resolution luma planes,
@@ -68,6 +68,7 @@ aom-sys = { version = "0.1.3", optional = true }
 scan_fmt = { version = "0.2.3", optional = true }
 ivf = { version = "0.1", path = "ivf/", optional = true }
 rayon = "1.0"
+toml = { version = "0.5", optional = true }
 arrayvec = "0.5"
 better-panic = { version = "0.2", optional = true }
 err-derive = "0.2.1"

--- a/src/api/color.rs
+++ b/src/api/color.rs
@@ -7,12 +7,17 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use crate::serialize::*;
+
 use arg_enum_proc_macro::ArgEnum;
 use num_derive::FromPrimitive;
+
 use std::fmt;
 
 /// Sample position for subsampled chroma
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(
+  Copy, Clone, Debug, PartialEq, FromPrimitive, Serialize, Deserialize,
+)]
 #[repr(C)]
 pub enum ChromaSamplePosition {
   /// The source video transfer function must be signaled
@@ -32,7 +37,9 @@ impl Default for ChromaSamplePosition {
 }
 
 /// Chroma subsampling format
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(
+  Copy, Clone, Debug, PartialEq, FromPrimitive, Serialize, Deserialize,
+)]
 #[repr(C)]
 pub enum ChromaSampling {
   /// Both vertically and horizontally subsampled.
@@ -98,7 +105,9 @@ impl ChromaSampling {
 /// Supported Color Primaries
 ///
 /// As defined by “Color primaries” section of ISO/IEC 23091-4/ITU-T H.273
-#[derive(ArgEnum, Debug, Clone, Copy, PartialEq, FromPrimitive)]
+#[derive(
+  ArgEnum, Debug, Clone, Copy, PartialEq, FromPrimitive, Serialize, Deserialize,
+)]
 #[repr(C)]
 pub enum ColorPrimaries {
   /// BT.709
@@ -136,7 +145,9 @@ impl Default for ColorPrimaries {
 /// Supported Transfer Characteristics
 ///
 /// As defined by “Transfer characteristics” section of ISO/IEC 23091-4/ITU-TH.273.
-#[derive(ArgEnum, Debug, Clone, Copy, PartialEq, FromPrimitive)]
+#[derive(
+  ArgEnum, Debug, Clone, Copy, PartialEq, FromPrimitive, Serialize, Deserialize,
+)]
 #[repr(C)]
 pub enum TransferCharacteristics {
   /// BT.709
@@ -184,7 +195,9 @@ impl Default for TransferCharacteristics {
 /// Matrix coefficients
 ///
 /// As defined by the “Matrix coefficients” section of ISO/IEC 23091-4/ITU-TH.273.
-#[derive(ArgEnum, Debug, Clone, Copy, PartialEq, FromPrimitive)]
+#[derive(
+  ArgEnum, Debug, Clone, Copy, PartialEq, FromPrimitive, Serialize, Deserialize,
+)]
 #[repr(C)]
 pub enum MatrixCoefficients {
   /// Identity matrix
@@ -224,7 +237,7 @@ impl Default for MatrixCoefficients {
 }
 
 /// Signal the content color description
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct ColorDescription {
   /// Color primaries.
   pub color_primaries: ColorPrimaries,
@@ -237,7 +250,9 @@ pub struct ColorDescription {
 /// Allowed pixel value range
 ///
 /// C.f. VideoFullRangeFlag variable specified in ISO/IEC 23091-4/ITU-T H.273
-#[derive(ArgEnum, Debug, Clone, Copy, PartialEq, FromPrimitive)]
+#[derive(
+  ArgEnum, Debug, Clone, Copy, PartialEq, FromPrimitive, Serialize, Deserialize,
+)]
 #[repr(C)]
 pub enum PixelRange {
   /// Studio swing representation
@@ -255,7 +270,7 @@ impl Default for PixelRange {
 /// High dynamic range content light level
 ///
 /// As defined by CEA-861.3, Appendix A.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct ContentLight {
   /// Maximum content light level
   pub max_content_light_level: u16,
@@ -265,7 +280,7 @@ pub struct ContentLight {
 
 /// Chromaticity coordinates as defined by CIE 1931, expressed as 0.16
 /// fixed-point values.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[repr(C)]
 pub struct ChromaticityPoint {
   /// The X coordinate.
@@ -277,7 +292,7 @@ pub struct ChromaticityPoint {
 /// High dynamic range mastering display color volume
 ///
 /// As defined by CIE 1931
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct MasteringDisplay {
   /// Chromaticity coordinates in Red, Green, Blue order
   /// expressed as 0.16 fixed-point

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -11,6 +11,7 @@ use err_derive::Error;
 use itertools::Itertools;
 use num_derive::*;
 
+use crate::serialize::{Deserialize, Serialize};
 use crate::api::color::*;
 use crate::api::Rational;
 use crate::api::{Context, ContextInner};
@@ -28,13 +29,15 @@ const MAX_RDO_LOOKAHEAD_FRAMES: usize = usize::max_value() - 1;
 const MAX_MAX_KEY_FRAME_INTERVAL: u64 = i32::max_value() as u64 / 3;
 
 /// Encoder settings which impact the produced bitstream.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct EncoderConfig {
   // output size
   /// Width of the frames in pixels.
   pub width: usize,
   /// Height of the frames in pixels.
   pub height: usize,
+  /// Video time base.
+  pub time_base: Rational,
 
   // data format and ancillary color information
   /// Bit depth.
@@ -59,8 +62,6 @@ pub struct EncoderConfig {
   pub still_picture: bool,
 
   // encoder configuration
-  /// Video time base.
-  pub time_base: Rational,
   /// The *minimum* interval between two keyframes
   pub min_key_frame_interval: u64,
   /// The *maximum* interval between two keyframes
@@ -102,12 +103,13 @@ pub struct EncoderConfig {
   pub tiles: usize,
   /// Number of frames to read ahead for the RDO lookahead computation.
   pub rdo_lookahead_frames: usize,
-  /// Settings which affect the enconding speed vs. quality trade-off.
-  pub speed_settings: SpeedSettings,
   /// If enabled, computes the PSNR values and stores them in [`Packet`].
   ///
   /// [`Packet`]: struct.Packet.html#structfield.psnr
   pub show_psnr: bool,
+
+  /// Settings which affect the enconding speed vs. quality trade-off.
+  pub speed_settings: SpeedSettings,
 }
 
 /// Default preset for EncoderConfig: it is a balance between quality and
@@ -236,7 +238,7 @@ impl fmt::Display for EncoderConfig {
 }
 
 /// Contains the speed settings.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct SpeedSettings {
   /// Minimum block size. Smaller is slower.
   ///
@@ -464,7 +466,16 @@ impl SpeedSettings {
 }
 
 /// Prediction modes to search.
-#[derive(Clone, Copy, Debug, PartialOrd, PartialEq, FromPrimitive)]
+#[derive(
+  Clone,
+  Copy,
+  Debug,
+  PartialOrd,
+  PartialEq,
+  FromPrimitive,
+  Serialize,
+  Deserialize,
+)]
 pub enum PredictionModesSetting {
   /// Only simple prediction modes.
   Simple,

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -11,13 +11,13 @@ use err_derive::Error;
 use itertools::Itertools;
 use num_derive::*;
 
-use crate::serialize::{Deserialize, Serialize};
 use crate::api::color::*;
 use crate::api::Rational;
 use crate::api::{Context, ContextInner};
 use crate::cpu_features::CpuFeatureLevel;
 use crate::encoder::Tune;
 use crate::partition::BlockSize;
+use crate::serialize::{Deserialize, Serialize};
 use crate::tiling::TilingInfo;
 use crate::util::Pixel;
 

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -301,6 +301,9 @@ pub struct SpeedSettings {
   ///
   /// Enabled is slower.
   pub non_square_partition: bool,
+
+  /// Use segmentation.
+  pub enable_segmentation: bool,
 }
 
 impl Default for SpeedSettings {
@@ -325,6 +328,7 @@ impl Default for SpeedSettings {
       quantizer_rdo: true,
       use_satd_subpel: true,
       non_square_partition: true,
+      enable_segmentation: false,
     }
   }
 }
@@ -363,6 +367,7 @@ impl SpeedSettings {
       quantizer_rdo: Self::quantizer_rdo_preset(speed),
       use_satd_subpel: Self::use_satd_subpel(speed),
       non_square_partition: Self::non_square_partition_preset(speed),
+      enable_segmentation: false,
     }
   }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -60,6 +60,27 @@ impl Rational {
     self.num as f64 / self.den as f64
   }
 }
+#[cfg(feature = "serialize")]
+impl serde::Serialize for Rational {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    (self.num, self.den).serialize(serializer)
+  }
+}
+
+#[cfg(feature = "serialize")]
+impl<'a> serde::Deserialize<'a> for Rational {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'a>,
+  {
+    let (num, den) = serde::Deserialize::deserialize(deserializer)?;
+
+    Ok(Rational::new(num, den))
+  }
+}
 
 /// Possible types of a frame.
 #[allow(dead_code, non_camel_case_types)]

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -1660,6 +1660,7 @@ fn log_q_exp_overflow() {
         quantizer_rdo: false,
         use_satd_subpel: false,
         non_square_partition: false,
+        ..Default::default()
       },
       show_psnr: false,
     },
@@ -1722,6 +1723,7 @@ fn guess_frame_subtypes_assert() {
         quantizer_rdo: false,
         use_satd_subpel: false,
         non_square_partition: false,
+        ..Default::default()
       },
       show_psnr: false,
     },

--- a/src/bin/kv.rs
+++ b/src/bin/kv.rs
@@ -1,0 +1,223 @@
+#![allow(unused_variables)]
+use err_derive::Error;
+use serde::{ser, Serialize, Serializer};
+
+use std::fmt;
+
+struct KVString {
+  output: String,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Error)]
+enum Error {
+  #[error(display = "unsupported")]
+  Unsupported,
+}
+
+impl ser::Error for Error {
+  #[cold]
+  fn custom<T: fmt::Display>(msg: T) -> Error {
+    Error::Unsupported
+  }
+}
+
+/// Serialize a configuration as a Key-Value string.
+pub fn to_string<T>(value: &T) -> Result<String, ()>
+where
+  T: Serialize,
+{
+  let mut serializer = KVString { output: String::new() };
+  value.serialize(&mut serializer).map_err(|_| ())?;
+  Ok(serializer.output)
+}
+
+impl Serializer for &mut KVString {
+  type Ok = ();
+  type Error = Error;
+  type SerializeSeq = ser::Impossible<(), Self::Error>;
+  type SerializeTuple = ser::Impossible<(), Self::Error>;
+  type SerializeTupleStruct = ser::Impossible<(), Self::Error>;
+  type SerializeTupleVariant = ser::Impossible<(), Self::Error>;
+  type SerializeMap = ser::Impossible<(), Self::Error>;
+  type SerializeStruct = Self;
+  type SerializeStructVariant = ser::Impossible<(), Self::Error>;
+
+  fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+    self.output += if v { "true" } else { "false" };
+    Ok(())
+  }
+  fn serialize_i8(self, v: i8) -> Result<(), Self::Error> {
+    self.serialize_i64(i64::from(v))
+  }
+
+  fn serialize_i16(self, v: i16) -> Result<(), Self::Error> {
+    self.serialize_i64(i64::from(v))
+  }
+
+  fn serialize_i32(self, v: i32) -> Result<(), Self::Error> {
+    self.serialize_i64(i64::from(v))
+  }
+
+  fn serialize_i64(self, v: i64) -> Result<(), Self::Error> {
+    self.output += &v.to_string();
+    Ok(())
+  }
+
+  fn serialize_u8(self, v: u8) -> Result<(), Self::Error> {
+    self.serialize_u64(u64::from(v))
+  }
+
+  fn serialize_u16(self, v: u16) -> Result<(), Self::Error> {
+    self.serialize_u64(u64::from(v))
+  }
+
+  fn serialize_u32(self, v: u32) -> Result<(), Self::Error> {
+    self.serialize_u64(u64::from(v))
+  }
+
+  fn serialize_u64(self, v: u64) -> Result<(), Self::Error> {
+    self.output += &v.to_string();
+    Ok(())
+  }
+  fn serialize_f32(self, v: f32) -> Result<(), Self::Error> {
+    self.serialize_f64(f64::from(v))
+  }
+
+  fn serialize_f64(self, v: f64) -> Result<(), Self::Error> {
+    self.output += &v.to_string();
+    Ok(())
+  }
+  fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+    unimplemented!()
+  }
+  fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+    self.output += v;
+    Ok(())
+  }
+
+  fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+    unimplemented!()
+  }
+  fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+    self.output += "None";
+    Ok(())
+  }
+  fn serialize_some<T: ?Sized>(
+    self, value: &T,
+  ) -> Result<Self::Ok, Self::Error>
+  where
+    T: Serialize,
+  {
+    value.serialize(self)
+  }
+  fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+    self.output += "";
+    Ok(())
+  }
+  fn serialize_unit_struct(
+    self, name: &'static str,
+  ) -> Result<Self::Ok, Self::Error> {
+    self.serialize_unit()
+  }
+
+  fn serialize_unit_variant(
+    self, name: &'static str, variant_index: u32, variant: &'static str,
+  ) -> Result<Self::Ok, Self::Error> {
+    self.serialize_str(variant)
+  }
+
+  fn serialize_newtype_struct<T: ?Sized>(
+    self, name: &'static str, value: &T,
+  ) -> Result<Self::Ok, Self::Error>
+  where
+    T: Serialize,
+  {
+    unimplemented!()
+  }
+
+  fn serialize_newtype_variant<T: ?Sized>(
+    self, name: &'static str, variant_index: u32, variant: &'static str,
+    value: &T,
+  ) -> Result<Self::Ok, Self::Error>
+  where
+    T: Serialize,
+  {
+    unimplemented!()
+  }
+
+  fn serialize_seq(
+    self, len: Option<usize>,
+  ) -> Result<Self::SerializeSeq, Self::Error> {
+    unimplemented!()
+  }
+  fn serialize_tuple(
+    self, len: usize,
+  ) -> Result<Self::SerializeTuple, Self::Error> {
+    unimplemented!()
+  }
+  fn serialize_tuple_struct(
+    self, name: &'static str, len: usize,
+  ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+    unimplemented!()
+  }
+  fn serialize_tuple_variant(
+    self, name: &'static str, variant_index: u32, variant: &'static str,
+    len: usize,
+  ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+    unimplemented!()
+  }
+  fn serialize_map(
+    self, len: Option<usize>,
+  ) -> Result<Self::SerializeMap, Self::Error> {
+    unimplemented!()
+  }
+  fn serialize_struct(
+    self, name: &'static str, len: usize,
+  ) -> Result<Self::SerializeStruct, Self::Error> {
+    Ok(self)
+  }
+  fn serialize_struct_variant(
+    self, name: &'static str, variant_index: u32, variant: &'static str,
+    len: usize,
+  ) -> Result<Self::SerializeStructVariant, Self::Error> {
+    unimplemented!()
+  }
+}
+
+impl<'a> ser::SerializeStruct for &mut KVString {
+  type Ok = ();
+  type Error = Error;
+
+  // Assume a single flat struct for now
+  fn serialize_field<T>(
+    &mut self, key: &'static str, value: &T,
+  ) -> Result<(), Self::Error>
+  where
+    T: ?Sized + Serialize,
+  {
+    if !self.output.is_empty() {
+      self.output += ", "
+    }
+    self.output += key;
+    self.output += " = ";
+    value.serialize(&mut **self)
+  }
+
+  fn end(self) -> Result<(), Self::Error> {
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use rav1e::prelude::SpeedSettings;
+
+  #[test]
+  fn serialize_speed_settings() {
+    for preset in 0..=10 {
+      let s = SpeedSettings::from_preset(preset);
+      let out = super::to_string(&s).unwrap();
+      println!("preset {}: {}", preset, out);
+    }
+  }
+}

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -312,6 +312,18 @@ fn run() -> Result<(), error::CliError> {
 
   let cfg = Config { enc: cli.enc, threads: cli.threads };
 
+  #[cfg(feature = "serialize")]
+  {
+    if let Some(save_config) = cli.save_config {
+      let mut out = File::create(save_config)
+        .map_err(|e| e.context("Cannot create configuration file"))?;
+      let s = toml::to_string(&cfg.enc).unwrap();
+      out
+        .write_all(s.as_bytes())
+        .map_err(|e| e.context("Cannot write the configuration file"))?
+    }
+  }
+
   cli.io.output.write_header(
     video_info.width,
     video_info.height,

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -25,6 +25,8 @@ extern crate log;
 mod common;
 mod decoder;
 mod error;
+#[cfg(feature = "serialize")]
+mod kv;
 mod muxer;
 mod stats;
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -743,7 +743,7 @@ impl<T: Pixel> FrameInvariants<T> {
       block_importances: vec![0.; w_in_imp_b * h_in_imp_b].into_boxed_slice(),
       cpu_feature_level: Default::default(),
       activity_mask: Default::default(),
-      enable_segmentation: false,
+      enable_segmentation: config.speed_settings.enable_segmentation,
     }
   }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -36,10 +36,13 @@ use crate::stats::EncoderStats;
 use crate::tiling::*;
 use crate::transform::*;
 use crate::util::*;
+use crate::serialize::{Deserialize, Serialize};
+
 use arg_enum_proc_macro::ArgEnum;
 use arrayvec::*;
 use bitstream_io::{BigEndian, BitWriter};
 use rayon::iter::*;
+
 use std::collections::VecDeque;
 use std::io::Write;
 use std::sync::Arc;
@@ -81,7 +84,7 @@ impl<T: Pixel> ReferenceFramesSet<T> {
   }
 }
 
-#[derive(ArgEnum, Copy, Clone, Debug, PartialEq)]
+#[derive(ArgEnum, Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[repr(C)]
 pub enum Tune {
   Psnr,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -32,11 +32,11 @@ use crate::rate::FRAME_SUBTYPE_P;
 use crate::rate::QSCALE;
 use crate::rdo::*;
 use crate::segmentation::*;
+use crate::serialize::{Deserialize, Serialize};
 use crate::stats::EncoderStats;
 use crate::tiling::*;
 use crate::transform::*;
 use crate::util::*;
-use crate::serialize::{Deserialize, Serialize};
 
 use arg_enum_proc_macro::ArgEnum;
 use arrayvec::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,16 @@ extern crate pretty_assertions;
 #[macro_use]
 extern crate log;
 
+mod serialize {
+  cfg_if::cfg_if! {
+    if #[cfg(feature="serialize")] {
+      pub use serde::*;
+    } else {
+      pub use noop_proc_macro::{Deserialize, Serialize};
+    }
+  }
+}
+
 mod hawktracer {
   cfg_if::cfg_if! {
     if #[cfg(feature="tracing")] {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -10,6 +10,8 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
+use crate::serialize::{Deserialize, Serialize};
+
 use self::BlockSize::*;
 use self::TxSize::*;
 use crate::context::*;
@@ -112,7 +114,9 @@ pub enum PartitionType {
   PARTITION_INVALID,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(
+  Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Serialize, Deserialize,
+)]
 pub enum BlockSize {
   BLOCK_4X4,
   BLOCK_4X8,


### PR DESCRIPTION
It is useful to debug so maybe we could use it in another hidden subcommand, right now I put it in the `advanced` one.

``` sh
# cargo run -- advanced --help
rav1e-advanced
Advanced features

USAGE:
    rav1e advanced [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -l, --load_config <LOAD_CONFIG>    Save the encoder configuration from a toml file
    -s, --save_config <SAVE_CONFIG>    Save the current configuration in a toml file
    -c, --completion <SHELL>           Output to stdout the completion definition for the shell [possible values: zsh,
                                       bash, fish, powershell, elvish]
```

It should make easier to reproduce specific scenarios and avoid repeating manually what is set or not set in the speed levels.

```
   -s, --speed <SPEED>
            Speed level (0 is best quality, 10 is fastest)
            Speeds 10 and 0 are extremes and are generally not recommended
            -0:
            min_block_size = BLOCK_4X4, multiref = true, fast_deblock = false, reduced_tx_set = false,
            tx_domain_distortion = true, tx_domain_rate = false, encode_bottomup = true, rdo_tx_decision = true,
            prediction_modes = ComplexAll, include_near_mvs = true, no_scene_detection = false, diamond_me = true, cdef
            = true, quantizer_rdo = true, use_satd_subpel = true, non_square_partition = true
            -1:
            min_block_size = BLOCK_4X4, multiref = true, fast_deblock = false, reduced_tx_set = false,
            tx_domain_distortion = true, tx_domain_rate = false, encode_bottomup = true, rdo_tx_decision = true,
            prediction_modes = ComplexAll, include_near_mvs = true, no_scene_detection = false, diamond_me = true, cdef
            = true, quantizer_rdo = true, use_satd_subpel = true, non_square_partition = false
            -2:
            min_block_size = BLOCK_4X4, multiref = true, fast_deblock = false, reduced_tx_set = false,
            tx_domain_distortion = true, tx_domain_rate = false, encode_bottomup = false, rdo_tx_decision = true,
            prediction_modes = ComplexAll, include_near_mvs = true, no_scene_detection = false, diamond_me = true, cdef
            = true, quantizer_rdo = true, use_satd_subpel = true, non_square_partition = false
            -3:
            min_block_size = BLOCK_8X8, multiref = true, fast_deblock = false, reduced_tx_set = false,
            tx_domain_distortion = true, tx_domain_rate = false, encode_bottomup = false, rdo_tx_decision = true,
            prediction_modes = ComplexKeyframes, include_near_mvs = true, no_scene_detection = false, diamond_me = true,
            cdef = true, quantizer_rdo = true, use_satd_subpel = true, non_square_partition = false
            -4:
            min_block_size = BLOCK_8X8, multiref = true, fast_deblock = false, reduced_tx_set = false,
            tx_domain_distortion = true, tx_domain_rate = false, encode_bottomup = false, rdo_tx_decision = true,
            prediction_modes = ComplexKeyframes, include_near_mvs = false, no_scene_detection = false, diamond_me =
            true, cdef = true, quantizer_rdo = false, use_satd_subpel = true, non_square_partition = false
            -5:
```

