### PR TITLE
Enable auto-vectorization of av1_round_shift_array

### DIFF
--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -303,12 +303,12 @@ fn av1_round_shift_array_rs(arr: &mut [i32], size: usize, bit: i8) {
   }
   if bit > 0 {
     let bit = bit as usize;
-    for i in 0..size {
-      arr[i] = round_shift(arr[i], bit);
+    for i in arr.iter_mut().take(size) {
+      *i = round_shift(*i, bit);
     }
   } else {
-    for i in 0..size {
-      arr[i] <<= -bit;
+    for i in arr.iter_mut().take(size) {
+      *i <<= -bit;
     }
   }
 }


### PR DESCRIPTION
This results in approximately a 25% speedup of the
forward_transform native code and a 1.5% overall speedup
at default speed settings.