### PR TITLE
Ensure that frame sizes passed to the API are valid

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -465,10 +465,10 @@ impl fmt::Display for PredictionModesSetting {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Error)]
 pub enum InvalidConfig {
   /// The width is invalid.
-  #[error(display = "invalid width {} (expected > 0, <= 32767)", _0)]
+  #[error(display = "invalid width {} (expected >= 16, <= 32767)", _0)]
   InvalidWidth(usize),
   /// The height is invalid.
-  #[error(display = "invalid height {} (expected > 0, <= 32767)", _0)]
+  #[error(display = "invalid height {} (expected >= 16, <= 32767)", _0)]
   InvalidHeight(usize),
   /// RDO lookahead frame count is invalid.
   #[error(
@@ -621,10 +621,10 @@ impl Config {
 
     let config = &self.enc;
 
-    if config.width == 0 || config.width > u16::max_value() as usize {
+    if config.width < 16 || config.width > u16::max_value() as usize {
       return Err(InvalidWidth(config.width));
     }
-    if config.height == 0 || config.height > u16::max_value() as usize {
+    if config.height < 16 || config.height > u16::max_value() as usize {
       return Err(InvalidHeight(config.height));
     }
 

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -1609,8 +1609,8 @@ fn rdo_lookahead_frames_overflow() {
 fn log_q_exp_overflow() {
   let config = Config {
     enc: EncoderConfig {
-      width: 1,
-      height: 1,
+      width: 16,
+      height: 16,
       bit_depth: 8,
       chroma_sampling: ChromaSampling::Cs420,
       chroma_sample_position: ChromaSamplePosition::Unknown,
@@ -1671,8 +1671,8 @@ fn log_q_exp_overflow() {
 fn guess_frame_subtypes_assert() {
   let config = Config {
     enc: EncoderConfig {
-      width: 1,
-      height: 1,
+      width: 16,
+      height: 16,
       bit_depth: 8,
       chroma_sampling: ChromaSampling::Cs420,
       chroma_sample_position: ChromaSamplePosition::Unknown,

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -414,6 +414,19 @@ fn check_tile_log2(n: Result<usize, ()>) -> Result<usize, ()> {
   }
 }
 
+fn check_frame_size(n: Result<usize, ()>) -> Result<usize, ()> {
+  match n {
+    Ok(n) => {
+      if n >= 16 && n < u16::max_value().into() {
+        Ok(n)
+      } else {
+        Err(())
+      }
+    }
+    Err(e) => Err(e),
+  }
+}
+
 unsafe fn option_match(
   cfg: *mut Config, key: *const c_char, value: *const c_char,
 ) -> Result<(), ()> {
@@ -422,8 +435,8 @@ unsafe fn option_match(
   let enc = &mut (*cfg).cfg.enc;
 
   match key {
-    "width" => enc.width = value.parse().map_err(|_| ())?,
-    "height" => enc.height = value.parse().map_err(|_| ())?,
+    "width" => enc.width = check_frame_size(value.parse().map_err(|_| ()))?,
+    "height" => enc.height = check_frame_size(value.parse().map_err(|_| ()))?,
     "speed" => {
       enc.speed_settings =
         rav1e::SpeedSettings::from_preset(value.parse().map_err(|_| ())?)

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -259,7 +259,6 @@ mod small_dimension {
 
 mod tiny_dimension {
   test_dimensions! {
-    (8, 8),
     (16, 16),
     (32, 32),
     (64, 64),


### PR DESCRIPTION
The AV1 format specification, section A.3 specifies that
the frame width and height must be at minimum 16 px for
a valid AV1 stream. Since we are not upscaling or padding
input video below that size, ~panic with a friendly error message~ return an error in the API.