### PR TITLE
Refactor BlockWxH out of predict intra

### DIFF
--- a/src/asm/aarch64/transform/inverse.rs
+++ b/src/asm/aarch64/transform/inverse.rs
@@ -109,7 +109,7 @@ macro_rules! impl_itx_fns {
     )*
     paste::item! {
       // Implement InvTxfm2D for WxH
-      impl InvTxfm2D for crate::predict::[<Block $W x $H>] {
+      impl InvTxfm2D for crate::util::[<Block $W x $H>] {
         $(
           impl_itx_fns!($TYPES, $W, $H, $OPT);
         )*
@@ -225,10 +225,10 @@ mod test {
             );
             let mut native_dst = dst.clone();
 
-            unsafe { crate::predict::[<Block $W x $H>]::[<inv_txfm2d_add_ $OPT>](
+            unsafe { crate::util::[<Block $W x $H>]::[<inv_txfm2d_add_ $OPT>](
               freq, &mut dst.as_region_mut(), $ENUM, 8
             ); }
-            <crate::predict::[<Block $W x $H>] as native::InvTxfm2D>::inv_txfm2d_add(
+            <crate::util::[<Block $W x $H>] as native::InvTxfm2D>::inv_txfm2d_add(
               freq, &mut native_dst.as_region_mut(), $ENUM, 8, CpuFeatureLevel::NATIVE
             );
             assert_eq!(native_dst.data_origin(), dst.data_origin());

--- a/src/asm/x86/transform/inverse.rs
+++ b/src/asm/x86/transform/inverse.rs
@@ -144,7 +144,7 @@ macro_rules! impl_itx_fns {
     )*
     paste::item! {
       // Implement InvTxfm2D for WxH
-      impl InvTxfm2D for crate::predict::[<Block $W x $H>] {
+      impl InvTxfm2D for crate::util::[<Block $W x $H>] {
         $(
           impl_itx_fns!($TYPES, $W, $H, $OPT);
         )*
@@ -264,10 +264,10 @@ mod test {
             );
             let mut native_dst = dst.clone();
 
-            unsafe { crate::predict::[<Block $W x $H>]::[<inv_txfm2d_add_ $OPT>](
+            unsafe { crate::util::[<Block $W x $H>]::[<inv_txfm2d_add_ $OPT>](
               freq, &mut dst.as_region_mut(), $ENUM, 8
             ); }
-            <crate::predict::[<Block $W x $H>] as native::InvTxfm2D>::inv_txfm2d_add(
+            <crate::util::[<Block $W x $H>] as native::InvTxfm2D>::inv_txfm2d_add(
               freq, &mut native_dst.as_region_mut(), $ENUM, 8, CpuFeatureLevel::NATIVE
             );
             assert_eq!(native_dst.data_origin(), dst.data_origin());

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -23,9 +23,9 @@ cfg_if::cfg_if! {
 pub mod native {
   use super::*;
 
-  use crate::predict::Dim;
   use crate::transform::av1_round_shift_array;
   use crate::transform::forward_shared::*;
+  use crate::transform::Dim;
   use crate::transform::TxSize;
 
   pub trait TxOperations: Copy {

--- a/src/transform/forward_shared.rs
+++ b/src/transform/forward_shared.rs
@@ -160,7 +160,7 @@ macro_rules! impl_fwd_txs {
   ($(($W:expr, $H:expr)),+) => {
     $(
       paste::item! {
-        pub use crate::predict::[<Block $W x $H>];
+        pub use crate::util::[<Block $W x $H>];
         impl FwdTxfm2D for [<Block $W x $H>] {}
       }
     )*

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -18,7 +18,6 @@ cfg_if::cfg_if! {
 }
 
 use crate::cpu_features::CpuFeatureLevel;
-use crate::predict::Dim;
 use crate::tiling::PlaneRegionMut;
 use crate::util::*;
 
@@ -1665,7 +1664,7 @@ pub(crate) mod native {
     ($(($W:expr, $H:expr)),+ $SH:expr) => {
       $(
         paste::item! {
-          impl InvTxfm2D for crate::predict::[<Block $W x $H>] {
+          impl InvTxfm2D for crate::util::[<Block $W x $H>] {
             const INTERMEDIATE_SHIFT: usize = $SH;
           }
         }
@@ -1693,7 +1692,7 @@ macro_rules! impl_iht_fns {
         ) where
           T: Pixel,
         {
-          crate::predict::[<Block $W x $H>]::inv_txfm2d_add(
+          crate::util::[<Block $W x $H>]::inv_txfm2d_add(
             input, output, tx_type, bit_depth, cpu
           );
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -219,3 +219,31 @@ pub fn msb(x: i32) -> i32 {
 pub const fn round_shift(value: i32, bit: usize) -> i32 {
   (value + (1 << bit >> 1)) >> bit
 }
+
+pub trait Dim {
+  const W: usize;
+  const H: usize;
+}
+
+macro_rules! blocks_dimension {
+  ($(($W:expr, $H:expr)),+) => {
+    paste::item! {
+      $(
+        pub struct [<Block $W x $H>];
+
+        impl Dim for [<Block $W x $H>] {
+          const W: usize = $W;
+          const H: usize = $H;
+        }
+      )*
+    }
+  };
+}
+
+blocks_dimension! {
+  (4, 4), (8, 8), (16, 16), (32, 32), (64, 64),
+  (4, 8), (8, 16), (16, 32), (32, 64),
+  (8, 4), (16, 8), (32, 16), (64, 32),
+  (4, 16), (8, 32), (16, 64),
+  (16, 4), (32, 8), (64, 16)
+}


### PR DESCRIPTION
Reduces binary size from 42.5 MB to 37.8 MB.
Removes 40% of the LLVM-IR currently being created.
Reduces --release compile times by 15 seconds (Ryzen 5 3600).