### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -1,0 +1,241 @@
+name: rav1e
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  rustfmt-clippy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install nasm
+      run: |
+        sudo apt-get install nasm
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: clippy, rustfmt
+    - name: Run rustfmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: -- --check --verbose
+    - name: Run clippy
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: -- -D warnings --verbose -A clippy::wrong-self-convention
+
+  build-unix:
+
+    strategy:
+      matrix:
+        conf:
+         - 1.36.0-tests
+         - aom-tests
+         - dav1d-tests
+         - grcov-coveralls
+         - bench
+         - doc
+         - check-no-default
+         - check-extra-feats
+        include:
+         - conf: 1.36.0-tests
+           toolchain: 1.36.0
+         - conf: aom-tests
+           toolchain: stable
+         - conf: dav1d-tests
+           toolchain: stable
+         - conf: grcov-coveralls
+           toolchain: nightly
+         - conf: bench
+           toolchain: stable
+         - conf: doc
+           toolchain: stable
+         - conf: check-no-default
+           toolchain: stable
+         - conf: check-extra-feats
+           toolchain: stable
+
+    env:
+      RUST_BACKTRACE: 1
+      DAV1D_DIR: dav1d-dir
+      AOM_DIR: aom-dir
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install deps
+      run: |
+        sudo apt-get install libsdl2-dev libvulkan-dev libcurl4-openssl-dev \
+                     zlib1g-dev libdw-dev libiberty-dev
+    - name: Install nasm
+      run: |
+        sudo apt-get install nasm
+    - name: Install Python3 packages
+      if: >
+        matrix.conf == '1.36.0-tests' || matrix.conf == 'dav1d-tests' ||
+        matrix.conf == 'grcov-coveralls'
+      run: |
+        sudo apt-get install python3-setuptools python3-wheel
+    - name: Install meson
+      if: >
+        matrix.conf == '1.36.0-tests' || matrix.conf == 'dav1d-tests' ||
+        matrix.conf == 'grcov-coveralls'
+      run: |
+        sudo pip3 install meson
+    - name: Install ninja
+      if: >
+        matrix.conf == '1.36.0-tests' || matrix.conf == 'dav1d-tests' ||
+        matrix.conf == 'aom-tests' || matrix.conf == 'grcov-coveralls'
+      run: |
+        sudo pip3 install ninja
+    - name: Install aom
+      if: >
+        matrix.conf == '1.36.0-tests' || matrix.conf == 'aom-tests' ||
+        matrix.conf == 'grcov-coveralls'
+      env:
+        LINK: https://aomedia.googlesource.com/aom
+        AOM_VERSION: 1.0.0-errata1
+      run: |
+        git clone --depth 1 -b "v$AOM_VERSION" $LINK "aom-$AOM_VERSION"
+        cd aom-$AOM_VERSION
+        rm -rf CMakeCache.txt CMakeFiles
+        mkdir -p build
+        cd build
+        cmake -GNinja .. \
+              -DCMAKE_INSTALL_PREFIX=$HOME/$AOM_DIR \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DENABLE_TESTS=0 \
+              -DENABLE_DOCS=0 \
+              -DCONFIG_LOWBITDEPTH=1 \
+              -DCONFIG_PIC=1
+        ninja
+        ninja install
+    - name: Install dav1d
+      if: >
+        matrix.conf == '1.36.0-tests' || matrix.conf == 'dav1d-tests' ||
+        matrix.conf == 'grcov-coveralls'
+      env:
+        LINK: https://code.videolan.org/videolan/dav1d/-/archive/
+        DAV1D_VERSION: 0.4.0
+      run: |
+        curl -L "$LINK/$DAV1D_VERSION/dav1d-$DAV1D_VERSION.tar.gz" | tar xz
+        cd dav1d-$DAV1D_VERSION
+        meson build --buildtype release -Dprefix=$HOME/$DAV1D_DIR
+        ninja -C build install
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.toolchain }}
+        override: true
+    - name: Run 1.36.0 tests
+      if: matrix.toolchain == '1.36.0' && matrix.conf == '1.36.0-tests'
+      run: |
+        DAV1D="$HOME/$DAV1D_DIR/lib/x86_64-linux-gnu"
+        export PKG_CONFIG_PATH=$HOME/$AOM_DIR/lib/pkgconfig:$DAV1D/pkgconfig
+        export LD_LIBRARY_PATH=$HOME/$AOM_DIR/lib:$DAV1D
+        cargo test --verbose \
+                   --features=decode_test,decode_test_dav1d,quick_test,capi
+    - name: Run aom tests
+      if: matrix.toolchain == 'stable' && matrix.conf == 'aom-tests'
+      run: |
+        export PKG_CONFIG_PATH=$HOME/$AOM_DIR/lib/pkgconfig
+        export LD_LIBRARY_PATH=$HOME/$AOM_DIR/lib
+        cargo test --verbose --release \
+                   --features=decode_test \
+                   --color=always -- --color=always --ignored
+    - name: Run dav1d tests
+      if: matrix.toolchain == 'stable' && matrix.conf == 'dav1d-tests'
+      run: |
+        export PKG_CONFIG_PATH=$HOME/$DAV1D_DIR/lib/x86_64-linux-gnu/pkgconfig
+        export LD_LIBRARY_PATH=$HOME/$DAV1D_DIR/lib/x86_64-linux-gnu
+        cargo test --verbose --release \
+                   --features=decode_test_dav1d \
+                   --color=always -- --color=always --ignored
+    - name: Run bench
+      if: matrix.toolchain == 'stable' && matrix.conf == 'bench'
+      run: |
+        cargo bench --features=bench --no-run --verbose
+    - name: Run doc
+      if: matrix.toolchain == 'stable' && matrix.conf == 'doc'
+      run: |
+        cargo doc --verbose --no-deps
+    - name: Check no default features
+      if: matrix.toolchain == 'stable' && matrix.conf == 'check-no-default'
+      run: |
+        cargo check --no-default-features
+    - name: Check extra features
+      if: matrix.toolchain == 'stable' && matrix.conf == 'check-extra-feats'
+      run: |
+        cargo check --features=capi,dump_lookahead_data
+    - name: Run cargo clean
+      if: matrix.conf == 'grcov-coveralls'
+      uses: actions-rs/cargo@v1
+      with:
+        command: clean
+    - name: Run tests
+      if: matrix.conf == 'grcov-coveralls'
+      env:
+        CARGO_INCREMENTAL: '0'
+        RUSTFLAGS: >
+          -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off
+          -Zno-landing-pads
+      run: |
+        DAV1D="$HOME/$DAV1D_DIR/lib/x86_64-linux-gnu"
+        export PKG_CONFIG_PATH=$HOME/$AOM_DIR/lib/pkgconfig:$DAV1D/pkgconfig
+        export LD_LIBRARY_PATH=$HOME/$AOM_DIR/lib:$DAV1D
+        cargo test --features=decode_test,decode_test_dav1d,quick_test --verbose
+    - name: Run grcov
+      if: matrix.conf == 'grcov-coveralls'
+      id: coverage
+      uses: actions-rs/grcov@v0.1
+    - name: Coveralls upload
+      if: matrix.conf == 'grcov-coveralls'
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: ${{ steps.coverage.outputs.report }}
+
+  build-windows:
+
+    env:
+      RUST_BACKTRACE: 1
+      VS_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
+      COMPILER_SUBPATH: VC\Tools\MSVC\14.23.28105\bin\Hostx64\x64
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install nasm
+      run: |
+        $NASM_VERSION="nasm-2.14.02"
+        curl -LO "https://people.xiph.org/~tdaede/$NASM_VERSION-win64.zip"
+        7z e -y "$NASM_VERSION-win64.zip" -o"C:\nasm"
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Build
+      run: |
+        $Env:Path += ";$Env:VS_PATH\$Env:COMPILER_SUBPATH;C:\nasm;"
+        cargo build --release
+    - name: Test
+      run: |
+        $Env:Path += ";$Env:VS_PATH\$Env:COMPILER_SUBPATH;C:\nasm;"
+        cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rav1e [![Travis Build Status](https://travis-ci.org/xiph/rav1e.svg?branch=master)](https://travis-ci.org/xiph/rav1e) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/xiph/rav1e?branch=master&svg=true)](https://ci.appveyor.com/project/tdaede/rav1e/history) [![Coverage Status](https://coveralls.io/repos/github/xiph/rav1e/badge.svg?branch=master)](https://coveralls.io/github/xiph/rav1e?branch=master)
+# rav1e [![Travis Build Status](https://travis-ci.org/xiph/rav1e.svg?branch=master)](https://travis-ci.org/xiph/rav1e) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/xiph/rav1e?branch=master&svg=true)](https://ci.appveyor.com/project/tdaede/rav1e/history) [![Actions Status](https://github.com/xiph/rav1e/workflows/rav1e/badge.svg)](https://github.com/xiph/rav1e/actions) [![Coverage Status](https://coveralls.io/repos/github/xiph/rav1e/badge.svg?branch=master)](https://coveralls.io/github/xiph/rav1e?branch=master)
 
 The fastest and safest AV1 encoder.
 


### PR DESCRIPTION
As requested by @lu-zero, I've ported most of the CI tasks to the `Github Actions` system with the exception of the `arm` tests that will remain on `Travis` and `AppVeyor`.

The "Build and Coveralls" test is now done using `grcov` instead of `kcov` and can be run only on the nightly because of the [-Z profile feature](https://github.com/rust-lang/rust/issues/42524).

The entire CI process takes approximately 25 minutes.

Thanks in advance for your review! :)