### PR TITLE
Implement FusedIterator for all applicable iterators

### DIFF
--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -488,6 +488,8 @@ impl<'a, T: Pixel> Iterator for PlaneIter<'a, T> {
   }
 }
 
+impl<T: Pixel> FusedIterator for PlaneIter<'_, T> {}
+
 #[derive(Clone, Copy, Debug)]
 pub struct PlaneSlice<'a, T: Pixel> {
   pub plane: &'a Plane<T>,

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -30,6 +30,7 @@ use crate::util::ILog;
 use crate::util::Pixel;
 
 use std::cmp;
+use std::iter::FusedIterator;
 use std::ops::{Index, IndexMut};
 
 pub const RESTORATION_TILESIZE_MAX_LOG2: usize = 8;
@@ -430,6 +431,7 @@ impl<'a, T: Pixel> Iterator for VertPaddedIter<'a, T> {
 }
 
 impl<T: Pixel> ExactSizeIterator for VertPaddedIter<'_, T> {}
+impl<T: Pixel> FusedIterator for VertPaddedIter<'_, T> {}
 
 struct HorzPaddedIter<'a, T: Pixel> {
   // Active area cropping is done using the length of the slice
@@ -477,6 +479,7 @@ impl<'a, T: Pixel> Iterator for HorzPaddedIter<'a, T> {
 }
 
 impl<T: Pixel> ExactSizeIterator for HorzPaddedIter<'_, T> {}
+impl<T: Pixel> FusedIterator for HorzPaddedIter<'_, T> {}
 
 pub fn setup_integral_image<T: Pixel>(
   integral_image_buffer: &mut IntegralImageBuffer,

--- a/src/tiling/plane_region.rs
+++ b/src/tiling/plane_region.rs
@@ -11,6 +11,7 @@ use crate::context::*;
 use crate::frame::*;
 use crate::util::*;
 
+use std::iter::FusedIterator;
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
 use std::slice;
@@ -499,7 +500,9 @@ impl<'a, T: Pixel> Iterator for RowsIterMut<'a, T> {
 }
 
 impl<T: Pixel> ExactSizeIterator for RowsIter<'_, T> {}
+impl<T: Pixel> FusedIterator for RowsIter<'_, T> {}
 impl<T: Pixel> ExactSizeIterator for RowsIterMut<'_, T> {}
+impl<T: Pixel> FusedIterator for RowsIterMut<'_, T> {}
 
 pub struct VertWindows<'a, T: Pixel> {
   data: *const T,
@@ -584,7 +587,9 @@ impl<'a, T: Pixel> Iterator for HorzWindows<'a, T> {
 }
 
 impl<T: Pixel> ExactSizeIterator for VertWindows<'_, T> {}
+impl<T: Pixel> FusedIterator for VertWindows<'_, T> {}
 impl<T: Pixel> ExactSizeIterator for HorzWindows<'_, T> {}
+impl<T: Pixel> FusedIterator for HorzWindows<'_, T> {}
 
 #[test]
 fn area_test() {

--- a/src/tiling/tiler.rs
+++ b/src/tiling/tiler.rs
@@ -13,6 +13,7 @@ use crate::context::*;
 use crate::encoder::*;
 use crate::util::*;
 
+use std::iter::FusedIterator;
 use std::marker::PhantomData;
 
 pub const MAX_TILE_WIDTH: usize = 4096;
@@ -216,6 +217,7 @@ impl<'a, 'b, T: Pixel> Iterator for TileContextIterMut<'a, 'b, T> {
 }
 
 impl<T: Pixel> ExactSizeIterator for TileContextIterMut<'_, '_, T> {}
+impl<T: Pixel> FusedIterator for TileContextIterMut<'_, '_, T> {}
 
 #[cfg(test)]
 pub mod test {


### PR DESCRIPTION
See https://doc.rust-lang.org/std/iter/trait.FusedIterator.html

"Calling next on a fused iterator that has returned None once is
guaranteed to return None again. This trait should be implemented by
all iterators that behave this way because it allows optimizing
Iterator::fuse."