### PR TITLE
Integrate SATD ASM for SSSE3 and SSE4.1

### DIFF
--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -313,6 +313,7 @@ decl_mc_fns!(
 pub(crate) static PUT_FNS: [[Option<PutFn>; 16]; CpuFeatureLevel::len()] = {
   let mut out = [[None; 16]; CpuFeatureLevel::len()];
   out[CpuFeatureLevel::SSSE3 as usize] = PUT_FNS_SSSE3;
+  out[CpuFeatureLevel::SSE4_1 as usize] = PUT_FNS_SSSE3;
   out[CpuFeatureLevel::AVX2 as usize] = PUT_FNS_AVX2;
   out
 };
@@ -372,6 +373,7 @@ decl_mct_fns!(
 pub(crate) static PREP_FNS: [[Option<PrepFn>; 16]; CpuFeatureLevel::len()] = {
   let mut out = [[None; 16]; CpuFeatureLevel::len()];
   out[CpuFeatureLevel::SSSE3 as usize] = PREP_FNS_SSSE3;
+  out[CpuFeatureLevel::SSE4_1 as usize] = PREP_FNS_SSSE3;
   out[CpuFeatureLevel::AVX2 as usize] = PREP_FNS_AVX2;
   out
 };
@@ -395,6 +397,7 @@ pub(crate) static AVG_FNS: [Option<AvgFn>; CpuFeatureLevel::len()] = {
   let mut out: [Option<AvgFn>; CpuFeatureLevel::len()] =
     [None; CpuFeatureLevel::len()];
   out[CpuFeatureLevel::SSSE3 as usize] = Some(rav1e_avg_ssse3);
+  out[CpuFeatureLevel::SSE4_1 as usize] = Some(rav1e_avg_ssse3);
   out[CpuFeatureLevel::AVX2 as usize] = Some(rav1e_avg_avx2);
   out
 };

--- a/src/cpu_features/aarch64.rs
+++ b/src/cpu_features/aarch64.rs
@@ -23,9 +23,7 @@ impl CpuFeatureLevel {
 
   #[inline(always)]
   pub fn as_index(self) -> usize {
-    const LEN: usize = CpuFeatureLevel::len();
-    assert_eq!(LEN & (LEN - 1), 0);
-    self as usize & (LEN - 1)
+    self as usize
   }
 }
 

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -7,6 +7,7 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use arg_enum_proc_macro::ArgEnum;
 use std::env;
 use std::str::FromStr;
 

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -8,49 +8,16 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use std::env;
-use std::fmt;
 use std::str::FromStr;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, ArgEnum)]
 pub enum CpuFeatureLevel {
   NATIVE,
   SSE2,
   SSSE3,
+  #[arg_enum(alias = "sse4.1")]
   SSE4_1,
   AVX2,
-}
-
-impl FromStr for CpuFeatureLevel {
-  type Err = ();
-
-  fn from_str(s: &str) -> Result<Self, Self::Err> {
-    Ok(match s.to_lowercase().as_str() {
-      "rust" | "native" => CpuFeatureLevel::NATIVE,
-      "avx2" => CpuFeatureLevel::AVX2,
-      "sse4" | "sse4_1" | "sse4.1" => CpuFeatureLevel::SSE4_1,
-      "ssse3" => CpuFeatureLevel::SSSE3,
-      "sse2" => CpuFeatureLevel::SSE2,
-      _ => {
-        return Err(());
-      }
-    })
-  }
-}
-
-impl fmt::Display for CpuFeatureLevel {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(
-      f,
-      "{}",
-      match self {
-        CpuFeatureLevel::NATIVE => "Native",
-        CpuFeatureLevel::SSE2 => "SSE2",
-        CpuFeatureLevel::SSSE3 => "SSSE3",
-        CpuFeatureLevel::SSE4_1 => "SSE4.1",
-        CpuFeatureLevel::AVX2 => "AVX2",
-      }
-    )
-  }
 }
 
 impl CpuFeatureLevel {

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -13,6 +13,7 @@ use std::str::FromStr;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, ArgEnum)]
 pub enum CpuFeatureLevel {
+  #[arg_enum(alias = "rust")]
   NATIVE,
   SSE2,
   SSSE3,


### PR DESCRIPTION
This involves adding a new CpuFeatureLevel for SSE4.1.
Because of being unable to use a decimal in an enum variant name,
this required manually implementing FromStr and Display
instead of using the arg enum proc macro.