### PR TITLE
Use eob in inverse transforms

### DIFF
--- a/src/asm/aarch64/transform/inverse.rs
+++ b/src/asm/aarch64/transform/inverse.rs
@@ -17,8 +17,8 @@ use crate::asm::shared::transform::inverse::*;
 use crate::asm::shared::transform::*;
 
 pub fn inverse_transform_add<T: Pixel>(
-  input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, tx_size: TxSize,
-  tx_type: TxType, bd: usize, cpu: CpuFeatureLevel,
+  input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, eob: usize,
+  tx_size: TxSize, tx_type: TxType, bd: usize, cpu: CpuFeatureLevel,
 ) {
   match T::type_enum() {
     PixelType::U8 => {
@@ -29,6 +29,7 @@ pub fn inverse_transform_add<T: Pixel>(
           func,
           input,
           output,
+          eob,
           tx_size.width(),
           tx_size.height(),
           bd,
@@ -38,7 +39,7 @@ pub fn inverse_transform_add<T: Pixel>(
     PixelType::U16 => {}
   };
 
-  native::inverse_transform_add(input, output, tx_size, tx_type, bd, cpu);
+  native::inverse_transform_add(input, output, eob, tx_size, tx_type, bd, cpu);
 }
 
 macro_rules! decl_itx_fns {

--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -16,15 +16,12 @@ pub type InvTxfmFunc =
 
 pub fn call_inverse_func<T: Pixel>(
   func: InvTxfmFunc, input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>,
-  width: usize, height: usize, bd: usize,
+  eob: usize, width: usize, height: usize, bd: usize,
 ) {
   debug_assert!(bd == 8);
 
-  // 64x only uses 32 coeffs
-  let area = width.min(32) * height.min(32);
-
   // Only use at most 32 columns and 32 rows of input coefficients.
-  let input: &[T::Coeff] = &input[..area];
+  let input: &[T::Coeff] = &input[..width.min(32) * height.min(32)];
 
   let mut copied: AlignedArray<[T::Coeff; 32 * 32]> =
     AlignedArray::uninitialized();
@@ -41,7 +38,7 @@ pub fn call_inverse_func<T: Pixel>(
       output.data_ptr_mut() as *mut _,
       output.plane_cfg.stride as isize,
       copied.array.as_mut_ptr() as *mut _,
-      area as i32,
+      eob as i32,
     );
   }
 }
@@ -49,57 +46,115 @@ pub fn call_inverse_func<T: Pixel>(
 #[cfg(test)]
 pub mod test {
   use super::*;
+  use crate::context::av1_get_coded_tx_size;
   use crate::cpu_features::CpuFeatureLevel;
   use crate::frame::{AsRegion, Plane};
+  use crate::scan_order::av1_scan_orders;
   use crate::transform::*;
-  use rand::random;
+  use rand::{random, thread_rng, Rng};
+
+  pub fn pick_eob<T: Coefficient>(
+    coeffs: &mut [T], tx_size: TxSize, tx_type: TxType, sub_w: usize,
+  ) -> usize {
+    /* From dav1d
+     * copy the topleft coefficients such that the return value (being the
+     * coefficient scantable index for the eob token) guarantees that only
+     * the topleft $sub out of $sz (where $sz >= $sub) coefficients in both
+     * dimensions are non-zero. This leads to braching to specific optimized
+     * simd versions (e.g. dc-only) so that we get full asm coverage in this
+     * test */
+    let coeff_w = av1_get_coded_tx_size(tx_size).width();
+    let sub_high: usize = if sub_w > 0 { sub_w * 8 - 1 } else { 0 };
+    let sub_low: usize = if sub_w > 1 { sub_high - 8 } else { 0 };
+    let mut eob = 0;
+    let mut exit = 0;
+
+    let scan = av1_scan_orders[tx_size as usize][tx_type as usize].scan;
+
+    for (i, &pos) in scan.iter().enumerate() {
+      exit = i;
+
+      let rc = pos as usize;
+      let rcx = rc % coeff_w;
+      let rcy = rc / coeff_w;
+
+      if rcx > sub_high || rcy > sub_high {
+        break;
+      } else if eob == 0 && (rcx > sub_low || rcy > sub_low) {
+        eob = i;
+      }
+    }
+
+    if eob != 0 {
+      eob += thread_rng().gen_range(0, (exit - eob).min(1));
+    }
+    for &pos in scan.iter().skip(eob + 1) {
+      coeffs[pos as usize] = T::cast_from(0);
+    }
+
+    eob
+  }
 
   pub fn test_transform(
     tx_size: TxSize, tx_type: TxType, cpu: CpuFeatureLevel,
   ) {
-    let mut src_storage = [0u8; 64 * 64];
-    let src = &mut src_storage[..tx_size.area()];
-    let mut dst = Plane::wrap(vec![0u8; tx_size.area()], tx_size.width());
-    let mut res_storage: AlignedArray<[i16; 64 * 64]> =
-      AlignedArray::uninitialized();
-    let res = &mut res_storage.array[..tx_size.area()];
-    let mut freq_storage: AlignedArray<[i16; 64 * 64]> =
-      AlignedArray::uninitialized();
-    let freq = &mut freq_storage.array[..tx_size.area()];
-    for ((r, s), d) in
-      res.iter_mut().zip(src.iter_mut()).zip(dst.data.iter_mut())
-    {
-      *s = random::<u8>();
-      *d = random::<u8>();
-      *r = i16::from(*s) - i16::from(*d);
-    }
-    forward_transform(
-      res,
-      freq,
-      tx_size.width(),
-      tx_size,
-      tx_type,
-      8,
-      CpuFeatureLevel::NATIVE,
-    );
-    let mut native_dst = dst.clone();
+    let sub_w_iterations: usize = match tx_size.height().max(tx_size.width()) {
+      4 => 2,
+      8 => 2,
+      16 => 3,
+      32 | 64 => 4,
+      _ => unreachable!(),
+    };
 
-    inverse_transform_add(
-      freq,
-      &mut dst.as_region_mut(),
-      tx_size,
-      tx_type,
-      8,
-      cpu,
-    );
-    inverse_transform_add(
-      freq,
-      &mut native_dst.as_region_mut(),
-      tx_size,
-      tx_type,
-      8,
-      CpuFeatureLevel::NATIVE,
-    );
-    assert_eq!(native_dst.data_origin(), dst.data_origin());
+    for sub_w in 0..sub_w_iterations {
+      let mut src_storage = [0u8; 64 * 64];
+      let src = &mut src_storage[..tx_size.area()];
+      let mut dst = Plane::wrap(vec![0u8; tx_size.area()], tx_size.width());
+      let mut res_storage: AlignedArray<[i16; 64 * 64]> =
+        AlignedArray::uninitialized();
+      let res = &mut res_storage.array[..tx_size.area()];
+      let mut freq_storage: AlignedArray<[i16; 64 * 64]> =
+        AlignedArray::uninitialized();
+      let freq = &mut freq_storage.array[..tx_size.area()];
+      for ((r, s), d) in
+        res.iter_mut().zip(src.iter_mut()).zip(dst.data.iter_mut())
+      {
+        *s = random::<u8>();
+        *d = random::<u8>();
+        *r = i16::from(*s) - i16::from(*d);
+      }
+      forward_transform(
+        res,
+        freq,
+        tx_size.width(),
+        tx_size,
+        tx_type,
+        8,
+        CpuFeatureLevel::NATIVE,
+      );
+
+      let eob: usize = pick_eob(freq, tx_size, tx_type, sub_w);
+      let mut native_dst = dst.clone();
+
+      inverse_transform_add(
+        freq,
+        &mut dst.as_region_mut(),
+        eob,
+        tx_size,
+        tx_type,
+        8,
+        cpu,
+      );
+      inverse_transform_add(
+        freq,
+        &mut native_dst.as_region_mut(),
+        eob,
+        tx_size,
+        tx_type,
+        8,
+        CpuFeatureLevel::NATIVE,
+      );
+      assert_eq!(native_dst.data_origin(), dst.data_origin());
+    }
   }
 }

--- a/src/asm/x86/transform/inverse.rs
+++ b/src/asm/x86/transform/inverse.rs
@@ -17,8 +17,8 @@ use crate::asm::shared::transform::inverse::*;
 use crate::asm::shared::transform::*;
 
 pub fn inverse_transform_add<T: Pixel>(
-  input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, tx_size: TxSize,
-  tx_type: TxType, bd: usize, cpu: CpuFeatureLevel,
+  input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, eob: usize,
+  tx_size: TxSize, tx_type: TxType, bd: usize, cpu: CpuFeatureLevel,
 ) {
   match T::type_enum() {
     PixelType::U8 => {
@@ -29,6 +29,7 @@ pub fn inverse_transform_add<T: Pixel>(
           func,
           input,
           output,
+          eob,
           tx_size.width(),
           tx_size.height(),
           bd,
@@ -38,7 +39,7 @@ pub fn inverse_transform_add<T: Pixel>(
     PixelType::U16 => {}
   };
 
-  native::inverse_transform_add(input, output, tx_size, tx_type, bd, cpu);
+  native::inverse_transform_add(input, output, eob, tx_size, tx_type, bd, cpu);
 }
 
 macro_rules! decl_itx_fns {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1266,6 +1266,7 @@ pub fn encode_tx_block<T: Pixel>(
     inverse_transform_add(
       rcoeffs,
       &mut rec.subregion_mut(area),
+      eob,
       tx_size,
       tx_type,
       fi.sequence.bit_depth,

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1591,8 +1591,8 @@ pub(crate) mod native {
 
   #[cold_for_target_arch("x86_64", "aarch64")]
   pub fn inverse_transform_add<T>(
-    input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, tx_size: TxSize,
-    tx_type: TxType, bd: usize, _cpu: CpuFeatureLevel,
+    input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, _eob: usize,
+    tx_size: TxSize, tx_type: TxType, bd: usize, _cpu: CpuFeatureLevel,
   ) where
     T: Pixel,
   {

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -403,6 +403,7 @@ pub fn forward_transform<T: Coefficient>(
 mod test {
   use super::TxType::*;
   use super::*;
+  use crate::context::av1_get_coded_tx_size;
   use crate::frame::*;
   use rand::random;
 
@@ -411,6 +412,7 @@ mod test {
   ) {
     let cpu = CpuFeatureLevel::default();
 
+    let coeff_area: usize = av1_get_coded_tx_size(tx_size).area();
     let mut src_storage = [T::cast_from(0); 64 * 64];
     let src = &mut src_storage[..tx_size.area()];
     // dynamic allocation: test
@@ -431,6 +433,7 @@ mod test {
     inverse_transform_add(
       freq,
       &mut dst.as_region_mut(),
+      coeff_area,
       tx_size,
       tx_type,
       8,


### PR DESCRIPTION
The inverse transforms from dav1d have eob optimizations. It is as
simple as providing those functions with the needed parameters.

Very small performance improvement. Measures in the scale of tenths of a
percent.