### PR TITLE
Enable rav1e_sad16x16_sse2 by enforcing alignment

### DIFF
--- a/src/asm/x86/dist.rs
+++ b/src/asm/x86/dist.rs
@@ -54,7 +54,7 @@ declare_asm_dist_fn![
   (rav1e_sad8x8_sse2, u8),
   (rav1e_sad8x16_sse2, u8),
   (rav1e_sad8x32_sse2, u8),
-  //  (rav1e_sad16x16_sse2, u8),
+  (rav1e_sad16x16_sse2, u8),
   (rav1e_sad32x32_sse2, u8),
   (rav1e_sad64x64_sse2, u8),
   (rav1e_sad128x128_sse2, u8),
@@ -207,8 +207,7 @@ static SAD_FNS_SSE2: [Option<SadFn>; DIST_FNS_LENGTH] = {
   out[BLOCK_8X16 as usize] = Some(rav1e_sad8x16_sse2);
   out[BLOCK_8X32 as usize] = Some(rav1e_sad8x32_sse2);
 
-  // FIXME: This function is currently broken, see https://github.com/xiph/rav1e/issues/1715
-  // out[BLOCK_16X16 as usize] = Some(rav1e_sad16x16_sse2);
+  out[BLOCK_16X16 as usize] = Some(rav1e_sad16x16_sse2);
   out[BLOCK_32X32 as usize] = Some(rav1e_sad32x32_sse2);
   out[BLOCK_64X64 as usize] = Some(rav1e_sad64x64_sse2);
   out[BLOCK_128X128 as usize] = Some(rav1e_sad128x128_sse2);

--- a/src/me.rs
+++ b/src/me.rs
@@ -990,13 +990,15 @@ fn full_search<T: Pixel>(
 }
 
 // Adjust block offset such that entire block lies within boundaries
+// Align to block width, to admit aligned SAD instructions
 fn adjust_bo(
   bo: TileBlockOffset, mi_width: usize, mi_height: usize, blk_w: usize,
   blk_h: usize,
 ) -> TileBlockOffset {
   TileBlockOffset(BlockOffset {
     x: (bo.0.x as isize).min(mi_width as isize - blk_w as isize / 4).max(0)
-      as usize,
+      as usize
+      & !(blk_w / 4 - 1),
     y: (bo.0.y as isize).min(mi_height as isize - blk_h as isize / 4).max(0)
       as usize,
   })


### PR DESCRIPTION
By aligning blocks that overlap the right edge to block width, the result is effectively cloned from the adjacent block. Note that only the bottom/right edge blocks can be unaligned anyhow; this is only in motion estimation, not motion compensation.

Fixes #1715. No change in [AWCY results at default speed](
https://beta.arewecompressedyet.com/?job=master-588d7219bc7d1f360f24f64b9cf6485ce41928f7&job=sad16x16_sse2%402019-11-01T15%3A39%3A27.558Z).