### PR TITLE
Restore before_install for Travis on arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,7 @@ jobs:
       rust: stable
       arch: arm64
       script:
-        - cargo build --release --tests --verbose
-        - cargo test --release --verbose
+        - cargo test --features=decode_test,decode_test_dav1d,quick_test,capi --verbose
     - name: "Ignored Tests (aom)"
       rust: stable
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,22 +19,19 @@ addons:
 before_install:
   - export BUILD_DIR="$TRAVIS_HOME/.build"
   - export DEPS_DIR="$TRAVIS_HOME/.local"
+  - export ARCH="`uname -m`"
   - mkdir -p "$BUILD_DIR"
   - mkdir -p "$DEPS_DIR/bin"
   - mkdir -p "$DEPS_DIR/lib/pkgconfig"
   - export PATH="$PATH:$DEPS_DIR/bin"
-  - export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$DEPS_DIR/lib/pkgconfig:$DEPS_DIR/lib/x86_64-linux-gnu/pkgconfig"
-  - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEPS_DIR/lib:$DEPS_DIR/lib/x86_64-linux-gnu"
+  - export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$DEPS_DIR/lib/pkgconfig:$DEPS_DIR/lib/$ARCH-linux-gnu/pkgconfig"
+  - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEPS_DIR/lib:$DEPS_DIR/lib/$ARCH-linux-gnu"
   - pip3 install meson
-  - bash "$TRAVIS_BUILD_DIR/.travis/install-sccache.sh"
-  - export RUSTC_WRAPPER=sccache
+  - source "$TRAVIS_BUILD_DIR/.travis/install-sccache.sh"
   - export SCCACHE_CACHE_SIZE=500M
   - export SCCACHE_DIR="$TRAVIS_HOME/.cache/sccache"
-  - sccache --version
   - bash "$TRAVIS_BUILD_DIR/.travis/install-nasm.sh"
-  - nasm --version
   - bash "$TRAVIS_BUILD_DIR/.travis/install-kcov.sh"
-  - kcov --version
   - bash "$TRAVIS_BUILD_DIR/.travis/install-aom.sh"
   - aomenc --help | grep "AV1 Encoder"
   - bash "$TRAVIS_BUILD_DIR/.travis/install-dav1d.sh"
@@ -78,7 +75,6 @@ jobs:
     - name: "Arm build and test"
       rust: stable
       arch: arm64
-      before_install: skip
       script:
         - cargo build --release --tests --verbose
         - cargo test --release --verbose

--- a/.travis/install-aom.sh
+++ b/.travis/install-aom.sh
@@ -9,7 +9,10 @@ if [[ "$(aomenc --help)" != *"AV1 Encoder $AOM_VERSION"* ]]; then
   rm -rf CMakeCache.txt CMakeFiles
   mkdir -p .build
   cd .build
-  cmake -GNinja .. -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=0 -DENABLE_DOCS=0 -DCONFIG_LOWBITDEPTH=1 -DCMAKE_INSTALL_PREFIX="$DEPS_DIR" -DCONFIG_PIC=1
+  if command -v sccache; then
+    LAUNCHER_OPTS="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+  fi
+  cmake -GNinja .. $LAUNCHER_OPTS -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=0 -DENABLE_DOCS=0 -DCONFIG_LOWBITDEPTH=1 -DCMAKE_INSTALL_PREFIX="$DEPS_DIR" -DCONFIG_PIC=1
   ninja && ninja install
 else
   echo "Using cached directory."

--- a/.travis/install-dav1d.sh
+++ b/.travis/install-dav1d.sh
@@ -7,10 +7,12 @@ DAV1D_VERSION="0.4.0"
 if [ "$(dav1d --version 2>&1 > /dev/null)" != "$DAV1D_VERSION" ]; then
   curl -L "https://code.videolan.org/videolan/dav1d/-/archive/$DAV1D_VERSION/dav1d-$DAV1D_VERSION.tar.gz" | tar xz
   cd "dav1d-$DAV1D_VERSION"
-  # Tell meson where to look for nasm, because it doesn't respect our $PATH
-  export NASM_PATH="$DEPS_DIR/bin/nasm"
-  export NASM_PATH="${NASM_PATH//'/'/'\/'}"
-  sed -i "s/nasm = find_program('nasm')/nasm = find_program(['nasm', '$NASM_PATH'])/g" meson.build
+  if command -v nasm; then
+    # Tell meson where to look for nasm, because it doesn't respect our $PATH
+    export NASM_PATH="$DEPS_DIR/bin/nasm"
+    export NASM_PATH="${NASM_PATH//'/'/'\/'}"
+    sed -i "s/nasm = find_program('nasm')/nasm = find_program(['nasm', '$NASM_PATH'])/g" meson.build
+  fi
   meson build --buildtype release --prefix "$DEPS_DIR"
   ninja -C build install
 else

--- a/.travis/install-kcov.sh
+++ b/.travis/install-kcov.sh
@@ -3,11 +3,13 @@ set -ex
 
 KCOV_VERSION="36"
 
-if [ "$(kcov --version)" != "kcov $KCOV_VERSION" ]; then
+if [ "$(kcov --version)" = "kcov $KCOV_VERSION" ]; then
+  echo "Using cached directory."
+elif [ "$ARCH" = "x86_64" ]; then
   curl -L "https://github.com/SimonKagstrom/kcov/archive/v$KCOV_VERSION.tar.gz" | tar xz
   cd "kcov-$KCOV_VERSION"
   mkdir .build && cd .build
   cmake -GNinja -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .. -DCMAKE_INSTALL_PREFIX="$DEPS_DIR" && ninja && ninja install
 else
-  echo "Using cached directory."
+  echo "Skipping kcov installation on $ARCH."
 fi

--- a/.travis/install-nasm.sh
+++ b/.travis/install-nasm.sh
@@ -3,10 +3,12 @@ set -ex
 
 NASM_VERSION="2.14"
 
-if [[ "$(nasm --version)" != "NASM version $NASM_VERSION"* ]]; then
+if [[ "$(nasm --version)" = "NASM version $NASM_VERSION"* ]]; then
+  echo "Using cached directory."
+elif [ "$ARCH" = "x86_64" ]; then
   curl -L "https://download.videolan.org/contrib/nasm/nasm-$NASM_VERSION.tar.gz" | tar xz
   cd "nasm-$NASM_VERSION"
   ./configure CC='sccache gcc' --prefix="$DEPS_DIR" && make -j2 && make install
 else
-  echo "Using cached directory."
+  echo "Skipping nasm installation on $ARCH."
 fi

--- a/.travis/install-sccache.sh
+++ b/.travis/install-sccache.sh
@@ -3,9 +3,17 @@ set -ex
 
 SCCACHE_VERSION="0.2.10"
 
-if [ "$(sccache --version)" != "sccache $SCCACHE_VERSION" ]; then
+export RUSTC_WRAPPER=sccache
+
+if [ "$(sccache --version)" = "sccache $SCCACHE_VERSION" ]; then
+  echo "Using cached directory."
+elif [ "$ARCH" = "x86_64" ]; then
   curl -L "https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz" | tar xz
   mv -f "sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl/sccache" "$DEPS_DIR/bin/sccache"
 else
-  echo "Using cached directory."
+  # cargo install --version "$SCCACHE_VERSION" --root "$DEPS_DIR" --no-default-features sccache
+  echo "Skipping sccache installation on $ARCH."
+  unset RUSTC_WRAPPER
 fi
+
+set +ex


### PR DESCRIPTION
Some of our deps should be optional until caching is available on arm64 Travis builds.

Fixes #1771.