### PR TITLE
CI: Update libdav1d to 0.5.2

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -131,11 +131,11 @@ jobs:
         matrix.conf == 'grcov-coveralls'
       env:
         LINK: http://www.deb-multimedia.org/pool/main/d/dav1d-dmo
-        DAV1D_VERSION: 0.5.1-dmo1
+        DAV1D_VERSION: 0.5.2-dmo1
         DAV1D_DEV_SHA256: >-
-          feb8fd535ae7747963d3d17ed394dc5bdb3e6163fdb77df787ec72a8ca9aac2e
+          9f61ffe439c95a934996a6c35ab986983bb36d93057f8d1c958fd839982b6cb1
         DAV1D_LIB_SHA256: >-
-          682fd52fcfd73c225f9aaee200cbe69eceefdc687b8ce03f354731f5288a28ce
+          9d9618445d5f79867d7aa2e338e11b48386c961a3c58002523efe2bad3b3f815
       run: |
         curl -O "$LINK/libdav1d-dev_${DAV1D_VERSION}_amd64.deb" \
              -O "$LINK/libdav1d3_${DAV1D_VERSION}_amd64.deb"

--- a/.travis/install-dav1d.sh
+++ b/.travis/install-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-DAV1D_VERSION="0.5.1-dmo1"
+DAV1D_VERSION="0.5.2-dmo1"
 PKG_URL="http://www.deb-multimedia.org/pool/main/d/dav1d-dmo"
 
 case "$ARCH" in
@@ -13,10 +13,10 @@ curl -O "$PKG_URL/libdav1d-dev_${DAV1D_VERSION}_$ARCH.deb" \
      -O "$PKG_URL/libdav1d3_${DAV1D_VERSION}_$ARCH.deb"
 
 sha256sum --check --ignore-missing <<EOF
-682fd52fcfd73c225f9aaee200cbe69eceefdc687b8ce03f354731f5288a28ce  libdav1d3_0.5.1-dmo1_amd64.deb
-de8550873cd7c7a7ede789f9be5db079cb3eafa91facc883dec833da887fa831  libdav1d3_0.5.1-dmo1_arm64.deb
-feb8fd535ae7747963d3d17ed394dc5bdb3e6163fdb77df787ec72a8ca9aac2e  libdav1d-dev_0.5.1-dmo1_amd64.deb
-a4ebf7794c9ac2b9eeef90386c4655c7f16e4e299435fccb41c815dd380d05da  libdav1d-dev_0.5.1-dmo1_arm64.deb
+9d9618445d5f79867d7aa2e338e11b48386c961a3c58002523efe2bad3b3f815  libdav1d3_0.5.2-dmo1_amd64.deb
+fb0e7d592fa2324c52ac3fb6f79d4ff1ec01923280afcac1bdd74beb174532ca  libdav1d3_0.5.2-dmo1_arm64.deb
+9f61ffe439c95a934996a6c35ab986983bb36d93057f8d1c958fd839982b6cb1  libdav1d-dev_0.5.2-dmo1_amd64.deb
+d2af1ebe3d953a07dc9512f45aac62be2622d361b3262faf71ac2ed9cb4bbfdd  libdav1d-dev_0.5.2-dmo1_arm64.deb
 EOF
 
 sudo dpkg -i "libdav1d3_${DAV1D_VERSION}_$ARCH.deb" \


### PR DESCRIPTION
We are exchanging the time to fetch package lists on every CI task for effort to periodically update selected package metadata.