### PR TITLE
[WIP] Avoid checking for scene flashes if scene detection disabled

### DIFF
--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -75,7 +75,12 @@ impl SceneChangeDetector {
       }
     };
 
-    self.exclude_scene_flashes(&frame_set, input_frameno, inter_cfg);
+    if !(config.speed_settings.no_scene_detection
+      || config.min_key_frame_interval == config.max_key_frame_interval)
+    {
+      // Not needed if smart scene detection disabled
+      self.exclude_scene_flashes(&frame_set, input_frameno, inter_cfg);
+    }
 
     if self.is_key_frame(
       &frame_set[0],


### PR DESCRIPTION
~1% overall speedup when scene detection disabled.
(Tested on 1080p 60-frames, 8-tiles, speed 6.)