### PR TITLE
Build assembler files with dwarf debug symbols

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -63,7 +63,7 @@ fn build_nasm_files() {
       "src/x86/cdef.asm",
       "src/x86/tables.asm",
     ],
-    &[&config_include_arg, "-Isrc/"],
+    &[&config_include_arg, "-Isrc/", "-Fdwarf"],
   );
   println!("cargo:rustc-link-lib=static=rav1easm");
   rerun_dir("src/x86");


### PR DESCRIPTION
This is needed for debuginfo package generation for distributions. E.g.
for openSUSE or Fedora

This should be set if '-C debuginfo=X' is passed to rust. However I'm a total Rust newbie especially when it comes to the build system.