### PR TITLE
Hot fix for Travis cache failure on arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
       - python3-wheel
       - libsdl2-dev
       - libvulkan-dev
+      - ruby # needed by casher on arm64
 before_install:
   - export BUILD_DIR="$TRAVIS_HOME/.build"
   - export DEPS_DIR="$TRAVIS_HOME/.local"

--- a/.travis/install-sccache.sh
+++ b/.travis/install-sccache.sh
@@ -11,9 +11,7 @@ elif [ "$ARCH" = "x86_64" ]; then
   curl -L "https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz" | tar xz
   mv -f "sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl/sccache" "$DEPS_DIR/bin/sccache"
 else
-  # cargo install --version "$SCCACHE_VERSION" --root "$DEPS_DIR" --no-default-features sccache
-  echo "Skipping sccache installation on $ARCH."
-  unset RUSTC_WRAPPER
+  RUSTC_WRAPPER='' cargo install --version "$SCCACHE_VERSION" --root "$DEPS_DIR" --no-default-features sccache
 fi
 
 set +ex


### PR DESCRIPTION
As seen on [Travis job 600798255](https://travis-ci.org/xiph/rav1e/jobs/600798255#L986)
```
Setting up build cache
$ export CASHER_DIR=${TRAVIS_HOME}/.casher
$ Installing caching utilities
attempting to download cache archive
fetching PR.1784/cache-linux-bionic-95fb48e796aab48d30b2fe4364d7a581547ec2aa7892c330f8706fbe1d260fee--cargo-stable.tgz
fetching PR.1784/cache--cargo-stable.tgz
fetching master/cache-linux-bionic-95fb48e796aab48d30b2fe4364d7a581547ec2aa7892c330f8706fbe1d260fee--cargo-stable.tgz
fetching master/cache--cargo-stable.tgz
could not download cache
/home/travis/.casher/bin/casher: line 259: ruby: command not found
```