### PR TITLE
Allow "native" for setting the CPU feature level

### DIFF
--- a/src/cpu_features/aarch64.rs
+++ b/src/cpu_features/aarch64.rs
@@ -34,7 +34,7 @@ impl Default for CpuFeatureLevel {
     let detected = CpuFeatureLevel::NEON;
     let manual: CpuFeatureLevel = match env::var("RAV1E_CPU_TARGET") {
       Ok(feature) => match feature.as_ref() {
-        "rust" => CpuFeatureLevel::NATIVE,
+        "rust" | "native" => CpuFeatureLevel::NATIVE,
         "neon" => CpuFeatureLevel::NEON,
         _ => detected,
       },

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -44,7 +44,7 @@ impl Default for CpuFeatureLevel {
     };
     let manual: CpuFeatureLevel = match env::var("RAV1E_CPU_TARGET") {
       Ok(feature) => match feature.as_ref() {
-        "rust" => CpuFeatureLevel::NATIVE,
+        "rust" | "native" => CpuFeatureLevel::NATIVE,
         "avx2" => CpuFeatureLevel::AVX2,
         "ssse3" => CpuFeatureLevel::SSSE3,
         "sse2" => CpuFeatureLevel::SSE2,


### PR DESCRIPTION
It's confusing that the enum variant is called "NATIVE",
but the string to set it is called "rust".
This commit will match "rust" or "native" to disable ASM.