### PR TITLE
Pin nightly toolchain for grcov

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -64,7 +64,7 @@ jobs:
          - conf: dav1d-tests
            toolchain: stable
          - conf: grcov-coveralls
-           toolchain: nightly
+           toolchain: nightly-2019-12-02
          - conf: bench
            toolchain: stable
          - conf: doc


### PR DESCRIPTION
This avoids churning the build cache daily.