### PR TITLE
Derive sccache cache key from Cargo.lock

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -162,6 +162,13 @@ jobs:
     - name: Generate Cargo.lock
       run: |
         cargo update
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry/cache
+        key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
     - name: Cache sccache output
       uses: actions/cache@v1
       with:
@@ -277,6 +284,13 @@ jobs:
     - name: Generate Cargo.lock
       run: |
         cargo update
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry/cache
+        key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
     - name: Cache sccache output
       uses: actions/cache@v1
       with:

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -85,11 +85,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Cache sccache output
-      uses: actions/cache@v1
-      with:
-        path: /home/runner/.cache/sccache
-        key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.toml') }}
     - name: Install sccache
       env:
         LINK: https://github.com/mozilla/sccache/releases/download
@@ -164,6 +159,16 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.toolchain }}
         override: true
+    - name: Generate Cargo.lock
+      run: |
+        cargo update
+    - name: Cache sccache output
+      uses: actions/cache@v1
+      with:
+        path: /home/runner/.cache/sccache
+        key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.conf }}-sccache-
     - name: Start sccache server
       run: |
         sccache --start-server
@@ -248,11 +253,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Cache sccache output
-      uses: actions/cache@v1
-      with:
-        path: C:\sccache
-        key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.toml') }}
     - name: Install sccache
       run: |
         $LINK="https://github.com/mozilla/sccache/releases/download/0.2.12"
@@ -274,6 +274,16 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+    - name: Generate Cargo.lock
+      run: |
+        cargo update
+    - name: Cache sccache output
+      uses: actions/cache@v1
+      with:
+        path: C:\sccache
+        key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.conf }}-sccache-
     - name: Start sccache server
       run: |
         sccache --start-server


### PR DESCRIPTION
This ensures that the cache key is bound to the specific crate versions that will be built.