### PR TITLE
Add and Update licensing 

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,11 @@
-// build.rs
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use rustc_version::{version, Version};
 #[allow(unused_imports)]

--- a/examples/simple_encoding.rs
+++ b/examples/simple_encoding.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 // Encode the same tiny blank frame 30 times
 use rav1e::config::SpeedSettings;
 use rav1e::*;

--- a/fuzz/fuzz_targets/construct_context.rs
+++ b/fuzz/fuzz_targets/construct_context.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 #![no_main]
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rav1e;

--- a/fuzz/fuzz_targets/encode.rs
+++ b/fuzz/fuzz_targets/encode.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 #![no_main]
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rav1e;

--- a/fuzz/fuzz_targets/encode_decode.rs
+++ b/fuzz/fuzz_targets/encode_decode.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 #![no_main]
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rav1e;

--- a/license_template.txt
+++ b/license_template.txt
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 use super::*;
 
 use crate::partition::BlockSize;

--- a/src/asm/x86/transform/inverse.rs
+++ b/src/asm/x86/transform/inverse.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 use crate::cpu_features::CpuFeatureLevel;
 use crate::tiling::PlaneRegionMut;
 use crate::transform::*;

--- a/src/asm/x86/transform/mod.rs
+++ b/src/asm/x86/transform/mod.rs
@@ -1,1 +1,10 @@
+// Copyright (c) 2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 pub mod inverse;

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/bin/decoder/mod.rs
+++ b/src/bin/decoder/mod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/bin/error.rs
+++ b/src/bin/error.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/bin/muxer/ivf.rs
+++ b/src/bin/muxer/ivf.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/bin/muxer/y4m.rs
+++ b/src/bin/muxer/y4m.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 use rav1e::data::EncoderStats;
 use rav1e::prelude::*;
 use rav1e::{Packet, Pixel};

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/entropymode.rs
+++ b/src/entropymode.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 use std::sync::Arc;
 
 use arbitrary::*;

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/me.rs
+++ b/src/me.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/rdo_tables.rs
+++ b/src/rdo_tables.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/scan_order.rs
+++ b/src/scan_order.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
 use crate::partition::BlockSize;
 use crate::prelude::PredictionMode;
 use crate::transform::TxType;

--- a/src/token_cdfs.rs
+++ b/src/token_cdfs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License


### PR DESCRIPTION
Hi,

This Patchset adds licensing to missing files and makes years in files up-to-date 

Copyright added files list 
```diff 
+ build.rs
+ examples/simple_encoding.rs
+ fuzz/fuzz_targets/construct_context.rs
+ fuzz/fuzz_targets/encode.rs
+ fuzz/fuzz_targets/encode_decode.rs
+ src/api/test.rs
+ src/asm/x86/transform/inverse.rs
+ src/asm/x86/transform/mod.rs
+ src/bin/stats.rs
+ src/fuzzing.rs
+ src/stats.rs
```


Licensing updated files list 
```diff 
+ src/api/internal.rs
+ src/api/mod.rs
+ src/bin/common.rs
+ src/bin/decoder/mod.rs
+ src/bin/decoder/y4m.rs
+ src/bin/error.rs
+ src/bin/muxer/ivf.rs
+ src/bin/muxer/y4m.rs
+ src/bin/rav1e.rs
+ src/capi.rs
+ src/cdef.rs
+ src/context.rs
+ src/deblock.rs
+ src/ec.rs
+ src/encoder.rs
+ src/entropymode.rs
+ src/frame/mod.rs
+ src/frame/plane.rs
+ src/header.rs
+ src/lib.rs
+ src/lrf.rs
+ src/me.rs
+ src/metrics.rs
+ src/partition.rs
+ src/predict.rs
+ src/quantize.rs
+ src/rdo.rs
+ src/rdo_tables.rs
+ src/scan_order.rs
+ src/scenechange/mod.rs
+ src/segmentation.rs
+ src/token_cdfs.rs
+ src/transform/forward.rs
+ src/transform/inverse.rs
+ src/transform/mod.rs
```

Also Update the `LICENSE` file

Also some files, we have taken from libaom, dav1d, Theora too, I am not sure which all was it and how to tackle those. 

On some files, it is written as 
`// Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved`
I am not sure if adding this line to those files(??) is sufficient.


This advances #1867 


Best, 
Vibhoothi