### PR TITLE
Revert angle dir intrapred

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -107,7 +107,6 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
               qindex as u8,
               ac,
               0,
-              0,
               RDOType::PixelDistRealRate,
               true,
             );

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -87,7 +87,6 @@ pub(crate) fn estimate_intra_costs<T: Pixel>(
         bit_depth,
         &[], // Not used by DC_PRED.
         0,   // Not used by DC_PRED.
-        0,   // Not used by DC_PRED.
         &edge_buf,
         cpu_feature_level,
       );

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -22,7 +22,7 @@ use crate::me::*;
 use crate::partition::PartitionType::*;
 use crate::partition::RefType::*;
 use crate::partition::*;
-use crate::predict::{AngleDelta, PredictionMode};
+use crate::predict::PredictionMode;
 use crate::quantize::*;
 use crate::rate::bexp64;
 use crate::rate::q57;
@@ -1142,7 +1142,6 @@ pub fn encode_tx_block<T: Pixel>(
   skip: bool,
   qidx: u8,
   ac: &[i16],
-  angle_delta: i8,
   alpha: i16,
   rdo_type: RDOType,
   need_recon_pixel: bool,
@@ -1181,7 +1180,6 @@ pub fn encode_tx_block<T: Pixel>(
       tx_size,
       bit_depth,
       &ac,
-      angle_delta,
       alpha,
       &edge_buf,
       fi.cpu_feature_level,
@@ -1546,11 +1544,11 @@ pub fn encode_block_pre_cdef<T: Pixel>(
 pub fn encode_block_post_cdef<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, w: &mut dyn Writer, luma_mode: PredictionMode,
-  chroma_mode: PredictionMode, angle_delta: AngleDelta,
-  ref_frames: [RefType; 2], mvs: [MotionVector; 2], bsize: BlockSize,
-  tile_bo: TileBlockOffset, skip: bool, cfl: CFLParams, tx_size: TxSize,
-  tx_type: TxType, mode_context: usize, mv_stack: &[CandidateMV],
-  rdo_type: RDOType, need_recon_pixel: bool, record_stats: bool,
+  chroma_mode: PredictionMode, ref_frames: [RefType; 2],
+  mvs: [MotionVector; 2], bsize: BlockSize, tile_bo: TileBlockOffset,
+  skip: bool, cfl: CFLParams, tx_size: TxSize, tx_type: TxType,
+  mode_context: usize, mv_stack: &[CandidateMV], rdo_type: RDOType,
+  need_recon_pixel: bool, record_stats: bool,
 ) -> (bool, ScaledDistortion) {
   let is_inter = !luma_mode.is_intra();
   if is_inter {
@@ -1689,7 +1687,7 @@ pub fn encode_block_post_cdef<T: Pixel>(
 
   if !is_inter {
     if luma_mode.is_directional() && bsize >= BlockSize::BLOCK_8X8 {
-      cw.write_angle_delta(w, angle_delta.y, luma_mode);
+      cw.write_angle_delta(w, 0, luma_mode);
     }
     if has_chroma(tile_bo, bsize, xdec, ydec) {
       cw.write_intra_uv_mode(w, chroma_mode, luma_mode, bsize);
@@ -1698,7 +1696,7 @@ pub fn encode_block_post_cdef<T: Pixel>(
         cw.write_cfl_alphas(w, cfl);
       }
       if chroma_mode.is_directional() && bsize >= BlockSize::BLOCK_8X8 {
-        cw.write_angle_delta(w, angle_delta.uv, chroma_mode);
+        cw.write_angle_delta(w, 0, chroma_mode);
       }
     }
     // TODO: Extra condition related to palette mode, see `read_filter_intra_mode_info` in decodemv.c
@@ -1748,7 +1746,6 @@ pub fn encode_block_post_cdef<T: Pixel>(
       cw,
       w,
       luma_mode,
-      angle_delta.y,
       tile_bo,
       bsize,
       tx_size,
@@ -1766,7 +1763,6 @@ pub fn encode_block_post_cdef<T: Pixel>(
       w,
       luma_mode,
       chroma_mode,
-      angle_delta,
       tile_bo,
       bsize,
       tx_size,
@@ -1826,10 +1822,9 @@ pub fn luma_ac<T: Pixel>(
 pub fn write_tx_blocks<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, w: &mut dyn Writer, luma_mode: PredictionMode,
-  chroma_mode: PredictionMode, angle_delta: AngleDelta,
-  tile_bo: TileBlockOffset, bsize: BlockSize, tx_size: TxSize,
-  tx_type: TxType, skip: bool, cfl: CFLParams, luma_only: bool,
-  rdo_type: RDOType, need_recon_pixel: bool,
+  chroma_mode: PredictionMode, tile_bo: TileBlockOffset, bsize: BlockSize,
+  tx_size: TxSize, tx_type: TxType, skip: bool, cfl: CFLParams,
+  luma_only: bool, rdo_type: RDOType, need_recon_pixel: bool,
 ) -> (bool, ScaledDistortion) {
   let bw = bsize.width_mi() / tx_size.width_mi();
   let bh = bsize.height_mi() / tx_size.height_mi();
@@ -1877,7 +1872,6 @@ pub fn write_tx_blocks<T: Pixel>(
         skip,
         qidx,
         &ac.array,
-        angle_delta.y,
         0,
         rdo_type,
         need_recon_pixel,
@@ -1962,7 +1956,6 @@ pub fn write_tx_blocks<T: Pixel>(
             skip,
             qidx,
             &ac.array,
-            angle_delta.uv,
             alpha,
             rdo_type,
             need_recon_pixel,
@@ -1982,9 +1975,9 @@ pub fn write_tx_blocks<T: Pixel>(
 pub fn write_tx_tree<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, w: &mut dyn Writer, luma_mode: PredictionMode,
-  angle_delta_y: i8, tile_bo: TileBlockOffset, bsize: BlockSize,
-  tx_size: TxSize, tx_type: TxType, skip: bool, luma_only: bool,
-  rdo_type: RDOType, need_recon_pixel: bool,
+  tile_bo: TileBlockOffset, bsize: BlockSize, tx_size: TxSize,
+  tx_type: TxType, skip: bool, luma_only: bool, rdo_type: RDOType,
+  need_recon_pixel: bool,
 ) -> (bool, ScaledDistortion) {
   if skip {
     return (false, ScaledDistortion::zero());
@@ -2025,7 +2018,6 @@ pub fn write_tx_tree<T: Pixel>(
     skip,
     qidx,
     ac,
-    angle_delta_y,
     0,
     rdo_type,
     need_recon_pixel,
@@ -2100,7 +2092,6 @@ pub fn write_tx_tree<T: Pixel>(
             skip,
             qidx,
             ac,
-            angle_delta_y,
             0,
             rdo_type,
             need_recon_pixel,
@@ -2158,7 +2149,6 @@ pub fn encode_block_with_modes<T: Pixel>(
     if cdef_coded { w_post_cdef } else { w_pre_cdef },
     mode_luma,
     mode_chroma,
-    mode_decision.angle_delta,
     ref_frames,
     mvs,
     bsize,
@@ -2715,7 +2705,6 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
         if cdef_coded { w_post_cdef } else { w_pre_cdef },
         mode_luma,
         mode_chroma,
-        part_decision.angle_delta,
         ref_frames,
         mvs,
         bsize,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -28,8 +28,8 @@ use crate::motion_compensate;
 use crate::partition::RefType::*;
 use crate::partition::*;
 use crate::predict::{
-  AngleDelta, PredictionMode, RAV1E_INTER_COMPOUND_MODES,
-  RAV1E_INTER_MODES_MINIMAL, RAV1E_INTRA_MODES,
+  PredictionMode, RAV1E_INTER_COMPOUND_MODES, RAV1E_INTER_MODES_MINIMAL,
+  RAV1E_INTRA_MODES,
 };
 use crate::rdo_tables::*;
 use crate::tiling::*;
@@ -89,7 +89,6 @@ pub struct PartitionParameters {
   pub pred_mode_luma: PredictionMode,
   pub pred_mode_chroma: PredictionMode,
   pub pred_cfl_params: CFLParams,
-  pub angle_delta: AngleDelta,
   pub ref_frames: [RefType; 2],
   pub mvs: [MotionVector; 2],
   pub skip: bool,
@@ -108,7 +107,6 @@ impl Default for PartitionParameters {
       pred_mode_luma: PredictionMode::default(),
       pred_mode_chroma: PredictionMode::default(),
       pred_cfl_params: CFLParams::default(),
-      angle_delta: AngleDelta::default(),
       ref_frames: [RefType::INTRA_FRAME, RefType::NONE_FRAME],
       mvs: [MotionVector::default(); 2],
       skip: false,
@@ -629,7 +627,6 @@ fn luma_chroma_mode_rdo<T: Pixel>(
   mvs: [MotionVector; 2], ref_frames: [RefType; 2],
   mode_set_chroma: &[PredictionMode], luma_mode_is_intra: bool,
   mode_context: usize, mv_stack: &ArrayVec<[CandidateMV; 9]>,
-  angle_delta: AngleDelta,
 ) {
   let PlaneConfig { xdec, ydec, .. } = ts.input.planes[1].cfg;
 
@@ -682,7 +679,6 @@ fn luma_chroma_mode_rdo<T: Pixel>(
           wr,
           luma_mode,
           chroma_mode,
-          angle_delta,
           ref_frames,
           mvs,
           bsize,
@@ -720,7 +716,6 @@ fn luma_chroma_mode_rdo<T: Pixel>(
           best.rd_cost = rd;
           best.pred_mode_luma = luma_mode;
           best.pred_mode_chroma = chroma_mode;
-          best.angle_delta = angle_delta;
           best.ref_frames = ref_frames;
           best.mvs = mvs;
           best.skip = skip;
@@ -811,7 +806,6 @@ pub fn rdo_mode_decision<T: Pixel>(
       wr,
       best.pred_mode_luma,
       best.pred_mode_luma,
-      best.angle_delta,
       tile_bo,
       bsize,
       best.tx_size,
@@ -849,7 +843,6 @@ pub fn rdo_mode_decision<T: Pixel>(
         wr,
         best.pred_mode_luma,
         chroma_mode,
-        best.angle_delta,
         best.ref_frames,
         best.mvs,
         bsize,
@@ -894,7 +887,6 @@ pub fn rdo_mode_decision<T: Pixel>(
     pred_mode_luma: best.pred_mode_luma,
     pred_mode_chroma: best.pred_mode_chroma,
     pred_cfl_params: best.pred_cfl_params,
-    angle_delta: best.angle_delta,
     ref_frames: best.ref_frames,
     mvs: best.mvs,
     rd_cost: best.rd_cost,
@@ -1104,7 +1096,6 @@ fn inter_frame_rdo_mode_decision<T: Pixel>(
       false,
       mode_contexts[i],
       &mv_stacks[i],
-      AngleDelta::default(),
     );
   });
 
@@ -1171,7 +1162,6 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
             tx_size,
             fi.sequence.bit_depth,
             &[0i16; 2],
-            0,
             0,
             &edge_buf,
             fi.cpu_feature_level,
@@ -1260,55 +1250,8 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
       true,
       0,
       &ArrayVec::<[CandidateMV; 9]>::new(),
-      AngleDelta::default(),
     );
   });
-
-  // Find the best angle delta for the current best prediction mode
-  let luma_angle_delta_count = best.pred_mode_luma.angle_delta_count();
-  let chroma_angle_delta_count = best.pred_mode_chroma.angle_delta_count();
-
-  'luma_loop: for i in 0..luma_angle_delta_count {
-    for j in 0..chroma_angle_delta_count {
-      let mvs = [MotionVector::default(); 2];
-      let ref_frames = [INTRA_FRAME, NONE_FRAME];
-      let mut mode_set_chroma = ArrayVec::<[_; 2]>::new();
-      mode_set_chroma.push(best.pred_mode_chroma);
-
-      let angle_delta_y: i8 = if luma_angle_delta_count == 1 {
-        0
-      } else {
-        i - MAX_ANGLE_DELTA as i8
-      };
-      let angle_delta_uv: i8 = if chroma_angle_delta_count == 1 {
-        0
-      } else {
-        j - MAX_ANGLE_DELTA as i8
-      };
-      if luma_angle_delta_count == 1 && chroma_angle_delta_count == 1 {
-        break 'luma_loop;
-      }
-
-      luma_chroma_mode_rdo(
-        best.pred_mode_luma,
-        fi,
-        bsize,
-        tile_bo,
-        ts,
-        cw,
-        rdo_type,
-        &cw_checkpoint,
-        &mut best,
-        mvs,
-        ref_frames,
-        &mode_set_chroma,
-        true,
-        0,
-        &ArrayVec::<[CandidateMV; 9]>::new(),
-        AngleDelta { y: angle_delta_y, uv: angle_delta_uv },
-      );
-    }
-  }
 
   best
 }
@@ -1350,7 +1293,6 @@ pub fn rdo_cfl_alpha<T: Pixel>(
           uv_tx_size,
           bit_depth,
           &ac.array,
-          0,
           alpha,
           &edge_buf,
           cpu,
@@ -1436,7 +1378,6 @@ pub fn rdo_tx_type_decision<T: Pixel>(
         cw,
         wr,
         mode,
-        0,
         tile_bo,
         bsize,
         tx_size,
@@ -1454,7 +1395,6 @@ pub fn rdo_tx_type_decision<T: Pixel>(
         wr,
         mode,
         mode,
-        AngleDelta::default(),
         tile_bo,
         bsize,
         tx_size,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -803,7 +803,6 @@ pub fn rdo_mode_decision<T: Pixel>(
     let chroma_mode = PredictionMode::UV_CFL_PRED;
     let cw_checkpoint = cw.checkpoint();
     let wr: &mut dyn Writer = &mut WriterCounter::new();
-    let angle_delta = AngleDelta { y: best.angle_delta.y, uv: 0 };
 
     write_tx_blocks(
       fi,
@@ -812,7 +811,7 @@ pub fn rdo_mode_decision<T: Pixel>(
       wr,
       best.pred_mode_luma,
       best.pred_mode_luma,
-      angle_delta,
+      best.angle_delta,
       tile_bo,
       bsize,
       best.tx_size,
@@ -850,7 +849,7 @@ pub fn rdo_mode_decision<T: Pixel>(
         wr,
         best.pred_mode_luma,
         chroma_mode,
-        angle_delta,
+        best.angle_delta,
         best.ref_frames,
         best.mvs,
         bsize,
@@ -875,7 +874,6 @@ pub fn rdo_mode_decision<T: Pixel>(
       if rd < best.rd_cost {
         best.rd_cost = rd;
         best.pred_mode_chroma = chroma_mode;
-        best.angle_delta = angle_delta;
         best.has_coeff = has_coeff;
         best.pred_cfl_params = cfl;
       }


### PR DESCRIPTION
Because enabling this new coding modes, i.e. encode fine angle of directional intra prediction, causes desync at speed 0,1,2, revert the related commits.