### PR TITLE
Disable only the broken SSE2 function

### DIFF
--- a/src/asm/x86/dist.rs
+++ b/src/asm/x86/dist.rs
@@ -53,7 +53,7 @@ declare_asm_dist_fn![
   (rav1e_sad8x8_sse2, u8),
   (rav1e_sad8x16_sse2, u8),
   (rav1e_sad8x32_sse2, u8),
-  (rav1e_sad16x16_sse2, u8),
+  //  (rav1e_sad16x16_sse2, u8),
   (rav1e_sad32x32_sse2, u8),
   (rav1e_sad64x64_sse2, u8),
   (rav1e_sad128x128_sse2, u8),
@@ -204,7 +204,8 @@ static SAD_FNS_SSE2: [Option<SadFn>; DIST_FNS_LENGTH] = {
   out[BLOCK_8X16 as usize] = Some(rav1e_sad8x16_sse2);
   out[BLOCK_8X32 as usize] = Some(rav1e_sad8x32_sse2);
 
-  out[BLOCK_16X16 as usize] = Some(rav1e_sad16x16_sse2);
+  // FIXME: This function is currently broken, see https://github.com/xiph/rav1e/issues/1715
+  // out[BLOCK_16X16 as usize] = Some(rav1e_sad16x16_sse2);
   out[BLOCK_32X32 as usize] = Some(rav1e_sad32x32_sse2);
   out[BLOCK_64X64 as usize] = Some(rav1e_sad64x64_sse2);
   out[BLOCK_128X128 as usize] = Some(rav1e_sad128x128_sse2);

--- a/src/cpu_features.rs
+++ b/src/cpu_features.rs
@@ -44,9 +44,8 @@ mod x86 {
         CpuFeatureLevel::AVX2
       } else if is_x86_feature_detected!("ssse3") {
         CpuFeatureLevel::SSSE3
-      // FIXME: SSE2 is currently broken, see https://github.com/xiph/rav1e/issues/1715
-      // } else if is_x86_feature_detected!("sse2") {
-      //   CpuFeatureLevel::SSE2
+      } else if is_x86_feature_detected!("sse2") {
+        CpuFeatureLevel::SSE2
       } else {
         CpuFeatureLevel::NATIVE
       };
@@ -55,7 +54,7 @@ mod x86 {
           "rust" => CpuFeatureLevel::NATIVE,
           "avx2" => CpuFeatureLevel::AVX2,
           "ssse3" => CpuFeatureLevel::SSSE3,
-          // "sse2" => CpuFeatureLevel::SSE2,
+          "sse2" => CpuFeatureLevel::SSE2,
           _ => detected,
         },
         Err(_e) => detected,


### PR DESCRIPTION
The broken SSE2 functions don't get overridden
until AVX2, so #1755 failed to fix the issue
for SSSE3 CPUs. This is also a more targeted approach.

Verified testing against speed 0 locally with SSSE3 feature set enabled.