### PR TITLE
Change debug optimization level to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ path = "benches/bench.rs"
 harness = false
 
 [profile.dev]
-opt-level = 2
+opt-level = 1
 
 [profile.release]
 debug = true


### PR DESCRIPTION
There is an outstanding bug in Rust/LLVM
where certain panics are optimized away
in debug mode when optimization level
is set to 2.
Until this is fixed,
this commit changes the optimization level
to avoid confusion around the Illegal Instruction
segfaults that are produced due to the compiler bug.