### PR TITLE
Unify angle_delta and alpha to enum

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -108,8 +108,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
               false,
               qindex as u8,
               ac,
-              0,
-              0,
+              IntraParam::None,
               RDOType::PixelDistRealRate,
               true,
             );

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -13,7 +13,7 @@ use crate::encoder::{
 use crate::frame::{AsRegion, PlaneOffset};
 use crate::hawktracer::*;
 use crate::partition::{get_intra_edges, BlockSize};
-use crate::predict::PredictionMode;
+use crate::predict::{IntraParam, PredictionMode};
 use crate::tiling::{Area, TileRect};
 use crate::transform::TxSize;
 use crate::{Frame, Pixel};
@@ -86,8 +86,7 @@ pub(crate) fn estimate_intra_costs<T: Pixel>(
         tx_size,
         bit_depth,
         &[], // Not used by DC_PRED.
-        0,   // Not used by DC_PRED.
-        0,   // Not used by DC_PRED.
+        IntraParam::None,
         &edge_buf,
         cpu_feature_level,
       );

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -22,7 +22,7 @@ use crate::me::*;
 use crate::partition::PartitionType::*;
 use crate::partition::RefType::*;
 use crate::partition::*;
-use crate::predict::{AngleDelta, PredictionMode};
+use crate::predict::{AngleDelta, IntraParam, PredictionMode};
 use crate::quantize::*;
 use crate::rate::bexp64;
 use crate::rate::q57;
@@ -1143,8 +1143,7 @@ pub fn encode_tx_block<T: Pixel>(
   skip: bool,
   qidx: u8,
   ac: &[i16],
-  angle_delta: i8,
-  alpha: i16,
+  pred_intra_param: IntraParam,
   rdo_type: RDOType,
   need_recon_pixel: bool,
 ) -> (bool, ScaledDistortion) {
@@ -1182,8 +1181,7 @@ pub fn encode_tx_block<T: Pixel>(
       tx_size,
       bit_depth,
       &ac,
-      angle_delta,
-      alpha,
+      pred_intra_param,
       &edge_buf,
       fi.cpu_feature_level,
     );
@@ -1886,8 +1884,7 @@ pub fn write_tx_blocks<T: Pixel>(
         skip,
         qidx,
         &ac.array,
-        angle_delta.y,
-        0,
+        IntraParam::Angle_delta(angle_delta.y),
         rdo_type,
         need_recon_pixel,
       );
@@ -1971,8 +1968,11 @@ pub fn write_tx_blocks<T: Pixel>(
             skip,
             qidx,
             &ac.array,
-            angle_delta.uv,
-            alpha,
+            if chroma_mode.is_cfl() {
+              IntraParam::Alpha(alpha)
+            } else {
+              IntraParam::Angle_delta(angle_delta.uv)
+            },
             rdo_type,
             need_recon_pixel,
           );
@@ -2034,8 +2034,7 @@ pub fn write_tx_tree<T: Pixel>(
     skip,
     qidx,
     ac,
-    angle_delta_y,
-    0,
+    IntraParam::Angle_delta(angle_delta_y),
     rdo_type,
     need_recon_pixel,
   );
@@ -2109,8 +2108,7 @@ pub fn write_tx_tree<T: Pixel>(
             skip,
             qidx,
             ac,
-            angle_delta_y,
-            0,
+            IntraParam::Angle_delta(angle_delta_y),
             rdo_type,
             need_recon_pixel,
           );

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -28,7 +28,7 @@ use crate::motion_compensate;
 use crate::partition::RefType::*;
 use crate::partition::*;
 use crate::predict::{
-  AngleDelta, PredictionMode, RAV1E_INTER_COMPOUND_MODES,
+  AngleDelta, IntraParam, PredictionMode, RAV1E_INTER_COMPOUND_MODES,
   RAV1E_INTER_MODES_MINIMAL, RAV1E_INTRA_MODES,
 };
 use crate::rdo_tables::*;
@@ -1164,8 +1164,7 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
             tx_size,
             fi.sequence.bit_depth,
             &[0i16; 2],
-            0,
-            0,
+            IntraParam::None,
             &edge_buf,
             fi.cpu_feature_level,
           );
@@ -1345,8 +1344,7 @@ pub fn rdo_cfl_alpha<T: Pixel>(
           uv_tx_size,
           bit_depth,
           &ac.array,
-          0,
-          alpha,
+          IntraParam::Alpha(alpha),
           &edge_buf,
           cpu,
         );


### PR DESCRIPTION
Only one of angle_delta or alpha is used for predict_intra().
This ensures that (alpha == 0) || (angle_delta == 0) which avoids invalid calculation of angle.