### PR TITLE
Carry over segmentation data between frames

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -565,6 +565,7 @@ impl<T: Pixel> ContextInner<T> {
         // right now instead of in encode_tile?
         frame_mvs: fs.frame_mvs,
         output_frameno,
+        segmentation: fs.segmentation,
       });
       for i in 0..(REF_FRAMES as usize) {
         if (fi.refresh_frame_flags & (1 << i)) != 0 {
@@ -666,6 +667,7 @@ impl<T: Pixel> ContextInner<T> {
       cdfs: fs.cdfs,
       frame_mvs: fs.frame_mvs,
       output_frameno,
+      segmentation: fs.segmentation,
     });
     for i in 0..(REF_FRAMES as usize) {
       if (fi.refresh_frame_flags & (1 << i)) != 0 {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -671,7 +671,7 @@ fn luma_chroma_mode_rdo<T: Pixel>(
       if fi.base_q_idx as i16
         + ts.segmentation.data[heuristic_sidx as usize]
           [SegLvl::SEG_LVL_ALT_Q as usize]
-        < 2
+        < 1
       {
         0..=0
       } else {
@@ -679,7 +679,7 @@ fn luma_chroma_mode_rdo<T: Pixel>(
       }
     } else if fi.base_q_idx as i16
       + ts.segmentation.data[2][SegLvl::SEG_LVL_ALT_Q as usize]
-      < 2
+      < 1
     {
       0..=1
     } else {

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -24,6 +24,10 @@ pub fn segmentation_optimize<T: Pixel>(
   // We don't change the values between frames.
   fs.segmentation.update_data = fi.primary_ref_frame == PRIMARY_REF_NONE;
 
+  if !fs.segmentation.update_data {
+    return;
+  }
+
   // A series of AWCY runs with deltas 13, 15, 17, 18, 19, 20, 21, 22, 23
   // showed this to be the optimal one.
   const TEMPORAL_RDO_QI_DELTA: i16 = 21;


### PR DESCRIPTION
With the data carried over, we can remove a prior workaround and fix the outstanding desyncs.

Fixes #1815.