### PR TITLE
[WIP] Temporary fix for desync from quantizer rdo

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -450,8 +450,9 @@ impl SpeedSettings {
     true
   }
 
-  const fn quantizer_rdo_preset(speed: usize) -> bool {
-    speed <= 1
+  const fn quantizer_rdo_preset(_speed: usize) -> bool {
+    // Until the desync caused by quantizer_rdo is fixed, disable this feature
+    false
   }
 
   const fn use_satd_subpel(speed: usize) -> bool {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -578,6 +578,9 @@ fn luma_chroma_mode_rdo<T: Pixel>(
         0..=2
       }
     } else {
+      // FIXME:
+      // Until the desync caused by heuristic quantizer selection is fixed, disable this feature
+      /*
       let importance =
         compute_mean_importance(fi, ts.to_frame_block_offset(tile_bo), bsize);
       // Chosen based on the RDO segment ID statistics for speed 2 on the DOTA2
@@ -602,6 +605,8 @@ fn luma_chroma_mode_rdo<T: Pixel>(
       } else {
         heuristic_sidx..=heuristic_sidx
       }
+      */
+      0..=0
     };
 
     for sidx in sidx_range {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -568,7 +568,16 @@ fn luma_chroma_mode_rdo<T: Pixel>(
     // If quantizer RDO is disabled, sidx isn't coded either.
     let sidx_range = if skip {
       0..=0
-    } else if !fi.config.speed_settings.quantizer_rdo {
+    } else if fi.config.speed_settings.quantizer_rdo {
+      if fi.base_q_idx as i16
+        + ts.segmentation.data[2][SegLvl::SEG_LVL_ALT_Q as usize]
+        < 1
+      {
+        0..=1
+      } else {
+        0..=2
+      }
+    } else {
       let importance =
         compute_mean_importance(fi, ts.to_frame_block_offset(tile_bo), bsize);
       // Chosen based on the RDO segment ID statistics for speed 2 on the DOTA2
@@ -593,13 +602,6 @@ fn luma_chroma_mode_rdo<T: Pixel>(
       } else {
         heuristic_sidx..=heuristic_sidx
       }
-    } else if fi.base_q_idx as i16
-      + ts.segmentation.data[2][SegLvl::SEG_LVL_ALT_Q as usize]
-      < 1
-    {
-      0..=1
-    } else {
-      0..=2
     };
 
     for sidx in sidx_range {


### PR DESCRIPTION
Temporary fIx for #1858.
It basically, revoke the commts from #1520 and #1564, since those commits are confirmed to cause the desync at speed 0,1,2.

Two commits that cause desync are:
https://github.com/xiph/rav1e/commit/3c79e025f7c13635558ce66370920fb5a8a38754 and
https://github.com/xiph/rav1e/commit/db0da3c97efb269cb23571f2c1f68afdf1ad9813
those needs different temporary fixes.

One set of test runs to see desync that I used can be:
./target/release/rav1e nyan.y4m -o test.ivf -r test_rec.y4m --quantizer 50 --speed=0 --limit=30
./target/release/rav1e nyan.y4m -o test.ivf -r test_rec.y4m --quantizer 50 --speed=1 --limit=30
./target/release/rav1e nyan.y4m -o test.ivf -r test_rec.y4m --quantizer 50 --speed=2 --limit=30

Note that the desync happens regardless of --tune.