### PR TITLE
Do not zip rav1e.exe

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/p')
       run: |
         cd rav1e-binaries
-        zip -r rav1e-windows.zip rav1e.exe $FILENAME
+        zip -r rav1e-windows.zip $FILENAME
     - name: Package release binaries
       if: startsWith(github.ref, 'refs/tags/v')
       id: data
@@ -81,7 +81,7 @@ jobs:
         VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
         echo "::set-output name=version::$VERSION"
         cd rav1e-binaries
-        zip -r rav1e-$VERSION-windows.zip rav1e.exe $FILENAME
+        zip -r rav1e-$VERSION-windows.zip $FILENAME
     - name: Create a pre-release
       if: startsWith(github.ref, 'refs/tags/p')
       uses: softprops/action-gh-release@v1
@@ -91,6 +91,7 @@ jobs:
         files: |
           Cargo.lock
           rav1e-binaries/rav1e-windows.zip
+          rav1e-binaries/rav1e.exe
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Create a release
@@ -101,5 +102,6 @@ jobs:
         files: |
           Cargo.lock
           rav1e-binaries/rav1e-${{ steps.data.outputs.version }}-windows.zip
+          rav1e-binaries/rav1e.exe
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In the latest releases, `rav1e.exe` is always placed outside the `Windows` zip file, so let's make this process automatized