### PR TITLE
Align end-of-encode stats to what AOMAnalyzer would show

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1671,12 +1671,15 @@ pub fn encode_block_post_cdef<T: Pixel>(
   }
 
   if record_stats {
-    *ts.enc_stats.block_size_counts.entry(bsize).or_insert(0) += 1;
-    *ts.enc_stats.tx_type_counts.entry(tx_type).or_insert(0) += 1;
-    *ts.enc_stats.luma_pred_mode_counts.entry(luma_mode).or_insert(0) += 1;
-    *ts.enc_stats.chroma_pred_mode_counts.entry(chroma_mode).or_insert(0) += 1;
+    let pixels = tx_size.area();
+    *ts.enc_stats.block_size_counts.entry(bsize).or_insert(0) += pixels;
+    *ts.enc_stats.tx_type_counts.entry(tx_type).or_insert(0) += pixels;
+    *ts.enc_stats.luma_pred_mode_counts.entry(luma_mode).or_insert(0) +=
+      pixels;
+    *ts.enc_stats.chroma_pred_mode_counts.entry(chroma_mode).or_insert(0) +=
+      pixels;
     if skip {
-      ts.enc_stats.skip_block_count += 1;
+      ts.enc_stats.skip_block_count += pixels;
     }
   }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -6,15 +6,15 @@ use std::ops::{Add, AddAssign};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EncoderStats {
-  /// Stores counts of each block size used in this frame
+  /// Stores count of pixels belonging to each block size in this frame
   pub block_size_counts: BTreeMap<BlockSize, usize>,
-  /// Stores the number of skip blocks used in this frame
+  /// Stores count of pixels belonging to skip blocks in this frame
   pub skip_block_count: usize,
-  /// Stores counts of each transform type used in this frame
+  /// Stores count of pixels belonging to each transform type in this frame
   pub tx_type_counts: BTreeMap<TxType, usize>,
-  /// Stores counts of each prediction mode used for luma in this frame
+  /// Stores count of pixels belonging to each luma prediction mode in this frame
   pub luma_pred_mode_counts: BTreeMap<PredictionMode, usize>,
-  /// Stores counts of each prediction mode used in this frame
+  /// Stores count of pixels belonging to each chroma prediction mode in this frame
   pub chroma_pred_mode_counts: BTreeMap<PredictionMode, usize>,
 }
 


### PR DESCRIPTION
AOMAnalyzer shows the percentage of pixels in a frame
that comprise each block size or transform type.
This commit updates rav1e to do the same.