### PR TITLE
 Implement PartialOrd for BlockSize

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2178,7 +2178,7 @@ impl<'a> ContextWriter<'a> {
     }
 
     debug_assert!(!self.bc.blocks[bo].is_inter());
-    debug_assert!(bsize.greater_than(BlockSize::BLOCK_4X4));
+    debug_assert!(bsize > BlockSize::BLOCK_4X4);
 
     let tx_size_ctx = self.get_tx_size_context(bo, bsize);
     let depth = tx_size_to_depth(tx_size, bsize);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1722,7 +1722,7 @@ pub fn encode_block_post_cdef<T: Pixel>(
 
   // write tx_size here
   if fi.tx_mode_select {
-    if bsize.greater_than(BlockSize::BLOCK_4X4) && !(is_inter && skip) {
+    if bsize > BlockSize::BLOCK_4X4 && !(is_inter && skip) {
       if !is_inter {
         cw.write_tx_size_intra(w, tile_bo, bsize, tx_size);
         cw.bc.update_tx_size_context(tile_bo, bsize, tx_size, false);
@@ -2208,7 +2208,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
   // Always split if the current partition is too large, i.e. right or bottom tile border
   let must_split = (tile_bo.0.x + bsw as usize > ts.mi_width
     || tile_bo.0.y + bsh as usize > ts.mi_height
-    || bsize.greater_than(BlockSize::BLOCK_64X64))
+    || bsize > BlockSize::BLOCK_64X64)
     && is_square;
 
   // must_split overrides the minimum partition size when applicable
@@ -2228,7 +2228,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
 
   // Code the whole block
   if !must_split {
-    let cost = if bsize.gte(BlockSize::BLOCK_8X8) && is_square {
+    let cost = if bsize >= BlockSize::BLOCK_8X8 && is_square {
       let w: &mut W = if cw.bc.cdef_coded { w_post_cdef } else { w_pre_cdef };
       let tell = w.tell_frac();
       cw.write_partition(w, tile_bo, PartitionType::PARTITION_NONE, bsize);
@@ -2237,7 +2237,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
       0.0
     };
 
-    let pmv_inner_idx = if bsize.greater_than(BlockSize::BLOCK_32X32) {
+    let pmv_inner_idx = if bsize > BlockSize::BLOCK_32X32 {
       0
     } else {
       ((tile_bo.0.x & 32) >> 5) + ((tile_bo.0.y & 32) >> 4) + 1
@@ -2333,7 +2333,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
       let mut child_modes = ArrayVec::<[PartitionParameters; 4]>::new();
       rd_cost = 0.0;
 
-      if bsize.gte(BlockSize::BLOCK_8X8) {
+      if bsize >= BlockSize::BLOCK_8X8 {
         let w: &mut W =
           if cw.bc.cdef_coded { w_post_cdef } else { w_pre_cdef };
         let tell = w.tell_frac();
@@ -2416,7 +2416,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
       assert!(best_partition != PartitionType::PARTITION_NONE || !must_split);
       let subsize = bsize.subsize(best_partition);
 
-      if bsize.gte(BlockSize::BLOCK_8X8) {
+      if bsize >= BlockSize::BLOCK_8X8 {
         let w: &mut W =
           if cw.bc.cdef_coded { w_post_cdef } else { w_pre_cdef };
         cw.write_partition(w, tile_bo, best_partition, bsize);
@@ -2454,7 +2454,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
   assert!(best_partition != PartitionType::PARTITION_INVALID);
 
   if is_square
-    && bsize.gte(BlockSize::BLOCK_8X8)
+    && bsize >= BlockSize::BLOCK_8X8
     && (bsize == BlockSize::BLOCK_8X8
       || best_partition != PartitionType::PARTITION_SPLIT)
   {
@@ -2492,7 +2492,7 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
   // Always split if the current partition is too large, i.e. right or bottom tile border
   let must_split = (tile_bo.0.x + bsw as usize > ts.mi_width
     || tile_bo.0.y + bsh as usize > ts.mi_height
-    || bsize.greater_than(BlockSize::BLOCK_64X64))
+    || bsize > BlockSize::BLOCK_64X64)
     && is_square;
 
   let mut rdo_output =
@@ -2572,7 +2572,7 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
 
   let subsize = bsize.subsize(partition);
 
-  if bsize.gte(BlockSize::BLOCK_8X8) && is_square {
+  if bsize >= BlockSize::BLOCK_8X8 && is_square {
     let w: &mut W = if cw.bc.cdef_coded { w_post_cdef } else { w_pre_cdef };
     cw.write_partition(w, tile_bo, partition, bsize);
   }
@@ -2583,7 +2583,7 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
         // The optimal prediction mode is known from a previous iteration
         rdo_output.part_modes[0].clone()
       } else {
-        let pmv_inner_idx = if bsize.greater_than(BlockSize::BLOCK_32X32) {
+        let pmv_inner_idx = if bsize > BlockSize::BLOCK_32X32 {
           0
         } else {
           ((tile_bo.0.x & 32) >> 5) + ((tile_bo.0.y & 32) >> 4) + 1
@@ -2803,7 +2803,7 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
   }
 
   if is_square
-    && bsize.gte(BlockSize::BLOCK_8X8)
+    && bsize >= BlockSize::BLOCK_8X8
     && (bsize == BlockSize::BLOCK_8X8
       || partition != PartitionType::PARTITION_SPLIT)
   {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -338,16 +338,6 @@ impl BlockSize {
     (offset_x, offset_y)
   }
 
-  pub fn greater_than(self, other: BlockSize) -> bool {
-    (self.width() > other.width() && self.height() >= other.height())
-      || (self.width() >= other.width() && self.height() > other.height())
-  }
-
-  pub fn gte(self, other: BlockSize) -> bool {
-    self.greater_than(other)
-      || (self.width() == other.width() && self.height() == other.height())
-  }
-
   pub fn subsize(self, partition: PartitionType) -> BlockSize {
     use PartitionType::*;
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -114,9 +114,7 @@ pub enum PartitionType {
   PARTITION_INVALID,
 }
 
-#[derive(
-  Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Serialize, Deserialize,
-)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BlockSize {
   BLOCK_4X4,
   BLOCK_4X8,
@@ -141,6 +139,21 @@ pub enum BlockSize {
   BLOCK_16X64,
   BLOCK_64X16,
   BLOCK_INVALID,
+}
+
+impl PartialOrd for BlockSize {
+  fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    use std::cmp::Ordering::{Equal, Greater, Less};
+    match (
+      self.width().cmp(&other.width()),
+      self.height().cmp(&other.height()),
+    ) {
+      (Greater, Less) | (Less, Greater) => None,
+      (Equal, Equal) => Some(Equal),
+      (Greater, _) | (_, Greater) => Some(Greater),
+      (Less, _) | (_, Less) => Some(Less),
+    }
+  }
 }
 
 impl BlockSize {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -142,6 +142,7 @@ pub enum BlockSize {
 }
 
 impl PartialOrd for BlockSize {
+  #[inline(always)]
   fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
     use std::cmp::Ordering::{Equal, Greater, Less};
     match (

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1256,7 +1256,7 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
     );
   });
 
-  if bsize.gte(BlockSize::BLOCK_8X8) {
+  if bsize >= BlockSize::BLOCK_8X8 {
     // Find the best angle delta for the current best prediction mode
     let luma_angle_delta_count = best.pred_mode_luma.angle_delta_count();
     let chroma_angle_delta_count = best.pred_mode_chroma.angle_delta_count();
@@ -1634,7 +1634,7 @@ fn rdo_partition_simple<T: Pixel, W: Writer>(
   let pmv_idxs = partitions
     .iter()
     .map(|&offset| {
-      if subsize.greater_than(BlockSize::BLOCK_32X32) {
+      if subsize > BlockSize::BLOCK_32X32 {
         0
       } else {
         ((offset.0.x & 32) >> 5) + ((offset.0.y & 32) >> 4) + 1


### PR DESCRIPTION
Drop derivation of Ord, there is not a total order. Remove greater_than() and gte() from BlockSize; replace with the equivalent operators. Alternative to #2061.