### PR TITLE
Make sure --tune Psnr doesn't use cdef_dist

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1806,7 +1806,7 @@ fn rdo_loop_plane_error<T: Pixel>(
           ts.to_frame_block_offset(bo),
           BlockSize::BLOCK_8X8,
         );
-        err += if pli == 0 {
+        err += if pli == 0 && fi.config.tune == Tune::Psychovisual {
           cdef_dist_wxh_8x8(&in_region, &test_region, fi.sequence.bit_depth)
             * bias
         } else {


### PR DESCRIPTION
Results on objective-1-fast with --tune Psnr:

```
   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000
-0.0174 |  0.2795 |  0.0697 |   0.1647 | 0.7486 |  0.5762 |    -0.0329
```