### PR TITLE
Fix tile rate restriction calculation in tiler

### DIFF
--- a/src/tiling/tiler.rs
+++ b/src/tiling/tiler.rs
@@ -77,12 +77,12 @@ impl TilingInfo {
     // Implements restriction in Annex A of the spec.
     // Unlike the other restrictions, this one does not change
     // the header coding of the tile rows/cols.
-    let min_tiles_ratelimit_log2 =
-      min_tiles_log2.max(
-        (((frame_width * frame_height) as f64 * frame_rate / MAX_TILE_RATE
-          + 0.5) as usize)
-          .ilog(),
-      );
+    let min_tiles_ratelimit_log2 = min_tiles_log2.max(
+      ((frame_width * frame_height) as f64 * frame_rate / MAX_TILE_RATE)
+        .ceil()
+        .log2()
+        .ceil() as usize,
+    );
 
     let tile_cols_log2 =
       tile_cols_log2.max(min_tile_cols_log2).min(max_tile_cols_log2);


### PR DESCRIPTION
When calculating the minimum number of tiles needed
to code a valid bitstream, the rate restriction did
not return valid results. This uses the Rust log2()
function instead of an integer logarithm, and rounds
the result up rather than to the nearest integer.