### PR TITLE
CI: Use vswhere to query compiler path

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -280,7 +280,6 @@ jobs:
         7z e -y "$NASM_VERSION-win64.zip" -o"C:\nasm"
         echo "::add-path::C:\nasm"
     - name: Set MSVC x86_64 linker path
-      shell: pwsh
       run: |
         $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
         $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -282,9 +282,9 @@ jobs:
     - name: Set MSVC x86_64 linker path
       shell: pwsh
       run: |
-        $LinkGlob = "VC\Tools\MSVC\**\bin\Hostx64\x64\link.exe"
-        Set-Alias vswhere "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-        $LinkPath = Split-Path (& vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1) -Parent
+        $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
+        $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+        $LinkPath = vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1
         echo "::add-path::$LinkPath"
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -261,8 +261,6 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 300M
       SCCACHE_DIR: C:\sccache
-      VS_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
-      COMPILER_SUBPATH: VC\Tools\MSVC\14.24.28314\bin\Hostx64\x64
 
     runs-on: windows-latest
 
@@ -280,9 +278,14 @@ jobs:
         $NASM_VERSION="nasm-2.14.02"
         curl -LO "https://people.xiph.org/~tdaede/$NASM_VERSION-win64.zip"
         7z e -y "$NASM_VERSION-win64.zip" -o"C:\nasm"
-    - name: Set environment variables
+        echo "::add-path::C:\nasm"
+    - name: Set MSVC x86_64 linker path
+      shell: pwsh
       run: |
-        echo "::add-path::$Env:VS_PATH\$Env:COMPILER_SUBPATH;C:\nasm"
+        $LinkGlob = "VC\Tools\MSVC\**\bin\Hostx64\x64\link.exe"
+        Set-Alias vswhere "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $LinkPath = Split-Path (& vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1) -Parent
+        echo "::add-path::$LinkPath"
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
Follow up to #1965. The nasm-rs crate requires `link.exe` on the path.