### PR TITLE
Use explicit block size checking

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1649,7 +1649,7 @@ impl<'a> BlockContext<'a> {
     &mut self, bo: TileBlockOffset, bsize: BlockSize, xdec: usize, ydec: usize,
   ) {
     const num_planes: usize = 3;
-    let nplanes = if bsize >= BLOCK_8X8 {
+    let nplanes = if bsize.gte(BLOCK_8X8) {
       3
     } else {
       1 + (num_planes - 1) * has_chroma(bo, bsize, xdec, ydec) as usize
@@ -2059,7 +2059,7 @@ impl<'a> ContextWriter<'a> {
     bsize: BlockSize,
   ) {
     debug_assert!(bsize.is_sqr());
-    assert!(bsize >= BlockSize::BLOCK_8X8);
+    assert!(bsize.gte(BlockSize::BLOCK_8X8));
     let hbs = bsize.width_mi() / 2;
     let has_cols = (bo.0.x + hbs) < self.bc.blocks.cols();
     let has_rows = (bo.0.y + hbs) < self.bc.blocks.rows();
@@ -2082,7 +2082,7 @@ impl<'a> ContextWriter<'a> {
         p == PartitionType::PARTITION_SPLIT
           || p == PartitionType::PARTITION_HORZ
       );
-      assert!(bsize > BlockSize::BLOCK_8X8);
+      assert!(bsize.greater_than(BlockSize::BLOCK_8X8));
       let mut cdf = [0u16; 2];
       ContextWriter::partition_gather_vert_alike(
         &mut cdf,
@@ -2095,7 +2095,7 @@ impl<'a> ContextWriter<'a> {
         p == PartitionType::PARTITION_SPLIT
           || p == PartitionType::PARTITION_VERT
       );
-      assert!(bsize > BlockSize::BLOCK_8X8);
+      assert!(bsize.greater_than(BlockSize::BLOCK_8X8));
       let mut cdf = [0u16; 2];
       ContextWriter::partition_gather_horz_alike(
         &mut cdf,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1698,7 +1698,7 @@ pub fn encode_block_post_cdef<T: Pixel>(
   }
 
   if !is_inter {
-    if luma_mode.is_directional() && bsize >= BlockSize::BLOCK_8X8 {
+    if luma_mode.is_directional() && bsize.gte(BlockSize::BLOCK_8X8) {
       cw.write_angle_delta(w, angle_delta.y, luma_mode);
     }
     if has_chroma(tile_bo, bsize, xdec, ydec) {
@@ -1707,7 +1707,7 @@ pub fn encode_block_post_cdef<T: Pixel>(
         assert!(bsize.cfl_allowed());
         cw.write_cfl_alphas(w, cfl);
       }
-      if chroma_mode.is_directional() && bsize >= BlockSize::BLOCK_8X8 {
+      if chroma_mode.is_directional() && bsize.gte(BlockSize::BLOCK_8X8) {
         cw.write_angle_delta(w, angle_delta.uv, chroma_mode);
       }
     }
@@ -2530,7 +2530,7 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
       // FIXME: sub-8x8 inter blocks not supported for non-4:2:0 sampling
       !fi.frame_type.has_inter()
         || fi.config.chroma_sampling == ChromaSampling::Cs420
-        || bsize > BlockSize::BLOCK_8X8
+        || bsize.greater_than(BlockSize::BLOCK_8X8)
     )
   {
     debug_assert!(bsize.is_sqr());

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -335,6 +335,10 @@ impl BlockSize {
       || (self.width() == other.width() && self.height() == other.height())
   }
 
+  pub fn lte(self, other: BlockSize) -> bool {
+    !self.greater_than(other)
+  }
+
   pub fn subsize(self, partition: PartitionType) -> BlockSize {
     use PartitionType::*;
 


### PR DESCRIPTION
Instead of enum type based comparison, which become clearly wrong once
1:4 ratio nonsquare partitions are introduced or any block sizes after
BLOCK_64X64 in enum type.