### PR TITLE
SSE2 Optimizations for sse_wxh function

### DIFF
--- a/benches/rdo.rs
+++ b/benches/rdo.rs
@@ -2,6 +2,7 @@ use criterion::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use rav1e::bench::context::{BlockOffset, PlaneBlockOffset};
+use rav1e::bench::cpu_features::CpuFeatureLevel;
 use rav1e::bench::encoder::{
   FrameInvariants, Sequence, IMPORTANCE_BLOCK_SIZE,
 };
@@ -44,6 +45,7 @@ pub fn cdef_dist_wxh_8x8(c: &mut Criterion) {
 pub fn sse_wxh_8x8(c: &mut Criterion) {
   let src1 = init_plane_u8(8, 8, 1);
   let src2 = init_plane_u8(8, 8, 2);
+  let cpu = CpuFeatureLevel::default();
 
   c.bench_function("sse_wxh_8x8", move |b| {
     b.iter(|| {
@@ -53,6 +55,7 @@ pub fn sse_wxh_8x8(c: &mut Criterion) {
         8,
         8,
         |_, _| 1.0,
+        cpu,
       )
     })
   });
@@ -61,6 +64,7 @@ pub fn sse_wxh_8x8(c: &mut Criterion) {
 pub fn sse_wxh_4x4(c: &mut Criterion) {
   let src1 = init_plane_u8(8, 8, 1);
   let src2 = init_plane_u8(8, 8, 2);
+  let cpu = CpuFeatureLevel::default();
 
   c.bench_function("sse_wxh_4x4", move |b| {
     b.iter(|| {
@@ -70,6 +74,7 @@ pub fn sse_wxh_4x4(c: &mut Criterion) {
         4,
         4,
         |_, _| 1.0,
+        cpu,
       )
     })
   });
@@ -82,6 +87,7 @@ pub fn sse_wxh_2x2(c: &mut Criterion) {
   src1.cfg.ydec = 1;
   src2.cfg.xdec = 1;
   src2.cfg.ydec = 1;
+  let cpu = CpuFeatureLevel::default();
 
   c.bench_function("sse_wxh_2x2", move |b| {
     b.iter(|| {
@@ -91,6 +97,7 @@ pub fn sse_wxh_2x2(c: &mut Criterion) {
         4,
         4,
         |_, _| 1.0,
+        cpu,
       )
     })
   });
@@ -99,6 +106,7 @@ pub fn sse_wxh_2x2(c: &mut Criterion) {
 pub fn sse_wxh_hbd_8x8(c: &mut Criterion) {
   let src1 = init_plane_u16(8, 8, 1);
   let src2 = init_plane_u16(8, 8, 2);
+  let cpu = CpuFeatureLevel::default();
 
   c.bench_function("sse_wxh_hbd_8x8", move |b| {
     b.iter(|| {
@@ -108,6 +116,7 @@ pub fn sse_wxh_hbd_8x8(c: &mut Criterion) {
         8,
         8,
         |_, _| 1.0,
+        cpu,
       )
     })
   });
@@ -116,6 +125,7 @@ pub fn sse_wxh_hbd_8x8(c: &mut Criterion) {
 pub fn sse_wxh_hbd_4x4(c: &mut Criterion) {
   let src1 = init_plane_u16(8, 8, 1);
   let src2 = init_plane_u16(8, 8, 2);
+  let cpu = CpuFeatureLevel::default();
 
   c.bench_function("sse_wxh_hbd_4x4", move |b| {
     b.iter(|| {
@@ -125,6 +135,7 @@ pub fn sse_wxh_hbd_4x4(c: &mut Criterion) {
         4,
         4,
         |_, _| 1.0,
+        cpu,
       )
     })
   });
@@ -137,6 +148,7 @@ pub fn sse_wxh_hbd_2x2(c: &mut Criterion) {
   src1.cfg.ydec = 1;
   src2.cfg.xdec = 1;
   src2.cfg.ydec = 1;
+  let cpu = CpuFeatureLevel::default();
 
   c.bench_function("sse_wxh_hbd_2x2", move |b| {
     b.iter(|| {
@@ -146,6 +158,7 @@ pub fn sse_wxh_hbd_2x2(c: &mut Criterion) {
         4,
         4,
         |_, _| 1.0,
+        cpu,
       )
     })
   });

--- a/benches/rdo.rs
+++ b/benches/rdo.rs
@@ -17,6 +17,12 @@ fn init_plane_u8(width: usize, height: usize, seed: u8) -> Plane<u8> {
   Plane::wrap(data, width)
 }
 
+fn init_plane_u16(width: usize, height: usize, seed: u8) -> Plane<u16> {
+  let mut ra = ChaChaRng::from_seed([seed; 32]);
+  let data: Vec<u16> = (0..(width * height)).map(|_| ra.gen()).collect();
+  Plane::wrap(data, width)
+}
+
 pub fn cdef_dist_wxh_8x8(c: &mut Criterion) {
   let src1 = init_plane_u8(8, 8, 1);
   let src2 = init_plane_u8(8, 8, 2);
@@ -78,6 +84,61 @@ pub fn sse_wxh_2x2(c: &mut Criterion) {
   src2.cfg.ydec = 1;
 
   c.bench_function("sse_wxh_2x2", move |b| {
+    b.iter(|| {
+      rdo::sse_wxh(
+        &src1.region(Area::Rect { x: 0, y: 0, width: 4, height: 4 }),
+        &src2.region(Area::Rect { x: 0, y: 0, width: 4, height: 4 }),
+        4,
+        4,
+        |_, _| 1.0,
+      )
+    })
+  });
+}
+
+pub fn sse_wxh_hbd_8x8(c: &mut Criterion) {
+  let src1 = init_plane_u16(8, 8, 1);
+  let src2 = init_plane_u16(8, 8, 2);
+
+  c.bench_function("sse_wxh_hbd_8x8", move |b| {
+    b.iter(|| {
+      rdo::sse_wxh(
+        &src1.region(Area::Rect { x: 0, y: 0, width: 8, height: 8 }),
+        &src2.region(Area::Rect { x: 0, y: 0, width: 8, height: 8 }),
+        8,
+        8,
+        |_, _| 1.0,
+      )
+    })
+  });
+}
+
+pub fn sse_wxh_hbd_4x4(c: &mut Criterion) {
+  let src1 = init_plane_u16(8, 8, 1);
+  let src2 = init_plane_u16(8, 8, 2);
+
+  c.bench_function("sse_wxh_hbd_4z4", move |b| {
+    b.iter(|| {
+      rdo::sse_wxh(
+        &src1.region(Area::Rect { x: 0, y: 0, width: 4, height: 4 }),
+        &src2.region(Area::Rect { x: 0, y: 0, width: 4, height: 4 }),
+        4,
+        4,
+        |_, _| 1.0,
+      )
+    })
+  });
+}
+
+pub fn sse_wxh_hbd_2x2(c: &mut Criterion) {
+  let mut src1 = init_plane_u16(8, 8, 1);
+  let mut src2 = init_plane_u16(8, 8, 2);
+  src1.cfg.xdec = 1;
+  src1.cfg.ydec = 1;
+  src2.cfg.xdec = 1;
+  src2.cfg.ydec = 1;
+
+  c.bench_function("sse_wxh_hbd_2x2", move |b| {
     b.iter(|| {
       rdo::sse_wxh(
         &src1.region(Area::Rect { x: 0, y: 0, width: 4, height: 4 }),
@@ -154,6 +215,9 @@ criterion_group!(
   sse_wxh_8x8,
   sse_wxh_4x4,
   sse_wxh_2x2,
+  sse_wxh_hbd_8x8,
+  sse_wxh_hbd_4x4,
+  sse_wxh_hbd_2x2,
   compute_distortion_scale_8x8,
   compute_distortion_scale_64x64
 );

--- a/benches/rdo.rs
+++ b/benches/rdo.rs
@@ -62,7 +62,7 @@ pub fn sse_wxh_4x4(c: &mut Criterion) {
   let src1 = init_plane_u8(8, 8, 1);
   let src2 = init_plane_u8(8, 8, 2);
 
-  c.bench_function("sse_wxh_4z4", move |b| {
+  c.bench_function("sse_wxh_4x4", move |b| {
     b.iter(|| {
       rdo::sse_wxh(
         &src1.region(Area::Rect { x: 0, y: 0, width: 4, height: 4 }),
@@ -117,7 +117,7 @@ pub fn sse_wxh_hbd_4x4(c: &mut Criterion) {
   let src1 = init_plane_u16(8, 8, 1);
   let src2 = init_plane_u16(8, 8, 2);
 
-  c.bench_function("sse_wxh_hbd_4z4", move |b| {
+  c.bench_function("sse_wxh_hbd_4x4", move |b| {
     b.iter(|| {
       rdo::sse_wxh(
         &src1.region(Area::Rect { x: 0, y: 0, width: 4, height: 4 }),

--- a/src/asm/x86/mod.rs
+++ b/src/asm/x86/mod.rs
@@ -13,4 +13,5 @@ pub mod ec;
 pub mod lrf;
 pub mod mc;
 pub mod predict;
+pub mod rdo;
 pub mod transform;

--- a/src/asm/x86/rdo.rs
+++ b/src/asm/x86/rdo.rs
@@ -1,0 +1,71 @@
+use crate::partition::BlockSize;
+use crate::rdo::{Distortion, RawDistortion};
+use crate::tiling::{Area, PlaneRegion};
+use crate::util::AlignedArray;
+use crate::{CastFromPrimitive, Pixel};
+use std::arch::x86_64::*;
+
+#[target_feature(enable = "sse2")]
+pub(crate) unsafe fn sse_wxh_8x8_sse2<
+  T: Pixel,
+  F: Fn(Area, BlockSize) -> f64,
+>(
+  src1: &PlaneRegion<'_, T>, src2: &PlaneRegion<'_, T>, w: usize, h: usize,
+  compute_bias: F,
+) -> Distortion {
+  let block_h = 8;
+  let block_w = 8;
+
+  let mut sse = Distortion::zero();
+  for block_y in 0..h / block_h {
+    let y_offset = block_y * block_h;
+
+    for block_x in 0..w / block_w {
+      let x_offset = block_x * block_w;
+
+      let mut value = 0;
+      for j in 0..block_h {
+        let src1_ptr = src1[y_offset + j].as_ptr().add(x_offset);
+        let src2_ptr = src2[y_offset + j].as_ptr().add(x_offset);
+
+        let s1 = _mm_set_epi16(
+          i16::cast_from(*src1_ptr.add(7)),
+          i16::cast_from(*src1_ptr.add(6)),
+          i16::cast_from(*src1_ptr.add(5)),
+          i16::cast_from(*src1_ptr.add(4)),
+          i16::cast_from(*src1_ptr.add(3)),
+          i16::cast_from(*src1_ptr.add(2)),
+          i16::cast_from(*src1_ptr.add(1)),
+          i16::cast_from(*src1_ptr.add(0)),
+        );
+        let s2 = _mm_set_epi16(
+          i16::cast_from(*src2_ptr.add(7)),
+          i16::cast_from(*src2_ptr.add(6)),
+          i16::cast_from(*src2_ptr.add(5)),
+          i16::cast_from(*src2_ptr.add(4)),
+          i16::cast_from(*src2_ptr.add(3)),
+          i16::cast_from(*src2_ptr.add(2)),
+          i16::cast_from(*src2_ptr.add(1)),
+          i16::cast_from(*src2_ptr.add(0)),
+        );
+
+        let mut results: AlignedArray<[i32; 4]> =
+          AlignedArray::uninitialized();
+        let diffs = _mm_sub_epi16(s1, s2);
+        let squares = _mm_madd_epi16(diffs, diffs);
+        _mm_store_si128(results.array.as_mut_ptr() as *mut _, squares);
+
+        value +=
+          results.array.iter().copied().map(|val| val as u64).sum::<u64>();
+      }
+
+      let bias = compute_bias(
+        // StartingAt gives the correct block offset.
+        Area::StartingAt { x: x_offset as isize, y: y_offset as isize },
+        BlockSize::BLOCK_8X8,
+      );
+      sse += RawDistortion::new(value) * bias;
+    }
+  }
+  sse
+}


### PR DESCRIPTION
We can use SSE2 to optimize 8x8 block sse_wxh computations,
for both low-bit-depth and high-bit-depth.

This commit also includes minor improvements
to the native version of the function
to reduce redundant computations.

Microbenchmarks show a 60-65% improvement for 8x8 block sizes,
and a 3-25% improvement for smaller block sizes.

<img width="600" alt="Image 2020-01-02 at 3 17 39 PM" src="https://user-images.githubusercontent.com/5951392/71690932-103b4f00-2d74-11ea-920f-c0666e51a648.png">
