### PR TITLE
Fix for issue #1903 (Krøyer_PS.y4m desync)

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -3280,7 +3280,7 @@ fn encode_tile<'a, T: Pixel>(
               as i32;
             sbs_qe.lru_index[pli] = lru_index;
             if ts.restoration.planes[pli]
-              .restoration_unit_last_sb_for_rdo(fi, tile_sbo)
+              .restoration_unit_last_sb_for_rdo(fi, ts.sbo, tile_sbo)
             {
               last_lru_ready[pli] = lru_index;
               check_queue = true;
@@ -3371,7 +3371,12 @@ fn encode_tile<'a, T: Pixel>(
       }
     }
   }
-
+  assert!(
+    sbs_q.is_empty(),
+    "Superblock queue not empty in tile at offset {}:{}",
+    ts.sbo.0.x,
+    ts.sbo.0.y
+  );
   w.done()
 }
 


### PR DESCRIPTION
Tiling had broken an edge-of-frame check in superblock queue flush triggering.  It was checking tile-local superblock offset against the edge of the frame instead of checking *global* superblock offset against the edge of frame.  This should fix the desync bug with no other functional change.

Fixes #1903 