### PR TITLE
Rebalance transform set speed presets

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -361,7 +361,7 @@ impl SpeedSettings {
   }
 
   const fn reduced_tx_set_preset(speed: usize) -> bool {
-    speed >= 6
+    speed >= 5
   }
 
   /// TX domain distortion is always faster, with no significant quality change
@@ -378,7 +378,7 @@ impl SpeedSettings {
   }
 
   const fn rdo_tx_decision_preset(speed: usize) -> bool {
-    speed <= 4
+    speed <= 5
   }
 
   fn prediction_modes_preset(speed: usize) -> PredictionModesSetting {


### PR DESCRIPTION
Closes #1707 via @ycho's suggested solution.

[Here](https://beta.arewecompressedyet.com/?job=master-s4%402019-10-17T18%3A18%3A25.883Z&job=master-s5%402019-10-17T18%3A19%3A08.579Z&job=s5-txset%402019-10-17T16%3A41%3A04.262Z&job=master-s6%402019-10-17T18%3A20%3A01.049Z) is a comparison between speed level 4, 5 as of now, 5 with this PR, and 6. It is clear that 5 and 6 are far too similar right now. This PR enables transform type and size RDO with a reduced transform set for speed level 5, which differentiates level 5 from 6 while remaining a reasonable speed/quality tradeoff compared to level 4.