### PR TITLE
Remove CpuFeatureLevel in favor of std_detect

### DIFF
--- a/benches/dist.rs
+++ b/benches/dist.rs
@@ -10,7 +10,6 @@
 use criterion::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
-use rav1e::bench::cpu_features::*;
 use rav1e::bench::dist;
 use rav1e::bench::frame::*;
 use rav1e::bench::partition::BlockSize::*;
@@ -90,14 +89,12 @@ type DistFn<T> = fn(
   plane_ref: &PlaneRegion<'_, T>,
   bsize: BlockSize,
   bit_depth: usize,
-  cpu: CpuFeatureLevel,
 ) -> u32;
 
 fn run_dist_bench<T: Pixel>(
   b: &mut Bencher, &(bs, bit_depth): &(BlockSize, usize), func: DistFn<T>,
 ) {
   let mut ra = ChaChaRng::from_seed([0; 32]);
-  let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
   let input_plane = new_plane::<T>(&mut ra, w, h);
@@ -107,7 +104,7 @@ fn run_dist_bench<T: Pixel>(
   let plane_ref = rec_plane.as_region();
 
   b.iter(|| {
-    let _ = black_box(func(&plane_org, &plane_ref, bs, bit_depth, cpu));
+    let _ = black_box(func(&plane_org, &plane_ref, bs, bit_depth));
   })
 }
 

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -574,7 +574,10 @@ impl Config {
 
     self.validate()?;
 
-    info!("Using CPU Features: {}", get_detected_cpu_features().join(" "));
+    info!(
+      "Using CPU Features: {}",
+      get_detected_cpu_features().join(" ").to_ascii_uppercase()
+    );
 
     let pool = rayon::ThreadPoolBuilder::new()
       .num_threads(self.threads)

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -14,7 +14,7 @@ use num_derive::*;
 use crate::api::color::*;
 use crate::api::Rational;
 use crate::api::{Context, ContextInner};
-use crate::cpu_features::CpuFeatureLevel;
+use crate::cpu_features::get_detected_cpu_features;
 use crate::encoder::Tune;
 use crate::partition::BlockSize;
 use crate::tiling::TilingInfo;
@@ -574,7 +574,7 @@ impl Config {
 
     self.validate()?;
 
-    info!("CPU Feature Level: {}", CpuFeatureLevel::default());
+    info!("Using CPU Features: {}", get_detected_cpu_features().join(" "));
 
     let pool = rayon::ThreadPoolBuilder::new()
       .num_threads(self.threads)

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -751,7 +751,6 @@ impl<T: Pixel> ContextInner<T> {
           &plane_after_prediction_region,
           bsize,
           self.config.bit_depth,
-          fi.cpu_feature_level,
         );
 
         fi.lookahead_intra_costs[y * fi.w_in_imp_b + x] = intra_cost;
@@ -917,13 +916,9 @@ impl<T: Pixel> ContextInner<T> {
               height: IMPORTANCE_BLOCK_SIZE,
             });
 
-            let inter_cost = get_satd(
-              &plane_org,
-              &plane_ref,
-              bsize,
-              self.config.bit_depth,
-              fi.cpu_feature_level,
-            ) as f32;
+            let inter_cost =
+              get_satd(&plane_org, &plane_ref, bsize, self.config.bit_depth)
+                as f32;
 
             let intra_cost =
               fi.lookahead_intra_costs[y * fi.w_in_imp_b + x] as f32;

--- a/src/asm/x86/cdef.rs
+++ b/src/asm/x86/cdef.rs
@@ -8,7 +8,6 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use crate::cdef::*;
-use crate::cpu_features::CpuFeatureLevel;
 #[cfg(feature = "check_asm")]
 use crate::frame::*;
 use crate::tiling::PlaneRegionMut;
@@ -45,7 +44,7 @@ const fn decimate_index(xdec: usize, ydec: usize) -> usize {
 pub unsafe fn cdef_filter_block<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, src: *const u16, src_stride: isize,
   pri_strength: i32, sec_strength: i32, dir: usize, damping: i32,
-  bit_depth: usize, xdec: usize, ydec: usize, cpu: CpuFeatureLevel,
+  bit_depth: usize, xdec: usize, ydec: usize,
 ) {
   let call_native = |dst: &mut PlaneRegionMut<T>| {
     native::cdef_filter_block(
@@ -59,7 +58,6 @@ pub unsafe fn cdef_filter_block<T: Pixel>(
       bit_depth,
       xdec,
       ydec,
-      cpu,
     );
   };
   #[cfg(feature = "check_asm")]

--- a/src/asm/x86/dist.rs
+++ b/src/asm/x86/dist.rs
@@ -7,7 +7,6 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use crate::cpu_features::CpuFeatureLevel;
 use crate::dist::*;
 use crate::partition::BlockSize;
 use crate::tiling::*;
@@ -108,10 +107,9 @@ fn to_index(bsize: BlockSize) -> usize {
 #[allow(clippy::let_and_return)]
 pub fn get_sad<T: Pixel>(
   src: &PlaneRegion<'_, T>, dst: &PlaneRegion<'_, T>, bsize: BlockSize,
-  bit_depth: usize, cpu: CpuFeatureLevel,
+  bit_depth: usize,
 ) -> u32 {
-  let call_native =
-    || -> u32 { native::get_sad(dst, src, bsize, bit_depth, cpu) };
+  let call_native = || -> u32 { native::get_sad(dst, src, bsize, bit_depth) };
 
   #[cfg(feature = "check_asm")]
   let ref_dist = call_native();
@@ -151,10 +149,9 @@ pub fn get_sad<T: Pixel>(
 #[allow(clippy::let_and_return)]
 pub fn get_satd<T: Pixel>(
   src: &PlaneRegion<'_, T>, dst: &PlaneRegion<'_, T>, bsize: BlockSize,
-  bit_depth: usize, cpu: CpuFeatureLevel,
+  bit_depth: usize,
 ) -> u32 {
-  let call_native =
-    || -> u32 { native::get_satd(dst, src, bsize, bit_depth, cpu) };
+  let call_native = || -> u32 { native::get_satd(dst, src, bsize, bit_depth) };
 
   #[cfg(feature = "check_asm")]
   let ref_dist = call_native();

--- a/src/asm/x86/dist.rs
+++ b/src/asm/x86/dist.rs
@@ -28,8 +28,6 @@ type SadHBDFn = unsafe extern fn(
   dst_stride: isize,
 ) -> u32;
 
-type SatdHBDFn = SadHBDFn;
-
 macro_rules! declare_asm_dist_fn {
   ($(($name: ident, $T: ident)),+) => (
     $(

--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -34,15 +34,6 @@ type PrepFn = unsafe extern fn(
   row_frac: i32,
 );
 
-type AvgFn = unsafe extern fn(
-  dst: *mut u8,
-  dst_stride: isize,
-  tmp1: *const i16,
-  tmp2: *const i16,
-  width: i32,
-  height: i32,
-);
-
 pub fn put_8tap<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, src: PlaneSlice<'_, T>, width: usize,
   height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,

--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -7,7 +7,6 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use crate::cpu_features::CpuFeatureLevel;
 use crate::frame::*;
 use crate::mc::FilterMode::*;
 use crate::mc::*;
@@ -85,12 +84,11 @@ const fn get_2d_mode_idx(mode_x: FilterMode, mode_y: FilterMode) -> usize {
 pub fn put_8tap<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, src: PlaneSlice<'_, T>, width: usize,
   height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
-  mode_y: FilterMode, bit_depth: usize, cpu: CpuFeatureLevel,
+  mode_y: FilterMode, bit_depth: usize,
 ) {
   let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
     native::put_8tap(
       dst, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
-      cpu,
     );
   };
   #[cfg(feature = "check_asm")]
@@ -151,12 +149,11 @@ pub fn put_8tap<T: Pixel>(
 pub fn prep_8tap<T: Pixel>(
   tmp: &mut [i16], src: PlaneSlice<'_, T>, width: usize, height: usize,
   col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,
-  bit_depth: usize, cpu: CpuFeatureLevel,
+  bit_depth: usize,
 ) {
   let call_native = |tmp: &mut [i16]| {
     native::prep_8tap(
       tmp, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
-      cpu,
     );
   };
   #[cfg(feature = "check_asm")]
@@ -209,10 +206,10 @@ pub fn prep_8tap<T: Pixel>(
 
 pub fn mc_avg<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
-  height: usize, bit_depth: usize, cpu: CpuFeatureLevel,
+  height: usize, bit_depth: usize,
 ) {
   let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
-    native::mc_avg(dst, tmp1, tmp2, width, height, bit_depth, cpu);
+    native::mc_avg(dst, tmp1, tmp2, width, height, bit_depth);
   };
   #[cfg(feature = "check_asm")]
   let ref_dst = {

--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -24,18 +24,6 @@ type PutFn = unsafe extern fn(
   row_frac: i32,
 );
 
-type PutHBDFn = unsafe extern fn(
-  dst: *mut u8,
-  dst_stride: isize,
-  src: *const u8,
-  src_stride: isize,
-  width: i32,
-  height: i32,
-  col_frac: i32,
-  row_frac: i32,
-  bit_depth: i32,
-);
-
 type PrepFn = unsafe extern fn(
   tmp: *mut i16,
   src: *const u8,
@@ -44,17 +32,6 @@ type PrepFn = unsafe extern fn(
   height: i32,
   col_frac: i32,
   row_frac: i32,
-);
-
-type PrepHBDFn = unsafe extern fn(
-  tmp: *mut i16,
-  src: *const u16,
-  src_stride: isize,
-  width: i32,
-  height: i32,
-  col_frac: i32,
-  row_frac: i32,
-  bit_depth: i32,
 );
 
 type AvgFn = unsafe extern fn(
@@ -66,74 +43,38 @@ type AvgFn = unsafe extern fn(
   height: i32,
 );
 
-type AvgHBDFn = unsafe extern fn(
-  dst: *mut u16,
-  dst_stride: isize,
-  tmp1: *const i16,
-  tmp2: *const i16,
-  width: i32,
-  height: i32,
-  bit_depth: i32,
-);
-
-// gets an index that can be mapped to a function for a pair of filter modes
-const fn get_2d_mode_idx(mode_x: FilterMode, mode_y: FilterMode) -> usize {
-  (mode_x as usize + 4 * (mode_y as usize)) & 15
-}
-
 pub fn put_8tap<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, src: PlaneSlice<'_, T>, width: usize,
   height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
   mode_y: FilterMode, bit_depth: usize,
 ) {
-  let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
-    native::put_8tap(
-      dst, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
-    );
-  };
   #[cfg(feature = "check_asm")]
   let ref_dst = {
     let mut copy = dst.scratch_copy();
-    call_native(&mut copy.as_region_mut());
+    Put8TapNative::put_8tap(
+      &mut copy.as_region_mut(),
+      src,
+      width,
+      height,
+      col_frac,
+      row_frac,
+      mode_x,
+      mode_y,
+      bit_depth,
+    );
     copy
   };
-  match T::type_enum() {
-    PixelType::U8 => {
-      match PUT_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
-        Some(func) => unsafe {
-          (func)(
-            dst.data_ptr_mut() as *mut _,
-            T::to_asm_stride(dst.plane_cfg.stride),
-            src.as_ptr() as *const _,
-            T::to_asm_stride(src.plane.cfg.stride),
-            width as i32,
-            height as i32,
-            col_frac,
-            row_frac,
-          );
-        },
-        None => call_native(dst),
-      }
-    }
-    PixelType::U16 => {
-      match PUT_HBD_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
-        Some(func) => unsafe {
-          (func)(
-            dst.data_ptr_mut() as *mut _,
-            T::to_asm_stride(dst.plane_cfg.stride),
-            src.as_ptr() as *const _,
-            T::to_asm_stride(src.plane.cfg.stride),
-            width as i32,
-            height as i32,
-            col_frac,
-            row_frac,
-            bit_depth as i32,
-          );
-        },
-        None => call_native(dst),
-      }
-    }
+
+  if is_x86_feature_detected!("avx2") {
+    Put8TapAvx2::put_8tap(
+      dst, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
+    )
+  } else {
+    Put8TapNative::put_8tap(
+      dst, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
+    )
   }
+
   #[cfg(feature = "check_asm")]
   {
     for (dst_row, ref_row) in
@@ -151,53 +92,27 @@ pub fn prep_8tap<T: Pixel>(
   col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,
   bit_depth: usize,
 ) {
-  let call_native = |tmp: &mut [i16]| {
-    native::prep_8tap(
-      tmp, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
-    );
-  };
   #[cfg(feature = "check_asm")]
   let ref_tmp = {
     let mut copy = vec![0; width * height];
     copy[..].copy_from_slice(&tmp[..width * height]);
-    call_native(&mut copy);
+    Prep8TapNative::prep_8tap(
+      &mut copy, src, width, height, col_frac, row_frac, mode_x, mode_y,
+      bit_depth,
+    );
     copy
   };
-  match T::type_enum() {
-    PixelType::U8 => {
-      match PREP_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
-        Some(func) => unsafe {
-          (func)(
-            tmp.as_mut_ptr(),
-            src.as_ptr() as *const _,
-            T::to_asm_stride(src.plane.cfg.stride),
-            width as i32,
-            height as i32,
-            col_frac,
-            row_frac,
-          );
-        },
-        None => call_native(tmp),
-      }
-    }
-    PixelType::U16 => {
-      match PREP_HBD_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
-        Some(func) => unsafe {
-          (func)(
-            tmp.as_mut_ptr() as *mut _,
-            src.as_ptr() as *const _,
-            T::to_asm_stride(src.plane.cfg.stride),
-            width as i32,
-            height as i32,
-            col_frac,
-            row_frac,
-            bit_depth as i32,
-          );
-        },
-        None => call_native(tmp),
-      }
-    }
+
+  if is_x86_feature_detected!("avx2") {
+    Prep8TapAvx2::prep_8tap(
+      tmp, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
+    )
+  } else {
+    Prep8TapNative::prep_8tap(
+      tmp, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
+    )
   }
+
   #[cfg(feature = "check_asm")]
   {
     assert_eq!(&tmp[..width * height], &ref_tmp[..]);
@@ -208,44 +123,26 @@ pub fn mc_avg<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
   height: usize, bit_depth: usize,
 ) {
-  let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
-    native::mc_avg(dst, tmp1, tmp2, width, height, bit_depth);
-  };
   #[cfg(feature = "check_asm")]
   let ref_dst = {
     let mut copy = dst.scratch_copy();
-    call_native(&mut copy.as_region_mut());
+    McAvgNative::mc_avg(
+      &mut copy.as_region_mut(),
+      tmp1,
+      tmp2,
+      width,
+      height,
+      bit_depth,
+    );
     copy
   };
-  match T::type_enum() {
-    PixelType::U8 => match AVG_FNS[cpu.as_index()] {
-      Some(func) => unsafe {
-        (func)(
-          dst.data_ptr_mut() as *mut _,
-          T::to_asm_stride(dst.plane_cfg.stride),
-          tmp1.as_ptr(),
-          tmp2.as_ptr(),
-          width as i32,
-          height as i32,
-        );
-      },
-      None => call_native(dst),
-    },
-    PixelType::U16 => match AVG_HBD_FNS[cpu.as_index()] {
-      Some(func) => unsafe {
-        (func)(
-          dst.data_ptr_mut() as *mut _,
-          T::to_asm_stride(dst.plane_cfg.stride),
-          tmp1.as_ptr(),
-          tmp2.as_ptr(),
-          width as i32,
-          height as i32,
-          bit_depth as i32,
-        );
-      },
-      None => call_native(dst),
-    },
+
+  if is_x86_feature_detected!("avx2") {
+    McAvgAvx2::mc_avg(dst, tmp1, tmp2, width, height, bit_depth)
+  } else {
+    McAvgNative::mc_avg(dst, tmp1, tmp2, width, height, bit_depth)
   }
+
   #[cfg(feature = "check_asm")]
   {
     for (dst_row, ref_row) in
@@ -258,6 +155,14 @@ pub fn mc_avg<T: Pixel>(
   }
 }
 
+trait Put8Tap<T: Pixel> {
+  fn put_8tap(
+    dst: &mut PlaneRegionMut<'_, T>, src: PlaneSlice<'_, T>, width: usize,
+    height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
+    mode_y: FilterMode, bit_depth: usize,
+  );
+}
+
 macro_rules! decl_mc_fns {
   ($(($mode_x:expr, $mode_y:expr, $func_name:ident)),+) => {
     extern {
@@ -268,14 +173,6 @@ macro_rules! decl_mc_fns {
         );
       )*
     }
-
-    static PUT_FNS_AVX2: [Option<PutFn>; 16] = {
-      let mut out: [Option<PutFn>; 16] = [None; 16];
-      $(
-        out[get_2d_mode_idx($mode_x, $mode_y)] = Some($func_name);
-      )*
-      out
-    };
   }
 }
 
@@ -292,14 +189,64 @@ decl_mc_fns!(
   (BILINEAR, BILINEAR, rav1e_put_bilin_avx2)
 );
 
-pub(crate) static PUT_FNS: [[Option<PutFn>; 16]; CpuFeatureLevel::len()] = {
-  let mut out = [[None; 16]; CpuFeatureLevel::len()];
-  out[CpuFeatureLevel::AVX2 as usize] = PUT_FNS_AVX2;
-  out
-};
+struct Put8TapAvx2;
 
-pub(crate) static PUT_HBD_FNS: [[Option<PutHBDFn>; 16];
-  CpuFeatureLevel::len()] = [[None; 16]; CpuFeatureLevel::len()];
+impl<T: Pixel> Put8Tap<T> for Put8TapAvx2 {
+  fn put_8tap(
+    dst: &mut PlaneRegionMut<'_, T>, src: PlaneSlice<'_, T>, width: usize,
+    height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
+    mode_y: FilterMode, bit_depth: usize,
+  ) {
+    if T::type_enum() == PixelType::U8 {
+      let func: Option<PutFn> = match (mode_x, mode_y) {
+        (REGULAR, REGULAR) => Some(rav1e_put_8tap_regular_avx2),
+        (REGULAR, SMOOTH) => Some(rav1e_put_8tap_regular_smooth_avx2),
+        (REGULAR, SHARP) => Some(rav1e_put_8tap_regular_sharp_avx2),
+        (SMOOTH, REGULAR) => Some(rav1e_put_8tap_smooth_regular_avx2),
+        (SMOOTH, SMOOTH) => Some(rav1e_put_8tap_smooth_avx2),
+        (SMOOTH, SHARP) => Some(rav1e_put_8tap_smooth_sharp_avx2),
+        (SHARP, REGULAR) => Some(rav1e_put_8tap_sharp_regular_avx2),
+        (SHARP, SMOOTH) => Some(rav1e_put_8tap_sharp_smooth_avx2),
+        (SHARP, SHARP) => Some(rav1e_put_8tap_sharp_avx2),
+        (BILINEAR, BILINEAR) => Some(rav1e_put_bilin_avx2),
+        _ => None,
+      };
+      if let Some(func) = func {
+        unsafe {
+          return func(
+            dst.data_ptr_mut() as *mut _,
+            u8::to_asm_stride(dst.plane_cfg.stride),
+            src.as_ptr() as *const _,
+            u8::to_asm_stride(src.plane.cfg.stride),
+            width as i32,
+            height as i32,
+            col_frac,
+            row_frac,
+          );
+        }
+      }
+    }
+
+    Put8TapNative::put_8tap(
+      dst, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
+    );
+  }
+}
+
+struct Put8TapNative;
+
+impl<T: Pixel> Put8Tap<T> for Put8TapNative {
+  #[inline(always)]
+  fn put_8tap(
+    dst: &mut PlaneRegionMut<'_, T>, src: PlaneSlice<'_, T>, width: usize,
+    height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
+    mode_y: FilterMode, bit_depth: usize,
+  ) {
+    native::put_8tap(
+      dst, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
+    );
+  }
+}
 
 macro_rules! decl_mct_fns {
   ($(($mode_x:expr, $mode_y:expr, $func_name:ident)),+) => {
@@ -311,14 +258,6 @@ macro_rules! decl_mct_fns {
         );
       )*
     }
-
-    static PREP_FNS_AVX2: [Option<PrepFn>; 16] = {
-      let mut out: [Option<PrepFn>; 16] = [None; 16];
-      $(
-        out[get_2d_mode_idx($mode_x, $mode_y)] = Some($func_name);
-      )*
-      out
-    };
   }
 }
 
@@ -335,14 +274,71 @@ decl_mct_fns!(
   (BILINEAR, BILINEAR, rav1e_prep_bilin_avx2)
 );
 
-pub(crate) static PREP_FNS: [[Option<PrepFn>; 16]; CpuFeatureLevel::len()] = {
-  let mut out = [[None; 16]; CpuFeatureLevel::len()];
-  out[CpuFeatureLevel::AVX2 as usize] = PREP_FNS_AVX2;
-  out
-};
+trait Prep8Tap<T: Pixel> {
+  fn prep_8tap(
+    tmp: &mut [i16], src: PlaneSlice<'_, T>, width: usize, height: usize,
+    col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,
+    bit_depth: usize,
+  );
+}
 
-pub(crate) static PREP_HBD_FNS: [[Option<PrepHBDFn>; 16];
-  CpuFeatureLevel::len()] = [[None; 16]; CpuFeatureLevel::len()];
+struct Prep8TapAvx2;
+
+impl<T: Pixel> Prep8Tap<T> for Prep8TapAvx2 {
+  fn prep_8tap(
+    tmp: &mut [i16], src: PlaneSlice<'_, T>, width: usize, height: usize,
+    col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,
+    bit_depth: usize,
+  ) {
+    if T::type_enum() == PixelType::U8 {
+      let func: Option<PrepFn> = match (mode_x, mode_y) {
+        (REGULAR, REGULAR) => Some(rav1e_prep_8tap_regular_avx2),
+        (REGULAR, SMOOTH) => Some(rav1e_prep_8tap_regular_smooth_avx2),
+        (REGULAR, SHARP) => Some(rav1e_prep_8tap_regular_sharp_avx2),
+        (SMOOTH, REGULAR) => Some(rav1e_prep_8tap_smooth_regular_avx2),
+        (SMOOTH, SMOOTH) => Some(rav1e_prep_8tap_smooth_avx2),
+        (SMOOTH, SHARP) => Some(rav1e_prep_8tap_smooth_sharp_avx2),
+        (SHARP, REGULAR) => Some(rav1e_prep_8tap_sharp_regular_avx2),
+        (SHARP, SMOOTH) => Some(rav1e_prep_8tap_sharp_smooth_avx2),
+        (SHARP, SHARP) => Some(rav1e_prep_8tap_sharp_avx2),
+        (BILINEAR, BILINEAR) => Some(rav1e_prep_bilin_avx2),
+        _ => None,
+      };
+      if let Some(func) = func {
+        unsafe {
+          return func(
+            tmp.as_mut_ptr(),
+            src.as_ptr() as *const _,
+            T::to_asm_stride(src.plane.cfg.stride),
+            width as i32,
+            height as i32,
+            col_frac,
+            row_frac,
+          );
+        }
+      }
+    }
+
+    Prep8TapNative::prep_8tap(
+      tmp, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
+    );
+  }
+}
+
+struct Prep8TapNative;
+
+impl<T: Pixel> Prep8Tap<T> for Prep8TapNative {
+  #[inline(always)]
+  fn prep_8tap(
+    tmp: &mut [i16], src: PlaneSlice<'_, T>, width: usize, height: usize,
+    col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,
+    bit_depth: usize,
+  ) {
+    native::prep_8tap(
+      tmp, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
+    );
+  }
+}
 
 extern {
   fn rav1e_avg_avx2(
@@ -351,12 +347,45 @@ extern {
   );
 }
 
-pub(crate) static AVG_FNS: [Option<AvgFn>; CpuFeatureLevel::len()] = {
-  let mut out: [Option<AvgFn>; CpuFeatureLevel::len()] =
-    [None; CpuFeatureLevel::len()];
-  out[CpuFeatureLevel::AVX2 as usize] = Some(rav1e_avg_avx2);
-  out
-};
+trait McAvg<T: Pixel> {
+  fn mc_avg(
+    dst: &mut PlaneRegionMut<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
+    height: usize, bit_depth: usize,
+  );
+}
 
-pub(crate) static AVG_HBD_FNS: [Option<AvgHBDFn>; CpuFeatureLevel::len()] =
-  [None; CpuFeatureLevel::len()];
+struct McAvgAvx2;
+
+impl<T: Pixel> McAvg<T> for McAvgAvx2 {
+  fn mc_avg(
+    dst: &mut PlaneRegionMut<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
+    height: usize, bit_depth: usize,
+  ) {
+    if T::type_enum() == PixelType::U8 {
+      unsafe {
+        return rav1e_avg_avx2(
+          dst.data_ptr_mut() as *mut _,
+          T::to_asm_stride(dst.plane_cfg.stride),
+          tmp1.as_ptr(),
+          tmp2.as_ptr(),
+          width as i32,
+          height as i32,
+        );
+      }
+    }
+
+    McAvgNative::mc_avg(dst, tmp1, tmp2, width, height, bit_depth);
+  }
+}
+
+struct McAvgNative;
+
+impl<T: Pixel> McAvg<T> for McAvgNative {
+  #[inline(always)]
+  fn mc_avg(
+    dst: &mut PlaneRegionMut<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
+    height: usize, bit_depth: usize,
+  ) {
+    native::mc_avg(dst, tmp1, tmp2, width, height, bit_depth);
+  }
+}

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -16,7 +16,6 @@ use crate::frame::*;
 use crate::tiling::*;
 use crate::util::{clamp, msb, CastFromPrimitive, Pixel};
 
-use crate::cpu_features::CpuFeatureLevel;
 use std::cmp;
 
 #[cfg(not(all(
@@ -152,7 +151,7 @@ pub(crate) mod native {
   pub(crate) unsafe fn cdef_filter_block<T: Pixel>(
     dst: &mut PlaneRegionMut<'_, T>, input: *const u16, istride: isize,
     pri_strength: i32, sec_strength: i32, dir: usize, damping: i32,
-    bit_depth: usize, xdec: usize, ydec: usize, _cpu: CpuFeatureLevel,
+    bit_depth: usize, xdec: usize, ydec: usize,
   ) {
     let xsize = (8 >> xdec) as isize;
     let ysize = (8 >> ydec) as isize;
@@ -509,7 +508,6 @@ pub fn cdef_filter_superblock<T: Pixel>(
                 bit_depth,
                 xdec,
                 ydec,
-                fi.cpu_feature_level,
               );
             }
           } else {

--- a/src/cpu_features.rs
+++ b/src/cpu_features.rs
@@ -7,91 +7,31 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-#[cfg(not(all(
-  feature = "nasm",
-  any(target_arch = "x86", target_arch = "x86_64")
-)))]
-pub use native::*;
-#[cfg(all(
-  feature = "nasm",
-  any(target_arch = "x86", target_arch = "x86_64")
-))]
-pub use x86::*;
+use arrayvec::ArrayVec;
 
-#[cfg(all(
-  feature = "nasm",
-  any(target_arch = "x86", target_arch = "x86_64")
-))]
-mod x86 {
-  use arg_enum_proc_macro::ArgEnum;
-  use std::env;
-
-  #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, ArgEnum)]
-  pub enum CpuFeatureLevel {
-    NATIVE,
-    SSE2,
-    SSSE3,
-    AVX2,
-  }
-
-  impl CpuFeatureLevel {
-    pub const fn len() -> usize {
-      CpuFeatureLevel::AVX2 as usize + 1
-    }
-
-    #[inline(always)]
-    pub fn as_index(self) -> usize {
-      const LEN: usize = CpuFeatureLevel::len();
-      assert_eq!(LEN & (LEN - 1), 0);
-      self as usize & (LEN - 1)
-    }
-  }
-
-  impl Default for CpuFeatureLevel {
-    fn default() -> CpuFeatureLevel {
-      let detected: CpuFeatureLevel = if is_x86_feature_detected!("avx2") {
-        CpuFeatureLevel::AVX2
-      } else if is_x86_feature_detected!("ssse3") {
-        CpuFeatureLevel::SSSE3
-      } else if is_x86_feature_detected!("sse2") {
-        CpuFeatureLevel::SSE2
-      } else {
-        CpuFeatureLevel::NATIVE
-      };
-      let manual: CpuFeatureLevel = match env::var("RAV1E_CPU_TARGET") {
-        Ok(feature) => match feature.as_ref() {
-          "rust" => CpuFeatureLevel::NATIVE,
-          "avx2" => CpuFeatureLevel::AVX2,
-          "ssse3" => CpuFeatureLevel::SSSE3,
-          "sse2" => CpuFeatureLevel::SSE2,
-          _ => detected,
-        },
-        Err(_e) => detected,
-      };
-      if manual > detected {
-        detected
-      } else {
-        manual
+// This macro helps reduce some code duplication
+macro_rules! detect_feature {
+  ($platform:ident, $feature:literal, $arr:ident) => {
+    paste::expr! {
+      if [<is_ $platform _feature_detected>]!($feature) {
+        $arr.push($feature);
       }
     }
-  }
+  };
 }
 
-#[cfg(not(all(
-  feature = "nasm",
-  any(target_arch = "x86", target_arch = "x86_64")
-)))]
-mod native {
-  use arg_enum_proc_macro::ArgEnum;
+pub fn get_detected_cpu_features() -> ArrayVec<[&'static str; 3]> {
+  let mut features = ArrayVec::new();
 
-  #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, ArgEnum)]
-  pub enum CpuFeatureLevel {
-    NATIVE,
+  #[cfg(all(
+    feature = "nasm",
+    any(target_arch = "x86", target_arch = "x86_64")
+  ))]
+  {
+    detect_feature!(x86, "sse2", features);
+    detect_feature!(x86, "ssse3", features);
+    detect_feature!(x86, "avx2", features);
   }
 
-  impl Default for CpuFeatureLevel {
-    fn default() -> CpuFeatureLevel {
-      CpuFeatureLevel::NATIVE
-    }
-  }
+  features
 }

--- a/src/cpu_features.rs
+++ b/src/cpu_features.rs
@@ -10,6 +10,7 @@
 use arrayvec::ArrayVec;
 
 // This macro helps reduce some code duplication
+#[allow(unused_macros)]
 macro_rules! detect_feature {
   ($platform:ident, $feature:literal, $arr:ident) => {
     paste::expr! {
@@ -20,6 +21,7 @@ macro_rules! detect_feature {
   };
 }
 
+#[allow(unused_mut)]
 pub fn get_detected_cpu_features() -> ArrayVec<[&'static str; 3]> {
   let mut features = ArrayVec::new();
 

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -19,14 +19,13 @@ pub use self::native::*;
 pub use crate::asm::x86::dist::*;
 
 pub(crate) mod native {
-  use crate::cpu_features::CpuFeatureLevel;
   use crate::partition::BlockSize;
   use crate::tiling::*;
   use crate::util::*;
 
   pub fn get_sad<T: Pixel>(
     plane_org: &PlaneRegion<'_, T>, plane_ref: &PlaneRegion<'_, T>,
-    bsize: BlockSize, _bit_depth: usize, _cpu: CpuFeatureLevel,
+    bsize: BlockSize, _bit_depth: usize,
   ) -> u32 {
     let blk_w = bsize.width();
     let blk_h = bsize.height();
@@ -123,7 +122,7 @@ pub(crate) mod native {
   /// *x4 blocks use 4x4 and all others use 8x8.
   pub fn get_satd<T: Pixel>(
     plane_org: &PlaneRegion<'_, T>, plane_ref: &PlaneRegion<'_, T>,
-    bsize: BlockSize, _bit_depth: usize, _cpu: CpuFeatureLevel,
+    bsize: BlockSize, _bit_depth: usize,
   ) -> u32 {
     let blk_w = bsize.width();
     let blk_h = bsize.height();
@@ -177,7 +176,6 @@ pub(crate) mod native {
 #[cfg(test)]
 pub mod test {
   use super::*;
-  use crate::cpu_features::CpuFeatureLevel;
   use crate::frame::*;
   use crate::partition::BlockSize;
   use crate::partition::BlockSize::*;
@@ -316,13 +314,7 @@ pub mod test {
 
       assert_eq!(
         block.1,
-        get_satd(
-          &mut input_region,
-          &mut rec_region,
-          block.0,
-          bit_depth,
-          CpuFeatureLevel::default()
-        )
+        get_satd(&mut input_region, &mut rec_region, block.0, bit_depth)
       );
     }
   }

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -256,13 +256,7 @@ pub mod test {
 
       assert_eq!(
         block.1,
-        get_sad(
-          &mut input_region,
-          &mut rec_region,
-          block.0,
-          bit_depth,
-          CpuFeatureLevel::default()
-        )
+        get_sad(&mut input_region, &mut rec_region, block.0, bit_depth,)
       );
     }
   }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -539,9 +539,6 @@ pub struct FrameInvariants<T: Pixel> {
   /// indicating how much future frames depend on the block (for example, via
   /// inter-prediction).
   pub block_importances: Box<[f32]>,
-
-  /// Target CPU feature level.
-  pub cpu_feature_level: crate::cpu_features::CpuFeatureLevel,
 }
 
 pub(crate) const fn pos_to_lvl(pos: u64, pyramid_depth: u64) -> u64 {
@@ -708,7 +705,6 @@ impl<T: Pixel> FrameInvariants<T> {
       lookahead_intra_costs: vec![0; w_in_imp_b * h_in_imp_b]
         .into_boxed_slice(),
       block_importances: vec![0.; w_in_imp_b * h_in_imp_b].into_boxed_slice(),
-      cpu_feature_level: Default::default(),
     }
   }
 

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -18,7 +18,6 @@ pub use self::native::*;
 ))]
 pub use crate::asm::x86::mc::*;
 
-use crate::cpu_features::CpuFeatureLevel;
 use crate::frame::*;
 use crate::tiling::*;
 use crate::util::*;
@@ -210,7 +209,7 @@ pub(crate) mod native {
   pub fn put_8tap<T: Pixel>(
     dst: &mut PlaneRegionMut<'_, T>, src: PlaneSlice<'_, T>, width: usize,
     height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
-    mode_y: FilterMode, bit_depth: usize, _cpu: CpuFeatureLevel,
+    mode_y: FilterMode, bit_depth: usize,
   ) {
     let ref_stride = src.plane.cfg.stride;
     let y_filter = get_filter(mode_y, row_frac, height);
@@ -306,7 +305,7 @@ pub(crate) mod native {
   pub fn prep_8tap<T: Pixel>(
     tmp: &mut [i16], src: PlaneSlice<'_, T>, width: usize, height: usize,
     col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,
-    bit_depth: usize, _cpu: CpuFeatureLevel,
+    bit_depth: usize,
   ) {
     let ref_stride = src.plane.cfg.stride;
     let y_filter = get_filter(mode_y, row_frac, height);
@@ -384,7 +383,7 @@ pub(crate) mod native {
 
   pub fn mc_avg<T: Pixel>(
     dst: &mut PlaneRegionMut<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
-    height: usize, bit_depth: usize, _cpu: CpuFeatureLevel,
+    height: usize, bit_depth: usize,
   ) {
     let max_sample_val = ((1 << bit_depth) - 1) as i32;
     let intermediate_bits = 4 - if bit_depth == 12 { 2 } else { 0 };

--- a/src/me.rs
+++ b/src/me.rs
@@ -843,9 +843,9 @@ fn compute_mv_rd_cost<T: Pixel>(
   plane_org: &PlaneRegion<'_, T>, plane_ref: &PlaneRegion<'_, T>,
 ) -> u64 {
   let sad = if use_satd {
-    get_satd(&plane_org, &plane_ref, bsize, bit_depth, fi.cpu_feature_level)
+    get_satd(&plane_org, &plane_ref, bsize, bit_depth)
   } else {
-    get_sad(&plane_org, &plane_ref, bsize, bit_depth, fi.cpu_feature_level)
+    get_sad(&plane_org, &plane_ref, bsize, bit_depth)
   };
 
   let rate1 = get_mv_rate(cand_mv, pmv[0], fi.allow_high_precision_mv);
@@ -961,13 +961,7 @@ fn full_search<T: Pixel>(
   // Select rectangular regions within search region with vert+horz windows
   for vert_window in search_region.vert_windows(blk_h).step_by(step) {
     for ref_window in vert_window.horz_windows(blk_w).step_by(step) {
-      let sad = get_sad(
-        &plane_org,
-        &ref_window,
-        bsize,
-        bit_depth,
-        fi.cpu_feature_level,
-      );
+      let sad = get_sad(&plane_org, &ref_window, bsize, bit_depth);
 
       let &Rect { x, y, .. } = ref_window.rect();
 

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -367,7 +367,6 @@ impl PredictionMode {
           mode,
           mode,
           fi.sequence.bit_depth,
-          fi.cpu_feature_level,
         );
       }
     } else {
@@ -389,7 +388,6 @@ impl PredictionMode {
             mode,
             mode,
             fi.sequence.bit_depth,
-            fi.cpu_feature_level,
           );
         }
       }
@@ -400,7 +398,6 @@ impl PredictionMode {
         width,
         height,
         fi.sequence.bit_depth,
-        fi.cpu_feature_level,
       );
     }
   }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1036,7 +1036,6 @@ pub fn rdo_mode_decision<T: Pixel>(
                 &plane_ref,
                 tx_size.block_size(),
                 fi.sequence.bit_depth,
-                fi.cpu_feature_level,
               ),
             )
           })

--- a/src/util.rs
+++ b/src/util.rs
@@ -125,6 +125,7 @@ impl_cast_from_primitive!(i32 => { u32, u64, usize });
 impl_cast_from_primitive!(i32 => { i8, i16, i32, i64, isize });
 
 /// Types that can be used as pixel types.
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum PixelType {
   /// 8 bits per pixel, stored in a `u8`.
   U8,


### PR DESCRIPTION
This uses the trait based approach discussed in IRC. In order to be able to set the env var for testing, https://github.com/rust-lang/stdarch/commit/b8aecbfb8ea2ac028426da48b0f9ca6a730b9730 will need to be pulled into the Rust tree and released in a nightly, but unfortunately it is not released yet. In lieu of that, I would like to make a follow-up PR to this one to create automated tests for each version of each ASM function that doesn't already have tests.