### PR TITLE
Use intra and inter costs to determine frame type

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -304,7 +304,7 @@ pub struct SpeedSettings {
   ///
   /// Enabled is faster.
   pub no_scene_detection: bool,
-  /// Fast scene detection mode, ignoring chroma planes.
+  /// Fast scene detection mode, uses simple SAD instead of encoder cost estimates.
   pub fast_scene_detection: bool,
   /// Enables diamond motion vector search rather than full search.
   pub diamond_me: bool,

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -115,7 +115,6 @@ pub(crate) fn estimate_intra_costs<T: Pixel>(
   intra_costs.into_boxed_slice()
 }
 
-#[allow(dead_code)]
 pub(crate) fn estimate_inter_costs<T: Pixel>(
   frame: Arc<Frame<T>>, ref_frame: Arc<Frame<T>>, bit_depth: usize,
   mut config: EncoderConfig, sequence: Sequence,

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -571,13 +571,14 @@ fn output_frameno_reorder_scene_change_at(scene_change_at: u64) {
   // TODO: when we support more pyramid depths, this test will need tweaks.
   assert_eq!(ctx.inner.inter_cfg.pyramid_depth, 2);
 
-  let limit = 5;
+  let limit = 10;
   send_frames(&mut ctx, limit, scene_change_at);
   ctx.flush();
 
   // data[output_frameno] = (input_frameno, !invalid)
   let data = get_frame_invariants(ctx)
     .map(|fi| (fi.input_frameno, !fi.invalid))
+    .filter(|&(frameno, _)| frameno < 5)
     .collect::<Vec<_>>();
 
   assert_eq!(
@@ -596,14 +597,12 @@ fn output_frameno_reorder_scene_change_at(scene_change_at: u64) {
       }
       1 => {
         &[
-          (0, true),  // I-frame
-          (1, true),  // I-frame
-          (1, false), // Missing
-          (3, true),  // B0-frame
-          (2, true),  // B1-frame (first)
-          (3, true),  // B0-frame (show existing)
-          (4, true),  // B1-frame (second)
-          (4, false), // Missing
+          (0, true), // I-frame
+          (1, true), // I-frame
+          (3, true), // B0-frame
+          (2, true), // B1-frame (first)
+          (3, true), // B0-frame (show existing)
+          (4, true), // B1-frame (second)
         ][..]
       }
       2 => {
@@ -616,12 +615,9 @@ fn output_frameno_reorder_scene_change_at(scene_change_at: u64) {
           (1, false), // Missing
           (1, false), // Missing
           (2, true),  // I-frame
-          (2, false), // Missing
           (4, true),  // B0-frame
           (3, true),  // B1-frame (first)
           (4, true),  // B0-frame (show existing)
-          (4, false), // Missing
-          (4, false), // Missing
         ][..]
       }
       3 => {
@@ -634,12 +630,7 @@ fn output_frameno_reorder_scene_change_at(scene_change_at: u64) {
           (2, false), // Missing
           (2, false), // Missing
           (3, true),  // I-frame
-          (3, false), // Missing
-          (3, false), // Missing
           (4, true),  // B1-frame (first)
-          (4, false), // Missing
-          (4, false), // Missing
-          (4, false), // Missing
         ][..]
       }
       4 => {
@@ -686,13 +677,15 @@ fn pyramid_level_reorder_scene_change_at(scene_change_at: u64) {
   // TODO: when we support more pyramid depths, this test will need tweaks.
   assert_eq!(ctx.inner.inter_cfg.pyramid_depth, 2);
 
-  let limit = 5;
+  let limit = 10;
   send_frames(&mut ctx, limit, scene_change_at);
   ctx.flush();
 
   // data[output_frameno] = pyramid_level
-  let data =
-    get_frame_invariants(ctx).map(|fi| fi.pyramid_level).collect::<Vec<_>>();
+  let data = get_frame_invariants(ctx)
+    .filter(|fi| fi.input_frameno < 5)
+    .map(|fi| fi.pyramid_level)
+    .collect::<Vec<_>>();
 
   assert_eq!(
     &data[..],
@@ -712,12 +705,10 @@ fn pyramid_level_reorder_scene_change_at(scene_change_at: u64) {
         &[
           0, // I-frame
           0, // I-frame
-          0, // Missing
           1, // B0-frame
           2, // B1-frame (first)
           1, // B0-frame (show existing)
           2, // B1-frame (second)
-          2, // Missing
         ][..]
       }
       2 => {
@@ -730,12 +721,9 @@ fn pyramid_level_reorder_scene_change_at(scene_change_at: u64) {
           2, // Missing
           2, // Missing
           0, // I-frame
-          0, // Missing
           1, // B0-frame
           2, // B1-frame (first)
           1, // B0-frame (show existing)
-          1, // Missing
-          1, // Missing
         ][..]
       }
       3 => {
@@ -748,12 +736,7 @@ fn pyramid_level_reorder_scene_change_at(scene_change_at: u64) {
           1, // Missing
           1, // Missing
           0, // I-frame
-          0, // Missing
-          0, // Missing
           2, // B1-frame (first)
-          2, // Missing
-          2, // Missing
-          2, // Missing
         ][..]
       }
       4 => {
@@ -930,7 +913,7 @@ fn output_frameno_incremental_reorder_scene_change_at(scene_change_at: u64) {
   // TODO: when we support more pyramid depths, this test will need tweaks.
   assert_eq!(ctx.inner.inter_cfg.pyramid_depth, 2);
 
-  let limit = 5;
+  let limit = 10;
   for i in 0..limit {
     send_frames(&mut ctx, 1, scene_change_at.saturating_sub(i));
   }
@@ -939,6 +922,7 @@ fn output_frameno_incremental_reorder_scene_change_at(scene_change_at: u64) {
   // data[output_frameno] = (input_frameno, !invalid)
   let data = get_frame_invariants(ctx)
     .map(|fi| (fi.input_frameno, !fi.invalid))
+    .filter(|&(frameno, _)| frameno < 5)
     .collect::<Vec<_>>();
 
   assert_eq!(
@@ -957,14 +941,12 @@ fn output_frameno_incremental_reorder_scene_change_at(scene_change_at: u64) {
       }
       1 => {
         &[
-          (0, true),  // I-frame
-          (1, true),  // I-frame
-          (1, false), // Missing
-          (3, true),  // B0-frame
-          (2, true),  // B1-frame (first)
-          (3, true),  // B0-frame (show existing)
-          (4, true),  // B1-frame (second)
-          (4, false), // Missing
+          (0, true), // I-frame
+          (1, true), // I-frame
+          (3, true), // B0-frame
+          (2, true), // B1-frame (first)
+          (3, true), // B0-frame (show existing)
+          (4, true), // B1-frame (second)
         ][..]
       }
       2 => {
@@ -977,12 +959,9 @@ fn output_frameno_incremental_reorder_scene_change_at(scene_change_at: u64) {
           (1, false), // Missing
           (1, false), // Missing
           (2, true),  // I-frame
-          (2, false), // Missing
           (4, true),  // B0-frame
           (3, true),  // B1-frame (first)
           (4, true),  // B0-frame (show existing)
-          (4, false), // Missing
-          (4, false), // Missing
         ][..]
       }
       3 => {
@@ -995,12 +974,7 @@ fn output_frameno_incremental_reorder_scene_change_at(scene_change_at: u64) {
           (2, false), // Missing
           (2, false), // Missing
           (3, true),  // I-frame
-          (3, false), // Missing
-          (3, false), // Missing
           (4, true),  // B1-frame (first)
-          (4, false), // Missing
-          (4, false), // Missing
-          (4, false), // Missing
         ][..]
       }
       4 => {
@@ -1291,10 +1265,15 @@ fn output_frameno_scene_change_past_max_len_flash() {
   send_test_frame(&mut ctx, u8::max_value());
   send_test_frame(&mut ctx, u8::max_value());
   send_test_frame(&mut ctx, u8::min_value());
+  send_test_frame(&mut ctx, u8::min_value());
+  send_test_frame(&mut ctx, u8::min_value());
+  send_test_frame(&mut ctx, u8::min_value());
+  send_test_frame(&mut ctx, u8::min_value());
   ctx.flush();
 
   let data = get_frame_invariants(ctx)
     .map(|fi| (fi.input_frameno, !fi.invalid))
+    .filter(|&(frameno, _)| frameno <= 7)
     .collect::<Vec<_>>();
 
   assert_eq!(
@@ -1350,29 +1329,30 @@ fn output_frameno_no_scene_change_at_multiple_flashes() {
   send_test_frame(&mut ctx, 240);
   send_test_frame(&mut ctx, 240);
   send_test_frame(&mut ctx, 240);
+  send_test_frame(&mut ctx, 240);
+  send_test_frame(&mut ctx, 240);
+  send_test_frame(&mut ctx, 240);
   ctx.flush();
 
   let data = get_frame_invariants(ctx)
     .map(|fi| (fi.input_frameno, !fi.invalid))
+    .filter(|&(frameno, _)| frameno <= 7)
     .collect::<Vec<_>>();
 
   assert_eq!(
     &data[..],
     &[
-      (0, true),  // I-frame
-      (4, true),  // P-frame
-      (2, true),  // B0-frame
-      (1, true),  // B1-frame (first)
-      (2, true),  // B0-frame (show existing)
-      (3, true),  // B1-frame (second)
-      (4, true),  // P-frame (show existing),
-      (5, true),  // P-frame
-      (5, false), // invalid
-      (7, true),  // B0-frame
-      (6, true),  // B1-frame (first)
-      (7, true),  // B0-frame (show existing)
-      (7, false), // invalid
-      (7, false), // invalid
+      (0, true), // I-frame
+      (4, true), // P-frame
+      (2, true), // B0-frame
+      (1, true), // B1-frame (first)
+      (2, true), // B0-frame (show existing)
+      (3, true), // B1-frame (second)
+      (4, true), // P-frame (show existing),
+      (5, true), // P-frame
+      (7, true), // B0-frame
+      (6, true), // B1-frame (first)
+      (7, true), // B0-frame (show existing)
     ]
   );
 }

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -7,31 +7,39 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use crate::api::EncoderConfig;
-use crate::api::InterConfig;
+use crate::api::lookahead::*;
+use crate::api::{EncoderConfig, InterConfig};
+use crate::cpu_features::CpuFeatureLevel;
+use crate::encoder::Sequence;
 use crate::frame::*;
+use crate::hawktracer::*;
 use crate::util::CastFromPrimitive;
 use crate::util::Pixel;
-
-use crate::hawktracer::*;
-
-use std::cmp;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
 /// Runs keyframe detection on frames from the lookahead queue.
 pub(crate) struct SceneChangeDetector {
   /// Minimum average difference between YUV deltas that will trigger a scene change.
-  threshold: u8,
-  /// Fast scene cut detection mode, ignoing chroma planes.
+  threshold: u64,
+  /// Fast scene cut detection mode, uses simple SAD instead of encoder cost estimates.
   fast_mode: bool,
   /// Frames that cannot be marked as keyframes due to the algorithm excluding them.
   /// Storing the frame numbers allows us to avoid looking back more than one frame.
   excluded_frames: BTreeSet<u64>,
+  /// The bit depth of the video.
+  bit_depth: usize,
+  /// The CPU feature level to be used.
+  cpu_feature_level: CpuFeatureLevel,
+  encoder_config: EncoderConfig,
+  sequence: Sequence,
 }
 
 impl SceneChangeDetector {
-  pub fn new(bit_depth: u8, fast_mode: bool) -> Self {
+  pub fn new(
+    bit_depth: usize, fast_mode: bool, cpu_feature_level: CpuFeatureLevel,
+    encoder_config: EncoderConfig, sequence: Sequence,
+  ) -> Self {
     // This implementation is based on a Python implementation at
     // https://pyscenedetect.readthedocs.io/en/latest/reference/detection-methods/.
     // The Python implementation uses HSV values and a threshold of 30. Comparing the
@@ -41,11 +49,17 @@ impl SceneChangeDetector {
     // very unlikely to have a delta greater than 3 in YUV, whereas they may reach into
     // the double digits in HSV. Therefore, 12 was chosen as a reasonable default threshold.
     // This may be adjusted later.
-    const BASE_THRESHOLD: u8 = 12;
+    //
+    // This threshold is only used for the fast scenecut implementation.
+    const BASE_THRESHOLD: u64 = 12;
     Self {
-      threshold: BASE_THRESHOLD * bit_depth / 8,
+      threshold: BASE_THRESHOLD * bit_depth as u64 / 8,
       fast_mode,
       excluded_frames: BTreeSet::new(),
+      bit_depth,
+      cpu_feature_level,
+      encoder_config,
+      sequence,
     }
   }
 
@@ -77,33 +91,67 @@ impl SceneChangeDetector {
       return false;
     }
 
-    self.exclude_scene_flashes(&frame_set, input_frameno, inter_cfg);
+    self.exclude_scene_flashes(
+      &frame_set,
+      input_frameno,
+      inter_cfg,
+      previous_keyframe,
+    );
 
-    self.is_key_frame(&frame_set[0], &frame_set[1], input_frameno)
+    self.is_key_frame(
+      frame_set[0].clone(),
+      frame_set[1].clone(),
+      input_frameno,
+      previous_keyframe,
+    )
   }
 
   /// Determines if `current_frame` should be a keyframe.
   fn is_key_frame<T: Pixel>(
-    &self, previous_frame: &Frame<T>, current_frame: &Frame<T>,
-    current_frameno: u64,
+    &self, previous_frame: Arc<Frame<T>>, current_frame: Arc<Frame<T>>,
+    current_frameno: u64, previous_keyframe: u64,
   ) -> bool {
     if self.excluded_frames.contains(&current_frameno) {
       return false;
     }
 
-    self.has_scenecut(previous_frame, current_frame)
+    let result = self.has_scenecut(
+      previous_frame,
+      current_frame,
+      current_frameno,
+      previous_keyframe,
+    );
+    debug!(
+      "[SC-Detect] Frame {} to {}: I={:.3} T={:.3} P={:.3} {}",
+      current_frameno - 1,
+      current_frameno,
+      result.intra_cost,
+      result.threshold,
+      result.inter_cost,
+      if result.has_scenecut { "Scenecut" } else { "No cut" }
+    );
+    result.has_scenecut
   }
 
   /// Uses lookahead to avoid coding short flashes as scenecuts.
   /// Saves excluded frame numbers in `self.excluded_frames`.
   fn exclude_scene_flashes<T: Pixel>(
     &mut self, frame_subset: &[Arc<Frame<T>>], frameno: u64,
-    inter_cfg: &InterConfig,
+    inter_cfg: &InterConfig, previous_keyframe: u64,
   ) {
-    let lookahead_distance = cmp::min(
-      inter_cfg.keyframe_lookahead_distance() as usize,
-      frame_subset.len() - 1,
-    );
+    let lookahead_distance = inter_cfg.keyframe_lookahead_distance() as usize;
+
+    if frame_subset.len() - 1 < lookahead_distance {
+      // Don't add a keyframe in the last frame pyramid.
+      // It's effectively the same as a scene flash,
+      // and really wasteful for compression.
+      for frame in
+        frameno..=(frameno + inter_cfg.keyframe_lookahead_distance())
+      {
+        self.excluded_frames.insert(frame);
+      }
+      return;
+    }
 
     // Where A and B are scenes: AAAAAABBBAAAAAA
     // If BBB is shorter than lookahead_distance, it is detected as a flash
@@ -112,7 +160,22 @@ impl SceneChangeDetector {
     // Search starting with the furthest frame,
     // to enable early loop exit if we find a scene flash.
     for j in (1..=lookahead_distance).rev() {
-      if !self.has_scenecut(&frame_subset[0], &frame_subset[j]) {
+      let result = self.has_scenecut(
+        frame_subset[0].clone(),
+        frame_subset[j].clone(),
+        frameno - 1 + j as u64,
+        previous_keyframe,
+      );
+      debug!(
+        "[SF-Detect-1] Frame {} to {}: I={:.3} T={:.3} P={:.3} {}",
+        frameno - 1,
+        frameno - 1 + j as u64,
+        result.intra_cost,
+        result.threshold,
+        result.inter_cost,
+        if result.has_scenecut { "No flash" } else { "Scene flash" }
+      );
+      if !result.has_scenecut {
         // Any frame in between `0` and `j` cannot be a real scenecut.
         for i in 0..=j {
           let frameno = frameno + i as u64 - 1;
@@ -130,8 +193,22 @@ impl SceneChangeDetector {
     // Instead, the first F frame becomes a scenecut.
     // If the video ends before F, no frame becomes a scenecut.
     for i in 1..lookahead_distance {
-      if self.has_scenecut(&frame_subset[i], &frame_subset[lookahead_distance])
-      {
+      let result = self.has_scenecut(
+        frame_subset[i].clone(),
+        frame_subset[lookahead_distance].clone(),
+        frameno - 1 + lookahead_distance as u64,
+        previous_keyframe,
+      );
+      debug!(
+        "[SF-Detect-2] Frame {} to {}: I={:.3} T={:.3} P={:.3} {}",
+        frameno - 1 + i as u64,
+        frameno - 1 + lookahead_distance as u64,
+        result.intra_cost,
+        result.threshold,
+        result.inter_cost,
+        if result.has_scenecut { "Scene flash" } else { "No flash" }
+      );
+      if result.has_scenecut {
         // If the current frame is the frame before a scenecut, it cannot also be the frame of a scenecut.
         let frameno = frameno + i as u64 - 1;
         self.excluded_frames.insert(frameno);
@@ -141,33 +218,80 @@ impl SceneChangeDetector {
 
   /// Run a comparison between two frames to determine if they qualify for a scenecut.
   ///
-  /// The current algorithm detects fast cuts using changes in colour and intensity between frames.
-  /// Since the difference between frames is used, only fast cuts are detected
-  /// with this method. This is intended to change via https://github.com/xiph/rav1e/issues/794.
+  /// The standard algorithm uses block intra and inter costs
+  /// to determine which method would be more efficient
+  /// for coding this frame.
+  ///
+  /// The fast algorithm detects fast cuts using a raw difference
+  /// in pixel values between the frames.
+  /// It does not handle pans well, but the scene flash detection compensates for this
+  /// in many cases.
   fn has_scenecut<T: Pixel>(
-    &self, frame1: &Frame<T>, frame2: &Frame<T>,
-  ) -> bool {
-    let mut len = frame2.planes[0].cfg.width * frame2.planes[0].cfg.height;
-    let mut delta = 0;
+    &self, frame1: Arc<Frame<T>>, frame2: Arc<Frame<T>>, frameno: u64,
+    previous_keyframe: u64,
+  ) -> ScenecutResult {
+    if self.fast_mode {
+      let len = frame2.planes[0].cfg.width * frame2.planes[0].cfg.height;
+      let delta = self.delta_in_planes(&frame1.planes[0], &frame2.planes[0]);
+      let threshold = self.threshold * len as u64;
+      ScenecutResult {
+        intra_cost: threshold as f64,
+        threshold: threshold as f64,
+        inter_cost: delta as f64,
+        has_scenecut: delta >= threshold,
+      }
+    } else {
+      let intra_costs =
+        estimate_intra_costs(&*frame2, self.bit_depth, self.cpu_feature_level);
+      let intra_cost = intra_costs.iter().map(|&cost| cost as u64).sum::<u64>()
+        as f64
+        / intra_costs.len() as f64;
 
-    delta += self.delta_in_planes(&frame1.planes[0], &frame2.planes[0]);
+      let inter_costs = estimate_inter_costs(
+        frame2,
+        frame1,
+        self.bit_depth,
+        self.encoder_config,
+        self.sequence,
+      );
+      let inter_cost = inter_costs.iter().map(|&cost| cost as u64).sum::<u64>()
+        as f64
+        / inter_costs.len() as f64;
 
-    if !self.fast_mode {
-      let u_dec = frame1.planes[1].cfg.xdec + frame1.planes[1].cfg.ydec;
-      len +=
-        (frame2.planes[1].cfg.width * frame2.planes[1].cfg.height) << u_dec;
+      // Sliding scale, more likely to choose a keyframe
+      // as we get farther from the last keyframe.
+      // Based on x264 scenecut code.
+      //
+      // `THRESH_MAX` determines how likely we are
+      // to choose a keyframe, between 0.0-1.0.
+      // Higher values mean we are more likely to choose a keyframe.
+      // `0.4` was chosen based on trials of the `scenecut-720p` set in AWCY,
+      // as it appeared to provide the best average compression.
+      // This also matches the default scenecut threshold in x264.
+      const THRESH_MAX: f64 = 0.4;
+      const THRESH_MIN: f64 = THRESH_MAX * 0.25;
+      let distance_from_keyframe = frameno - previous_keyframe;
+      let min_keyint = self.encoder_config.min_key_frame_interval;
+      let max_keyint = self.encoder_config.max_key_frame_interval;
+      let bias = if distance_from_keyframe <= min_keyint / 4 {
+        THRESH_MIN / 4.0
+      } else if distance_from_keyframe <= min_keyint {
+        THRESH_MIN * distance_from_keyframe as f64 / min_keyint as f64
+      } else {
+        THRESH_MIN
+          + (THRESH_MAX - THRESH_MIN)
+            * (distance_from_keyframe - min_keyint) as f64
+            / (max_keyint - min_keyint) as f64
+      };
+      let threshold = intra_cost * (1.0 - bias);
 
-      delta +=
-        self.delta_in_planes(&frame1.planes[1], &frame2.planes[1]) << u_dec;
-
-      let v_dec = frame1.planes[2].cfg.xdec + frame1.planes[2].cfg.ydec;
-      len +=
-        (frame2.planes[2].cfg.width * frame2.planes[2].cfg.height) << v_dec;
-      delta +=
-        self.delta_in_planes(&frame1.planes[2], &frame2.planes[2]) << v_dec;
+      ScenecutResult {
+        intra_cost,
+        threshold,
+        inter_cost,
+        has_scenecut: inter_cost > threshold,
+      }
     }
-
-    delta >= self.threshold as u64 * len as u64
   }
 
   fn delta_in_planes<T: Pixel>(
@@ -188,4 +312,14 @@ impl SceneChangeDetector {
     }
     delta
   }
+}
+
+/// This struct primarily exists for returning metrics to the caller
+/// for logging debug information.
+#[derive(Debug, Clone, Copy)]
+struct ScenecutResult {
+  intra_cost: f64,
+  inter_cost: f64,
+  threshold: f64,
+  has_scenecut: bool,
 }


### PR DESCRIPTION
Closes #1528

Provides .1-.2% BD Rate improvement on scenecut-720p set.
Because the threshold scales based on distance
since the last keyframe,
it is expected that the improvement will be more on real content
(i.e. clips with more than 240 frames).

Overall is about 1% slower (with 1 tile) compared to master.

[AWCY](https://beta.arewecompressedyet.com/?job=scenecut-master%402019-12-09T01%3A05%3A19.889Z&job=scenecut-cost-3%402019-12-09T12%3A36%3A04.496Z)