### PR TITLE
Remove the unused allow safe_extern_statics

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -7,8 +7,6 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-#![allow(safe_extern_statics)]
-
 use crate::context::*;
 use crate::encoder::FrameInvariants;
 use crate::frame::Frame;

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,7 +7,6 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-#![allow(safe_extern_statics)]
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -7,8 +7,6 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-#![allow(safe_extern_statics)]
-
 use crate::api::FrameType;
 use crate::context::*;
 use crate::encoder::FrameInvariants;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@
 //! [`Context`]: struct.Context.html
 //! [`Context::receive_packet`]: struct.Context.html#method.receive_packet
 
-#![allow(safe_extern_statics)]
 #![deny(bare_trait_objects)]
 #![allow(clippy::cast_lossless)]
 #![allow(clippy::cast_ptr_alignment)]

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -7,8 +7,6 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-#![allow(safe_extern_statics)]
-
 cfg_if::cfg_if! {
   if #[cfg(nasm_x86_64)] {
     use crate::asm::x86::lrf::*;

--- a/src/scan_order.rs
+++ b/src/scan_order.rs
@@ -7,7 +7,6 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-#![allow(safe_extern_statics)]
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -7,8 +7,6 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-#![allow(safe_extern_statics)]
-
 use crate::context::*;
 use crate::header::PRIMARY_REF_NONE;
 use crate::util::Pixel;


### PR DESCRIPTION
It had been also updated to be an hard error in rust 1.40.