### PR TITLE
Rename RDO(Partition)Output to Partition(Group)Parameters and reuse them where appropriate

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -34,9 +34,9 @@ use crate::transform::*;
 use crate::util::{clamp, msb, AlignedArray, Pixel};
 
 use arrayvec::*;
+use std::default::Default;
 use std::ops::{Index, IndexMut};
 use std::*;
-use std::default::Default;
 
 pub const PLANES: usize = 3;
 
@@ -1272,7 +1272,7 @@ impl TileSuperBlockOffset {
 
 /// Absolute offset in blocks, where a block is defined
 /// to be an N*N square where N = (1 << BLOCK_TO_PLANE_SHIFT).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BlockOffset {
   pub x: usize,
   pub y: usize,
@@ -1285,7 +1285,7 @@ pub struct PlaneBlockOffset(pub BlockOffset);
 
 /// Absolute offset in blocks inside a tile, where a block is defined
 /// to be an N*N square where N = (1 << BLOCK_TO_PLANE_SHIFT).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct TileBlockOffset(pub BlockOffset);
 
 impl BlockOffset {

--- a/src/context.rs
+++ b/src/context.rs
@@ -2227,6 +2227,7 @@ impl<'a> ContextWriter<'a> {
     let left_ctx = intra_mode_context[left_mode as usize];
     &self.fc.kf_y_cdf[above_ctx][left_ctx]
   }
+
   pub fn write_intra_mode_kf(
     &mut self, w: &mut dyn Writer, bo: TileBlockOffset, mode: PredictionMode,
   ) {
@@ -2247,11 +2248,13 @@ impl<'a> ContextWriter<'a> {
     let cdf = &mut self.fc.kf_y_cdf[above_ctx][left_ctx];
     symbol_with_update!(self, w, mode as u32, cdf);
   }
+
   pub fn get_cdf_intra_mode(
     &self, bsize: BlockSize,
   ) -> &[u16; INTRA_MODES + 1] {
     &self.fc.y_mode_cdf[size_group_lookup[bsize as usize] as usize]
   }
+
   pub fn write_intra_mode(
     &mut self, w: &mut dyn Writer, bsize: BlockSize, mode: PredictionMode,
   ) {
@@ -2259,6 +2262,7 @@ impl<'a> ContextWriter<'a> {
       &mut self.fc.y_mode_cdf[size_group_lookup[bsize as usize] as usize];
     symbol_with_update!(self, w, mode as u32, cdf);
   }
+
   pub fn write_intra_uv_mode(
     &mut self, w: &mut dyn Writer, uv_mode: PredictionMode,
     y_mode: PredictionMode, bs: BlockSize,
@@ -2271,6 +2275,7 @@ impl<'a> ContextWriter<'a> {
       symbol_with_update!(self, w, uv_mode as u32, &mut cdf[..UV_INTRA_MODES]);
     }
   }
+
   pub fn write_cfl_alphas(&mut self, w: &mut dyn Writer, cfl: CFLParams) {
     symbol_with_update!(self, w, cfl.joint_sign(), &mut self.fc.cfl_sign_cdf);
     for uv in 0..2 {
@@ -2284,6 +2289,7 @@ impl<'a> ContextWriter<'a> {
       }
     }
   }
+
   pub fn write_angle_delta(
     &mut self, w: &mut dyn Writer, angle: i8, mode: PredictionMode,
   ) {
@@ -2295,6 +2301,7 @@ impl<'a> ContextWriter<'a> {
         [mode as usize - PredictionMode::V_PRED as usize]
     );
   }
+
   pub fn write_use_filter_intra(
     &mut self, w: &mut dyn Writer, enable: bool, block_size: BlockSize,
   ) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -36,6 +36,7 @@ use crate::util::{clamp, msb, AlignedArray, Pixel};
 use arrayvec::*;
 use std::ops::{Index, IndexMut};
 use std::*;
+use std::default::Default;
 
 pub const PLANES: usize = 3;
 
@@ -1413,7 +1414,16 @@ pub struct Block {
 }
 
 impl Block {
-  pub fn default() -> Block {
+  pub fn is_inter(&self) -> bool {
+    self.mode >= PredictionMode::NEARESTMV
+  }
+  pub fn has_second_ref(&self) -> bool {
+    self.ref_frames[1] != INTRA_FRAME && self.ref_frames[1] != NONE_FRAME
+  }
+}
+
+impl Default for Block {
+  fn default() -> Block {
     Block {
       mode: PredictionMode::DC_PRED,
       partition: PartitionType::PARTITION_NONE,
@@ -1429,12 +1439,6 @@ impl Block {
       deblock_deltas: [0, 0, 0, 0],
       segmentation_idx: 0,
     }
-  }
-  pub fn is_inter(&self) -> bool {
-    self.mode >= PredictionMode::NEARESTMV
-  }
-  pub fn has_second_ref(&self) -> bool {
-    self.ref_frames[1] != INTRA_FRAME && self.ref_frames[1] != NONE_FRAME
   }
 }
 

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -90,6 +90,12 @@ pub enum PredictionMode {
   NEW_NEWMV,
 }
 
+impl Default for PredictionMode {
+  fn default() -> Self {
+    PredictionMode::DC_PRED
+  }
+}
+
 impl PredictionMode {
   pub fn is_compound(self) -> bool {
     self >= PredictionMode::NEAREST_NEARESTMV

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -78,14 +78,14 @@ impl RDOType {
 }
 
 #[derive(Clone)]
-pub struct RDOOutput {
+pub struct PartitionGroupParameters {
   pub rd_cost: f64,
   pub part_type: PartitionType,
-  pub part_modes: Vec<RDOPartitionOutput>,
+  pub part_modes: Vec<PartitionParameters>,
 }
 
 #[derive(Clone)]
-pub struct RDOPartitionOutput {
+pub struct PartitionParameters {
   pub rd_cost: f64,
   pub bo: TileBlockOffset,
   pub bsize: BlockSize,
@@ -797,7 +797,7 @@ pub fn rdo_mode_decision<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, bsize: BlockSize, tile_bo: TileBlockOffset,
   pmvs: &mut [Option<MotionVector>], inter_cfg: &InterConfig,
-) -> RDOPartitionOutput {
+) -> PartitionParameters {
   let mut best = EncodingSettings::default();
 
   let PlaneConfig { xdec, ydec, .. } = ts.input.planes[1].cfg;
@@ -1253,7 +1253,7 @@ pub fn rdo_mode_decision<T: Pixel>(
 
   assert!(best.rd >= 0_f64);
 
-  RDOPartitionOutput {
+  PartitionParameters {
     bo: tile_bo,
     bsize,
     pred_mode_luma: best.mode_luma,
@@ -1512,11 +1512,12 @@ pub fn get_sub_partitions_with_border_check(
 pub fn rdo_partition_decision<T: Pixel, W: Writer>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, w_pre_cdef: &mut W, w_post_cdef: &mut W,
-  bsize: BlockSize, tile_bo: TileBlockOffset, cached_block: &RDOOutput,
+  bsize: BlockSize, tile_bo: TileBlockOffset,
+  cached_block: &PartitionGroupParameters,
   pmvs: &mut [[Option<MotionVector>; REF_FRAMES]; 5],
   partition_types: &[PartitionType], rdo_type: RDOType,
   inter_cfg: &InterConfig,
-) -> RDOOutput {
+) -> PartitionGroupParameters {
   let mut best_partition = cached_block.part_type;
   let mut best_rd = cached_block.rd_cost;
   let mut best_pred_modes = cached_block.part_modes.clone();
@@ -1676,7 +1677,7 @@ pub fn rdo_partition_decision<T: Pixel, W: Writer>(
 
   assert!(best_rd >= 0_f64);
 
-  RDOOutput {
+  PartitionGroupParameters {
     rd_cost: best_rd,
     part_type: best_partition,
     part_modes: best_pred_modes,


### PR DESCRIPTION
Part of larger cleanup effort, but I'm opening this first in case there are comments on this change. I have thought for a while that the current names are a bit vague, and the parameters are reused without transformation in the encoder module, so they are not necessarily specific to RDO.