### PR TITLE
Remove broken clamp from the forward transforms.

### DIFF
--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -300,8 +300,7 @@ fn av1_round_shift_array_rs(arr: &mut [i32], size: usize, bit: i8) {
     }
   } else {
     for i in 0..size {
-      arr[i] =
-        clamp((1 << (-bit)) * arr[i], i32::min_value(), i32::max_value());
+      arr[i] <<= -bit;
     }
   }
 }


### PR DESCRIPTION
This clamp isn't needed and is broken (clamping a i32 to i32 ranges).
This code was only being reached at the start of the forward transform,
where we are shifting our pixels up. We are never shifting out of i32s.