### PR TITLE
Remove RDOTracker and train-rdo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ decode_test_dav1d = ["dav1d-sys"]
 binaries = ["ivf", "y4m", "clap", "scan_fmt", "pretty_env_logger", "better-panic"]
 default = ["binaries", "asm", "signal_support"]
 asm = ["nasm-rs", "cc"]
-train_fastrdo = ["serde", "serde_derive", "bincode"]
 signal_support = ["signal-hook"]
 dump_ivf = ["ivf"]
 quick_test = []
@@ -47,8 +46,6 @@ num-traits = "0.2"
 num-derive = "0.3"
 paste = "0.1"
 noop_proc_macro = "0.2.0"
-serde = { version = "1.0", optional = true }
-serde_derive = { version = "1.0", optional = true }
 dav1d-sys = { version = "0.2", optional = true }
 aom-sys = { version = "0.1.3", optional = true }
 scan_fmt = { version = "0.2.3", optional = true }

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -108,8 +108,6 @@ pub struct EncoderConfig {
   ///
   /// [`Packet`]: struct.Packet.html#structfield.psnr
   pub show_psnr: bool,
-  /// Enables dumping of internal RDO training data.
-  pub train_rdo: bool,
 }
 
 /// Default preset for EncoderConfig: it is a balance between quality and
@@ -163,7 +161,6 @@ impl EncoderConfig {
       rdo_lookahead_frames: 40,
       speed_settings: SpeedSettings::from_preset(speed),
       show_psnr: false,
-      train_rdo: false,
     }
   }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -25,8 +25,6 @@ pub(crate) use internal::*;
 use bitstream_io::*;
 use err_derive::Error;
 
-use crate::{Deserialize, Serialize};
-
 use crate::encoder::*;
 use crate::frame::*;
 use crate::stats::EncoderStats;
@@ -65,7 +63,7 @@ impl Rational {
 
 /// Possible types of a frame.
 #[allow(dead_code, non_camel_case_types)]
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[repr(C)]
 pub enum FrameType {
   /// Key frame.

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -1662,7 +1662,6 @@ fn log_q_exp_overflow() {
         non_square_partition: false,
       },
       show_psnr: false,
-      train_rdo: false,
     },
     threads: 1,
   };
@@ -1725,7 +1724,6 @@ fn guess_frame_subtypes_assert() {
         non_square_partition: false,
       },
       show_psnr: false,
-      train_rdo: false,
     },
     threads: 1,
   };

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -321,11 +321,6 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
         .long("speed-test")
         .takes_value(true)
     )
-    .arg(
-      Arg::with_name("train-rdo")
-        .long("train-rdo")
-        .hidden(true)
-    )
     .subcommand(SubCommand::with_name("advanced")
                 .setting(AppSettings::Hidden)
                 .about("Advanced features")
@@ -419,7 +414,6 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
     }
   })? as usize;
   let bitrate: i32 = maybe_bitrate.unwrap_or(Ok(0))?;
-  let train_rdo = matches.is_present("train-rdo");
   if quantizer == 0 {
     unimplemented!("Lossless encoding not yet implemented");
   } else if quantizer > 255 {
@@ -575,7 +569,6 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
   }
 
   cfg.low_latency = matches.is_present("LOW_LATENCY");
-  cfg.train_rdo = train_rdo;
 
   Ok(cfg)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,14 +54,6 @@ extern crate pretty_assertions;
 #[macro_use]
 extern crate log;
 
-cfg_if::cfg_if! {
-  if #[cfg(feature="serde_derive")] {
-    pub(crate) use serde_derive::{Deserialize, Serialize};
-  } else {
-    pub(crate) use noop_proc_macro::{Deserialize, Serialize};
-  }
-}
-
 mod hawktracer {
   cfg_if::cfg_if! {
     if #[cfg(feature="tracing")] {

--- a/src/tiling/tile_state.rs
+++ b/src/tiling/tile_state.rs
@@ -62,7 +62,6 @@ pub struct TileStateMut<'a, T: Pixel> {
   pub restoration: TileRestorationStateMut<'a>,
   pub half_res_pmvs: &'a mut Vec<BlockPmv>,
   pub mvs: Vec<TileMotionVectorsMut<'a>>,
-  pub rdo: RDOTracker,
   pub integral_buffer: IntegralImageBuffer,
   pub enc_stats: EncoderStats,
 }
@@ -136,7 +135,6 @@ impl<'a, T: Pixel> TileStateMut<'a, T> {
           )
         })
         .collect(),
-      rdo: RDOTracker::new(),
       integral_buffer: IntegralImageBuffer::zeroed(SOLVE_IMAGE_SIZE),
       enc_stats: EncoderStats::default(),
     }

--- a/tools/rdo.sh
+++ b/tools/rdo.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-rm -f rdo.dat
-cargo build --release
-ls ~/sets/objective-1-fast/*.y4m | parallel target/release/rav1e --threads 1 --quantizer {2} -o /dev/null --train-rdo {1} :::: - ::: 16 48 80 112 144 176 208 240
-gnuplot rdo.plt -p


### PR DESCRIPTION
Per Guillaume:
"It's not usable currently,
and my patch should eventually completely replace it."