### PR TITLE
Add configuration for grcov action

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,4 @@
+ignore-not-existing: true
+ignore:
+  - "/*"
+  - "../*"


### PR DESCRIPTION
Remove some noise in results reported on Coveralls. Effectively limit results to the rav1e crate sources.