### PR TITLE
Reuse lookahead frame state and motion vectors

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -24,6 +24,7 @@ use rav1e::bench::transform::*;
 use crate::transform::{forward_transforms, inverse_transforms};
 
 use criterion::*;
+use std::sync::Arc;
 use std::time::Duration;
 
 fn write_b(c: &mut Criterion) {
@@ -133,7 +134,7 @@ fn cdef_frame_bench(b: &mut Bencher, width: usize, height: usize) {
   let fb = FrameBlocks::new(fi.sb_width * 16, fi.sb_height * 16);
   let mut fs = FrameState::new(&fi);
 
-  b.iter(|| cdef_filter_frame(&fi, &mut fs.rec, &fb));
+  b.iter(|| cdef_filter_frame(&fi, Arc::make_mut(&mut fs.rec), &fb));
 }
 
 fn cfl_rdo(c: &mut Criterion) {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -154,7 +154,7 @@ pub struct Packet<T: Pixel> {
   /// The packet data.
   pub data: Vec<u8>,
   /// The reconstruction of the shown frame.
-  pub rec: Option<Frame<T>>,
+  pub rec: Option<Arc<Frame<T>>>,
   /// The number of the input frame corresponding to the one shown frame in the
   /// TU stored in this packet. Since AV1 does not explicitly reorder frames,
   /// these will increase sequentially.

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -181,7 +181,7 @@ fn send_test_frame<T: Pixel>(ctx: &mut Context<T>, content_value: T) {
 fn get_frame_invariants<T: Pixel>(
   ctx: Context<T>,
 ) -> impl Iterator<Item = FrameInvariants<T>> {
-  ctx.inner.frame_invariants.into_iter().map(|(_, v)| v)
+  ctx.inner.frame_data.into_iter().map(|(_, v)| v.fi)
 }
 
 #[interpolate_test(0, 0)]
@@ -1501,7 +1501,7 @@ fn lookahead_size_properly_bounded(
       expectations.pre_receive_frame_q_lens[i]
     );
     assert_eq!(
-      ctx.inner.frame_invariants.len(),
+      ctx.inner.frame_data.len(),
       expectations.pre_receive_fi_lens[i]
     );
     while ctx.receive_packet().is_ok() {
@@ -1512,7 +1512,7 @@ fn lookahead_size_properly_bounded(
       expectations.post_receive_frame_q_lens[i]
     );
     assert_eq!(
-      ctx.inner.frame_invariants.len(),
+      ctx.inner.frame_data.len(),
       expectations.post_receive_fi_lens[i]
     );
   }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1203,7 +1203,7 @@ pub const LOCAL_BLOCK_MASK: usize = (1 << SUPERBLOCK_TO_BLOCK_SHIFT) - 1;
 
 /// Absolute offset in superblocks, where a superblock is defined
 /// to be an N*N square where N = (1 << SUPERBLOCK_TO_PLANE_SHIFT).
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SuperBlockOffset {
   pub x: usize,
   pub y: usize,
@@ -1211,12 +1211,12 @@ pub struct SuperBlockOffset {
 
 /// Absolute offset in superblocks inside a plane, where a superblock is defined
 /// to be an N*N square where N = (1 << SUPERBLOCK_TO_PLANE_SHIFT).
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PlaneSuperBlockOffset(pub SuperBlockOffset);
 
 /// Absolute offset in superblocks inside a tile, where a superblock is defined
 /// to be an N*N square where N = (1 << SUPERBLOCK_TO_PLANE_SHIFT).
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TileSuperBlockOffset(pub SuperBlockOffset);
 
 impl SuperBlockOffset {

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -19,6 +19,7 @@ use crate::util::Pixel;
 use crate::util::{clamp, ILog};
 use crate::DeblockState;
 use std::cmp;
+use std::sync::Arc;
 
 fn deblock_adjusted_level(
   deblock: &DeblockState, block: &Block, pli: usize, vertical: bool,
@@ -1408,8 +1409,9 @@ fn sse_plane<T: Pixel>(
 pub fn deblock_filter_frame<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>, blocks: &FrameBlocks,
 ) {
+  let fs_rec = Arc::make_mut(&mut fs.rec);
   for pli in 0..PLANES {
-    deblock_plane(fi, &fs.deblock, &mut fs.rec.planes[pli], pli, blocks);
+    deblock_plane(fi, &fs.deblock, &mut fs_rec.planes[pli], pli, blocks);
   }
 }
 

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -114,7 +114,7 @@ pub(crate) trait TestDecoder<T: Pixel> {
           ivf::write_ivf_frame(&mut out, pkt.input_frameno, &pkt.data);
 
           if let Some(pkt_rec) = pkt.rec {
-            rec_fifo.push_back(pkt_rec.clone());
+            rec_fifo.push_back((*pkt_rec).clone());
           }
           let packet = pkt.data;
           debug!("Decoding frame {}", pkt.input_frameno);


### PR DESCRIPTION
Results in 5-8% encoding time improvement with 1 tile. [AWCY](https://beta.arewecompressedyet.com/?job=master-edbc586999d6a1e49e1e35d84a0c8a2c9dcf7990&job=reuse-lookahead-mvs%402019-11-24T06%3A32%3A54.455Z)

Closes #1677