### PR TITLE
Early exit exclude scene flashes loop

### DIFF
--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -137,13 +137,16 @@ impl SceneChangeDetector {
     // Where A and B are scenes: AAAAAABBBAAAAAA
     // If BBB is shorter than lookahead_distance, it is detected as a flash
     // and not considered a scenecut.
-    for j in 1..=lookahead_distance {
+    for j in (1..=lookahead_distance).rev() {
       if !self.has_scenecut(&frame_subset[0], &frame_subset[j]) {
         // Any frame in between `0` and `j` cannot be a real scenecut.
         for i in 0..=j {
           let frameno = frameno + i as u64 - 1;
           self.excluded_frames.insert(frameno);
         }
+        // Because all frames in this gap are already excluded,
+        // exit the loop early as an optimization.
+        break;
       }
     }
 

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -137,6 +137,9 @@ impl SceneChangeDetector {
     // Where A and B are scenes: AAAAAABBBAAAAAA
     // If BBB is shorter than lookahead_distance, it is detected as a flash
     // and not considered a scenecut.
+    //
+    // Search starting with the furthest frame,
+    // to enable early loop exit if we find a scene flash.
     for j in (1..=lookahead_distance).rev() {
       if !self.has_scenecut(&frame_subset[0], &frame_subset[j]) {
         // Any frame in between `0` and `j` cannot be a real scenecut.


### PR DESCRIPTION
If we start with the furthest frame,
we can imply that all closer frames
are also scene flashes
and avoid testing them.

<1% overall speedup.
(Tested on 1080p 60-frames, 8-tiles, speed 6.)