### PR TITLE
Travis CI: Add Arm build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,9 +78,10 @@ jobs:
     - name: "Arm build and test"
       rust: stable
       arch: arm64
+      before_install: skip
       script:
         - cargo build --release --tests --verbose
-        - cargo test --release --features=decode_test,decode_test_dav1d,quick_test,capi --verbose
+        - cargo test --release --verbose
     - name: "Ignored Tests (aom)"
       rust: stable
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,12 @@ jobs:
         - cargo test --features=decode_test,decode_test_dav1d,quick_test,capi --verbose
       env:
         - CACHE_NAME=MIN_RUSTC
+    - name: "Arm build and test"
+      rust: stable
+      arch: arm64
+      script:
+        - cargo build --release --tests --verbose
+        - cargo test --release --features=decode_test,decode_test_dav1d,quick_test,capi --verbose
     - name: "Ignored Tests (aom)"
       rust: stable
       script:


### PR DESCRIPTION
Add a basic cargo build and cargo test configuration for the Arm (aarch64) platform.

@shssoichiro or @barrbrain Could you take a look at the sccache configuration to enable aom and dav1d decode tests?