### PR TITLE
Fix wrong init for preskip

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1545,7 +1545,7 @@ impl<'a> BlockContext<'a> {
       cdef_coded: false,
       code_deltas: false,
       update_seg: false,
-      preskip_segid: true,
+      preskip_segid: false,
       above_partition_context: [0; PARTITION_CONTEXT_MAX_WIDTH],
       left_partition_context: [0; MIB_SIZE >> 1],
       above_tx_context: [0; COEFF_CONTEXT_MAX_WIDTH],

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -468,7 +468,7 @@ impl Default for SegmentationState {
       enabled: false,
       update_data: false,
       update_map: false,
-      preskip: true,
+      preskip: false,
       last_active_segid: 0,
       features: [[false; SegLvl::SEG_LVL_MAX as usize]; 8],
       data: [[0; SegLvl::SEG_LVL_MAX as usize]; 8],
@@ -3424,6 +3424,7 @@ pub fn encode_frame<T: Pixel>(
 
   fs.segmentation = get_initial_segmentation(fi);
   segmentation_optimize(fi, fs);
+
   let tile_group = encode_tile_group(fi, fs, inter_cfg);
 
   write_obus(&mut packet, fi, fs, inter_cfg).unwrap();


### PR DESCRIPTION
The preskip should be initially false, then only become true if seg
feature >= SEG_LVL_REF_FRAME is enabled.