### PR TITLE
Refactor compute block importances

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -939,6 +939,8 @@ impl<T: Pixel> ContextInner<T> {
             len,
             reference_frame_block_importances,
           );
+
+          #[hawktracer(update_block_importances)]
           fn update_block_importances<T: Pixel>(
             fi: &FrameInvariants<T>, mvs: &crate::me::FrameMotionVectors,
             frame: &Frame<T>, reference_frame: &Frame<T>, bit_depth: usize,


### PR DESCRIPTION
Usual `Bosphorus_1920x1080_120fps_420_8bit_YUV`

master:
```
 INFO  rav1e::api::internal > Using 8 tiles (4x2)
 INFO  rav1e::stats         > encoded 600 frames, 1.122 fps, 1955.96 Kb/s
```
this pr:
```
 INFO  rav1e::api::internal > Using 8 tiles (4x2)
 INFO  rav1e::stats         > encoded 600 frames, 1.135 fps, 1955.96 Kb/s
```

About another 1% faster...