### PR TITLE
Explicit cdef search types

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -913,6 +913,30 @@ impl<T: Pixel> FrameInvariants<T> {
     }
   }
 
+  fn pick_strength_from_q(&mut self, qps: &QuantizerParameters) {
+    self.cdef_damping = 3 + (self.base_q_idx >> 6);
+    let q = bexp64(qps.log_target_q as i64 + q57(QSCALE)) as f32;
+    /* These coefficients were trained on libaom. */
+    let (y_f1, y_f2, uv_f1, uv_f2) = if !self.intra_only {
+      (
+        poly2(q, -0.0000023593946_f32, 0.0068615186_f32, 0.02709886_f32, 15),
+        poly2(q, -0.00000057629734_f32, 0.0013993345_f32, 0.03831067_f32, 3),
+        poly2(q, -0.0000007095069_f32, 0.0034628846_f32, 0.00887099_f32, 15),
+        poly2(q, 0.00000023874085_f32, 0.00028223585_f32, 0.05576307_f32, 3),
+      )
+    } else {
+      (
+        poly2(q, 0.0000033731974_f32, 0.008070594_f32, 0.0187634_f32, 15),
+        poly2(q, 0.0000029167343_f32, 0.0027798624_f32, 0.0079405_f32, 3),
+        poly2(q, -0.0000130790995_f32, 0.012892405_f32, -0.00748388_f32, 15),
+        poly2(q, 0.0000032651783_f32, 0.00035520183_f32, 0.00228092_f32, 3),
+      )
+    };
+    self.cdef_y_strengths[0] = (y_f1 * CDEF_SEC_STRENGTHS as i32 + y_f2) as u8;
+    self.cdef_uv_strengths[0] =
+      (uv_f1 * CDEF_SEC_STRENGTHS as i32 + uv_f2) as u8;
+  }
+
   pub fn set_quantizers(&mut self, qps: &QuantizerParameters) {
     self.base_q_idx = qps.ac_qi[0];
     let base_q_idx = self.base_q_idx as i32;
@@ -931,26 +955,7 @@ impl<T: Pixel> FrameInvariants<T> {
 
     match self.cdef_search_method {
       CDEFSearchMethod::PickFromQ => {
-        self.cdef_damping = 3 + (self.base_q_idx >> 6);
-        let q = bexp64(qps.log_target_q as i64 + q57(QSCALE)) as f32;
-        /* These coefficients were trained on libaom. */
-        let (y_f1, y_f2, uv_f1, uv_f2) = if !self.intra_only {
-          (
-            poly2(q, -0.0000023593946_f32, 0.0068615186_f32, 0.02709886_f32, 15),
-            poly2(q, -0.00000057629734_f32, 0.0013993345_f32, 0.03831067_f32, 3),
-            poly2(q, -0.0000007095069_f32, 0.0034628846_f32, 0.00887099_f32, 15),
-            poly2(q, 0.00000023874085_f32, 0.00028223585_f32, 0.05576307_f32, 3)
-          )
-        } else {
-          (
-            poly2(q, 0.0000033731974_f32, 0.008070594_f32, 0.0187634_f32, 15),
-            poly2(q, 0.0000029167343_f32, 0.0027798624_f32, 0.0079405_f32, 3),
-            poly2(q, -0.0000130790995_f32, 0.012892405_f32, -0.00748388_f32, 15),
-            poly2(q, 0.0000032651783_f32, 0.00035520183_f32, 0.00228092_f32, 3)
-          )
-        };
-        self.cdef_y_strengths[0] = (y_f1 * CDEF_SEC_STRENGTHS as i32 + y_f2) as u8;
-        self.cdef_uv_strengths[0] = (uv_f1 * CDEF_SEC_STRENGTHS as i32 + uv_f2) as u8;
+        self.pick_strength_from_q(qps);
       }
       // TODO: implement FastSearch and FullSearch
       _ => unreachable!(),

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -62,8 +62,8 @@ pub enum CDEFSearchMethod {
 }
 
 #[inline(always)]
-fn poly2(q: f32, a: f32, b: f32, c: f32) -> f32 {
-  q * q * a + q * b + c
+fn poly2(q: f32, a: f32, b: f32, c: f32) -> i32 {
+  (q * q * a + q * b + c).round() as i32
 }
 
 pub static TEMPORAL_DELIMITER: [u8; 2] = [0x12, 0x00];
@@ -940,8 +940,7 @@ impl<T: Pixel> FrameInvariants<T> {
                   q,
                   -0.0000023593946_f32,
                   0.0068615186_f32,
-                  0.02709886_f32)
-                  .round() as i32,
+                  0.02709886_f32),
                   0,
                   15,
                   );
@@ -950,8 +949,7 @@ impl<T: Pixel> FrameInvariants<T> {
                   q,
                   -0.00000057629734_f32,
                   0.0013993345_f32,
-                  0.03831067_f32)
-                  .round() as i32,
+                  0.03831067_f32),
                   0,
                   3,
                   );
@@ -960,8 +958,7 @@ impl<T: Pixel> FrameInvariants<T> {
                   q,
                   -0.0000007095069_f32,
                   0.0034628846_f32,
-                  0.00887099_f32)
-                  .round() as i32,
+                  0.00887099_f32),
                   0,
                   15,
                   );
@@ -970,8 +967,7 @@ impl<T: Pixel> FrameInvariants<T> {
                   q,
                   0.00000023874085_f32,
                   0.00028223585_f32,
-                  0.05576307_f32)
-                  .round() as i32,
+                  0.05576307_f32),
                   0,
                   3,
                   );
@@ -985,8 +981,7 @@ impl<T: Pixel> FrameInvariants<T> {
                   q,
                   0.0000033731974_f32,
                   0.008070594_f32,
-                  0.0187634_f32)
-                  .round() as i32,
+                  0.0187634_f32),
                   0,
                   15,
                   );
@@ -995,8 +990,7 @@ impl<T: Pixel> FrameInvariants<T> {
                   q,
                   0.0000029167343_f32,
                   0.0027798624_f32,
-                  0.0079405_f32)
-                  .round() as i32,
+                  0.0079405_f32),
                   0,
                   3,
                   );
@@ -1005,8 +999,7 @@ impl<T: Pixel> FrameInvariants<T> {
                   q,
                   -0.0000130790995_f32,
                   0.012892405_f32,
-                  -0.00748388_f32)
-                  .round() as i32,
+                  -0.00748388_f32),
                   0,
                   15,
                   );
@@ -1015,8 +1008,7 @@ impl<T: Pixel> FrameInvariants<T> {
                   q,
                   0.0000032651783_f32,
                   0.00035520183_f32,
-                  0.00228092_f32)
-                  .round() as i32,
+                  0.00228092_f32),
                   0,
                   3,
                   );

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -62,8 +62,8 @@ pub enum CDEFSearchMethod {
 }
 
 #[inline(always)]
-fn poly2(q: f32, a: f32, b: f32, c: f32) -> i32 {
-  (q * q * a + q * b + c).round() as i32
+fn poly2(q: f32, a: f32, b: f32, c: f32, max: i32) -> i32 {
+  clamp((q * q * a + q * b + c).round() as i32, 0, max)
 }
 
 pub static TEMPORAL_DELIMITER: [u8; 2] = [0x12, 0x00];
@@ -935,40 +935,32 @@ impl<T: Pixel> FrameInvariants<T> {
       let q = bexp64(qps.log_target_q as i64 + q57(QSCALE)) as f32;
       /* These coefficients were trained on libaom. */
       if !self.intra_only {
-          let predicted_y_f1 = clamp(
-                  poly2(
+          let predicted_y_f1 = poly2(
                   q,
                   -0.0000023593946_f32,
                   0.0068615186_f32,
-                  0.02709886_f32),
-                  0,
+                  0.02709886_f32,
                   15,
                   );
-          let predicted_y_f2 = clamp(
-                  poly2(
+          let predicted_y_f2 = poly2(
                   q,
                   -0.00000057629734_f32,
                   0.0013993345_f32,
-                  0.03831067_f32),
-                  0,
+                  0.03831067_f32,
                   3,
                   );
-          let predicted_uv_f1 = clamp(
-                  poly2(
+          let predicted_uv_f1 = poly2(
                   q,
                   -0.0000007095069_f32,
                   0.0034628846_f32,
-                  0.00887099_f32),
-                  0,
+                  0.00887099_f32,
                   15,
                   );
-          let predicted_uv_f2 = clamp(
-                  poly2(
+          let predicted_uv_f2 = poly2(
                   q,
                   0.00000023874085_f32,
                   0.00028223585_f32,
-                  0.05576307_f32),
-                  0,
+                  0.05576307_f32,
                   3,
                   );
           self.cdef_y_strengths[0] =
@@ -976,40 +968,32 @@ impl<T: Pixel> FrameInvariants<T> {
           self.cdef_uv_strengths[0] =
               (predicted_uv_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_uv_f2) as u8;
       } else {
-          let predicted_y_f1 = clamp(
-                  poly2(
+          let predicted_y_f1 = poly2(
                   q,
                   0.0000033731974_f32,
                   0.008070594_f32,
-                  0.0187634_f32),
-                  0,
+                  0.0187634_f32,
                   15,
                   );
-          let predicted_y_f2 = clamp(
-                  poly2(
+          let predicted_y_f2 = poly2(
                   q,
                   0.0000029167343_f32,
                   0.0027798624_f32,
-                  0.0079405_f32),
-                  0,
+                  0.0079405_f32,
                   3,
                   );
-          let predicted_uv_f1 = clamp(
-                  poly2(
+          let predicted_uv_f1 = poly2(
                   q,
                   -0.0000130790995_f32,
                   0.012892405_f32,
-                  -0.00748388_f32),
-                  0,
+                  -0.00748388_f32,
                   15,
                   );
-          let predicted_uv_f2 = clamp(
-                  poly2(
+          let predicted_uv_f2 = poly2(
                   q,
                   0.0000032651783_f32,
                   0.00035520183_f32,
-                  0.00228092_f32),
-                  0,
+                  0.00228092_f32,
                   3,
                   );
           self.cdef_y_strengths[0] =

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -66,11 +66,6 @@ fn poly2(q: f32, a: f32, b: f32, c: f32) -> f32 {
   q * q * a + q * b + c
 }
 
-#[inline(always)]
-fn neg_poly2(q: f32, a: f32, b: f32, c: f32) -> f32 {
-  -q * q * a + q * b + c
-}
-
 pub static TEMPORAL_DELIMITER: [u8; 2] = [0x12, 0x00];
 
 const MAX_NUM_TEMPORAL_LAYERS: usize = 8;
@@ -941,9 +936,9 @@ impl<T: Pixel> FrameInvariants<T> {
       /* These coefficients were trained on libaom. */
       if !self.intra_only {
           let predicted_y_f1 = clamp(
-                  neg_poly2(
+                  poly2(
                   q,
-                  0.0000023593946_f32,
+                  -0.0000023593946_f32,
                   0.0068615186_f32,
                   0.02709886_f32)
                   .round() as i32,
@@ -951,9 +946,9 @@ impl<T: Pixel> FrameInvariants<T> {
                   15,
                   );
           let predicted_y_f2 = clamp(
-                  neg_poly2(
+                  poly2(
                   q,
-                  0.00000057629734_f32,
+                  -0.00000057629734_f32,
                   0.0013993345_f32,
                   0.03831067_f32)
                   .round() as i32,
@@ -961,9 +956,9 @@ impl<T: Pixel> FrameInvariants<T> {
                   3,
                   );
           let predicted_uv_f1 = clamp(
-                  neg_poly2(
+                  poly2(
                   q,
-                  0.0000007095069_f32,
+                  -0.0000007095069_f32,
                   0.0034628846_f32,
                   0.00887099_f32)
                   .round() as i32,
@@ -996,9 +991,9 @@ impl<T: Pixel> FrameInvariants<T> {
                   15,
                   );
           let predicted_y_f2 = clamp(
-                  neg_poly2(
+                  poly2(
                   q,
-                  -0.0000029167343_f32,
+                  0.0000029167343_f32,
                   0.0027798624_f32,
                   0.0079405_f32)
                   .round() as i32,
@@ -1006,9 +1001,9 @@ impl<T: Pixel> FrameInvariants<T> {
                   3,
                   );
           let predicted_uv_f1 = clamp(
-                  neg_poly2(
+                  poly2(
                   q,
-                  0.0000130790995_f32,
+                  -0.0000130790995_f32,
                   0.012892405_f32,
                   -0.00748388_f32)
                   .round() as i32,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -931,79 +931,29 @@ impl<T: Pixel> FrameInvariants<T> {
 
     match self.cdef_search_method {
       CDEFSearchMethod::PickFromQ => {
-      self.cdef_damping = 3 + (self.base_q_idx >> 6);
-      let q = bexp64(qps.log_target_q as i64 + q57(QSCALE)) as f32;
-      /* These coefficients were trained on libaom. */
-      if !self.intra_only {
-          let predicted_y_f1 = poly2(
-                  q,
-                  -0.0000023593946_f32,
-                  0.0068615186_f32,
-                  0.02709886_f32,
-                  15,
-                  );
-          let predicted_y_f2 = poly2(
-                  q,
-                  -0.00000057629734_f32,
-                  0.0013993345_f32,
-                  0.03831067_f32,
-                  3,
-                  );
-          let predicted_uv_f1 = poly2(
-                  q,
-                  -0.0000007095069_f32,
-                  0.0034628846_f32,
-                  0.00887099_f32,
-                  15,
-                  );
-          let predicted_uv_f2 = poly2(
-                  q,
-                  0.00000023874085_f32,
-                  0.00028223585_f32,
-                  0.05576307_f32,
-                  3,
-                  );
-          self.cdef_y_strengths[0] =
-              (predicted_y_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_y_f2) as u8;
-          self.cdef_uv_strengths[0] =
-              (predicted_uv_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_uv_f2) as u8;
-      } else {
-          let predicted_y_f1 = poly2(
-                  q,
-                  0.0000033731974_f32,
-                  0.008070594_f32,
-                  0.0187634_f32,
-                  15,
-                  );
-          let predicted_y_f2 = poly2(
-                  q,
-                  0.0000029167343_f32,
-                  0.0027798624_f32,
-                  0.0079405_f32,
-                  3,
-                  );
-          let predicted_uv_f1 = poly2(
-                  q,
-                  -0.0000130790995_f32,
-                  0.012892405_f32,
-                  -0.00748388_f32,
-                  15,
-                  );
-          let predicted_uv_f2 = poly2(
-                  q,
-                  0.0000032651783_f32,
-                  0.00035520183_f32,
-                  0.00228092_f32,
-                  3,
-                  );
-          self.cdef_y_strengths[0] =
-              (predicted_y_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_y_f2) as u8;
-          self.cdef_uv_strengths[0] =
-              (predicted_uv_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_uv_f2) as u8;
+        self.cdef_damping = 3 + (self.base_q_idx >> 6);
+        let q = bexp64(qps.log_target_q as i64 + q57(QSCALE)) as f32;
+        /* These coefficients were trained on libaom. */
+        let (y_f1, y_f2, uv_f1, uv_f2) = if !self.intra_only {
+          (
+            poly2(q, -0.0000023593946_f32, 0.0068615186_f32, 0.02709886_f32, 15),
+            poly2(q, -0.00000057629734_f32, 0.0013993345_f32, 0.03831067_f32, 3),
+            poly2(q, -0.0000007095069_f32, 0.0034628846_f32, 0.00887099_f32, 15),
+            poly2(q, 0.00000023874085_f32, 0.00028223585_f32, 0.05576307_f32, 3)
+          )
+        } else {
+          (
+            poly2(q, 0.0000033731974_f32, 0.008070594_f32, 0.0187634_f32, 15),
+            poly2(q, 0.0000029167343_f32, 0.0027798624_f32, 0.0079405_f32, 3),
+            poly2(q, -0.0000130790995_f32, 0.012892405_f32, -0.00748388_f32, 15),
+            poly2(q, 0.0000032651783_f32, 0.00035520183_f32, 0.00228092_f32, 3)
+          )
+        };
+        self.cdef_y_strengths[0] = (y_f1 * CDEF_SEC_STRENGTHS as i32 + y_f2) as u8;
+        self.cdef_uv_strengths[0] = (uv_f1 * CDEF_SEC_STRENGTHS as i32 + uv_f2) as u8;
       }
-    }
       // TODO: implement FastSearch and FullSearch
-    _ => unreachable!(),
+      _ => unreachable!(),
     }
   }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -61,6 +61,16 @@ pub enum CDEFSearchMethod {
   FullSearch,
 }
 
+#[inline(always)]
+fn poly2(q: f32, a: f32, b: f32, c: f32) -> f32 {
+  q * q * a + q * b + c
+}
+
+#[inline(always)]
+fn neg_poly2(q: f32, a: f32, b: f32, c: f32) -> f32 {
+  -q * q * a + q * b + c
+}
+
 pub static TEMPORAL_DELIMITER: [u8; 2] = [0x12, 0x00];
 
 const MAX_NUM_TEMPORAL_LAYERS: usize = 8;
@@ -931,25 +941,41 @@ impl<T: Pixel> FrameInvariants<T> {
       /* These coefficients were trained on libaom. */
       if !self.intra_only {
           let predicted_y_f1 = clamp(
-                  (-q * q * 0.0000023593946_f32 + q * 0.0068615186_f32 + 0.02709886_f32)
+                  neg_poly2(
+                  q,
+                  0.0000023593946_f32,
+                  0.0068615186_f32,
+                  0.02709886_f32)
                   .round() as i32,
                   0,
                   15,
                   );
           let predicted_y_f2 = clamp(
-                  (-q * q * 0.00000057629734_f32 + q * 0.0013993345_f32 + 0.03831067_f32)
+                  neg_poly2(
+                  q,
+                  0.00000057629734_f32,
+                  0.0013993345_f32,
+                  0.03831067_f32)
                   .round() as i32,
                   0,
                   3,
                   );
           let predicted_uv_f1 = clamp(
-                  (-q * q * 0.0000007095069_f32 + q * 0.0034628846_f32 + 0.00887099_f32)
+                  neg_poly2(
+                  q,
+                  0.0000007095069_f32,
+                  0.0034628846_f32,
+                  0.00887099_f32)
                   .round() as i32,
                   0,
                   15,
                   );
           let predicted_uv_f2 = clamp(
-                  (q * q * 0.00000023874085_f32 + q * 0.00028223585_f32 + 0.05576307_f32)
+                  poly2(
+                  q,
+                  0.00000023874085_f32,
+                  0.00028223585_f32,
+                  0.05576307_f32)
                   .round() as i32,
                   0,
                   3,
@@ -960,25 +986,41 @@ impl<T: Pixel> FrameInvariants<T> {
               (predicted_uv_f1 * CDEF_SEC_STRENGTHS as i32 + predicted_uv_f2) as u8;
       } else {
           let predicted_y_f1 = clamp(
-                  (q * q * 0.0000033731974_f32 + q * 0.008070594_f32 + 0.0187634_f32)
+                  poly2(
+                  q,
+                  0.0000033731974_f32,
+                  0.008070594_f32,
+                  0.0187634_f32)
                   .round() as i32,
                   0,
                   15,
                   );
           let predicted_y_f2 = clamp(
-                  (-q * q * -0.0000029167343_f32 + q * 0.0027798624_f32 + 0.0079405_f32)
+                  neg_poly2(
+                  q,
+                  -0.0000029167343_f32,
+                  0.0027798624_f32,
+                  0.0079405_f32)
                   .round() as i32,
                   0,
                   3,
                   );
           let predicted_uv_f1 = clamp(
-                  (-q * q * 0.0000130790995_f32 + q * 0.012892405_f32 - 0.00748388_f32)
+                  neg_poly2(
+                  q,
+                  0.0000130790995_f32,
+                  0.012892405_f32,
+                  -0.00748388_f32)
                   .round() as i32,
                   0,
                   15,
                   );
           let predicted_uv_f2 = clamp(
-                  (q * q * 0.0000032651783_f32 + q * 0.00035520183_f32 + 0.00228092_f32)
+                  poly2(
+                  q,
+                  0.0000032651783_f32,
+                  0.00035520183_f32,
+                  0.00228092_f32)
                   .round() as i32,
                   0,
                   3,


### PR DESCRIPTION
Currently the only CDEF "search" we do is to select parameters based on quantizer. This makes this choice explicit and defines placeholders for the 2 other search types we will want to implement.