### PR TITLE
[WIP] Refine the avoidance of lossless in segmentation RDO

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -565,6 +565,7 @@ impl<T: Pixel> ContextInner<T> {
         // right now instead of in encode_tile?
         frame_mvs: fs.frame_mvs,
         output_frameno,
+        base_q_idx: fi.base_q_idx,
       });
       for i in 0..(REF_FRAMES as usize) {
         if (fi.refresh_frame_flags & (1 << i)) != 0 {
@@ -666,6 +667,7 @@ impl<T: Pixel> ContextInner<T> {
       cdfs: fs.cdfs,
       frame_mvs: fs.frame_mvs,
       output_frameno,
+      base_q_idx: fi.base_q_idx,
     });
     for i in 0..(REF_FRAMES as usize) {
       if (fi.refresh_frame_flags & (1 << i)) != 0 {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -66,6 +66,7 @@ pub struct ReferenceFrame<T: Pixel> {
   pub cdfs: CDFContext,
   pub frame_mvs: Vec<FrameMotionVectors>,
   pub output_frameno: u64,
+  pub base_q_idx: u8,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -3435,6 +3436,7 @@ pub fn update_rec_buffer<T: Pixel>(
     cdfs: fs.cdfs,
     frame_mvs: fs.frame_mvs,
     output_frameno,
+    base_q_idx: fi.base_q_idx,
   });
   for i in 0..(REF_FRAMES as usize) {
     if (fi.refresh_frame_flags & (1 << i)) != 0 {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -644,6 +644,9 @@ fn luma_chroma_mode_rdo<T: Pixel>(
 
   let is_chroma_block = has_chroma(tile_bo, bsize, xdec, ydec);
 
+  let min_delta_q =
+    *fi.ac_delta_q.iter().chain(fi.dc_delta_q.iter()).min().unwrap();
+
   // Find the best chroma prediction mode for the current luma prediction mode
   let mut chroma_rdo = |skip: bool| -> bool {
     let mut zero_distortion = false;
@@ -669,17 +672,19 @@ fn luma_chroma_mode_rdo<T: Pixel>(
       };
       // prevent the highest sidx from bringing us into lossless
       if fi.base_q_idx as i16
+        + min_delta_q as i16
         + ts.segmentation.data[heuristic_sidx as usize]
           [SegLvl::SEG_LVL_ALT_Q as usize]
-        < 2
+        < 1
       {
         0..=0
       } else {
         heuristic_sidx..=heuristic_sidx
       }
     } else if fi.base_q_idx as i16
+      + min_delta_q as i16
       + ts.segmentation.data[2][SegLvl::SEG_LVL_ALT_Q as usize]
-      < 2
+      < 1
     {
       0..=1
     } else {

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -32,7 +32,9 @@ pub fn segmentation_optimize<T: Pixel>(
   // Because base_q_idx changes more frequently than the segmentation
   // data, it is still possible for a segment to enter lossless, so
   // enforcement elsewhere is needed.
-  let offset_lower_limit = 1 - fi.base_q_idx as i16;
+  let min_delta_q =
+    *fi.ac_delta_q.iter().chain(fi.dc_delta_q.iter()).min().unwrap();
+  let offset_lower_limit = 1 - fi.base_q_idx as i16 - min_delta_q as i16;
 
   // Fill in 3 slots with 0, delta, -delta. The slot IDs are also used in
   // luma_chroma_mode_rdo() so if you change things here make sure to check

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -10,7 +10,6 @@
 #![allow(safe_extern_statics)]
 
 use crate::context::*;
-use crate::header::PRIMARY_REF_NONE;
 use crate::util::Pixel;
 use crate::FrameInvariants;
 use crate::FrameState;
@@ -21,8 +20,8 @@ pub fn segmentation_optimize<T: Pixel>(
   fs.segmentation.enabled = true;
   fs.segmentation.update_map = true;
 
-  // We don't change the values between frames.
-  fs.segmentation.update_data = fi.primary_ref_frame == PRIMARY_REF_NONE;
+  // Force an update on every frame until we carry over data.
+  fs.segmentation.update_data = true;
 
   // A series of AWCY runs with deltas 13, 15, 17, 18, 19, 20, 21, 22, 23
   // showed this to be the optimal one.


### PR DESCRIPTION
To be conservative, we avoid coding any quantizer index as zero.
This should address edge cases from #1649, as a follow-up to #1694.