### PR TITLE
Add sccache locally (with fixes)

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -77,11 +77,29 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       RUSTC_WRAPPER: sccache
+      SCCACHE_CACHE_SIZE: 300M
+      SCCACHE_DIR: /home/runner/.cache/sccache
+      SCCACHE_IDLE_TIMEOUT: 0
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
+    - name: Cache sccache output
+      uses: actions/cache@v1
+      with:
+        path: /home/runner/.cache/sccache
+        key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.toml') }}
+    - name: Install sccache
+      env:
+        LINK: https://github.com/mozilla/sccache/releases/download
+        SCCACHE_VERSION: 0.2.12
+      run: |
+        SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
+        mkdir -p $HOME/.local/bin
+        curl -L "$LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+        mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
+        echo "::add-path::$HOME/.local/bin"
     - name: Install nasm
       env:
         LINK: http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm
@@ -90,7 +108,7 @@ jobs:
           5225d0654783134ae616f56ce8649e4df09cba191d612a0300cfd0494bb5a3ef
       run: |
         curl -O "$LINK/nasm_${NASM_VERSION}_amd64.deb"
-        echo "$NASM_SHA256  nasm_${NASM_VERSION}_amd64.deb" | sha256sum --check
+        echo "$NASM_SHA256 nasm_${NASM_VERSION}_amd64.deb" | sha256sum --check
         sudo dpkg -i "nasm_${NASM_VERSION}_amd64.deb"
     - name: Install aom
       if: >
@@ -132,29 +150,23 @@ jobs:
         sha256sum --check
         sudo dpkg -i "libdav1d-dev_${DAV1D_VERSION}_amd64.deb" \
                      "libdav1d3_${DAV1D_VERSION}_amd64.deb"
+    - name: Install grcov
+      if: matrix.conf == 'grcov-coveralls'
+      env:
+        LINK: https://github.com/mozilla/grcov/releases/download
+        GRCOV_VERSION: 0.5.5
+      run: |
+        curl -L "$LINK/v$GRCOV_VERSION/grcov-linux-x86_64.tar.bz2" |
+        tar xj -C $HOME/.cargo/bin
     - name: Install ${{ matrix.toolchain }}
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: ${{ matrix.toolchain }}
         override: true
-    - name: Install sccache
-      env:
-        LINK: https://github.com/mozilla/sccache/releases/download
-        SCCACHE_VERSION: 0.2.12
+    - name: Start sccache server
       run: |
-        SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
-        mkdir -p $HOME/.local/bin
-        curl -L "$LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
-        mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
-        echo "::add-path::$HOME/.local/bin"
-    - name: Start sccache
-      env:
-        SCCACHE_AZURE_CONNECTION_STRING: >-
-          ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
-        SCCACHE_AZURE_BLOB_CONTAINER: xiph-rav1e-sccache
-        SCCACHE_IDLE_TIMEOUT: 0
-      run: sccache --start-server
+        sccache --start-server
     - name: Run 1.36.0 tests
       if: matrix.toolchain == '1.36.0' && matrix.conf == '1.36.0-tests'
       run: |
@@ -196,32 +208,25 @@ jobs:
     - name: Run tests
       if: matrix.conf == 'grcov-coveralls'
       env:
-        CARGO_INCREMENTAL: '0'
+        CARGO_INCREMENTAL: 0
         RUSTFLAGS: >
           -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off
           -Zno-landing-pads
       run: |
         cargo test --features=decode_test,decode_test_dav1d,quick_test --verbose
-    - name: Install grcov
-      if: matrix.conf == 'grcov-coveralls'
-      env:
-        LINK: https://github.com/mozilla/grcov/releases/download
-        GRCOV_VERSION: 0.5.5
-      run: |
-        curl -L "$LINK/v$GRCOV_VERSION/grcov-linux-x86_64.tar.bz2" |
-        tar xj -C ~/.cargo/bin
     - name: Run grcov
       if: matrix.conf == 'grcov-coveralls'
       id: coverage
       uses: actions-rs/grcov@v0.1
+    - name: Stop sccache server
+      run: |
+        sccache --stop-server
     - name: Coveralls upload
       if: matrix.conf == 'grcov-coveralls'
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ${{ steps.coverage.outputs.report }}
-    - name: Stop sccache
-      run: sccache --stop-server
 
   build-windows:
 
@@ -233,6 +238,9 @@ jobs:
 
     env:
       RUST_BACKTRACE: 1
+      RUSTC_WRAPPER: sccache
+      SCCACHE_CACHE_SIZE: 300M
+      SCCACHE_DIR: C:\sccache
       VS_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
       COMPILER_SUBPATH: VC\Tools\MSVC\14.23.28105\bin\Hostx64\x64
 
@@ -240,6 +248,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Cache sccache output
+      uses: actions/cache@v1
+      with:
+        path: C:\sccache
+        key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.toml') }}
+    - name: Install sccache
+      run: |
+        $LINK="https://github.com/mozilla/sccache/releases/download/0.2.12"
+        $SCCACHE_FILE="sccache-0.2.12-x86_64-pc-windows-msvc"
+        curl -LO "$LINK/$SCCACHE_FILE.tar.gz"
+        tar xzf "$SCCACHE_FILE.tar.gz"
+        echo "::add-path::$Env:GITHUB_WORKSPACE/$SCCACHE_FILE"
     - name: Install nasm
       run: |
         $NASM_VERSION="nasm-2.14.02"
@@ -254,6 +274,9 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+    - name: Start sccache server
+      run: |
+        sccache --start-server
     - name: Build
       if: matrix.conf == 'cargo-build'
       run: |
@@ -262,3 +285,6 @@ jobs:
       if: matrix.conf == 'cargo-test'
       run: |
         cargo test --verbose
+    - name: Stop sccache server
+      run: |
+        sccache --stop-server


### PR DESCRIPTION
Original patch from @Luni-4 moved back to local sccache store, populated by an actions/cache rule. There was a small, blocking issue with the syntax for setting a path relative to `HOME`. As well as resolving that, @barrbrain optimised the cache size and partitioning rules with consideration for the statistics in earlier runs.