### PR TITLE
Workaround rust 1.38 pipelined compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ bench = false
 
 [lib]
 bench = false
+crate-type = ["lib", "staticlib"]
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
It would otherwise break cargo-c.