### PR TITLE
Derive Copy for Block.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1381,7 +1381,7 @@ impl TileBlockOffset {
   }
 }
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct Block {
   pub mode: PredictionMode,
   pub partition: PartitionType,


### PR DESCRIPTION
FrameBlocks::new() is still pretty slow, at 0.223ms for 480p.