### PR TITLE
Prune intra modes with SATD instead of SAD.

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -968,7 +968,7 @@ pub fn rdo_mode_decision<T: Pixel>(
       };
 
       let intra_mode_set = RAV1E_INTRA_MODES;
-      let mut sads = {
+      let mut satds = {
         // FIXME: If tx partition is used, this whole sads block should be fixed
         debug_assert!(bsize == tx_size.block_size());
         let edge_buf = {
@@ -1011,7 +1011,7 @@ pub fn rdo_mode_decision<T: Pixel>(
 
             (
               luma_mode,
-              get_sad(
+              get_satd(
                 &plane_org,
                 &plane_ref,
                 tx_size.width(),
@@ -1023,7 +1023,7 @@ pub fn rdo_mode_decision<T: Pixel>(
           .collect::<Vec<_>>()
       };
 
-      sads.sort_by_key(|a| a.1);
+      satds.sort_by_key(|a| a.1);
 
       // Find mode with lowest rate cost
       let mut z = 32768;
@@ -1051,7 +1051,7 @@ pub fn rdo_mode_decision<T: Pixel>(
         .iter()
         .take(num_modes_rdo / 2)
         .for_each(|&(luma_mode, _prob)| modes.push(luma_mode));
-      sads.iter().take(num_modes_rdo).for_each(|&(luma_mode, _sad)| {
+      satds.iter().take(num_modes_rdo).for_each(|&(luma_mode, _stad)| {
         if !modes.contains(&luma_mode) {
           modes.push(luma_mode)
         }


### PR DESCRIPTION
Results on subset1:

master-2019-09-23_160214-b4d418a -> intra_prune_satd-2019-09-23_160204-1a821a8

   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-0.1007 | -0.0694 |     N/A |  -0.0845 | -0.1145 | -0.1157 |    -0.0402

https://beta.arewecompressedyet.com/?job=intra_prune_satd-2019-09-23_160204-1a821a8&job=master-2019-09-23_160214-b4d418a