### PR TITLE
Remove Option from get_1d_tx_types

### DIFF
--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1591,8 +1591,7 @@ pub(crate) mod native {
       //   to zero for filling out missing input coeffs.
       let buffer = &mut [0i32; 64 * 64][..Self::W * Self::H];
       let rect_type = get_rect_tx_log_ratio(Self::W, Self::H);
-      let tx_types_1d = get_1d_tx_types(tx_type)
-        .expect("TxType not supported by rust txfm code.");
+      let tx_types_1d = get_1d_tx_types(tx_type);
 
       // perform inv txfm on every row
       let range = bd + 8;

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -321,27 +321,24 @@ enum TxType1D {
   IDTX,
 }
 
-// Option can be removed when the table is completely filled
-fn get_1d_tx_types(tx_type: TxType) -> Option<(TxType1D, TxType1D)> {
+fn get_1d_tx_types(tx_type: TxType) -> (TxType1D, TxType1D) {
   match tx_type {
-    TxType::DCT_DCT => Some((TxType1D::DCT, TxType1D::DCT)),
-    TxType::ADST_DCT => Some((TxType1D::ADST, TxType1D::DCT)),
-    TxType::DCT_ADST => Some((TxType1D::DCT, TxType1D::ADST)),
-    TxType::ADST_ADST => Some((TxType1D::ADST, TxType1D::ADST)),
-    TxType::FLIPADST_DCT => Some((TxType1D::FLIPADST, TxType1D::DCT)),
-    TxType::DCT_FLIPADST => Some((TxType1D::DCT, TxType1D::FLIPADST)),
-    TxType::FLIPADST_FLIPADST => {
-      Some((TxType1D::FLIPADST, TxType1D::FLIPADST))
-    }
-    TxType::ADST_FLIPADST => Some((TxType1D::ADST, TxType1D::FLIPADST)),
-    TxType::FLIPADST_ADST => Some((TxType1D::FLIPADST, TxType1D::ADST)),
-    TxType::IDTX => Some((TxType1D::IDTX, TxType1D::IDTX)),
-    TxType::V_DCT => Some((TxType1D::DCT, TxType1D::IDTX)),
-    TxType::H_DCT => Some((TxType1D::IDTX, TxType1D::DCT)),
-    TxType::V_ADST => Some((TxType1D::ADST, TxType1D::IDTX)),
-    TxType::H_ADST => Some((TxType1D::IDTX, TxType1D::ADST)),
-    TxType::V_FLIPADST => Some((TxType1D::FLIPADST, TxType1D::IDTX)),
-    TxType::H_FLIPADST => Some((TxType1D::IDTX, TxType1D::FLIPADST)),
+    TxType::DCT_DCT => (TxType1D::DCT, TxType1D::DCT),
+    TxType::ADST_DCT => (TxType1D::ADST, TxType1D::DCT),
+    TxType::DCT_ADST => (TxType1D::DCT, TxType1D::ADST),
+    TxType::ADST_ADST => (TxType1D::ADST, TxType1D::ADST),
+    TxType::FLIPADST_DCT => (TxType1D::FLIPADST, TxType1D::DCT),
+    TxType::DCT_FLIPADST => (TxType1D::DCT, TxType1D::FLIPADST),
+    TxType::FLIPADST_FLIPADST => (TxType1D::FLIPADST, TxType1D::FLIPADST),
+    TxType::ADST_FLIPADST => (TxType1D::ADST, TxType1D::FLIPADST),
+    TxType::FLIPADST_ADST => (TxType1D::FLIPADST, TxType1D::ADST),
+    TxType::IDTX => (TxType1D::IDTX, TxType1D::IDTX),
+    TxType::V_DCT => (TxType1D::DCT, TxType1D::IDTX),
+    TxType::H_DCT => (TxType1D::IDTX, TxType1D::DCT),
+    TxType::V_ADST => (TxType1D::ADST, TxType1D::IDTX),
+    TxType::H_ADST => (TxType1D::IDTX, TxType1D::ADST),
+    TxType::V_FLIPADST => (TxType1D::FLIPADST, TxType1D::IDTX),
+    TxType::H_FLIPADST => (TxType1D::IDTX, TxType1D::FLIPADST),
   }
 }
 


### PR DESCRIPTION
This Option is no longer needed
since we now support all transform types.