### PR TITLE
encoder: adjust CDEF damping based on quantizer

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -866,6 +866,7 @@ impl<T: Pixel> FrameInvariants<T> {
   pub fn set_quantizers(&mut self, qps: &QuantizerParameters) {
     self.base_q_idx = qps.ac_qi[0];
     let base_q_idx = self.base_q_idx as i32;
+    self.cdef_damping = 3 + (self.base_q_idx >> 6);
     for pi in 0..3 {
       debug_assert!(qps.dc_qi[pi] as i32 - base_q_idx >= -128);
       debug_assert!((qps.dc_qi[pi] as i32 - base_q_idx) < 128);


### PR DESCRIPTION
master-4ab62c6273e0ec64656e85df9602a2046d0ed460 -> cdef-damping-by-quantizer@2019-11-10T07:03:15.921Z

   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-0.5995 |  0.1251 |  0.3360 |  -0.3509 | -0.3706 | -0.3460 |    -0.4835

https://beta.arewecompressedyet.com/?job=master-4ab62c6273e0ec64656e85df9602a2046d0ed460&job=cdef-damping-by-quantizer%402019-11-10T07%3A03%3A15.921Z