### PR TITLE
Fix an LRF crash when encoding tiny frames

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -187,6 +187,10 @@ impl Sequence {
       tier[i] = 0;
     }
 
+    // Restoration filters are not useful for very small frame sizes,
+    // so disable them in that case.
+    let enable_restoration_filters = config.width >= 32 && config.height >= 32;
+
     Sequence {
       profile,
       num_bits_width: width_bits,
@@ -220,8 +224,10 @@ impl Sequence {
       enable_warped_motion: false,
       enable_superres: false,
       enable_cdef: config.speed_settings.cdef
-        && config.chroma_sampling != ChromaSampling::Cs422,
-      enable_restoration: config.chroma_sampling != ChromaSampling::Cs422,
+        && config.chroma_sampling != ChromaSampling::Cs422
+        && enable_restoration_filters,
+      enable_restoration: config.chroma_sampling != ChromaSampling::Cs422
+        && enable_restoration_filters,
       enable_large_lru: true,
       operating_points_cnt_minus_1: 0,
       operating_point_idc,

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -1206,6 +1206,11 @@ impl RestorationState {
     let (lrf_y_shift, lrf_uv_shift) = if fi.sequence.enable_large_lru
       && fi.sequence.enable_restoration
     {
+      assert!(
+        fi.width > 1 && fi.height > 1,
+        "Width and height must be higher than 1 for LRF setup"
+      );
+
       // Specific content does affect optimal LRU size choice, but the
       // quantizer in use is a surprisingly strong selector.
       let lrf_base_shift = if fi.base_q_idx > 200 {


### PR DESCRIPTION
Found this while fuzzing and took the easy way out. An alternative or complementary solution would be to assert that the frame size is valid and display a proper error message if it is not (I could not find the minimum frame size requirements in the spec, but I seem to recall they exist).