### PR TITLE
quantize: initially zero coefficients

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1197,8 +1197,8 @@ pub fn encode_tx_block<T: Pixel>(
     AlignedArray::uninitialized();
   let mut coeffs_storage: AlignedArray<[T::Coeff; 64 * 64]> =
     AlignedArray::uninitialized();
-  let mut qcoeffs_storage: AlignedArray<[T::Coeff; 32 * 32]> =
-    AlignedArray::uninitialized();
+  let mut qcoeffs_storage =
+    AlignedArray::new([T::Coeff::cast_from(0); 32 * 32]);
   let mut rcoeffs_storage: AlignedArray<[T::Coeff; 32 * 32]> =
     AlignedArray::uninitialized();
   let residual = &mut residual_storage.array[..tx_size.area()];

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -306,9 +306,8 @@ impl QuantizationContext {
       qcoeffs[pos as usize] = T::cast_from(copysign(abs_qcoeff, coeff));
     }
 
-    for &pos in scan.iter().skip(eob) {
-      qcoeffs[pos as usize] = T::cast_from(0);
-    }
+    // Rather than zeroing the tail in scan order, assume that qcoeffs is
+    // pre-filled with zeros.
 
     // Check the eob is correct
     debug_assert_eq!(


### PR DESCRIPTION
Effectively replaces a hot branchy loop with memset.
Reduces encoding time by 1.8% to 5% at default speed preset.