### PR TITLE
Align PredictionMode code to the AV1 Spec

### DIFF
--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -64,17 +64,21 @@ pub fn pred_bench(c: &mut Criterion) {
   bench_pred_fn(c, "intra_dc_top_4x4", |b: &mut Bencher| {
     intra_bench::<u16>(b, PredictionMode::DC_PRED, PredictionVariant::TOP)
   });
-  bench_pred_fn(c, "intra_h_4x4", |b: &mut Bencher| {
-    intra_bench::<u16>(b, PredictionMode::H_PRED, PredictionVariant::BOTH)
-  });
   bench_pred_fn(c, "intra_v_4x4", |b: &mut Bencher| {
     intra_bench::<u16>(b, PredictionMode::V_PRED, PredictionVariant::BOTH)
   });
-  bench_pred_fn(c, "intra_paeth_4x4", |b: &mut Bencher| {
-    intra_bench::<u16>(b, PredictionMode::PAETH_PRED, PredictionVariant::BOTH)
+  bench_pred_fn(c, "intra_h_4x4", |b: &mut Bencher| {
+    intra_bench::<u16>(b, PredictionMode::H_PRED, PredictionVariant::BOTH)
   });
   bench_pred_fn(c, "intra_smooth_4x4", |b: &mut Bencher| {
     intra_bench::<u16>(b, PredictionMode::SMOOTH_PRED, PredictionVariant::BOTH)
+  });
+  bench_pred_fn(c, "intra_smooth_v_4x4", |b: &mut Bencher| {
+    intra_bench::<u16>(
+      b,
+      PredictionMode::SMOOTH_V_PRED,
+      PredictionVariant::BOTH,
+    )
   });
   bench_pred_fn(c, "intra_smooth_h_4x4", |b: &mut Bencher| {
     intra_bench::<u16>(
@@ -83,12 +87,8 @@ pub fn pred_bench(c: &mut Criterion) {
       PredictionVariant::BOTH,
     )
   });
-  bench_pred_fn(c, "intra_smooth_v_4x4", |b: &mut Bencher| {
-    intra_bench::<u16>(
-      b,
-      PredictionMode::SMOOTH_V_PRED,
-      PredictionVariant::BOTH,
-    )
+  bench_pred_fn(c, "intra_paeth_4x4", |b: &mut Bencher| {
+    intra_bench::<u16>(b, PredictionMode::PAETH_PRED, PredictionVariant::BOTH)
   });
   bench_pred_fn(c, "intra_dc_4x4_u8", |b: &mut Bencher| {
     intra_bench::<u8>(b, PredictionMode::DC_PRED, PredictionVariant::BOTH)
@@ -102,17 +102,21 @@ pub fn pred_bench(c: &mut Criterion) {
   bench_pred_fn(c, "intra_dc_top_4x4_u8", |b: &mut Bencher| {
     intra_bench::<u8>(b, PredictionMode::DC_PRED, PredictionVariant::TOP)
   });
-  bench_pred_fn(c, "intra_h_4x4_u8", |b: &mut Bencher| {
-    intra_bench::<u8>(b, PredictionMode::H_PRED, PredictionVariant::BOTH)
-  });
   bench_pred_fn(c, "intra_v_4x4_u8", |b: &mut Bencher| {
     intra_bench::<u8>(b, PredictionMode::V_PRED, PredictionVariant::BOTH)
   });
-  bench_pred_fn(c, "intra_paeth_4x4_u8", |b: &mut Bencher| {
-    intra_bench::<u8>(b, PredictionMode::PAETH_PRED, PredictionVariant::BOTH)
+  bench_pred_fn(c, "intra_h_4x4_u8", |b: &mut Bencher| {
+    intra_bench::<u8>(b, PredictionMode::H_PRED, PredictionVariant::BOTH)
   });
   bench_pred_fn(c, "intra_smooth_4x4_u8", |b: &mut Bencher| {
     intra_bench::<u8>(b, PredictionMode::SMOOTH_PRED, PredictionVariant::BOTH)
+  });
+  bench_pred_fn(c, "intra_smooth_v_4x4_u8", |b: &mut Bencher| {
+    intra_bench::<u8>(
+      b,
+      PredictionMode::SMOOTH_V_PRED,
+      PredictionVariant::BOTH,
+    )
   });
   bench_pred_fn(c, "intra_smooth_h_4x4_u8", |b: &mut Bencher| {
     intra_bench::<u8>(
@@ -121,12 +125,8 @@ pub fn pred_bench(c: &mut Criterion) {
       PredictionVariant::BOTH,
     )
   });
-  bench_pred_fn(c, "intra_smooth_v_4x4_u8", |b: &mut Bencher| {
-    intra_bench::<u8>(
-      b,
-      PredictionMode::SMOOTH_V_PRED,
-      PredictionVariant::BOTH,
-    )
+  bench_pred_fn(c, "intra_paeth_4x4_u8", |b: &mut Bencher| {
+    intra_bench::<u8>(b, PredictionMode::PAETH_PRED, PredictionVariant::BOTH)
   });
 }
 
@@ -142,8 +142,8 @@ pub fn intra_bench<T: Pixel>(
     PixelType::U16 => 10,
   };
   let angle = match mode {
-    PredictionMode::H_PRED => 180,
     PredictionMode::V_PRED => 90,
+    PredictionMode::H_PRED => 180,
     _ => 0,
   };
   b.iter(|| {

--- a/src/asm/aarch64/predict.rs
+++ b/src/asm/aarch64/predict.rs
@@ -35,12 +35,12 @@ decl_angular_ipred_fn! {
   rav1e_ipred_dc_128_neon,
   rav1e_ipred_dc_left_neon,
   rav1e_ipred_dc_top_neon,
-  rav1e_ipred_h_neon,
   rav1e_ipred_v_neon,
-  rav1e_ipred_paeth_neon,
+  rav1e_ipred_h_neon,
   rav1e_ipred_smooth_neon,
+  rav1e_ipred_smooth_v_neon,
   rav1e_ipred_smooth_h_neon,
-  rav1e_ipred_smooth_v_neon
+  rav1e_ipred_paeth_neon
 }
 
 macro_rules! decl_cfl_pred_fn {
@@ -100,6 +100,24 @@ pub fn dispatch_predict_intra<T: Pixel>(
             PredictionVariant::BOTH => rav1e_ipred_dc_neon,
           })(dst_ptr, stride, edge_ptr, w, h, angle);
         }
+        PredictionMode::V_PRED if angle == 90 => {
+          rav1e_ipred_v_neon(dst_ptr, stride, edge_ptr, w, h, angle);
+        }
+        PredictionMode::H_PRED if angle == 180 => {
+          rav1e_ipred_h_neon(dst_ptr, stride, edge_ptr, w, h, angle);
+        }
+        PredictionMode::SMOOTH_PRED => {
+          rav1e_ipred_smooth_neon(dst_ptr, stride, edge_ptr, w, h, angle);
+        }
+        PredictionMode::SMOOTH_V_PRED => {
+          rav1e_ipred_smooth_v_neon(dst_ptr, stride, edge_ptr, w, h, angle);
+        }
+        PredictionMode::SMOOTH_H_PRED => {
+          rav1e_ipred_smooth_h_neon(dst_ptr, stride, edge_ptr, w, h, angle);
+        }
+        PredictionMode::PAETH_PRED => {
+          rav1e_ipred_paeth_neon(dst_ptr, stride, edge_ptr, w, h, angle);
+        }
         PredictionMode::UV_CFL_PRED => {
           let ac_ptr = ac.as_ptr() as *const _;
           (match variant {
@@ -108,24 +126,6 @@ pub fn dispatch_predict_intra<T: Pixel>(
             PredictionVariant::TOP => rav1e_ipred_cfl_top_neon,
             PredictionVariant::BOTH => rav1e_ipred_cfl_neon,
           })(dst_ptr, stride, edge_ptr, w, h, ac_ptr, angle);
-        }
-        PredictionMode::H_PRED if angle == 180 => {
-          rav1e_ipred_h_neon(dst_ptr, stride, edge_ptr, w, h, angle);
-        }
-        PredictionMode::V_PRED if angle == 90 => {
-          rav1e_ipred_v_neon(dst_ptr, stride, edge_ptr, w, h, angle);
-        }
-        PredictionMode::PAETH_PRED => {
-          rav1e_ipred_paeth_neon(dst_ptr, stride, edge_ptr, w, h, angle);
-        }
-        PredictionMode::SMOOTH_PRED => {
-          rav1e_ipred_smooth_neon(dst_ptr, stride, edge_ptr, w, h, angle);
-        }
-        PredictionMode::SMOOTH_H_PRED => {
-          rav1e_ipred_smooth_h_neon(dst_ptr, stride, edge_ptr, w, h, angle);
-        }
-        PredictionMode::SMOOTH_V_PRED => {
-          rav1e_ipred_smooth_v_neon(dst_ptr, stride, edge_ptr, w, h, angle);
         }
         _ => call_native(dst),
       }

--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -147,11 +147,11 @@ pub fn dispatch_predict_intra<T: Pixel>(
         PredictionMode::H_PRED
         | PredictionMode::V_PRED
         | PredictionMode::D45_PRED
-        | PredictionMode::D63_PRED
-        | PredictionMode::D117_PRED
+        | PredictionMode::D67_PRED
+        | PredictionMode::D113_PRED
         | PredictionMode::D135_PRED
-        | PredictionMode::D153_PRED
-        | PredictionMode::D207_PRED => {
+        | PredictionMode::D157_PRED
+        | PredictionMode::D203_PRED => {
           (if angle <= 90 {
             rav1e_ipred_z1_avx2
           } else if angle < 180 {
@@ -240,7 +240,7 @@ mod test {
       (PredictionMode::SMOOTH_V_PRED, PredictionVariant::BOTH),
       (PredictionMode::D45_PRED, PredictionVariant::BOTH),
       (PredictionMode::D135_PRED, PredictionVariant::BOTH),
-      (PredictionMode::D207_PRED, PredictionVariant::BOTH),
+      (PredictionMode::D203_PRED, PredictionVariant::BOTH),
     ]
     .iter()
     {
@@ -255,7 +255,7 @@ mod test {
           144, 148, 151, 154, 157, 160, 163, 166,
         ]
         .iter(),
-        PredictionMode::D207_PRED => [
+        PredictionMode::D203_PRED => [
           194, 197, 200, 203, 206, 209, 212, 216, 219, 222, 225, 228, 231,
           234, 238, 241, 244, 247, 250, 253, 256, 261, 264, 267,
         ]

--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -236,7 +236,10 @@ mod test {
       (PredictionMode::H_PRED, PredictionVariant::BOTH),
       (PredictionMode::D45_PRED, PredictionVariant::BOTH),
       (PredictionMode::D135_PRED, PredictionVariant::BOTH),
+      (PredictionMode::D113_PRED, PredictionVariant::BOTH),
+      (PredictionMode::D157_PRED, PredictionVariant::BOTH),
       (PredictionMode::D203_PRED, PredictionVariant::BOTH),
+      (PredictionMode::D67_PRED, PredictionVariant::BOTH),
       (PredictionMode::SMOOTH_PRED, PredictionVariant::BOTH),
       (PredictionMode::SMOOTH_V_PRED, PredictionVariant::BOTH),
       (PredictionMode::SMOOTH_H_PRED, PredictionVariant::BOTH),
@@ -247,21 +250,20 @@ mod test {
       let angles = match mode {
         PredictionMode::V_PRED => [81, 84, 87, 90, 93, 96, 99].iter(),
         PredictionMode::H_PRED => [171, 174, 177, 180, 183, 186, 189].iter(),
-        PredictionMode::D45_PRED => [
-          3, 6, 9, 14, 17, 20, 23, 26, 29, 32, 36, 39, 42, 45, 48, 51, 54, 58,
-          61, 64, 67, 70, 73, 76,
-        ]
-        .iter(),
-        PredictionMode::D135_PRED => [
-          104, 107, 110, 113, 116, 119, 122, 126, 129, 132, 135, 138, 141,
-          144, 148, 151, 154, 157, 160, 163, 166,
-        ]
-        .iter(),
-        PredictionMode::D203_PRED => [
-          194, 197, 200, 203, 206, 209, 212, 216, 219, 222, 225, 228, 231,
-          234, 238, 241, 244, 247, 250, 253, 256, 261, 264, 267,
-        ]
-        .iter(),
+        PredictionMode::D45_PRED => [36, 39, 42, 45, 48, 51, 54].iter(),
+        PredictionMode::D135_PRED => {
+          [126, 129, 132, 135, 138, 141, 144].iter()
+        }
+        PredictionMode::D113_PRED => {
+          [104, 107, 110, 113, 116, 119, 122].iter()
+        }
+        PredictionMode::D157_PRED => {
+          [148, 151, 154, 157, 160, 163, 166].iter()
+        }
+        PredictionMode::D203_PRED => {
+          [194, 197, 200, 203, 206, 209, 212].iter()
+        }
+        PredictionMode::D67_PRED => [58, 61, 64, 67, 70, 73, 76].iter(),
         _ => [0].iter(),
       };
       for angle in angles {
@@ -297,7 +299,14 @@ mod test {
           &edge_buf,
           cpu,
         );
-        assert_eq!(expected, &output.data[..]);
+        assert_eq!(
+          expected,
+          &output.data[..],
+          "mode={:?} variant={:?} angle={}",
+          *mode,
+          *variant,
+          *angle
+        );
       }
     }
   }

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -505,6 +505,7 @@ impl ProgressInfo {
           frame_type
         ),
       );
+      // Keep angular order for presentation here, rather than enum order.
       info!(
       "        D: 45: {:.1}% | 67: {:.1}% | 113: {:.1}% | 135: {:.1}% | 157: {:.1}% | 203: {:.1}%",
       self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D45_PRED, frame_type),
@@ -513,7 +514,7 @@ impl ProgressInfo {
       self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D135_PRED, frame_type),
       self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D157_PRED, frame_type),
       self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D203_PRED, frame_type),
-    );
+      );
     } else if frame_type == FrameType::INTER {
       info!(
         "y modes {}: Nearest: {:.1}% | Near0: {:.1}% | Near1: {:.1}% | NearNear: {:.1}%",
@@ -562,6 +563,7 @@ impl ProgressInfo {
         self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::SMOOTH_H_PRED, frame_type),
         self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::UV_CFL_PRED, frame_type),
       );
+      // Keep angular order for presentation here, rather than enum order.
       info!(
         "         D: 45: {:.1}% | 67: {:.1}% | 113: {:.1}% | 135: {:.1}% | 157: {:.1}% | 203: {:.1}%",
         self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D45_PRED, frame_type),

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -506,13 +506,13 @@ impl ProgressInfo {
         ),
       );
       info!(
-      "        D: 45: {:.1}% | 63: {:.1}% | 117: {:.1}% | 135: {:.1}% | 153: {:.1}% | 207: {:.1}%",
+      "        D: 45: {:.1}% | 67: {:.1}% | 113: {:.1}% | 135: {:.1}% | 157: {:.1}% | 203: {:.1}%",
       self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D45_PRED, frame_type),
-      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D63_PRED, frame_type),
-      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D117_PRED, frame_type),
+      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D67_PRED, frame_type),
+      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D113_PRED, frame_type),
       self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D135_PRED, frame_type),
-      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D153_PRED, frame_type),
-      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D207_PRED, frame_type),
+      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D157_PRED, frame_type),
+      self.get_luma_pred_mode_pct_by_frame_type(PredictionMode::D203_PRED, frame_type),
     );
     } else if frame_type == FrameType::INTER {
       info!(
@@ -563,13 +563,13 @@ impl ProgressInfo {
         self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::UV_CFL_PRED, frame_type),
       );
       info!(
-        "         D: 45: {:.1}% | 63: {:.1}% | 117: {:.1}% | 135: {:.1}% | 153: {:.1}% | 207: {:.1}%",
+        "         D: 45: {:.1}% | 67: {:.1}% | 113: {:.1}% | 135: {:.1}% | 157: {:.1}% | 203: {:.1}%",
         self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D45_PRED, frame_type),
-        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D63_PRED, frame_type),
-        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D117_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D67_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D113_PRED, frame_type),
         self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D135_PRED, frame_type),
-        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D153_PRED, frame_type),
-        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D207_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D157_PRED, frame_type),
+        self.get_chroma_pred_mode_pct_by_frame_type(PredictionMode::D203_PRED, frame_type),
       );
     } else if frame_type == FrameType::INTER {
       info!(

--- a/src/context.rs
+++ b/src/context.rs
@@ -618,10 +618,10 @@ static intra_mode_to_tx_type_context: [TxType; INTRA_MODES] = [
   DCT_ADST,  // H
   DCT_DCT,   // D45
   ADST_ADST, // D135
-  ADST_DCT,  // D117
-  DCT_ADST,  // D153
-  DCT_ADST,  // D207
-  ADST_DCT,  // D63
+  ADST_DCT,  // D113
+  DCT_ADST,  // D157
+  DCT_ADST,  // D203
+  ADST_DCT,  // D67
   ADST_ADST, // SMOOTH
   ADST_DCT,  // SMOOTH_V
   DCT_ADST,  // SMOOTH_H
@@ -634,10 +634,10 @@ static uv2y: [PredictionMode; UV_INTRA_MODES] = [
   H_PRED,        // UV_H_PRED
   D45_PRED,      // UV_D45_PRED
   D135_PRED,     // UV_D135_PRED
-  D117_PRED,     // UV_D117_PRED
-  D153_PRED,     // UV_D153_PRED
-  D207_PRED,     // UV_D207_PRED
-  D63_PRED,      // UV_D63_PRED
+  D113_PRED,     // UV_D113_PRED
+  D157_PRED,     // UV_D157_PRED
+  D203_PRED,     // UV_D203_PRED
+  D67_PRED,      // UV_D67_PRED
   SMOOTH_PRED,   // UV_SMOOTH_PRED
   SMOOTH_V_PRED, // UV_SMOOTH_V_PRED
   SMOOTH_H_PRED, // UV_SMOOTH_H_PRED

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -558,19 +558,19 @@ pub fn get_intra_edges<T: Pixel>(
 
       needs_left = (!dc_or_cfl || x != 0)
         && !(mode == PredictionMode::D45_PRED
-          || mode == PredictionMode::D63_PRED);
+          || mode == PredictionMode::D67_PRED);
       needs_topleft = mode == PredictionMode::PAETH_PRED
         || mode == PredictionMode::H_PRED
         || mode == PredictionMode::V_PRED
-        || mode == PredictionMode::D117_PRED
+        || mode == PredictionMode::D113_PRED
         || mode == PredictionMode::D135_PRED
-        || mode == PredictionMode::D153_PRED;
+        || mode == PredictionMode::D157_PRED;
       needs_top = !dc_or_cfl || y != 0;
       needs_topright = mode == PredictionMode::V_PRED
         || mode == PredictionMode::D45_PRED
-        || mode == PredictionMode::D63_PRED;
+        || mode == PredictionMode::D67_PRED;
       needs_bottomleft =
-        mode == PredictionMode::H_PRED || mode == PredictionMode::D207_PRED;
+        mode == PredictionMode::H_PRED || mode == PredictionMode::D203_PRED;
     }
 
     // Needs left

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -546,8 +546,8 @@ pub fn get_intra_edges<T: Pixel>(
       mode = match mode {
         PredictionMode::PAETH_PRED => match (x, y) {
           (0, 0) => PredictionMode::DC_PRED,
-          (_, 0) => PredictionMode::H_PRED,
           (0, _) => PredictionMode::V_PRED,
+          (_, 0) => PredictionMode::H_PRED,
           _ => PredictionMode::PAETH_PRED,
         },
         _ => mode,
@@ -559,12 +559,12 @@ pub fn get_intra_edges<T: Pixel>(
       needs_left = (!dc_or_cfl || x != 0)
         && !(mode == PredictionMode::D45_PRED
           || mode == PredictionMode::D67_PRED);
-      needs_topleft = mode == PredictionMode::PAETH_PRED
+      needs_topleft = mode == PredictionMode::V_PRED
         || mode == PredictionMode::H_PRED
-        || mode == PredictionMode::V_PRED
-        || mode == PredictionMode::D113_PRED
         || mode == PredictionMode::D135_PRED
-        || mode == PredictionMode::D157_PRED;
+        || mode == PredictionMode::D113_PRED
+        || mode == PredictionMode::D157_PRED
+        || mode == PredictionMode::PAETH_PRED;
       needs_top = !dc_or_cfl || y != 0;
       needs_topright = mode == PredictionMode::V_PRED
         || mode == PredictionMode::D45_PRED

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -41,10 +41,10 @@ pub static RAV1E_INTRA_MODES: &[PredictionMode] = &[
   PredictionMode::PAETH_PRED,
   PredictionMode::D45_PRED,
   PredictionMode::D135_PRED,
-  PredictionMode::D117_PRED,
-  PredictionMode::D153_PRED,
-  PredictionMode::D207_PRED,
-  PredictionMode::D63_PRED,
+  PredictionMode::D113_PRED,
+  PredictionMode::D157_PRED,
+  PredictionMode::D203_PRED,
+  PredictionMode::D67_PRED,
 ];
 
 pub static RAV1E_INTER_MODES_MINIMAL: &[PredictionMode] =
@@ -64,12 +64,12 @@ pub enum PredictionMode {
   DC_PRED,     // Average of above and left pixels
   V_PRED,      // Vertical
   H_PRED,      // Horizontal
-  D45_PRED,    // Directional 45  deg = round(arctan(1/1) * 180/pi)
-  D135_PRED,   // Directional 135 deg = 180 - 45
-  D117_PRED,   // Directional 117 deg = 180 - 63
-  D153_PRED,   // Directional 153 deg = 180 - 27
-  D207_PRED,   // Directional 207 deg = 180 + 27
-  D63_PRED,    // Directional 63  deg = round(arctan(2/1) * 180/pi)
+  D45_PRED,    // Directional 45  degree
+  D135_PRED,   // Directional 135 degree
+  D113_PRED,   // Directional 113 degree
+  D157_PRED,   // Directional 157 degree
+  D203_PRED,   // Directional 203 degree
+  D67_PRED,    // Directional 67  degree
   SMOOTH_PRED, // Combination of horizontal and vertical interpolation
   SMOOTH_V_PRED,
   SMOOTH_H_PRED,
@@ -159,10 +159,10 @@ impl PredictionMode {
       PredictionMode::V_PRED => 90,
       PredictionMode::D45_PRED => 45,
       PredictionMode::D135_PRED => 135,
-      PredictionMode::D117_PRED => 113,
-      PredictionMode::D153_PRED => 157,
-      PredictionMode::D207_PRED => 203,
-      PredictionMode::D63_PRED => 67,
+      PredictionMode::D113_PRED => 113,
+      PredictionMode::D157_PRED => 157,
+      PredictionMode::D203_PRED => 203,
+      PredictionMode::D67_PRED => 67,
       _ => 0,
     } + (angle_delta * ANGLE_STEP) as isize;
 
@@ -180,7 +180,7 @@ impl PredictionMode {
   }
 
   pub fn is_directional(self) -> bool {
-    self >= PredictionMode::V_PRED && self <= PredictionMode::D63_PRED
+    self >= PredictionMode::V_PRED && self <= PredictionMode::D67_PRED
   }
 
   #[inline(always)]
@@ -190,10 +190,10 @@ impl PredictionMode {
       | PredictionMode::V_PRED
       | PredictionMode::D45_PRED
       | PredictionMode::D135_PRED
-      | PredictionMode::D117_PRED
-      | PredictionMode::D153_PRED
-      | PredictionMode::D207_PRED
-      | PredictionMode::D63_PRED => 7,
+      | PredictionMode::D113_PRED
+      | PredictionMode::D157_PRED
+      | PredictionMode::D203_PRED
+      | PredictionMode::D67_PRED => 7,
       _ => 1,
     }
   }
@@ -498,10 +498,10 @@ pub(crate) mod native {
       | PredictionMode::V_PRED
       | PredictionMode::D45_PRED
       | PredictionMode::D135_PRED
-      | PredictionMode::D117_PRED
-      | PredictionMode::D153_PRED
-      | PredictionMode::D207_PRED
-      | PredictionMode::D63_PRED => pred_directional(
+      | PredictionMode::D113_PRED
+      | PredictionMode::D157_PRED
+      | PredictionMode::D203_PRED
+      | PredictionMode::D67_PRED => pred_directional(
         dst,
         above_slice,
         left_and_left_below_slice,


### PR DESCRIPTION
- Align enum values to spec
- Reorder code to match enum order
- Tidy up fine angular prediction tests