### PR TITLE
Switch image feature to png_codec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ simd_helpers = "0.1"
 version = "0.22.1"
 optional = true
 default-features = false
-features = ["png"]
+features = ["png_codec"]
 
 [dependencies.rust_hawktracer]
 version = "0.5.0"


### PR DESCRIPTION
This is the one required for dump_lookahead_data, not png.