### PR TITLE
Use flat arrays in stats collection.

### DIFF
--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -179,7 +179,7 @@ impl ProgressInfo {
       .frame_info
       .iter()
       .filter(|frame| frame.frame_type == frame_type)
-      .map(|frame| frame.enc_stats.block_size_counts.values().sum::<usize>())
+      .map(|frame| frame.enc_stats.block_size_counts.iter().sum::<usize>())
       .sum()
   }
 
@@ -188,7 +188,7 @@ impl ProgressInfo {
       .frame_info
       .iter()
       .filter(|frame| frame.frame_type == frame_type)
-      .map(|frame| frame.enc_stats.tx_type_counts.values().sum::<usize>())
+      .map(|frame| frame.enc_stats.tx_type_counts.iter().sum::<usize>())
       .sum()
   }
 
@@ -203,9 +203,7 @@ impl ProgressInfo {
       .frame_info
       .iter()
       .filter(|frame| frame.frame_type == frame_type)
-      .map(|frame| {
-        frame.enc_stats.block_size_counts.get(&bsize).copied().unwrap_or(0)
-      })
+      .map(|frame| frame.enc_stats.block_size_counts[bsize as usize])
       .sum::<usize>() as f32
       / count as f32
       * 100.
@@ -237,9 +235,7 @@ impl ProgressInfo {
       .frame_info
       .iter()
       .filter(|frame| frame.frame_type == frame_type)
-      .map(|frame| {
-        frame.enc_stats.tx_type_counts.get(&txtype).copied().unwrap_or(0)
-      })
+      .map(|frame| frame.enc_stats.tx_type_counts[txtype as usize])
       .sum::<usize>() as f32
       / count as f32
       * 100.
@@ -250,9 +246,7 @@ impl ProgressInfo {
       .frame_info
       .iter()
       .filter(|frame| frame.frame_type == frame_type)
-      .map(|frame| {
-        frame.enc_stats.luma_pred_mode_counts.values().sum::<usize>()
-      })
+      .map(|frame| frame.enc_stats.luma_pred_mode_counts.iter().sum::<usize>())
       .sum()
   }
 
@@ -264,7 +258,7 @@ impl ProgressInfo {
       .iter()
       .filter(|frame| frame.frame_type == frame_type)
       .map(|frame| {
-        frame.enc_stats.chroma_pred_mode_counts.values().sum::<usize>()
+        frame.enc_stats.chroma_pred_mode_counts.iter().sum::<usize>()
       })
       .sum()
   }
@@ -280,14 +274,7 @@ impl ProgressInfo {
       .frame_info
       .iter()
       .filter(|frame| frame.frame_type == frame_type)
-      .map(|frame| {
-        frame
-          .enc_stats
-          .luma_pred_mode_counts
-          .get(&pred_mode)
-          .copied()
-          .unwrap_or(0)
-      })
+      .map(|frame| frame.enc_stats.luma_pred_mode_counts[pred_mode as usize])
       .sum::<usize>() as f32
       / count as f32
       * 100.
@@ -304,14 +291,7 @@ impl ProgressInfo {
       .frame_info
       .iter()
       .filter(|frame| frame.frame_type == frame_type)
-      .map(|frame| {
-        frame
-          .enc_stats
-          .chroma_pred_mode_counts
-          .get(&pred_mode)
-          .copied()
-          .unwrap_or(0)
-      })
+      .map(|frame| frame.enc_stats.chroma_pred_mode_counts[pred_mode as usize])
       .sum::<usize>() as f32
       / count as f32
       * 100.

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1737,12 +1737,10 @@ pub fn encode_block_post_cdef<T: Pixel>(
 
   if record_stats {
     let pixels = tx_size.area();
-    *ts.enc_stats.block_size_counts.entry(bsize).or_insert(0) += pixels;
-    *ts.enc_stats.tx_type_counts.entry(tx_type).or_insert(0) += pixels;
-    *ts.enc_stats.luma_pred_mode_counts.entry(luma_mode).or_insert(0) +=
-      pixels;
-    *ts.enc_stats.chroma_pred_mode_counts.entry(chroma_mode).or_insert(0) +=
-      pixels;
+    ts.enc_stats.block_size_counts[bsize as usize] += pixels;
+    ts.enc_stats.tx_type_counts[tx_type as usize] += pixels;
+    ts.enc_stats.luma_pred_mode_counts[luma_mode as usize] += pixels;
+    ts.enc_stats.chroma_pred_mode_counts[chroma_mode as usize] += pixels;
     if skip {
       ts.enc_stats.skip_block_count += pixels;
     }

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -92,6 +92,8 @@ pub enum PredictionMode {
   NEW_NEWMV,
 }
 
+pub const PREDICTION_MODES: usize = 28;
+
 #[derive(Copy, Clone, Debug)]
 pub enum PredictionVariant {
   NONE,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -8,33 +8,32 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use crate::partition::BlockSize;
-use crate::prelude::PredictionMode;
-use crate::transform::TxType;
-use std::collections::BTreeMap;
+use crate::predict::PREDICTION_MODES;
+use crate::transform::TX_TYPES;
 use std::ops::{Add, AddAssign};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EncoderStats {
   /// Stores count of pixels belonging to each block size in this frame
-  pub block_size_counts: BTreeMap<BlockSize, usize>,
+  pub block_size_counts: [usize; BlockSize::BLOCK_SIZES],
   /// Stores count of pixels belonging to skip blocks in this frame
   pub skip_block_count: usize,
   /// Stores count of pixels belonging to each transform type in this frame
-  pub tx_type_counts: BTreeMap<TxType, usize>,
+  pub tx_type_counts: [usize; TX_TYPES],
   /// Stores count of pixels belonging to each luma prediction mode in this frame
-  pub luma_pred_mode_counts: BTreeMap<PredictionMode, usize>,
+  pub luma_pred_mode_counts: [usize; PREDICTION_MODES],
   /// Stores count of pixels belonging to each chroma prediction mode in this frame
-  pub chroma_pred_mode_counts: BTreeMap<PredictionMode, usize>,
+  pub chroma_pred_mode_counts: [usize; PREDICTION_MODES],
 }
 
 impl Default for EncoderStats {
   fn default() -> Self {
     EncoderStats {
-      block_size_counts: BTreeMap::new(),
+      block_size_counts: [0; BlockSize::BLOCK_SIZES],
       skip_block_count: 0,
-      tx_type_counts: BTreeMap::new(),
-      luma_pred_mode_counts: BTreeMap::new(),
-      chroma_pred_mode_counts: BTreeMap::new(),
+      tx_type_counts: [0; TX_TYPES],
+      luma_pred_mode_counts: [0; PREDICTION_MODES],
+      chroma_pred_mode_counts: [0; PREDICTION_MODES],
     }
   }
 }
@@ -51,18 +50,29 @@ impl Add<&Self> for EncoderStats {
 
 impl AddAssign<&Self> for EncoderStats {
   fn add_assign(&mut self, rhs: &EncoderStats) {
-    rhs.block_size_counts.iter().for_each(|(&k, &v)| {
-      *self.block_size_counts.entry(k).or_insert(0) += v;
-    });
-    rhs.chroma_pred_mode_counts.iter().for_each(|(&k, &v)| {
-      *self.chroma_pred_mode_counts.entry(k).or_insert(0) += v;
-    });
-    rhs.luma_pred_mode_counts.iter().for_each(|(&k, &v)| {
-      *self.luma_pred_mode_counts.entry(k).or_insert(0) += v;
-    });
-    rhs.tx_type_counts.iter().for_each(|(&k, &v)| {
-      *self.tx_type_counts.entry(k).or_insert(0) += v;
-    });
+    for (s, v) in
+      self.block_size_counts.iter_mut().zip(rhs.block_size_counts.iter())
+    {
+      *s += v;
+    }
+    for (s, v) in self
+      .chroma_pred_mode_counts
+      .iter_mut()
+      .zip(rhs.chroma_pred_mode_counts.iter())
+    {
+      *s += v;
+    }
+    for (s, v) in self
+      .luma_pred_mode_counts
+      .iter_mut()
+      .zip(rhs.luma_pred_mode_counts.iter())
+    {
+      *s += v;
+    }
+    for (s, v) in self.tx_type_counts.iter_mut().zip(rhs.tx_type_counts.iter())
+    {
+      *s += v;
+    }
     self.skip_block_count += rhs.skip_block_count;
   }
 }


### PR DESCRIPTION
Reduces time taken for stats merging with 16 tiles from 575us
to 224us on my machine.