### PR TITLE
Implement missing LRF 4:2:2 support

### DIFF
--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -1259,7 +1259,8 @@ impl RestorationState {
     let uv_sb_h_log2 = y_sb_log2 - xdec;
     let uv_sb_v_log2 = y_sb_log2 - ydec;
 
-    let (lrf_y_shift, lrf_uv_shift) = if fi.sequence.enable_large_lru {
+    let (lrf_y_shift, lrf_uv_shift) = if fi.sequence.enable_large_lru
+      && fi.sequence.enable_restoration {
       // Specific content does affect optimal LRU size choice, but the
       // quantizer in use is a surprisingly strong selector.
       let lrf_base_shift = if fi.base_q_idx > 200 {

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -1201,9 +1201,9 @@ pub struct RestorationPlaneOffset {
 
 impl RestorationPlane {
   pub fn new(
-    lrf_type: u8, unit_size: usize, sb_h_shift: usize,
-    sb_v_shift: usize, sb_cols: usize, sb_rows: usize,
-    stripe_decimate: usize, cols: usize, rows: usize,
+    lrf_type: u8, unit_size: usize, sb_h_shift: usize, sb_v_shift: usize,
+    sb_cols: usize, sb_rows: usize, stripe_decimate: usize, cols: usize,
+    rows: usize,
   ) -> RestorationPlane {
     let stripe_height = if stripe_decimate != 0 { 32 } else { 64 };
     RestorationPlane {
@@ -1260,7 +1260,8 @@ impl RestorationState {
     let uv_sb_v_log2 = y_sb_log2 - ydec;
 
     let (lrf_y_shift, lrf_uv_shift) = if fi.sequence.enable_large_lru
-      && fi.sequence.enable_restoration {
+      && fi.sequence.enable_restoration
+    {
       // Specific content does affect optimal LRU size choice, but the
       // quantizer in use is a surprisingly strong selector.
       let lrf_base_shift = if fi.base_q_idx > 200 {
@@ -1314,14 +1315,15 @@ impl RestorationState {
       // despite suggestions to the contrary, apparently tiles can be
       // non-powers-of-2.
       let trailing_h_zeros = fi.tiling.tile_width_sb.trailing_zeros() as usize;
-      let trailing_v_zeros = fi.tiling.tile_height_sb.trailing_zeros() as usize;
-      let tile_aligned_y_unit_size = 1 << (y_sb_log2 + trailing_h_zeros
-        .min(trailing_v_zeros));
+      let trailing_v_zeros =
+        fi.tiling.tile_height_sb.trailing_zeros() as usize;
+      let tile_aligned_y_unit_size =
+        1 << (y_sb_log2 + trailing_h_zeros.min(trailing_v_zeros));
       let tile_aligned_uv_h_unit_size = 1 << (uv_sb_h_log2 + trailing_h_zeros);
       let tile_aligned_uv_v_unit_size = 1 << (uv_sb_v_log2 + trailing_v_zeros);
       y_unit_size = y_unit_size.min(tile_aligned_y_unit_size);
-      uv_unit_size = uv_unit_size.min(tile_aligned_uv_h_unit_size
-        .min(tile_aligned_uv_v_unit_size));
+      uv_unit_size = uv_unit_size
+        .min(tile_aligned_uv_h_unit_size.min(tile_aligned_uv_v_unit_size));
 
       // But it's actually worse: LRUs can't span tiles (in our design
       // that is, spec allows it).  However, the spec mandates the last

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1651,11 +1651,11 @@ pub fn rdo_loop_decision<T: Pixel>(
   // Determine area of optimization: Which plane has the largest LRUs?
   // How many LRUs for each?
   let mut sb_w = 1; // how many superblocks wide the largest LRU
-                    // is/how much we're processing (same thing)
+                    // is/how many SBs we're processing (same thing)
   let mut sb_h = 1; // how many superblocks wide the largest LRU
-                    // is/how much we're processing (same thing)
-  let mut lru_w = [0; PLANES]; // how manu LRUs we're processing
-  let mut lru_h = [0; PLANES]; // how manu LRUs we're processing
+                    // is/how many SBs we're processing (same thing)
+  let mut lru_w = [0; PLANES]; // how many LRUs we're processing
+  let mut lru_h = [0; PLANES]; // how many LRUs we're processing
   for pli in 0..PLANES {
     let sb_h_shift = ts.restoration.planes[pli].rp_cfg.sb_h_shift;
     let sb_v_shift = ts.restoration.planes[pli].rp_cfg.sb_v_shift;
@@ -1931,7 +1931,6 @@ pub fn rdo_loop_decision<T: Pixel>(
 
     // check for new best restoration filter if enabled
     if fi.sequence.enable_restoration {
-
       // need cdef output from best index, not just last iteration
       if let Some((cdef_input, cdef_dirs)) = cdef_data.as_ref() {
         for sby in 0..sb_h {


### PR DESCRIPTION
Restoration (or more specifically the LRU partition tracking code) did not implement support for the rectangular superblocks used by 4:2:2 inputs.  This implements the missing support and fixes #1692.

AWCY test metrics incoming.