### PR TITLE
Log correct tile settings

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -194,9 +194,6 @@ impl fmt::Display for EncoderConfig {
       ("min_quantizer", self.min_quantizer.to_string()),
       ("low_latency", self.low_latency.to_string()),
       ("tune", self.tune.to_string()),
-      ("tiles", self.tiles.to_string()),
-      ("tile_rows", self.tile_rows.to_string()),
-      ("tile_cols", self.tile_cols.to_string()),
       ("rdo_lookahead_frames", self.rdo_lookahead_frames.to_string()),
       ("min_block_size", self.speed_settings.min_block_size.to_string()),
       (

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -9,10 +9,6 @@
 #![deny(missing_docs)]
 
 use crate::api::{EncoderConfig, EncoderStatus, FrameType, Packet};
-
-use arrayvec::ArrayVec;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
-
 use crate::context::*;
 use crate::context::{FrameBlocks, SuperBlockOffset, TileSuperBlockOffset};
 use crate::dist::get_satd;
@@ -31,6 +27,9 @@ use crate::stats::EncoderStats;
 use crate::tiling::{Area, TileRect};
 use crate::transform::TxSize;
 use crate::util::Pixel;
+use arrayvec::ArrayVec;
+use log::Level::Info;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use std::cmp;
 use std::collections::BTreeMap;
@@ -362,6 +361,20 @@ impl<T: Pixel> ContextInner<T> {
     &mut self, output_frameno: u64,
   ) -> Result<(), EncoderStatus> {
     let fi = self.build_frame_properties(output_frameno)?;
+
+    if output_frameno == 0 && log_enabled!(Info) {
+      if fi.tiling.tile_count() == 1 {
+        info!("Using 1 tile");
+      } else {
+        info!(
+          "Using {} tiles ({}x{})",
+          fi.tiling.tile_count(),
+          fi.tiling.cols,
+          fi.tiling.rows
+        );
+      }
+    }
+
     self.frame_invariants.insert(output_frameno, fi);
 
     Ok(())

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -196,14 +196,14 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
     )
     .arg(
       Arg::with_name("TILE_ROWS")
-        .help("Number of tile rows. Must be a power of 2.")
+        .help("Number of tile rows. Must be a power of 2. rav1e may override this based on video resolution.")
         .long("tile-rows")
         .takes_value(true)
         .default_value("0")
     )
     .arg(
       Arg::with_name("TILE_COLS")
-        .help("Number of tile columns. Must be a power of 2.")
+        .help("Number of tile columns. Must be a power of 2. rav1e may override this based on video resolution.")
         .long("tile-cols")
         .takes_value(true)
         .default_value("0")


### PR DESCRIPTION
The tile settings are chosen based on video dimensions and
may not match the user input settings. This change moves the
tile settings log out of the encoder settings, and has it
show the real number of tiles chosen.

720p heuristically chosen:
```
Running `target/debug/rav1e /Users/jholmer/Downloads/ducks_take_off_420_720p50.y4m -s 10 -l 10 --keyint 3 --min-keyint 3 -o /dev/null`
 INFO  rav1e > Using y4m decoder: 1280x720p @ 50/1 fps, 4:2:0, 8-bit
 INFO  rav1e > Encoding settings: keyint_min=3 keyint_max=3 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=true diamond_me=true cdef=true quantizer_rdo=false use_satd_subpel=false non_square_partition=false
 INFO  rav1e::api::config > CPU Feature Level: AVX2
 INFO  rav1e::api::internal > Using 1 tile
```

720p set by CLI:
```
Running `target/debug/rav1e /Users/jholmer/Downloads/ducks_take_off_420_720p50.y4m -s 10 -l 10 --keyint 3 --min-keyint 3 -o /dev/null --tile-rows 2`
 INFO  rav1e > Using y4m decoder: 1280x720p @ 50/1 fps, 4:2:0, 8-bit
 INFO  rav1e > Encoding settings: keyint_min=3 keyint_max=3 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=true diamond_me=true cdef=true quantizer_rdo=false use_satd_subpel=false non_square_partition=false
 INFO  rav1e::api::config > CPU Feature Level: AVX2
 INFO  rav1e::api::internal > Using 2 tiles (2x1)
```

4K heuristically chosen:
```
Running `target/debug/rav1e /Users/jholmer/Downloads/ducks_take_off_2160p50.y4m -s 10 -l 10 --keyint 3 --min-keyint 3 -o /dev/null`
 INFO  rav1e > Using y4m decoder: 3840x2160p @ 50/1 fps, 4:2:0, 8-bit
 INFO  rav1e > Encoding settings: keyint_min=3 keyint_max=3 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=true diamond_me=true cdef=true quantizer_rdo=false use_satd_subpel=false non_square_partition=false
 INFO  rav1e::api::config > CPU Feature Level: AVX2
 INFO  rav1e::api::internal > Using 2 tiles (2x1)
```