### PR TITLE
Fix eob decision/computation in quantizer

### DIFF
--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -246,21 +246,6 @@ impl QuantizationContext {
   {
     let scan = av1_scan_orders[tx_size as usize][tx_type as usize].scan;
 
-    // Find the last non-zero coefficient using our smaller biases and
-    // zero everything else.
-    // This threshold is such that `abs(coeff) < deadzone` implies:
-    // (abs(coeff << log_tx_scale) + ac_offset_eob) / ac_quant == 0
-    let deadzone = (self.ac_quant as usize - self.ac_offset_eob as usize)
-      .align_power_of_two_and_shift(self.log_tx_scale)
-      as i32;
-    let eob = {
-      let eob_minus_one = scan[1..]
-        .iter()
-        .rposition(|&i| i32::cast_from(coeffs[i as usize].abs()) >= deadzone);
-      // We skip the DC coefficient since it has its own quantizer index.
-      eob_minus_one.map(|n| n + 1).unwrap_or(1)
-    };
-
     qcoeffs[0] = {
       let coeff: i32 =
         i32::cast_from(coeffs[0]) << (self.log_tx_scale as usize);
@@ -270,7 +255,22 @@ impl QuantizationContext {
       ))
     };
 
-    let mut actual_eob = if qcoeffs[0] == T::cast_from(0) { 0 } else { 1 };
+    // Find the last non-zero coefficient using our smaller biases and
+    // zero everything else.
+    // This threshold is such that `abs(coeff) < deadzone` implies:
+    // (abs(coeff << log_tx_scale) + ac_offset_eob) / ac_quant == 0
+    let deadzone = (self.ac_quant as usize - self.ac_offset_eob as usize)
+      .align_power_of_two_and_shift(self.log_tx_scale)
+      as i32;
+    let eob = {
+      // We skip the DC coefficient since it has its own quantizer index.
+      let eob_minus_two = scan[1..]
+        .iter()
+        .rposition(|&i| i32::cast_from(coeffs[i as usize].abs()) >= deadzone);
+      eob_minus_two
+        .map(|n| n + 2)
+        .unwrap_or(if qcoeffs[0] == T::cast_from(0) { 0 } else { 1 })
+    };
 
     // Here we use different rounding biases depending on whether we've
     // had recent coefficients that are larger than one, or less than
@@ -283,7 +283,7 @@ impl QuantizationContext {
     // To that end, we want to bias more toward rounding to zero for
     // that tail of zeroes and ones than we do for the larger coefficients.
     let mut level_mode = 1;
-    for (i, &pos) in (1..).zip(scan[1..].iter().take(eob)) {
+    for &pos in scan.iter().take(eob).skip(1) {
       let coeff = i32::cast_from(coeffs[pos as usize]) << self.log_tx_scale;
       let level0 =
         T::cast_from(divu_pair(i32::cast_from(coeff), self.ac_mul_add));
@@ -298,10 +298,6 @@ impl QuantizationContext {
       ));
       qcoeffs[pos as usize] = qcoeff;
 
-      if qcoeff != T::cast_from(0) {
-        actual_eob = i + 1;
-      }
-
       if level_mode != 0 && qcoeff == T::cast_from(0) {
         level_mode = 0;
       } else if qcoeff > T::cast_from(1) {
@@ -309,11 +305,21 @@ impl QuantizationContext {
       }
     }
 
-    for &pos in scan.iter().skip(eob + 1) {
+    for &pos in scan.iter().skip(eob) {
       qcoeffs[pos as usize] = T::cast_from(0);
     }
 
-    actual_eob
+    // Check the eob is correct
+    debug_assert_eq!(
+      eob,
+      scan
+        .iter()
+        .rposition(|&i| qcoeffs[i as usize] != T::cast_from(0))
+        .map(|n| n + 1)
+        .unwrap_or(0)
+    );
+
+    eob
   }
 }
 


### PR DESCRIPTION
Fix a off by one error in the eob calculation. We were treating eob
as if it didn't include the dc value except for one place. When we
found no ac values below our deadzone, we would try to quantize one ac
value.

Rework quantize so that eob is related both dc and ac values. We can
now return the precalculated eob.

Add a debug_assert for the eob.