### PR TITLE
Replace travis build deps with debian packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
   - bash "$TRAVIS_BUILD_DIR/.travis/install-nasm.sh"
   - bash "$TRAVIS_BUILD_DIR/.travis/install-kcov.sh"
   - bash "$TRAVIS_BUILD_DIR/.travis/install-aom.sh"
-  - aomenc --help | grep "AV1 Encoder"
   - bash "$TRAVIS_BUILD_DIR/.travis/install-dav1d.sh"
   - dav1d --version
   - cd "$TRAVIS_BUILD_DIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ before_install:
   - bash "$TRAVIS_BUILD_DIR/.travis/install-kcov.sh"
   - bash "$TRAVIS_BUILD_DIR/.travis/install-aom.sh"
   - bash "$TRAVIS_BUILD_DIR/.travis/install-dav1d.sh"
-  - dav1d --version
   - cd "$TRAVIS_BUILD_DIR"
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ addons:
       - libdw-dev
       - libiberty-dev
       - ninja-build
-      - python3-setuptools
-      - python3-pip
-      - python3-wheel
-      - libsdl2-dev
-      - libvulkan-dev
-      - ruby # needed by casher on arm64
 before_install:
   - export BUILD_DIR="$TRAVIS_HOME/.build"
   - export DEPS_DIR="$TRAVIS_HOME/.local"
@@ -27,7 +21,6 @@ before_install:
   - export PATH="$PATH:$DEPS_DIR/bin"
   - export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$DEPS_DIR/lib/pkgconfig:$DEPS_DIR/lib/$ARCH-linux-gnu/pkgconfig"
   - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEPS_DIR/lib:$DEPS_DIR/lib/$ARCH-linux-gnu"
-  - pip3 install meson
   - source "$TRAVIS_BUILD_DIR/.travis/install-sccache.sh"
   - export SCCACHE_CACHE_SIZE=500M
   - export SCCACHE_DIR="$TRAVIS_HOME/.cache/sccache"

--- a/.travis/install-nasm.sh
+++ b/.travis/install-nasm.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 set -ex
 
-NASM_VERSION="2.14"
+NASM_VERSION="2.14.02-1"
+PKG_URL="http://http.us.debian.org/debian/pool/main/n/nasm"
 
-if [[ "$(nasm --version)" = "NASM version $NASM_VERSION"* ]]; then
-  echo "Using cached directory."
-elif [ "$ARCH" = "x86_64" ]; then
-  curl -L "https://download.videolan.org/contrib/nasm/nasm-$NASM_VERSION.tar.gz" | tar xz
-  cd "nasm-$NASM_VERSION"
-  ./configure CC='sccache gcc' --prefix="$DEPS_DIR" && make -j2 && make install
-else
-  echo "Skipping nasm installation on $ARCH."
-fi
+case "$ARCH" in
+  x86_64) ARCH=amd64 ;;
+  *) echo "Skipping nasm installation on $ARCH."; exit 0 ;;
+esac
+
+curl -O "$PKG_URL/nasm_${NASM_VERSION}_$ARCH.deb"
+
+sha256sum --check --ignore-missing <<EOF
+5225d0654783134ae616f56ce8649e4df09cba191d612a0300cfd0494bb5a3ef  nasm_2.14.02-1_amd64.deb
+EOF
+
+sudo dpkg -i "nasm_${NASM_VERSION}_$ARCH.deb"


### PR DESCRIPTION
The only build-dep with significant transitive dependencies is kcov.
No changes to update or clean the cache for these yet.