### PR TITLE
Avoid marking the last frame in a clip as a scenecut

### DIFF
--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -633,15 +633,15 @@ fn output_frameno_reorder_scene_change_at(scene_change_at: u64) {
         ][..]
       }
       4 => {
+        // The algorithm cannot put a scenechange at the last frame of a video
         &[
-          (0, true),  // I-frame
-          (0, false), // Missing
-          (2, true),  // B0-frame
-          (1, true),  // B1-frame (first)
-          (2, true),  // B0-frame (show existing)
-          (3, true),  // B1-frame (second)
-          (3, false), // Missing
-          (4, true),  // I-frame
+          (0, true), // I-frame
+          (4, true), // P-frame
+          (2, true), // B0-frame
+          (1, true), // B1-frame (first)
+          (2, true), // B0-frame (show existing)
+          (3, true), // B1-frame (second)
+          (4, true), // P-frame (show existing)
         ][..]
       }
       _ => unreachable!(),
@@ -747,15 +747,15 @@ fn pyramid_level_reorder_scene_change_at(scene_change_at: u64) {
         ][..]
       }
       4 => {
+        // The algorithm cannot put a scenechange at the last frame of a video
         &[
           0, // I-frame
-          0, // Missing
+          0, // P-frame
           1, // B0-frame
           2, // B1-frame (first)
           1, // B0-frame (show existing)
           2, // B1-frame (second)
-          2, // Missing
-          0, // I-frame
+          0, // P-frame (show existing)
         ][..]
       }
       _ => unreachable!(),
@@ -994,15 +994,15 @@ fn output_frameno_incremental_reorder_scene_change_at(scene_change_at: u64) {
         ][..]
       }
       4 => {
+        // The algorithm cannot put a scenechange at the last frame of a video
         &[
-          (0, true),  // I-frame
-          (0, false), // Missing
-          (2, true),  // B0-frame
-          (1, true),  // B1-frame (first)
-          (2, true),  // B0-frame (show existing)
-          (3, true),  // B1-frame (second)
-          (3, false), // Missing
-          (4, true),  // I-frame
+          (0, true), // I-frame
+          (4, true), // P-frame
+          (2, true), // B0-frame
+          (1, true), // B1-frame (first)
+          (2, true), // B0-frame (show existing)
+          (3, true), // B1-frame (second)
+          (4, true), // P-frame (show existing)
         ][..]
       }
       _ => unreachable!(),
@@ -1281,6 +1281,7 @@ fn output_frameno_scene_change_past_max_len_flash() {
   send_test_frame(&mut ctx, u8::max_value());
   send_test_frame(&mut ctx, u8::max_value());
   send_test_frame(&mut ctx, u8::min_value());
+  send_test_frame(&mut ctx, u8::min_value());
   ctx.flush();
 
   let data = get_frame_invariants(ctx)
@@ -1305,6 +1306,12 @@ fn output_frameno_scene_change_past_max_len_flash() {
       (5, true),  // B1-frame (second)
       (6, true),  // P-frame (show existing)
       (7, true),  // I-frame
+      (7, false), // invalid
+      (7, false), // invalid
+      (8, true),  // P-frame
+      (8, false), // invalid
+      (8, false), // invalid
+      (8, false), // invalid
     ]
   );
 }

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -126,6 +126,12 @@ impl SceneChangeDetector {
     &mut self, frame_subset: &[Arc<Frame<T>>], frameno: u64,
     inter_cfg: &InterConfig,
   ) {
+    if frame_subset.len() == 2 {
+      // This is the last frame in the video,
+      // which is effectively a "flash" of content.
+      self.excluded_frames.insert(frameno);
+    }
+
     let lookahead_distance = cmp::min(
       inter_cfg.keyframe_lookahead_distance() as usize,
       frame_subset.len() - 1,


### PR DESCRIPTION
In real encoding, this will matter about 1/240 of the time. However, in our AWCY tests, this has slightly more of an impact. [AWCY vs master](https://beta.arewecompressedyet.com/?job=master-scenecut%402019-11-14T03%3A15%3A23.198Z&job=no-last-scenecut%402019-11-14T05%3A53%3A49.531Z); this will also help resolve some more noise in tests for tweaking of scenecuts in the future.