### PR TITLE
Fix bug in angle delta with UV_CFL_PRED

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -803,6 +803,7 @@ pub fn rdo_mode_decision<T: Pixel>(
     let chroma_mode = PredictionMode::UV_CFL_PRED;
     let cw_checkpoint = cw.checkpoint();
     let wr: &mut dyn Writer = &mut WriterCounter::new();
+    let angle_delta = AngleDelta { y: best.angle_delta.y, uv: 0 };
 
     write_tx_blocks(
       fi,
@@ -811,7 +812,7 @@ pub fn rdo_mode_decision<T: Pixel>(
       wr,
       best.pred_mode_luma,
       best.pred_mode_luma,
-      best.angle_delta,
+      angle_delta,
       tile_bo,
       bsize,
       best.tx_size,
@@ -849,7 +850,7 @@ pub fn rdo_mode_decision<T: Pixel>(
         wr,
         best.pred_mode_luma,
         chroma_mode,
-        best.angle_delta,
+        angle_delta,
         best.ref_frames,
         best.mvs,
         bsize,
@@ -874,6 +875,7 @@ pub fn rdo_mode_decision<T: Pixel>(
       if rd < best.rd_cost {
         best.rd_cost = rd;
         best.pred_mode_chroma = chroma_mode;
+        best.angle_delta = angle_delta;
         best.has_coeff = has_coeff;
         best.pred_cfl_params = cfl;
       }


### PR DESCRIPTION
Fix bug found in #2021.
best.angle_delta.uv was happened to be non-zero which should be zero for PredictionMode::UV_CFL_PRED.