### PR TITLE
Bump again err-derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ rayon = "1.0"
 bincode = "1.1"
 arrayvec = "0.5"
 better-panic = { version = "0.2", optional = true }
-err-derive = "0.2.0"
+err-derive = "0.2.1"
 image = { version = "0.22.1", optional = true, default-features = false, features = ["png"] }
 byteorder = { version = "1.3.2", optional = true }
 log = "0.4"


### PR DESCRIPTION
This version removes the build dependency on skeptic tests. 