### PR TITLE
Use fern and console instead of pretty_env_logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ noop_proc_macro = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 dav1d-sys = { version = "0.2", optional = true }
 aom-sys = { version = "0.1.3", optional = true }
-scan_fmt = { version = "0.2.3", optional = true }
+scan_fmt = { version = "0.2.3", optional = true, default-features = false }
 ivf = { version = "0.1", path = "ivf/", optional = true }
 rayon = "1.0"
 toml = { version = "0.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ binaries = [
     "y4m",
     "clap",
     "scan_fmt",
-    "pretty_env_logger",
+    "fern",
+    "console",
     "better-panic",
 ]
 default = ["binaries", "asm", "signal_support"]
@@ -74,7 +75,8 @@ better-panic = { version = "0.2", optional = true }
 err-derive = "0.2.1"
 byteorder = { version = "1.3.2", optional = true }
 log = "0.4"
-pretty_env_logger = { version = "0.3", optional = true }
+console = { version = "0.9", optional = true }
+fern = { version = "0.5", optional = true }
 itertools = "0.8"
 simd_helpers = "0.1"
 


### PR DESCRIPTION
It reduces significantly the build time and allows better output customization.

```
>  Using y4m decoder: 176x144p @ 30/1 fps, 4:2:0, 8-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=false diamond_me=true cdef=true use_satd_subpel=false non_square_partition=false enable_timing_info=false
>  CPU Feature Level: AVX2
>  Using 6 tiles (2x3)
?  debug message
!  warning message 
!! error message
>  encoded 600 frames, 80.182 fps, 55.64 Kb/s
>  ----------
>  Key frame:             3 | avg QP:  79.00 | avg size:    2822 B
>  Inter frame:         597 | avg QP: 134.00 | avg size:     218 B
>  Intra only frame:      0 | avg QP:   0.00 | avg size:       0 B
>  Switching frame:       0 | avg QP:   0.00 | avg size:       0 B
```

TODO
- [ ] document the env var to override the logging level
- [ ] provide verboseness levels (from quiet to verbose)