### PR TITLE
Change speed level when quant rdo is enabled from 3 downto 1

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -415,7 +415,7 @@ impl SpeedSettings {
   }
 
   const fn quantizer_rdo_preset(speed: usize) -> bool {
-    speed <= 3
+    speed <= 1
   }
 
   const fn use_satd_subpel(speed: usize) -> bool {


### PR DESCRIPTION
Because it casues x2 ~ x3 increase in encoding time but only gives less
than 0.5% gain.