### PR TITLE
[WIP] Speedup SGR RDO by avoiding duplicate box sum and box sqr sum

### DIFF
--- a/src/asm/x86/lrf.rs
+++ b/src/asm/x86/lrf.rs
@@ -155,6 +155,27 @@ static X_BY_XPLUS1: [u32; 256] = [
   255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 256,
 ];
 
+// Using an integral image, compute the sum of a square region
+#[allow(unused)]
+#[inline]
+#[target_feature(enable = "avx2")]
+pub unsafe fn get_integral_square_avx2(
+  iimg: &[u32], stride: usize, x: usize, y: usize, size: usize,
+) -> __m256i {
+  let iimg = iimg.as_ptr().add(y * stride + x);
+  // Cancel out overflow in iimg by using wrapping arithmetic
+  _mm256_sub_epi32(
+    _mm256_add_epi32(
+      _mm256_loadu_si256(iimg as *const _),
+      _mm256_loadu_si256(iimg.add(size * stride + size) as *const _),
+    ),
+    _mm256_add_epi32(
+      _mm256_loadu_si256(iimg.add(size * stride) as *const _),
+      _mm256_loadu_si256(iimg.add(size) as *const _),
+    ),
+  )
+}
+
 #[allow(unused)]
 #[inline]
 #[target_feature(enable = "avx2")]
@@ -165,7 +186,7 @@ unsafe fn sgrproj_box_ab_8_avx2(
   let d: usize = r * 2 + 1;
   let n: i32 = (d * d) as i32;
   let one_over_n = if r == 1 { 455 } else { 164 };
-
+/*
   // Using an integral image, compute the sum of a square region
   #[inline]
   #[target_feature(enable = "avx2")]
@@ -185,7 +206,8 @@ unsafe fn sgrproj_box_ab_8_avx2(
       ),
     )
   }
-
+*/
+  // fetch sum and ssq from pre-computed array under IntegralImageBuffer
   let sum = get_integral_square_avx2(iimg, iimg_stride, x, y, d);
   let ssq = get_integral_square_avx2(iimg_sq, iimg_stride, x, y, d);
   let scaled_sum = _mm256_srlv_epi32(

--- a/src/asm/x86/lrf.rs
+++ b/src/asm/x86/lrf.rs
@@ -188,7 +188,7 @@ unsafe fn sgrproj_box_ab_8_avx2(
 
   // Box sum and box square sum are already done by setup_integral_image() and done by only once.
   // fetch sum and ssq from pre-computed array under IntegralImageBuffer
-  let sum_array_offset = y * iimg_stride;
+  let sum_array_offset = y * iimg_stride + x;
 
   let sum_ptr = if r == 2 {
     &integral_image_buffer.sum_5x5 as &[u32]

--- a/src/asm/x86/lrf.rs
+++ b/src/asm/x86/lrf.rs
@@ -21,7 +21,7 @@ use std::mem;
 // computes an intermediate (ab) row for stripe_w + 2 columns at row y
 #[inline]
 pub fn sgrproj_box_ab_r1(
-  af: &mut [u32], bf: &mut [u32], iimg: &[u32], iimg_sq: &[u32],
+  af: &mut [u32], bf: &mut [u32],
   integral_image_buffer: &IntegralImageBuffer,
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
   cpu: CpuFeatureLevel,
@@ -45,8 +45,6 @@ pub fn sgrproj_box_ab_r1(
   native::sgrproj_box_ab_r1(
     af,
     bf,
-    iimg,
-    iimg_sq,
     integral_image_buffer,
     iimg_stride,
     y,
@@ -60,7 +58,7 @@ pub fn sgrproj_box_ab_r1(
 // computes an intermediate (ab) row for stripe_w + 2 columns at row y
 #[inline]
 pub fn sgrproj_box_ab_r2(
-  af: &mut [u32], bf: &mut [u32], iimg: &[u32], iimg_sq: &[u32],
+  af: &mut [u32], bf: &mut [u32],
   integral_image_buffer: &IntegralImageBuffer,
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
   cpu: CpuFeatureLevel,
@@ -84,8 +82,6 @@ pub fn sgrproj_box_ab_r2(
   native::sgrproj_box_ab_r2(
     af,
     bf,
-    iimg,
-    iimg_sq,
     integral_image_buffer,
     iimg_stride,
     y,
@@ -138,6 +134,7 @@ pub fn sgrproj_box_f_r2<T: Pixel>(
   native::sgrproj_box_f_r2(af, bf, f0, f1, y, w, cdeffed, cpu);
 }
 
+#[allow(unused)]
 static X_BY_XPLUS1: [u32; 256] = [
   // Special case: Map 0 -> 1 (corresponding to a value of 1/256)
   // instead of 0. See comments in selfguided_restoration_internal() for why
@@ -160,6 +157,7 @@ static X_BY_XPLUS1: [u32; 256] = [
   255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 256,
 ];
 
+#[allow(unused)]
 #[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn sgrproj_box_ab_8_avx2(
@@ -237,6 +235,7 @@ unsafe fn sgrproj_box_ab_8_avx2(
   _mm256_storeu_si256(bf.as_mut_ptr().add(x) as *mut _, b);
 }
 
+#[allow(unused)]
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
   af: &mut [u32], bf: &mut [u32], iimg: &[u32], iimg_sq: &[u32],
@@ -263,8 +262,6 @@ pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
         1,
         af,
         bf,
-        iimg,
-        iimg_sq,
         integral_image_buffer,
         iimg_stride,
         x,
@@ -284,8 +281,6 @@ pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
       1,
       &mut af_ref,
       &mut bf_ref,
-      iimg,
-      iimg_sq,
       integral_image_buffer,
       iimg_stride,
       0,
@@ -299,6 +294,7 @@ pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
   }
 }
 
+#[allow(unused)]
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn sgrproj_box_ab_r2_avx2(
   af: &mut [u32], bf: &mut [u32], iimg: &[u32], iimg_sq: &[u32],
@@ -325,8 +321,6 @@ pub(crate) unsafe fn sgrproj_box_ab_r2_avx2(
         2,
         af,
         bf,
-        iimg,
-        iimg_sq,
         integral_image_buffer,
         iimg_stride,
         x,
@@ -346,8 +340,6 @@ pub(crate) unsafe fn sgrproj_box_ab_r2_avx2(
       2,
       &mut af_ref,
       &mut bf_ref,
-      iimg,
-      iimg_sq,
       integral_image_buffer,
       iimg_stride,
       0,

--- a/src/asm/x86/lrf.rs
+++ b/src/asm/x86/lrf.rs
@@ -185,34 +185,9 @@ unsafe fn sgrproj_box_ab_8_avx2(
   let d: usize = r * 2 + 1;
   let n: i32 = (d * d) as i32;
   let one_over_n = if r == 1 { 455 } else { 164 };
-  /*
-    // Using an integral image, compute the sum of a square region
-    #[inline]
-    #[target_feature(enable = "avx2")]
-    unsafe fn get_integral_square_avx2(
-      iimg: &[u32], stride: usize, x: usize, y: usize, size: usize,
-    ) -> __m256i {
-      let iimg = iimg.as_ptr().add(y * stride + x);
-      // Cancel out overflow in iimg by using wrapping arithmetic
-      _mm256_sub_epi32(
-        _mm256_add_epi32(
-          _mm256_loadu_si256(iimg as *const _),
-          _mm256_loadu_si256(iimg.add(size * stride + size) as *const _),
-        ),
-        _mm256_add_epi32(
-          _mm256_loadu_si256(iimg.add(size * stride) as *const _),
-          _mm256_loadu_si256(iimg.add(size) as *const _),
-        ),
-      )
-    }
-  */
 
   // Box sum and box square sum are already done by setup_integral_image() and done by only once.
   // fetch sum and ssq from pre-computed array under IntegralImageBuffer
-
-  //let sum = get_integral_square_avx2(iimg, iimg_stride, x, y, d);
-  //let ssq = get_integral_square_avx2(iimg_sq, iimg_stride, x, y, d);
-
   let sum_array_offset = y * iimg_stride;
 
   let sum_ptr = if r == 2 {

--- a/src/asm/x86/lrf.rs
+++ b/src/asm/x86/lrf.rs
@@ -25,7 +25,7 @@ pub fn sgrproj_box_ab_r1(
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
   cpu: CpuFeatureLevel,
 ) {
-  if cpu >= CpuFeatureLevel::AVX2 {
+  /*if cpu >= CpuFeatureLevel::AVX2 {
     return unsafe {
       sgrproj_box_ab_r1_avx2(
         af,
@@ -39,7 +39,7 @@ pub fn sgrproj_box_ab_r1(
         bdm8,
       );
     };
-  }
+  }*/
 
   native::sgrproj_box_ab_r1(
     af,
@@ -62,7 +62,7 @@ pub fn sgrproj_box_ab_r2(
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
   cpu: CpuFeatureLevel,
 ) {
-  if cpu >= CpuFeatureLevel::AVX2 {
+  /*if cpu >= CpuFeatureLevel::AVX2 {
     return unsafe {
       sgrproj_box_ab_r2_avx2(
         af,
@@ -76,7 +76,7 @@ pub fn sgrproj_box_ab_r2(
         bdm8,
       );
     };
-  }
+  }*/
 
   native::sgrproj_box_ab_r2(
     af,

--- a/src/asm/x86/lrf.rs
+++ b/src/asm/x86/lrf.rs
@@ -21,8 +21,7 @@ use std::mem;
 // computes an intermediate (ab) row for stripe_w + 2 columns at row y
 #[inline]
 pub fn sgrproj_box_ab_r1(
-  af: &mut [u32], bf: &mut [u32],
-  integral_image_buffer: &IntegralImageBuffer,
+  af: &mut [u32], bf: &mut [u32], integral_image_buffer: &IntegralImageBuffer,
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
   cpu: CpuFeatureLevel,
 ) {
@@ -58,8 +57,7 @@ pub fn sgrproj_box_ab_r1(
 // computes an intermediate (ab) row for stripe_w + 2 columns at row y
 #[inline]
 pub fn sgrproj_box_ab_r2(
-  af: &mut [u32], bf: &mut [u32],
-  integral_image_buffer: &IntegralImageBuffer,
+  af: &mut [u32], bf: &mut [u32], integral_image_buffer: &IntegralImageBuffer,
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
   cpu: CpuFeatureLevel,
 ) {
@@ -239,8 +237,8 @@ unsafe fn sgrproj_box_ab_8_avx2(
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
   af: &mut [u32], bf: &mut [u32], iimg: &[u32], iimg_sq: &[u32],
-  integral_image_buffer: &IntegralImageBuffer,
-  iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
+  integral_image_buffer: &IntegralImageBuffer, iimg_stride: usize, y: usize,
+  stripe_w: usize, s: u32, bdm8: usize,
 ) {
   for x in (0..stripe_w + 2).step_by(8) {
     if x + 8 <= stripe_w + 2 {
@@ -298,8 +296,8 @@ pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn sgrproj_box_ab_r2_avx2(
   af: &mut [u32], bf: &mut [u32], iimg: &[u32], iimg_sq: &[u32],
-  integral_image_buffer: &IntegralImageBuffer,
-  iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
+  integral_image_buffer: &IntegralImageBuffer, iimg_stride: usize, y: usize,
+  stripe_w: usize, s: u32, bdm8: usize,
 ) {
   for x in (0..stripe_w + 2).step_by(8) {
     if x + 8 <= stripe_w + 2 {

--- a/src/asm/x86/lrf.rs
+++ b/src/asm/x86/lrf.rs
@@ -22,6 +22,7 @@ use std::mem;
 #[inline]
 pub fn sgrproj_box_ab_r1(
   af: &mut [u32], bf: &mut [u32], iimg: &[u32], iimg_sq: &[u32],
+  integral_image_buffer: &IntegralImageBuffer,
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
   cpu: CpuFeatureLevel,
 ) {
@@ -46,6 +47,7 @@ pub fn sgrproj_box_ab_r1(
     bf,
     iimg,
     iimg_sq,
+    integral_image_buffer,
     iimg_stride,
     y,
     stripe_w,
@@ -59,6 +61,7 @@ pub fn sgrproj_box_ab_r1(
 #[inline]
 pub fn sgrproj_box_ab_r2(
   af: &mut [u32], bf: &mut [u32], iimg: &[u32], iimg_sq: &[u32],
+  integral_image_buffer: &IntegralImageBuffer,
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
   cpu: CpuFeatureLevel,
 ) {
@@ -83,6 +86,7 @@ pub fn sgrproj_box_ab_r2(
     bf,
     iimg,
     iimg_sq,
+    integral_image_buffer,
     iimg_stride,
     y,
     stripe_w,
@@ -236,6 +240,7 @@ unsafe fn sgrproj_box_ab_8_avx2(
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
   af: &mut [u32], bf: &mut [u32], iimg: &[u32], iimg_sq: &[u32],
+  integral_image_buffer: &IntegralImageBuffer,
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
 ) {
   for x in (0..stripe_w + 2).step_by(8) {
@@ -260,6 +265,7 @@ pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
         bf,
         iimg,
         iimg_sq,
+        integral_image_buffer,
         iimg_stride,
         x,
         y,
@@ -280,6 +286,7 @@ pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
       &mut bf_ref,
       iimg,
       iimg_sq,
+      integral_image_buffer,
       iimg_stride,
       0,
       y,
@@ -295,6 +302,7 @@ pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn sgrproj_box_ab_r2_avx2(
   af: &mut [u32], bf: &mut [u32], iimg: &[u32], iimg_sq: &[u32],
+  integral_image_buffer: &IntegralImageBuffer,
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
 ) {
   for x in (0..stripe_w + 2).step_by(8) {
@@ -319,6 +327,7 @@ pub(crate) unsafe fn sgrproj_box_ab_r2_avx2(
         bf,
         iimg,
         iimg_sq,
+        integral_image_buffer,
         iimg_stride,
         x,
         y,
@@ -339,6 +348,7 @@ pub(crate) unsafe fn sgrproj_box_ab_r2_avx2(
       &mut bf_ref,
       iimg,
       iimg_sq,
+      integral_image_buffer,
       iimg_stride,
       0,
       y,

--- a/src/asm/x86/lrf.rs
+++ b/src/asm/x86/lrf.rs
@@ -178,33 +178,34 @@ pub unsafe fn get_integral_square_avx2(
 #[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn sgrproj_box_ab_8_avx2(
-  r: usize, af: &mut [u32], bf: &mut [u32], integral_image_buffer: &IntegralImageBuffer,
-  iimg_stride: usize, x: usize, y: usize, s: u32, bdm8: usize,
+  r: usize, af: &mut [u32], bf: &mut [u32],
+  integral_image_buffer: &IntegralImageBuffer, iimg_stride: usize, x: usize,
+  y: usize, s: u32, bdm8: usize,
 ) {
   let d: usize = r * 2 + 1;
   let n: i32 = (d * d) as i32;
   let one_over_n = if r == 1 { 455 } else { 164 };
-/*
-  // Using an integral image, compute the sum of a square region
-  #[inline]
-  #[target_feature(enable = "avx2")]
-  unsafe fn get_integral_square_avx2(
-    iimg: &[u32], stride: usize, x: usize, y: usize, size: usize,
-  ) -> __m256i {
-    let iimg = iimg.as_ptr().add(y * stride + x);
-    // Cancel out overflow in iimg by using wrapping arithmetic
-    _mm256_sub_epi32(
-      _mm256_add_epi32(
-        _mm256_loadu_si256(iimg as *const _),
-        _mm256_loadu_si256(iimg.add(size * stride + size) as *const _),
-      ),
-      _mm256_add_epi32(
-        _mm256_loadu_si256(iimg.add(size * stride) as *const _),
-        _mm256_loadu_si256(iimg.add(size) as *const _),
-      ),
-    )
-  }
-*/
+  /*
+    // Using an integral image, compute the sum of a square region
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn get_integral_square_avx2(
+      iimg: &[u32], stride: usize, x: usize, y: usize, size: usize,
+    ) -> __m256i {
+      let iimg = iimg.as_ptr().add(y * stride + x);
+      // Cancel out overflow in iimg by using wrapping arithmetic
+      _mm256_sub_epi32(
+        _mm256_add_epi32(
+          _mm256_loadu_si256(iimg as *const _),
+          _mm256_loadu_si256(iimg.add(size * stride + size) as *const _),
+        ),
+        _mm256_add_epi32(
+          _mm256_loadu_si256(iimg.add(size * stride) as *const _),
+          _mm256_loadu_si256(iimg.add(size) as *const _),
+        ),
+      )
+    }
+  */
 
   // Box sum and box square sum are already done by setup_integral_image() and done by only once.
   // fetch sum and ssq from pre-computed array under IntegralImageBuffer
@@ -227,11 +228,17 @@ unsafe fn sgrproj_box_ab_8_avx2(
   };
 
   let scaled_sum = _mm256_srlv_epi32(
-    _mm256_add_epi32(_mm256_loadu_si256(sum_ptr.as_ptr().add(sum_array_offset) as *const _), _mm256_set1_epi32(1 << bdm8 as i32 >> 1)),
+    _mm256_add_epi32(
+      _mm256_loadu_si256(sum_ptr.as_ptr().add(sum_array_offset) as *const _),
+      _mm256_set1_epi32(1 << bdm8 as i32 >> 1),
+    ),
     _mm256_set1_epi32(bdm8 as i32),
   );
   let scaled_ssq = _mm256_srlv_epi32(
-    _mm256_add_epi32(_mm256_loadu_si256(ssq_ptr.as_ptr().add(sum_array_offset) as *const _), _mm256_set1_epi32(1 << (2 * bdm8) as i32 >> 1)),
+    _mm256_add_epi32(
+      _mm256_loadu_si256(ssq_ptr.as_ptr().add(sum_array_offset) as *const _),
+      _mm256_set1_epi32(1 << (2 * bdm8) as i32 >> 1),
+    ),
     _mm256_set1_epi32(2 * bdm8 as i32),
   );
   let p = _mm256_max_epi32(
@@ -274,9 +281,8 @@ unsafe fn sgrproj_box_ab_8_avx2(
 #[allow(unused)]
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
-  af: &mut [u32], bf: &mut [u32],
-  integral_image_buffer: &IntegralImageBuffer, iimg_stride: usize, y: usize,
-  stripe_w: usize, s: u32, bdm8: usize,
+  af: &mut [u32], bf: &mut [u32], integral_image_buffer: &IntegralImageBuffer,
+  iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
 ) {
   for x in (0..stripe_w + 2).step_by(8) {
     if x + 8 <= stripe_w + 2 {
@@ -332,9 +338,8 @@ pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
 #[allow(unused)]
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn sgrproj_box_ab_r2_avx2(
-  af: &mut [u32], bf: &mut [u32],
-  integral_image_buffer: &IntegralImageBuffer, iimg_stride: usize, y: usize,
-  stripe_w: usize, s: u32, bdm8: usize,
+  af: &mut [u32], bf: &mut [u32], integral_image_buffer: &IntegralImageBuffer,
+  iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
 ) {
   for x in (0..stripe_w + 2).step_by(8) {
     if x + 8 <= stripe_w + 2 {

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -505,7 +505,6 @@ pub fn setup_integral_image<T: Pixel>(
   integral_image_buffer: &mut IntegralImageBuffer,
   integral_image_stride: usize, crop_w: usize, crop_h: usize, stripe_w: usize,
   stripe_h: usize, cdeffed: &PlaneSlice<T>, deblocked: &PlaneSlice<T>,
-  cpu: CpuFeatureLevel,
 ) {
   let integral_image = &mut integral_image_buffer.integral_image;
   let sq_integral_image = &mut integral_image_buffer.sq_integral_image;
@@ -599,7 +598,13 @@ pub fn setup_integral_image<T: Pixel>(
     integral_slice = integral_row;
     sq_integral_slice = sq_integral_row;
   }
+}
 
+pub fn sgrproj_compute_3x3_and_5x5_box_sums(
+  integral_image_buffer: &mut IntegralImageBuffer,
+  integral_image_stride: usize, stripe_w: usize, stripe_h: usize,
+  cpu: CpuFeatureLevel,
+) {
   // Place to do compute sum and sum of square
   #[cfg(target_arch = "x86")]
   use std::arch::x86::*;
@@ -1522,6 +1527,13 @@ impl RestorationState {
                   .slice(PlaneOffset { x: x as isize, y: stripe_start_y }),
                 &pre_cdef.planes[pli]
                   .slice(PlaneOffset { x: x as isize, y: stripe_start_y }),
+              );
+
+              sgrproj_compute_3x3_and_5x5_box_sums(
+                &mut stripe_filter_buffer,
+                STRIPE_IMAGE_STRIDE,
+                size,
+                stripe_size,
                 fi.cpu_feature_level,
               );
 

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -184,10 +184,7 @@ pub(crate) mod native {
     let sum_array_offset = y * iimg_stride;
 
     for x in start_x..stripe_w + 2 {
-      // if r = 1, i.e. 3x3, do as before
-      //let sum = get_integral_square(iimg, iimg_stride, x, y, d);
-      //let ssq = get_integral_square(iimg_sq, iimg_stride, x, y, d);
-      let sum2 = get_integral_square(iimg, iimg_stride, x, y, d);
+      /*let sum2 = get_integral_square(iimg, iimg_stride, x, y, d);
       let ssq2 = get_integral_square(iimg_sq, iimg_stride, x, y, d);
 
       if r == 1 {
@@ -201,7 +198,7 @@ pub(crate) mod native {
         let sq2 = integral_image_buffer.sum_sq_5x5[sum_array_offset + x];
         debug_assert!(sum2 == s2);
         debug_assert!(ssq2 == sq2);
-      }
+      }*/
       let sum = if r == 2 {integral_image_buffer.sum_5x5[sum_array_offset + x] }
                 else { integral_image_buffer.sum_3x3[sum_array_offset + x] };
       let ssq = if r == 2 { integral_image_buffer.sum_sq_5x5[sum_array_offset + x] }

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -599,65 +599,92 @@ pub fn setup_integral_image<T: Pixel>(
   }
 
   // Place to do compute sum and sum of square
-#[cfg(target_arch = "x86")]
-use std::arch::x86::*;
-#[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+  #[cfg(target_arch = "x86")]
+  use std::arch::x86::*;
+  #[cfg(target_arch = "x86_64")]
+  use std::arch::x86_64::*;
 
   for r in 1..=2 {
-  let d: usize = r * 2 + 1;
-  // and save the results sum and sum of square in different storage
-  let integral_image_offset =
-    if d == 3 { integral_image_stride + 1 } else { 0 };
-  let iimg = &integral_image_buffer.integral_image[integral_image_offset..];
-  let iimg_sq =
-    &integral_image_buffer.sq_integral_image[integral_image_offset..];
+    let d: usize = r * 2 + 1;
+    // and save the results sum and sum of square in different storage
+    let integral_image_offset =
+      if d == 3 { integral_image_stride + 1 } else { 0 };
+    let iimg = &integral_image_buffer.integral_image[integral_image_offset..];
+    let iimg_sq =
+      &integral_image_buffer.sq_integral_image[integral_image_offset..];
 
-  for y in 0..stripe_h + 2 {
-    if d == 5 && (y & 1) == 1 {
-      continue;
-    }
-    for x in (0..stripe_w + 2).step_by(8) {
-      if x + 8 <= stripe_w + 2 {
-        unsafe {
-        let sum = get_integral_square_avx2(iimg, integral_image_stride, x, y, d);
-        let ssq = get_integral_square_avx2(iimg_sq, integral_image_stride, x, y, d);
-        // save 4 x u32 sum and sum of square in storage
-        let ptr = if d == 3 { &mut integral_image_buffer.sum_3x3 } else { &mut integral_image_buffer.sum_5x5 };
-        let ptr_sq = if d == 3 { &mut integral_image_buffer.sum_sq_3x3 } else { &mut integral_image_buffer.sum_sq_5x5 };
+    for y in 0..stripe_h + 2 {
+      if d == 5 && (y & 1) == 1 {
+        continue;
+      }
+      for x in (0..stripe_w + 2).step_by(8) {
+        if x + 8 <= stripe_w + 2 {
+          unsafe {
+            let sum =
+              get_integral_square_avx2(iimg, integral_image_stride, x, y, d);
+            let ssq = get_integral_square_avx2(
+              iimg_sq,
+              integral_image_stride,
+              x,
+              y,
+              d,
+            );
+            // save 4 x u32 sum and sum of square in storage
+            let ptr = if d == 3 {
+              &mut integral_image_buffer.sum_3x3
+            } else {
+              &mut integral_image_buffer.sum_5x5
+            };
+            let ptr_sq = if d == 3 {
+              &mut integral_image_buffer.sum_sq_3x3
+            } else {
+              &mut integral_image_buffer.sum_sq_5x5
+            };
 
-        _mm256_storeu_si256(ptr.as_mut_ptr().add(y * integral_image_stride + x) as *mut _, sum);
-        _mm256_storeu_si256(ptr_sq.as_mut_ptr().add(y * integral_image_stride + x) as *mut _, ssq);
-        }
-      } else {
-        for x2 in x..stripe_w + 2 {
-          let sum = get_integral_square(iimg, integral_image_stride, x2, y, d);
-          let ssq = get_integral_square(iimg_sq, integral_image_stride, x2, y, d);
-          // save sum and sum of square in storage
-          if d == 3 {
-            integral_image_buffer.sum_3x3[y * integral_image_stride + x2] = sum;
-            integral_image_buffer.sum_sq_3x3[y * integral_image_stride + x2] = ssq;
-          } else {
-            integral_image_buffer.sum_5x5[y * integral_image_stride + x2] = sum;
-            integral_image_buffer.sum_sq_5x5[y * integral_image_stride + x2] = ssq;
+            _mm256_storeu_si256(
+              ptr.as_mut_ptr().add(y * integral_image_stride + x) as *mut _,
+              sum,
+            );
+            _mm256_storeu_si256(
+              ptr_sq.as_mut_ptr().add(y * integral_image_stride + x) as *mut _,
+              ssq,
+            );
+          }
+        } else {
+          for x2 in x..stripe_w + 2 {
+            let sum =
+              get_integral_square(iimg, integral_image_stride, x2, y, d);
+            let ssq =
+              get_integral_square(iimg_sq, integral_image_stride, x2, y, d);
+            // save sum and sum of square in storage
+            if d == 3 {
+              integral_image_buffer.sum_3x3[y * integral_image_stride + x2] =
+                sum;
+              integral_image_buffer.sum_sq_3x3
+                [y * integral_image_stride + x2] = ssq;
+            } else {
+              integral_image_buffer.sum_5x5[y * integral_image_stride + x2] =
+                sum;
+              integral_image_buffer.sum_sq_5x5
+                [y * integral_image_stride + x2] = ssq;
+            }
           }
         }
       }
     }
   }
-  }
-/*
-  for y in 0..stripe_h + 2 {
-    for x in 0..stripe_w + 2 {
-      let sum = get_integral_square(iimg, integral_image_stride, x, y, d);
-      let ssq = get_integral_square(iimg_sq, integral_image_stride, x, y, d);
-      // save sum and sum of square in storage
-      integral_image_buffer.sum_3x3[y * integral_image_stride + x] = sum;
-      integral_image_buffer.sum_sq_3x3[y * integral_image_stride + x] = ssq;
+  /*
+    for y in 0..stripe_h + 2 {
+      for x in 0..stripe_w + 2 {
+        let sum = get_integral_square(iimg, integral_image_stride, x, y, d);
+        let ssq = get_integral_square(iimg_sq, integral_image_stride, x, y, d);
+        // save sum and sum of square in storage
+        integral_image_buffer.sum_3x3[y * integral_image_stride + x] = sum;
+        integral_image_buffer.sum_sq_3x3[y * integral_image_stride + x] = ssq;
+      }
     }
-  }
-*/
-/*
+  */
+  /*
   {
     let r = 2; // now for 5x5
     let d: usize = r * 2 + 1;

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -96,13 +96,20 @@ pub const IMAGE_WIDTH_MAX: usize = [STRIPE_IMAGE_MAX, SOLVE_IMAGE_MAX]
 pub struct IntegralImageBuffer {
   pub integral_image: Vec<u32>,
   pub sq_integral_image: Vec<u32>,
+
+  pub sum_3x3: Vec<u32>,
+  pub sum_5x5: Vec<u32>,
+  pub sum_sq_3x3: Vec<u32>,
+  pub sum_sq_5x5: Vec<u32>,
 }
 
 impl IntegralImageBuffer {
   /// Creates a new buffer with the given size, filled with zeros.
   #[inline]
   pub fn zeroed(size: usize) -> Self {
-    Self { integral_image: vec![0; size], sq_integral_image: vec![0; size] }
+    Self { integral_image: vec![0; size], sq_integral_image: vec![0; size],
+           sum_3x3: vec![0; size], sum_5x5: vec![0; size],
+           sum_sq_3x3: vec![0; size], sum_sq_5x5: vec![0; size], }
   }
 }
 
@@ -323,7 +330,7 @@ fn sgrproj_sum_finish(
 }
 
 // Using an integral image, compute the sum of a square region
-fn get_integral_square(
+pub fn get_integral_square(
   iimg: &[u32], stride: usize, x: usize, y: usize, size: usize,
 ) -> u32 {
   // Cancel out overflow in iimg by using wrapping arithmetic

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -599,7 +599,12 @@ pub fn setup_integral_image<T: Pixel>(
   }
 
   // Place to do compute sum and sum of square
-  let r = 1; // for 3x3
+#[cfg(target_arch = "x86")]
+use std::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+  for r in 1..=2 {
   let d: usize = r * 2 + 1;
   // and save the results sum and sum of square in different storage
   let integral_image_offset =
@@ -609,18 +614,50 @@ pub fn setup_integral_image<T: Pixel>(
     &integral_image_buffer.sq_integral_image[integral_image_offset..];
 
   for y in 0..stripe_h + 2 {
-    //if r == 2 && (y & 1) == 1 { continue; }
+    if d == 5 && (y & 1) == 1 {
+      continue;
+    }
+    for x in (0..stripe_w + 2).step_by(8) {
+      if x + 8 <= stripe_w + 2 {
+        unsafe {
+        let sum = get_integral_square_avx2(iimg, integral_image_stride, x, y, d);
+        let ssq = get_integral_square_avx2(iimg_sq, integral_image_stride, x, y, d);
+        // save 4 x u32 sum and sum of square in storage
+        let ptr = if d == 3 { &mut integral_image_buffer.sum_3x3 } else { &mut integral_image_buffer.sum_5x5 };
+        let ptr_sq = if d == 3 { &mut integral_image_buffer.sum_sq_3x3 } else { &mut integral_image_buffer.sum_sq_5x5 };
+
+        _mm256_storeu_si256(ptr.as_mut_ptr().add(y * integral_image_stride + x) as *mut _, sum);
+        _mm256_storeu_si256(ptr_sq.as_mut_ptr().add(y * integral_image_stride + x) as *mut _, ssq);
+        }
+      } else {
+        for x2 in x..stripe_w + 2 {
+          let sum = get_integral_square(iimg, integral_image_stride, x2, y, d);
+          let ssq = get_integral_square(iimg_sq, integral_image_stride, x2, y, d);
+          // save sum and sum of square in storage
+          if d == 3 {
+            integral_image_buffer.sum_3x3[y * integral_image_stride + x2] = sum;
+            integral_image_buffer.sum_sq_3x3[y * integral_image_stride + x2] = ssq;
+          } else {
+            integral_image_buffer.sum_5x5[y * integral_image_stride + x2] = sum;
+            integral_image_buffer.sum_sq_5x5[y * integral_image_stride + x2] = ssq;
+          }
+        }
+      }
+    }
+  }
+  }
+/*
+  for y in 0..stripe_h + 2 {
     for x in 0..stripe_w + 2 {
       let sum = get_integral_square(iimg, integral_image_stride, x, y, d);
       let ssq = get_integral_square(iimg_sq, integral_image_stride, x, y, d);
       // save sum and sum of square in storage
       integral_image_buffer.sum_3x3[y * integral_image_stride + x] = sum;
       integral_image_buffer.sum_sq_3x3[y * integral_image_stride + x] = ssq;
-      //integral_image_buffer.sum_5x5[y * integral_image_stride + x] = sum;
-      //integral_image_buffer.sum_sq_5x5[y * integral_image_stride + x] = ssq;
     }
   }
-
+*/
+/*
   {
     let r = 2; // now for 5x5
     let d: usize = r * 2 + 1;
@@ -643,6 +680,7 @@ pub fn setup_integral_image<T: Pixel>(
       }
     }
   }
+  */
 }
 
 pub fn sgrproj_stripe_filter<T: Pixel>(

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -597,6 +597,27 @@ pub fn setup_integral_image<T: Pixel>(
     integral_slice = integral_row;
     sq_integral_slice = sq_integral_row;
   }
+
+  // Place to do compute sum and sum of square
+  let r = 2;  // do 5x5 first for now
+  let d: usize = r * 2 + 1;
+  // TODO: repeat for the case r = 1, i.e. d = 3
+  // and save the results sum and sum of square in different storage
+  let integral_image_offset = if d == 3 { SOLVE_IMAGE_STRIDE + 1 } else { 0 };
+  let iimg = &integral_image_buffer.integral_image[integral_image_offset..];
+  let iimg_sq = &integral_image_buffer.sq_integral_image[integral_image_offset..];
+
+  for y in 0..stripe_h {
+  for x in 0..stripe_w + 2 {
+    let sum = get_integral_square(iimg, SOLVE_IMAGE_STRIDE, x, y, d);
+    let ssq = get_integral_square(iimg_sq, SOLVE_IMAGE_STRIDE, x, y, d);
+    // save sum and sum of square in storage
+    //ts.integral_buffer.sum_3x3[y*SOLVE_IMAGE_STRIDE + x + 1] = sum;
+    //ts.integral_buffer.sum_sq_3x3[y*SOLVE_IMAGE_STRIDE + x + 1] = ssq;
+    integral_image_buffer.sum_5x5[y*SOLVE_IMAGE_STRIDE + x + 1] = sum;
+    integral_image_buffer.sum_sq_5x5[y*SOLVE_IMAGE_STRIDE + x + 1] = ssq;
+  }
+  }
 }
 
 pub fn sgrproj_stripe_filter<T: Pixel>(

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -187,11 +187,19 @@ pub(crate) mod native {
       // if r = 1, i.e. 3x3, do as before
       //let sum = get_integral_square(iimg, iimg_stride, x, y, d);
       //let ssq = get_integral_square(iimg_sq, iimg_stride, x, y, d);
+      let sum2 = get_integral_square(iimg, iimg_stride, x, y, d);
+      let ssq2 = get_integral_square(iimg_sq, iimg_stride, x, y, d);
 
-      let sum = if r == 1 { get_integral_square(iimg, iimg_stride, x, y, d) }
-                else { integral_image_buffer.sum_5x5[sum_array_offset + x] };
-      let ssq = if r == 1 { get_integral_square(iimg_sq, iimg_stride, x, y, d) }
-                else { integral_image_buffer.sum_sq_5x5[sum_array_offset + x] };
+      if r == 1 {
+        let s2 = integral_image_buffer.sum_3x3[sum_array_offset + x];
+        let sq2 = integral_image_buffer.sum_sq_3x3[sum_array_offset + x];
+        assert!(sum2 == s2);
+        assert!(ssq2 == sq2);
+      }
+      let sum = if r == 2 { get_integral_square(iimg, iimg_stride, x, y, d) }
+                else { integral_image_buffer.sum_3x3[sum_array_offset + x] };
+      let ssq = if r == 2 { get_integral_square(iimg_sq, iimg_stride, x, y, d) }
+                else { integral_image_buffer.sum_sq_3x3[sum_array_offset + x] };
       let (reta, retb) =
         sgrproj_sum_finish(ssq, sum, n as u32, one_over_n, s, bdm8);
       af[x] = reta;
@@ -599,24 +607,26 @@ pub fn setup_integral_image<T: Pixel>(
   }
 
   // Place to do compute sum and sum of square
-  let r = 2;  // do 5x5 first for now
+  //let r = 2;  // do 5x5 first for now
+  let r = 1;  // do 3x3 first for now
   let d: usize = r * 2 + 1;
   // TODO: repeat for the case r = 1, i.e. d = 3
   // and save the results sum and sum of square in different storage
-  let integral_image_offset = if d == 3 { SOLVE_IMAGE_STRIDE + 1 } else { 0 };
+  let integral_image_offset = if d == 3 { integral_image_stride + 1 } else { 0 };
   let iimg = &integral_image_buffer.integral_image[integral_image_offset..];
   let iimg_sq = &integral_image_buffer.sq_integral_image[integral_image_offset..];
 
-  for y in 0..stripe_h {
-  for x in 0..stripe_w + 2 {
-    let sum = get_integral_square(iimg, SOLVE_IMAGE_STRIDE, x, y, d);
-    let ssq = get_integral_square(iimg_sq, SOLVE_IMAGE_STRIDE, x, y, d);
-    // save sum and sum of square in storage
-    //ts.integral_buffer.sum_3x3[y*SOLVE_IMAGE_STRIDE + x + 1] = sum;
-    //ts.integral_buffer.sum_sq_3x3[y*SOLVE_IMAGE_STRIDE + x + 1] = ssq;
-    integral_image_buffer.sum_5x5[y*SOLVE_IMAGE_STRIDE + x + 1] = sum;
-    integral_image_buffer.sum_sq_5x5[y*SOLVE_IMAGE_STRIDE + x + 1] = ssq;
-  }
+  for y in 0..stripe_h + 2 {
+    //if r == 2 && (y & 1) == 1 { continue; }
+    for x in 0..stripe_w + 2 {
+      let sum = get_integral_square(iimg, integral_image_stride, x, y, d);
+      let ssq = get_integral_square(iimg_sq, integral_image_stride, x, y, d);
+      // save sum and sum of square in storage
+      integral_image_buffer.sum_3x3[y * integral_image_stride + x] = sum;
+      integral_image_buffer.sum_sq_3x3[y * integral_image_stride + x] = ssq;
+      //integral_image_buffer.sum_5x5[y * integral_image_stride + x] = sum;
+      //integral_image_buffer.sum_sq_5x5[y * integral_image_stride + x] = ssq;
+    }
   }
 }
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -10,7 +10,6 @@
 
 #![allow(non_camel_case_types)]
 
-use crate::lrf::get_integral_square;
 use crate::api::*;
 use crate::cdef::*;
 use crate::context::*;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -2114,7 +2114,7 @@ pub fn rdo_loop_decision<T: Pixel>(
                 &lrf_input.planes[pli].slice(loop_po),
               );
 
-              // Place to do compute sum and sum of square
+              /*// Place to do compute sum and sum of square
               let r = 2;  // do 5x5 first for now
               let d: usize = r * 2 + 1;
               // TODO: repeat for the case r = 1, i.e. d = 3
@@ -2133,7 +2133,7 @@ pub fn rdo_loop_decision<T: Pixel>(
                 ts.integral_buffer.sum_5x5[y*SOLVE_IMAGE_STRIDE + x + 1] = sum;
                 ts.integral_buffer.sum_sq_5x5[y*SOLVE_IMAGE_STRIDE + x + 1] = ssq;
               }
-              }
+              }*/
 
               for set in 0..16 {
                 // clip to encoded area

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1952,6 +1952,7 @@ pub fn rdo_loop_decision<T: Pixel>(
                       height,
                       &lrf_input.planes[pli].slice(loop_po),
                       &lrf_input.planes[pli].slice(loop_po),
+                      fi.cpu_feature_level,
                     );
 
                     sgrproj_stripe_filter(
@@ -2111,6 +2112,7 @@ pub fn rdo_loop_decision<T: Pixel>(
                 unit_height,
                 &lrf_input.planes[pli].slice(loop_po),
                 &lrf_input.planes[pli].slice(loop_po),
+                fi.cpu_feature_level,
               );
 
               for set in 0..16 {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -10,6 +10,7 @@
 
 #![allow(non_camel_case_types)]
 
+use crate::lrf::get_integral_square;
 use crate::api::*;
 use crate::cdef::*;
 use crate::context::*;
@@ -2112,6 +2113,27 @@ pub fn rdo_loop_decision<T: Pixel>(
                 &lrf_input.planes[pli].slice(loop_po),
                 &lrf_input.planes[pli].slice(loop_po),
               );
+
+              // Place to do compute sum and sum of square
+              let r = 2;  // do 5x5 first for now
+              let d: usize = r * 2 + 1;
+              // TODO: repeat for the case r = 1, i.e. d = 3
+              // and save the results sum and sum of square in different storage
+              let integral_image_offset = if d == 3 { SOLVE_IMAGE_STRIDE + 1 } else { 0 };
+              let iimg = &ts.integral_buffer.integral_image[integral_image_offset..];
+              let iimg_sq = &ts.integral_buffer.sq_integral_image[integral_image_offset..];
+
+              for y in 0..unit_height {
+              for x in 0..unit_width + 2 {
+                let sum = get_integral_square(iimg, SOLVE_IMAGE_STRIDE, x, y, d);
+                let ssq = get_integral_square(iimg_sq, SOLVE_IMAGE_STRIDE, x, y, d);
+                // save sum and sum of square in storage
+                //ts.integral_buffer.sum_3x3[y*SOLVE_IMAGE_STRIDE + x + 1] = sum;
+                //ts.integral_buffer.sum_sq_3x3[y*SOLVE_IMAGE_STRIDE + x + 1] = ssq;
+                ts.integral_buffer.sum_5x5[y*SOLVE_IMAGE_STRIDE + x + 1] = sum;
+                ts.integral_buffer.sum_sq_5x5[y*SOLVE_IMAGE_STRIDE + x + 1] = ssq;
+              }
+              }
 
               for set in 0..16 {
                 // clip to encoded area

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1952,6 +1952,13 @@ pub fn rdo_loop_decision<T: Pixel>(
                       height,
                       &lrf_input.planes[pli].slice(loop_po),
                       &lrf_input.planes[pli].slice(loop_po),
+                    );
+
+                    sgrproj_compute_3x3_and_5x5_box_sums(
+                      &mut ts.integral_buffer,
+                      SOLVE_IMAGE_STRIDE,
+                      width,
+                      height,
                       fi.cpu_feature_level,
                     );
 
@@ -2112,6 +2119,13 @@ pub fn rdo_loop_decision<T: Pixel>(
                 unit_height,
                 &lrf_input.planes[pli].slice(loop_po),
                 &lrf_input.planes[pli].slice(loop_po),
+              );
+
+              sgrproj_compute_3x3_and_5x5_box_sums(
+                &mut ts.integral_buffer,
+                SOLVE_IMAGE_STRIDE,
+                unit_width,
+                unit_height,
                 fi.cpu_feature_level,
               );
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1954,7 +1954,7 @@ pub fn rdo_loop_decision<T: Pixel>(
                       &lrf_input.planes[pli].slice(loop_po),
                     );
 
-                    sgrproj_compute_3x3_and_5x5_box_sums(
+                    crate::lrf::native::sgrproj_compute_3x3_and_5x5_box_sums(
                       &mut ts.integral_buffer,
                       SOLVE_IMAGE_STRIDE,
                       width,
@@ -2121,7 +2121,7 @@ pub fn rdo_loop_decision<T: Pixel>(
                 &lrf_input.planes[pli].slice(loop_po),
               );
 
-              sgrproj_compute_3x3_and_5x5_box_sums(
+              crate::lrf::native::sgrproj_compute_3x3_and_5x5_box_sums(
                 &mut ts.integral_buffer,
                 SOLVE_IMAGE_STRIDE,
                 unit_width,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -2114,27 +2114,6 @@ pub fn rdo_loop_decision<T: Pixel>(
                 &lrf_input.planes[pli].slice(loop_po),
               );
 
-              /*// Place to do compute sum and sum of square
-              let r = 2;  // do 5x5 first for now
-              let d: usize = r * 2 + 1;
-              // TODO: repeat for the case r = 1, i.e. d = 3
-              // and save the results sum and sum of square in different storage
-              let integral_image_offset = if d == 3 { SOLVE_IMAGE_STRIDE + 1 } else { 0 };
-              let iimg = &ts.integral_buffer.integral_image[integral_image_offset..];
-              let iimg_sq = &ts.integral_buffer.sq_integral_image[integral_image_offset..];
-
-              for y in 0..unit_height {
-              for x in 0..unit_width + 2 {
-                let sum = get_integral_square(iimg, SOLVE_IMAGE_STRIDE, x, y, d);
-                let ssq = get_integral_square(iimg_sq, SOLVE_IMAGE_STRIDE, x, y, d);
-                // save sum and sum of square in storage
-                //ts.integral_buffer.sum_3x3[y*SOLVE_IMAGE_STRIDE + x + 1] = sum;
-                //ts.integral_buffer.sum_sq_3x3[y*SOLVE_IMAGE_STRIDE + x + 1] = ssq;
-                ts.integral_buffer.sum_5x5[y*SOLVE_IMAGE_STRIDE + x + 1] = sum;
-                ts.integral_buffer.sum_sq_5x5[y*SOLVE_IMAGE_STRIDE + x + 1] = ssq;
-              }
-              }*/
-
               for set in 0..16 {
                 // clip to encoded area
                 let (xqd0, xqd1) = sgrproj_solve(


### PR DESCRIPTION
Avoid duplicate compute of box sum and box square sum during RDO of SGR (Self Guided Restoration). No change of bdrate on awcy, with giving 5~6% speedup at speed 10.
At default speed, less than 5% speedup.

[awcy, -s 10](https://beta.arewecompressedyet.com/?job=ref_native_sgrproj_box_ab_rebased1_s10%402019-11-04T19%3A30%3A52.568Z&job=test_avoid_dupli_all_sgrproj_box_ab_rebased_s10%402019-11-04T19%3A31%3A42.382Z)

[awcy, default speed](https://beta.arewecompressedyet.com/?job=ref_native_sgrproj_box_ab_rebased1%402019-11-04T19%3A01%3A57.818Z&job=test_avoid_dupli_all_sgrproj_box_ab_rebased%402019-11-04T19%3A02%3A12.799Z)

The reference I used is master with SIMD versions disabled by hard coding.  https://github.com/ycho/rav1e/tree/native_sgrproj_box_ab_rebase1.

I will want help from folks who writes SIMD code faster than me. Otherwise, please wait for me to write it and complete.
