### PR TITLE
Remove tiny allocs

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -437,7 +437,7 @@ impl MotionEstimation for DiamondSearch {
     mvy_max: isize, bsize: BlockSize, use_satd: bool,
     best_mv: &mut MotionVector, lowest_cost: &mut u64, ref_frame: RefType,
   ) {
-    let predictors = vec![*best_mv];
+    let predictors = [*best_mv; 1];
     let frame_bo = ts.to_frame_block_offset(tile_bo);
     diamond_me_search(
       fi,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1269,8 +1269,8 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
   modes.iter().take(num_modes_rdo).for_each(|&luma_mode| {
     let mvs = [MotionVector::default(); 2];
     let ref_frames = [INTRA_FRAME, NONE_FRAME];
-    let mut mode_set_chroma = vec![luma_mode];
-    //let mut mode_set_chroma = vec![PredictionMode::DC_PRED];
+    let mut mode_set_chroma = ArrayVec::<[_; 2]>::new();
+    mode_set_chroma.push(luma_mode);
     if is_chroma_block && luma_mode != PredictionMode::DC_PRED {
       mode_set_chroma.push(PredictionMode::DC_PRED);
     }


### PR DESCRIPTION
Drop about a 36% of the overall (re)allocations over a 200 frames encoding (usual Bosphorus 1080p 8 tiles).

On Linux it makes the encoding slightly faster as well.