### PR TITLE
Temporary disable asm-optimizations for x86

### DIFF
--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -7,8 +7,5 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-#[cfg(all(
-  feature = "nasm",
-  any(target_arch = "x86", target_arch = "x86_64")
-))]
+#[cfg(all(feature = "nasm", target_arch = "x86_64"))]
 pub mod x86;


### PR DESCRIPTION
Fix #1741.

Later we should add a x86 target (maybe using github actions @tdaede?)