### PR TITLE
Fix for serious bug in deblocking RDO sse calculation

### DIFF
--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -422,16 +422,25 @@ fn deblock_h_size4<T: Pixel>(
 // Accesses four taps, accumulates four pixels into the tally
 fn sse_size4<T: Pixel>(
   rec: &PlaneSlice<'_, T>, src: &PlaneSlice<'_, T>,
-  tally: &mut [i64; MAX_LOOP_FILTER + 2], horizontal_p: bool,
-  bd: usize,
+  tally: &mut [i64; MAX_LOOP_FILTER + 2], horizontal_p: bool, bd: usize,
 ) {
   for i in 0..4 {
     let (p1, p0, q0, q1, a) = if horizontal_p {
-      (rec[0][i].as_(), rec[1][i].as_(), rec[2][i].as_(), rec[3][i].as_(),
-       [src[0][i].as_(), src[1][i].as_(), src[2][i].as_(), src[3][i].as_()])
+      (
+        rec[0][i].as_(),
+        rec[1][i].as_(),
+        rec[2][i].as_(),
+        rec[3][i].as_(),
+        [src[0][i].as_(), src[1][i].as_(), src[2][i].as_(), src[3][i].as_()],
+      )
     } else {
-      (rec[i][0].as_(), rec[i][1].as_(), rec[i][2].as_(), rec[i][3].as_(),
-       [src[i][0].as_(), src[i][1].as_(), src[i][2].as_(), src[i][3].as_()])
+      (
+        rec[i][0].as_(),
+        rec[i][1].as_(),
+        rec[i][2].as_(),
+        rec[i][3].as_(),
+        [src[i][0].as_(), src[i][1].as_(), src[i][2].as_(), src[i][3].as_()],
+      )
     };
 
     // three possibilities: no filter, narrow2 and narrow4
@@ -545,32 +554,34 @@ fn deblock_h_size6<T: Pixel>(
 // Accesses six taps, accumulates four pixels into the tally
 fn sse_size6<T: Pixel>(
   rec: &PlaneSlice<'_, T>, src: &PlaneSlice<'_, T>,
-  tally: &mut [i64; MAX_LOOP_FILTER + 2], horizontal_p: bool,
-  bd: usize,
+  tally: &mut [i64; MAX_LOOP_FILTER + 2], horizontal_p: bool, bd: usize,
 ) {
   let flat = 1 << (bd - 8);
   for i in 0..4 {
-
     let (p2, p1, p0, q0, q1, q2, a) = if horizontal_p {
-       // six taps
-      (rec[0][i].as_(),
-       rec[1][i].as_(),
-       rec[2][i].as_(),
-       rec[3][i].as_(),
-       rec[4][i].as_(),
-       rec[5][i].as_(),
-       // four pixels to compare so offset one forward
-       [src[1][i].as_(), src[2][i].as_(), src[3][i].as_(), src[4][i].as_()])
+      // six taps
+      (
+        rec[0][i].as_(),
+        rec[1][i].as_(),
+        rec[2][i].as_(),
+        rec[3][i].as_(),
+        rec[4][i].as_(),
+        rec[5][i].as_(),
+        // four pixels to compare so offset one forward
+        [src[1][i].as_(), src[2][i].as_(), src[3][i].as_(), src[4][i].as_()],
+      )
     } else {
       // six taps
-      (rec[i][0].as_(),
+      (
+        rec[i][0].as_(),
         rec[i][1].as_(),
         rec[i][2].as_(),
         rec[i][3].as_(),
         rec[i][4].as_(),
         rec[i][5].as_(),
-       // four pixels to compare so offset one forward
-       [src[i][1].as_(), src[i][2].as_(), src[i][3].as_(), src[i][4].as_()])
+        // four pixels to compare so offset one forward
+        [src[i][1].as_(), src[i][2].as_(), src[i][3].as_(), src[i][4].as_()],
+      )
     };
 
     // Four possibilities: no filter, wide6, narrow2 and narrow4
@@ -597,11 +608,8 @@ fn sse_size6<T: Pixel>(
     } else {
       sse_none
     };
-    let sse_narrow2 = if !flatp && nhev != mask {
-      stride_sse(&a, &narrow2)
-    } else {
-      sse_none
-    };
+    let sse_narrow2 =
+      if !flatp && nhev != mask { stride_sse(&a, &narrow2) } else { sse_none };
     let sse_narrow4 = if !flatp && nhev <= MAX_LOOP_FILTER {
       stride_sse(&a, &narrow4)
     } else {
@@ -727,34 +735,36 @@ fn deblock_h_size8<T: Pixel>(
 // Accesses eight taps, accumulates six pixels into the tally
 fn sse_size8<T: Pixel>(
   rec: &PlaneSlice<'_, T>, src: &PlaneSlice<'_, T>,
-  tally: &mut [i64; MAX_LOOP_FILTER + 2], horizontal_p: bool,
-  bd: usize,
+  tally: &mut [i64; MAX_LOOP_FILTER + 2], horizontal_p: bool, bd: usize,
 ) {
   let flat = 1 << (bd - 8);
 
   for i in 0..4 {
-
     let (p3, p2, p1, p0, q0, q1, q2, q3, a) = if horizontal_p {
-       // eight taps
-      (rec[0][i].as_(),
-       rec[1][i].as_(),
-       rec[2][i].as_(),
-       rec[3][i].as_(),
-       rec[4][i].as_(),
-       rec[5][i].as_(),
-       rec[6][i].as_(),
-       rec[7][i].as_(),
-       // six pixels to compare so offset one forward
-       [src[1][i].as_(),
-        src[2][i].as_(),
-        src[3][i].as_(),
-        src[4][i].as_(),
-        src[5][i].as_(),
-        src[6][i].as_(),
-       ])
+      // eight taps
+      (
+        rec[0][i].as_(),
+        rec[1][i].as_(),
+        rec[2][i].as_(),
+        rec[3][i].as_(),
+        rec[4][i].as_(),
+        rec[5][i].as_(),
+        rec[6][i].as_(),
+        rec[7][i].as_(),
+        // six pixels to compare so offset one forward
+        [
+          src[1][i].as_(),
+          src[2][i].as_(),
+          src[3][i].as_(),
+          src[4][i].as_(),
+          src[5][i].as_(),
+          src[6][i].as_(),
+        ],
+      )
     } else {
       // eight taps
-      (rec[i][0].as_(),
+      (
+        rec[i][0].as_(),
         rec[i][1].as_(),
         rec[i][2].as_(),
         rec[i][3].as_(),
@@ -762,14 +772,16 @@ fn sse_size8<T: Pixel>(
         rec[i][5].as_(),
         rec[i][6].as_(),
         rec[i][7].as_(),
-       // six pixels to compare so offset one forward
-       [src[i][1].as_(),
-        src[i][2].as_(),
-        src[i][3].as_(),
-        src[i][4].as_(),
-        src[i][5].as_(),
-        src[i][6].as_(),
-       ])
+        // six pixels to compare so offset one forward
+        [
+          src[i][1].as_(),
+          src[i][2].as_(),
+          src[i][3].as_(),
+          src[i][4].as_(),
+          src[i][5].as_(),
+          src[i][6].as_(),
+        ],
+      )
     };
 
     // Four possibilities: no filter, wide8, narrow2 and narrow4
@@ -797,11 +809,8 @@ fn sse_size8<T: Pixel>(
     } else {
       sse_none
     };
-    let sse_narrow2 = if !flatp && nhev != mask {
-      stride_sse(&a, &narrow2)
-    } else {
-      sse_none
-    };
+    let sse_narrow2 =
+      if !flatp && nhev != mask { stride_sse(&a, &narrow2) } else { sse_none };
     let sse_narrow4 = if !flatp && nhev <= MAX_LOOP_FILTER {
       stride_sse(&a, &narrow4)
     } else {
@@ -927,75 +936,79 @@ fn deblock_h_size14<T: Pixel>(
 // Accesses fourteen taps, accumulates twelve pixels into the tally
 fn sse_size14<T: Pixel>(
   rec: &PlaneSlice<'_, T>, src: &PlaneSlice<'_, T>,
-  tally: &mut [i64; MAX_LOOP_FILTER + 2], horizontal_p: bool,
-  bd: usize,
+  tally: &mut [i64; MAX_LOOP_FILTER + 2], horizontal_p: bool, bd: usize,
 ) {
   let flat = 1 << (bd - 8);
   for i in 0..4 {
-    
-    let (p6, p5, p4, p3, p2, p1, p0,
-         q0, q1, q2, q3, q4, q5, q6, a) = if horizontal_p {
-      // 14 taps
-      (rec[0][i].as_(),
-       rec[1][i].as_(),
-       rec[2][i].as_(),
-       rec[3][i].as_(),
-       rec[4][i].as_(),
-       rec[5][i].as_(),
-       rec[6][i].as_(),
-       rec[7][i].as_(),
-       rec[8][i].as_(),
-       rec[9][i].as_(),
-       rec[10][i].as_(),
-       rec[11][i].as_(),
-       rec[12][i].as_(),
-       rec[13][i].as_(),
-       // 12 pixels to compare so offset one forward
-       [src[1][i].as_(),
-        src[2][i].as_(),
-        src[3][i].as_(),
-        src[4][i].as_(),
-        src[5][i].as_(),
-        src[6][i].as_(),
-        src[7][i].as_(),
-        src[8][i].as_(),
-        src[9][i].as_(),
-        src[10][i].as_(),
-        src[11][i].as_(),
-        src[12][i].as_(),
-       ])
-    } else {
-      // 14 taps
-      (rec[i][0].as_(),
-        rec[i][1].as_(),
-        rec[i][2].as_(),
-        rec[i][3].as_(),
-        rec[i][4].as_(),
-        rec[i][5].as_(),
-        rec[i][6].as_(),
-        rec[i][7].as_(),
-        rec[i][8].as_(),
-        rec[i][9].as_(),
-        rec[i][10].as_(),
-        rec[i][11].as_(),
-        rec[i][12].as_(),
-        rec[i][13].as_(),
-       // 12 pixels to compare so offset one forward
-       [src[i][1].as_(),
-        src[i][2].as_(),
-        src[i][3].as_(),
-        src[i][4].as_(),
-        src[i][5].as_(),
-        src[i][6].as_(),
-        src[i][7].as_(),
-        src[i][8].as_(),
-        src[i][9].as_(),
-        src[i][10].as_(),
-        src[i][11].as_(),
-        src[i][12].as_(),
-       ])
-    };
-  
+    let (p6, p5, p4, p3, p2, p1, p0, q0, q1, q2, q3, q4, q5, q6, a) =
+      if horizontal_p {
+        // 14 taps
+        (
+          rec[0][i].as_(),
+          rec[1][i].as_(),
+          rec[2][i].as_(),
+          rec[3][i].as_(),
+          rec[4][i].as_(),
+          rec[5][i].as_(),
+          rec[6][i].as_(),
+          rec[7][i].as_(),
+          rec[8][i].as_(),
+          rec[9][i].as_(),
+          rec[10][i].as_(),
+          rec[11][i].as_(),
+          rec[12][i].as_(),
+          rec[13][i].as_(),
+          // 12 pixels to compare so offset one forward
+          [
+            src[1][i].as_(),
+            src[2][i].as_(),
+            src[3][i].as_(),
+            src[4][i].as_(),
+            src[5][i].as_(),
+            src[6][i].as_(),
+            src[7][i].as_(),
+            src[8][i].as_(),
+            src[9][i].as_(),
+            src[10][i].as_(),
+            src[11][i].as_(),
+            src[12][i].as_(),
+          ],
+        )
+      } else {
+        // 14 taps
+        (
+          rec[i][0].as_(),
+          rec[i][1].as_(),
+          rec[i][2].as_(),
+          rec[i][3].as_(),
+          rec[i][4].as_(),
+          rec[i][5].as_(),
+          rec[i][6].as_(),
+          rec[i][7].as_(),
+          rec[i][8].as_(),
+          rec[i][9].as_(),
+          rec[i][10].as_(),
+          rec[i][11].as_(),
+          rec[i][12].as_(),
+          rec[i][13].as_(),
+          // 12 pixels to compare so offset one forward
+          [
+            src[i][1].as_(),
+            src[i][2].as_(),
+            src[i][3].as_(),
+            src[i][4].as_(),
+            src[i][5].as_(),
+            src[i][6].as_(),
+            src[i][7].as_(),
+            src[i][8].as_(),
+            src[i][9].as_(),
+            src[i][10].as_(),
+            src[i][11].as_(),
+            src[i][12].as_(),
+          ],
+        )
+      };
+
     // Five possibilities: no filter, wide14, wide8, narrow2 and narrow4
     let none: [i32; 12] = [p5, p4, p3, p2, p1, p0, q0, q1, q2, q3, q4, q5];
     let wide14 =
@@ -1242,32 +1255,16 @@ fn sse_h_edge<T: Pixel>(
       let src_slice = src_plane.slice(po);
       match filter_size {
         4 => {
-          sse_size4(&rec_slice,
-                    &src_slice,
-                    tally,
-                    true,
-                    bd);
+          sse_size4(&rec_slice, &src_slice, tally, true, bd);
         }
         6 => {
-          sse_size6(&rec_slice,
-                    &src_slice,
-                    tally,
-                    true,
-                    bd);
+          sse_size6(&rec_slice, &src_slice, tally, true, bd);
         }
         8 => {
-          sse_size8(&rec_slice,
-                    &src_slice,
-                    tally,
-                    true,
-                    bd);
+          sse_size8(&rec_slice, &src_slice, tally, true, bd);
         }
         14 => {
-          sse_size14(&rec_slice,
-                     &src_slice,
-                     tally,
-                     true,
-                     bd);
+          sse_size14(&rec_slice, &src_slice, tally, true, bd);
         }
         _ => unreachable!(),
       }


### PR DESCRIPTION
At some point a code cleanup of the deblocking filter seriously broke the deblocking SSE calculation in optimization. The horizontal edge calculation was actually looking at random vertical edges through the frame.  Some potential for panic even if testing up to this point hadn't tripped it.

Better yet, fixing it actually improves metrics.

deblock-fix-baseline@2019-12-19T16:41:23.981Z -> deblock-fix-result@2019-12-19T16:41:55.514Z

   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-0.1511 | -0.1740 | -0.2082 |  -0.0815 | -0.1449 | -0.1509 |    -0.1157