### PR TITLE
Add angle delta for H_PRED and V_PRED

### DIFF
--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -141,6 +141,11 @@ pub fn intra_bench<T: Pixel>(
     PixelType::U8 => 8,
     PixelType::U16 => 10,
   };
+  let angle = match mode {
+    PredictionMode::H_PRED => 180,
+    PredictionMode::V_PRED => 90,
+    _ => 0,
+  };
   b.iter(|| {
     dispatch_predict_intra::<T>(
       mode,
@@ -149,7 +154,7 @@ pub fn intra_bench<T: Pixel>(
       TxSize::TX_4X4,
       bitdepth,
       &ac,
-      0,
+      angle,
       &edge_buf,
       cpu,
     );

--- a/src/asm/aarch64/predict.rs
+++ b/src/asm/aarch64/predict.rs
@@ -109,10 +109,10 @@ pub fn dispatch_predict_intra<T: Pixel>(
             PredictionVariant::BOTH => rav1e_ipred_cfl_neon,
           })(dst_ptr, stride, edge_ptr, w, h, ac_ptr, angle);
         }
-        PredictionMode::H_PRED => {
+        PredictionMode::H_PRED if angle == 180 => {
           rav1e_ipred_h_neon(dst_ptr, stride, edge_ptr, w, h, angle);
         }
-        PredictionMode::V_PRED => {
+        PredictionMode::V_PRED if angle == 90 => {
           rav1e_ipred_v_neon(dst_ptr, stride, edge_ptr, w, h, angle);
         }
         PredictionMode::PAETH_PRED => {

--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -126,10 +126,10 @@ pub fn dispatch_predict_intra<T: Pixel>(
             PredictionVariant::BOTH => rav1e_ipred_cfl_avx2,
           })(dst_ptr, stride, edge_ptr, w, h, ac_ptr, angle);
         }
-        PredictionMode::H_PRED => {
+        PredictionMode::H_PRED if angle == 180 => {
           rav1e_ipred_h_avx2(dst_ptr, stride, edge_ptr, w, h, angle);
         }
-        PredictionMode::V_PRED => {
+        PredictionMode::V_PRED if angle == 90 => {
           rav1e_ipred_v_avx2(dst_ptr, stride, edge_ptr, w, h, angle);
         }
         PredictionMode::PAETH_PRED => {
@@ -144,7 +144,9 @@ pub fn dispatch_predict_intra<T: Pixel>(
         PredictionMode::SMOOTH_V_PRED => {
           rav1e_ipred_smooth_v_avx2(dst_ptr, stride, edge_ptr, w, h, angle);
         }
-        PredictionMode::D45_PRED
+        PredictionMode::H_PRED
+        | PredictionMode::V_PRED
+        | PredictionMode::D45_PRED
         | PredictionMode::D63_PRED
         | PredictionMode::D117_PRED
         | PredictionMode::D135_PRED
@@ -179,10 +181,10 @@ pub fn dispatch_predict_intra<T: Pixel>(
             PredictionVariant::BOTH => rav1e_ipred_cfl_ssse3,
           })(dst_ptr, stride, edge_ptr, w, h, ac_ptr, angle);
         }
-        PredictionMode::H_PRED => {
+        PredictionMode::H_PRED if angle == 180 => {
           rav1e_ipred_h_ssse3(dst_ptr, stride, edge_ptr, w, h, angle);
         }
-        PredictionMode::V_PRED => {
+        PredictionMode::V_PRED if angle == 90 => {
           rav1e_ipred_v_ssse3(dst_ptr, stride, edge_ptr, w, h, angle);
         }
         PredictionMode::PAETH_PRED => {
@@ -245,20 +247,21 @@ mod test {
       let angles = match mode {
         PredictionMode::D45_PRED => [
           3, 6, 9, 14, 17, 20, 23, 26, 29, 32, 36, 39, 42, 45, 48, 51, 54, 58,
-          61, 64, 67, 70, 73, 76, 81, 84, 87,
+          61, 64, 67, 70, 73, 76,
         ]
         .iter(),
         PredictionMode::D135_PRED => [
-          93, 96, 99, 104, 107, 110, 113, 116, 119, 122, 126, 129, 132, 135,
-          138, 141, 144, 148, 151, 154, 157, 160, 163, 166, 171, 174, 177,
+          104, 107, 110, 113, 116, 119, 122, 126, 129, 132, 135, 138, 141,
+          144, 148, 151, 154, 157, 160, 163, 166,
         ]
         .iter(),
         PredictionMode::D207_PRED => [
-          183, 186, 189, 194, 197, 200, 203, 206, 209, 212, 216, 219, 222,
-          225, 228, 231, 234, 238, 241, 244, 247, 250, 253, 256, 261, 264,
-          267,
+          194, 197, 200, 203, 206, 209, 212, 216, 219, 222, 225, 228, 231,
+          234, 238, 241, 244, 247, 250, 253, 256, 261, 264, 267,
         ]
         .iter(),
+        PredictionMode::H_PRED => [171, 174, 177, 180, 183, 186, 189].iter(),
+        PredictionMode::V_PRED => [81, 84, 87, 90, 93, 96, 99].iter(),
         _ => [0].iter(),
       };
       for angle in angles {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -556,18 +556,21 @@ pub fn get_intra_edges<T: Pixel>(
       let dc_or_cfl =
         mode == PredictionMode::DC_PRED || mode == PredictionMode::UV_CFL_PRED;
 
-      needs_left = mode != PredictionMode::V_PRED
-        && (!dc_or_cfl || x != 0)
+      needs_left = (!dc_or_cfl || x != 0)
         && !(mode == PredictionMode::D45_PRED
           || mode == PredictionMode::D63_PRED);
       needs_topleft = mode == PredictionMode::PAETH_PRED
+        || mode == PredictionMode::H_PRED
+        || mode == PredictionMode::V_PRED
         || mode == PredictionMode::D117_PRED
         || mode == PredictionMode::D135_PRED
         || mode == PredictionMode::D153_PRED;
-      needs_top = mode != PredictionMode::H_PRED && (!dc_or_cfl || y != 0);
-      needs_topright =
-        mode == PredictionMode::D45_PRED || mode == PredictionMode::D63_PRED;
-      needs_bottomleft = mode == PredictionMode::D207_PRED;
+      needs_top = !dc_or_cfl || y != 0;
+      needs_topright = mode == PredictionMode::V_PRED
+        || mode == PredictionMode::D45_PRED
+        || mode == PredictionMode::D63_PRED;
+      needs_bottomleft =
+        mode == PredictionMode::H_PRED || mode == PredictionMode::D207_PRED;
     }
 
     // Needs left

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -155,6 +155,8 @@ impl PredictionMode {
 
     let angle = match mode {
       PredictionMode::UV_CFL_PRED => alpha as isize,
+      PredictionMode::H_PRED => 180,
+      PredictionMode::V_PRED => 90,
       PredictionMode::D45_PRED => 45,
       PredictionMode::D135_PRED => 135,
       PredictionMode::D117_PRED => 113,
@@ -184,8 +186,9 @@ impl PredictionMode {
   #[inline(always)]
   pub fn angle_delta_count(self) -> i8 {
     match self {
-      // TODO add H_PRED and V_PRED after implement angle delta for pred_h and pred_v
-      PredictionMode::D45_PRED
+      PredictionMode::H_PRED
+      | PredictionMode::V_PRED
+      | PredictionMode::D45_PRED
       | PredictionMode::D135_PRED
       | PredictionMode::D117_PRED
       | PredictionMode::D153_PRED
@@ -473,8 +476,12 @@ pub(crate) mod native {
         height,
         bit_depth,
       ),
-      PredictionMode::H_PRED => pred_h(dst, left_slice, width, height),
-      PredictionMode::V_PRED => pred_v(dst, above_slice, width, height),
+      PredictionMode::H_PRED if angle == 180 => {
+        pred_h(dst, left_slice, width, height)
+      }
+      PredictionMode::V_PRED if angle == 90 => {
+        pred_v(dst, above_slice, width, height)
+      }
       PredictionMode::PAETH_PRED => {
         pred_paeth(dst, above_slice, left_slice, top_left[0], width, height)
       }
@@ -487,7 +494,9 @@ pub(crate) mod native {
       PredictionMode::SMOOTH_V_PRED => {
         pred_smooth_v(dst, above_slice, left_slice, width, height)
       }
-      PredictionMode::D45_PRED
+      PredictionMode::H_PRED
+      | PredictionMode::V_PRED
+      | PredictionMode::D45_PRED
       | PredictionMode::D135_PRED
       | PredictionMode::D117_PRED
       | PredictionMode::D153_PRED


### PR DESCRIPTION
Support angle delta for H_PRED and V_PRED, which was not supported in #2009.
The full set of directions is supported as #1721.