### PR TITLE
Support intra edge filtering

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -167,15 +167,7 @@ fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
   let mut fs = FrameState::new(&fi);
   let mut ts = fs.as_tile_state_mut();
   let offset = TileBlockOffset(BlockOffset { x: 1, y: 1 });
-  b.iter(|| {
-    rdo_cfl_alpha(
-      &mut ts,
-      offset,
-      bsize,
-      fi.sequence.bit_depth,
-      fi.cpu_feature_level,
-    )
-  })
+  b.iter(|| rdo_cfl_alpha(&mut ts, offset, bsize, &fi))
 }
 
 fn ec_bench(c: &mut Criterion) {

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -155,6 +155,7 @@ pub fn intra_bench<T: Pixel>(
       bitdepth,
       &ac,
       angle,
+      false,
       &edge_buf,
       cpu,
     );

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -155,7 +155,7 @@ pub fn intra_bench<T: Pixel>(
       bitdepth,
       &ac,
       angle,
-      false,
+      None,
       &edge_buf,
       cpu,
     );

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -87,7 +87,7 @@ pub(crate) fn estimate_intra_costs<T: Pixel>(
         bit_depth,
         &[], // Not used by DC_PRED
         IntraParam::None,
-        false, // Not used by DC_PRED
+        None, // Not used by DC_PRED
         &edge_buf,
         cpu_feature_level,
       );

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -85,8 +85,9 @@ pub(crate) fn estimate_intra_costs<T: Pixel>(
         &mut plane_after_prediction_region,
         tx_size,
         bit_depth,
-        &[], // Not used by DC_PRED.
+        &[], // Not used by DC_PRED
         IntraParam::None,
+        false, // Not used by DC_PRED
         &edge_buf,
         cpu_feature_level,
       );

--- a/src/asm/aarch64/predict.rs
+++ b/src/asm/aarch64/predict.rs
@@ -68,12 +68,21 @@ decl_cfl_pred_fn! {
 pub fn dispatch_predict_intra<T: Pixel>(
   mode: PredictionMode, variant: PredictionVariant,
   dst: &mut PlaneRegionMut<'_, T>, tx_size: TxSize, bit_depth: usize,
-  ac: &[i16], angle: isize, edge_buf: &AlignedArray<[T; 4 * MAX_TX_SIZE + 1]>,
-  cpu: CpuFeatureLevel,
+  ac: &[i16], angle: isize, enable_edge_filter: bool,
+  edge_buf: &AlignedArray<[T; 4 * MAX_TX_SIZE + 1]>, cpu: CpuFeatureLevel,
 ) {
   let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
     native::dispatch_predict_intra(
-      mode, variant, dst, tx_size, bit_depth, ac, angle, edge_buf, cpu,
+      mode,
+      variant,
+      dst,
+      tx_size,
+      bit_depth,
+      ac,
+      angle,
+      enable_edge_filter,
+      edge_buf,
+      cpu,
     );
   };
 

--- a/src/asm/aarch64/predict.rs
+++ b/src/asm/aarch64/predict.rs
@@ -9,7 +9,9 @@
 
 use crate::context::MAX_TX_SIZE;
 use crate::cpu_features::CpuFeatureLevel;
-use crate::predict::{native, PredictionMode, PredictionVariant};
+use crate::predict::{
+  native, IntraEdgeFilterParameters, PredictionMode, PredictionVariant,
+};
 use crate::tiling::PlaneRegionMut;
 use crate::transform::TxSize;
 use crate::util::AlignedArray;
@@ -68,20 +70,12 @@ decl_cfl_pred_fn! {
 pub fn dispatch_predict_intra<T: Pixel>(
   mode: PredictionMode, variant: PredictionVariant,
   dst: &mut PlaneRegionMut<'_, T>, tx_size: TxSize, bit_depth: usize,
-  ac: &[i16], angle: isize, enable_edge_filter: bool,
+  ac: &[i16], angle: isize, ief_params: Option<IntraEdgeFilterParameters>,
   edge_buf: &AlignedArray<[T; 4 * MAX_TX_SIZE + 1]>, cpu: CpuFeatureLevel,
 ) {
   let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
     native::dispatch_predict_intra(
-      mode,
-      variant,
-      dst,
-      tx_size,
-      bit_depth,
-      ac,
-      angle,
-      enable_edge_filter,
-      edge_buf,
+      mode, variant, dst, tx_size, bit_depth, ac, angle, ief_params, edge_buf,
       cpu,
     );
   };

--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -9,7 +9,9 @@
 
 use crate::context::MAX_TX_SIZE;
 use crate::cpu_features::CpuFeatureLevel;
-use crate::predict::{native, PredictionMode, PredictionVariant};
+use crate::predict::{
+  native, IntraEdgeFilterParameters, PredictionMode, PredictionVariant,
+};
 use crate::tiling::PlaneRegionMut;
 use crate::transform::TxSize;
 use crate::util::AlignedArray;
@@ -85,20 +87,12 @@ decl_cfl_pred_fn! {
 pub fn dispatch_predict_intra<T: Pixel>(
   mode: PredictionMode, variant: PredictionVariant,
   dst: &mut PlaneRegionMut<'_, T>, tx_size: TxSize, bit_depth: usize,
-  ac: &[i16], angle: isize, enable_edge_filter: bool,
+  ac: &[i16], angle: isize, ief_params: Option<IntraEdgeFilterParameters>,
   edge_buf: &AlignedArray<[T; 4 * MAX_TX_SIZE + 1]>, cpu: CpuFeatureLevel,
 ) {
   let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
     native::dispatch_predict_intra(
-      mode,
-      variant,
-      dst,
-      tx_size,
-      bit_depth,
-      ac,
-      angle,
-      enable_edge_filter,
-      edge_buf,
+      mode, variant, dst, tx_size, bit_depth, ac, angle, ief_params, edge_buf,
       cpu,
     );
   };
@@ -286,7 +280,7 @@ mod test {
             bit_depth,
             &ac,
             *angle,
-            false,
+            None,
             &edge_buf,
             cpu,
           );
@@ -306,7 +300,7 @@ mod test {
           bit_depth,
           &ac,
           *angle,
-          false,
+          None,
           &edge_buf,
           cpu,
         );

--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -85,12 +85,21 @@ decl_cfl_pred_fn! {
 pub fn dispatch_predict_intra<T: Pixel>(
   mode: PredictionMode, variant: PredictionVariant,
   dst: &mut PlaneRegionMut<'_, T>, tx_size: TxSize, bit_depth: usize,
-  ac: &[i16], angle: isize, edge_buf: &AlignedArray<[T; 4 * MAX_TX_SIZE + 1]>,
-  cpu: CpuFeatureLevel,
+  ac: &[i16], angle: isize, enable_edge_filter: bool,
+  edge_buf: &AlignedArray<[T; 4 * MAX_TX_SIZE + 1]>, cpu: CpuFeatureLevel,
 ) {
   let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
     native::dispatch_predict_intra(
-      mode, variant, dst, tx_size, bit_depth, ac, angle, edge_buf, cpu,
+      mode,
+      variant,
+      dst,
+      tx_size,
+      bit_depth,
+      ac,
+      angle,
+      enable_edge_filter,
+      edge_buf,
+      cpu,
     );
   };
 
@@ -277,6 +286,7 @@ mod test {
             bit_depth,
             &ac,
             *angle,
+            false,
             &edge_buf,
             cpu,
           );
@@ -296,6 +306,7 @@ mod test {
           bit_depth,
           &ac,
           *angle,
+          false,
           &edge_buf,
           cpu,
         );

--- a/src/context.rs
+++ b/src/context.rs
@@ -1844,7 +1844,7 @@ impl<'a> BlockContext<'a> {
   }
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum CFLSign {
   CFL_SIGN_ZERO = 0,
   CFL_SIGN_NEG = 1,
@@ -1861,7 +1861,7 @@ use crate::context::CFLSign::*;
 const CFL_SIGNS: usize = 3;
 static cfl_sign_value: [i16; CFL_SIGNS] = [0, -1, 1];
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct CFLParams {
   sign: [CFLSign; 2],
   scale: [u8; 2],

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1767,12 +1767,10 @@ pub fn encode_block_post_cdef<T: Pixel>(
   if fi.sequence.enable_intra_edge_filter {
     for y in 0..bsize.height_mi() {
       for x in 0..bsize.width_mi() {
-        ts.coded_block_info[tile_bo.0.y + y][tile_bo.0.x + x].luma_mode =
-          luma_mode;
-        ts.coded_block_info[tile_bo.0.y + y][tile_bo.0.x + x].chroma_mode =
-          chroma_mode;
-        ts.coded_block_info[tile_bo.0.y + y][tile_bo.0.x + x]
-          .reference_types = ref_frames;
+        let bi = &mut ts.coded_block_info[tile_bo.0.y + y][tile_bo.0.x + x];
+        bi.luma_mode = luma_mode;
+        bi.chroma_mode = chroma_mode;
+        bi.reference_types = ref_frames;
       }
     }
   }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -223,7 +223,7 @@ impl Sequence {
       still_picture: config.still_picture,
       reduced_still_picture_hdr: false, // FIXME: config.still_picture,
       enable_filter_intra: false,
-      enable_intra_edge_filter: false, // FIXME: does not work with asm
+      enable_intra_edge_filter: true,
       enable_interintra_compound: false,
       enable_masked_compound: false,
       enable_dual_filter: false,
@@ -1149,80 +1149,81 @@ pub fn encode_tx_block<T: Pixel>(
     "mode.is_intra()={:#?}, plane={:#?}, tx_size.block_size()={:#?}, plane_bsize={:#?}, need_recon_pixel={:#?}",
     mode.is_intra(), p, tx_size.block_size(), plane_bsize, need_recon_pixel);
 
-  let ief_params = if fi.sequence.enable_intra_edge_filter {
-    let (bo_x, bo_y) = (tile_partition_bo.0.x, tile_partition_bo.0.y);
-    let above_block_info = if p == 0 {
-      if bo_y == 0 {
-        None
+  let ief_params =
+    if mode.is_directional() && fi.sequence.enable_intra_edge_filter {
+      let (bo_x, bo_y) = (tile_partition_bo.0.x, tile_partition_bo.0.y);
+      let above_block_info = if p == 0 {
+        if bo_y == 0 {
+          None
+        } else {
+          Some(ts.coded_block_info[bo_y - 1][bo_x])
+        }
       } else {
-        Some(ts.coded_block_info[bo_y - 1][bo_x])
-      }
-    } else {
-      let (mut bo_x_uv, mut bo_y_uv) = (bo_x, bo_y);
-      if bo_x & 1 == 0 {
-        bo_x_uv += 1
+        let (mut bo_x_uv, mut bo_y_uv) = (bo_x, bo_y);
+        if bo_x & 1 == 0 {
+          bo_x_uv += 1
+        };
+        if bo_y & 1 == 1 {
+          bo_y_uv -= 1
+        };
+        if bo_y_uv == 0 {
+          None
+        } else {
+          Some(ts.coded_block_info[bo_y_uv - 1][bo_x_uv])
+        }
       };
-      if bo_y & 1 == 1 {
-        bo_y_uv -= 1
-      };
-      if bo_y_uv == 0 {
-        None
+      let left_block_info = if p == 0 {
+        if bo_x == 0 {
+          None
+        } else {
+          Some(ts.coded_block_info[bo_y][bo_x - 1])
+        }
       } else {
-        Some(ts.coded_block_info[bo_y_uv - 1][bo_x_uv])
-      }
-    };
-    let left_block_info = if p == 0 {
-      if bo_x == 0 {
-        None
-      } else {
-        Some(ts.coded_block_info[bo_y][bo_x - 1])
-      }
-    } else {
-      let (mut bo_x_uv, mut bo_y_uv) = (bo_x, bo_y);
-      if bo_x & 1 == 1 {
-        bo_x_uv -= 1
+        let (mut bo_x_uv, mut bo_y_uv) = (bo_x, bo_y);
+        if bo_x & 1 == 1 {
+          bo_x_uv -= 1
+        };
+        if bo_y & 1 == 0 {
+          bo_y_uv += 1
+        };
+        if bo_x_uv == 0 {
+          None
+        } else {
+          Some(ts.coded_block_info[bo_y_uv][bo_x_uv - 1])
+        }
       };
-      if bo_y & 1 == 0 {
-        bo_y_uv += 1
-      };
-      if bo_x_uv == 0 {
-        None
-      } else {
-        Some(ts.coded_block_info[bo_y_uv][bo_x_uv - 1])
-      }
-    };
 
-    IntraEdgeFilterParameters {
-      plane: p,
-      above_mode: match above_block_info {
-        Some(bi) => match p {
-          0 => bi.luma_mode,
-          _ => bi.chroma_mode,
-        }
-        .into(),
-        None => None,
-      },
-      left_mode: match left_block_info {
-        Some(bi) => match p {
-          0 => bi.luma_mode,
-          _ => bi.chroma_mode,
-        }
-        .into(),
-        None => None,
-      },
-      above_ref_frame_types: match above_block_info {
-        Some(bi) => Some(bi.reference_types),
-        None => None,
-      },
-      left_ref_frame_types: match left_block_info {
-        Some(bi) => Some(bi.reference_types),
-        None => None,
-      },
-    }
-    .into()
-  } else {
-    None
-  };
+      IntraEdgeFilterParameters {
+        plane: p,
+        above_mode: match above_block_info {
+          Some(bi) => match p {
+            0 => bi.luma_mode,
+            _ => bi.chroma_mode,
+          }
+          .into(),
+          None => None,
+        },
+        left_mode: match left_block_info {
+          Some(bi) => match p {
+            0 => bi.luma_mode,
+            _ => bi.chroma_mode,
+          }
+          .into(),
+          None => None,
+        },
+        above_ref_frame_types: match above_block_info {
+          Some(bi) => Some(bi.reference_types),
+          None => None,
+        },
+        left_ref_frame_types: match left_block_info {
+          Some(bi) => Some(bi.reference_types),
+          None => None,
+        },
+      }
+      .into()
+    } else {
+      None
+    };
 
   if mode.is_intra() {
     let bit_depth = fi.sequence.bit_depth;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1136,7 +1136,6 @@ pub fn encode_tx_block<T: Pixel>(
 ) -> (bool, ScaledDistortion) {
   let PlaneConfig { xdec, ydec, .. } = ts.input.planes[p].cfg;
   let tile_rect = ts.tile_rect().decimated(xdec, ydec);
-  let rec = &mut ts.rec.planes[p];
   let area = Area::BlockStartingAt { bo: tx_bo.0 };
 
   debug_assert!(
@@ -1149,81 +1148,17 @@ pub fn encode_tx_block<T: Pixel>(
     "mode.is_intra()={:#?}, plane={:#?}, tx_size.block_size()={:#?}, plane_bsize={:#?}, need_recon_pixel={:#?}",
     mode.is_intra(), p, tx_size.block_size(), plane_bsize, need_recon_pixel);
 
-  let ief_params =
-    if mode.is_directional() && fi.sequence.enable_intra_edge_filter {
-      let (bo_x, bo_y) = (tile_partition_bo.0.x, tile_partition_bo.0.y);
-      let above_block_info = if p == 0 {
-        if bo_y == 0 {
-          None
-        } else {
-          Some(ts.coded_block_info[bo_y - 1][bo_x])
-        }
-      } else {
-        let (mut bo_x_uv, mut bo_y_uv) = (bo_x, bo_y);
-        if bo_x & 1 == 0 {
-          bo_x_uv += 1
-        };
-        if bo_y & 1 == 1 {
-          bo_y_uv -= 1
-        };
-        if bo_y_uv == 0 {
-          None
-        } else {
-          Some(ts.coded_block_info[bo_y_uv - 1][bo_x_uv])
-        }
-      };
-      let left_block_info = if p == 0 {
-        if bo_x == 0 {
-          None
-        } else {
-          Some(ts.coded_block_info[bo_y][bo_x - 1])
-        }
-      } else {
-        let (mut bo_x_uv, mut bo_y_uv) = (bo_x, bo_y);
-        if bo_x & 1 == 1 {
-          bo_x_uv -= 1
-        };
-        if bo_y & 1 == 0 {
-          bo_y_uv += 1
-        };
-        if bo_x_uv == 0 {
-          None
-        } else {
-          Some(ts.coded_block_info[bo_y_uv][bo_x_uv - 1])
-        }
-      };
+  let ief_params = if mode.is_directional()
+    && fi.sequence.enable_intra_edge_filter
+  {
+    let above_block_info = ts.above_block_info(tile_partition_bo, p);
+    let left_block_info = ts.left_block_info(tile_partition_bo, p);
+    Some(IntraEdgeFilterParameters::new(p, above_block_info, left_block_info))
+  } else {
+    None
+  };
 
-      IntraEdgeFilterParameters {
-        plane: p,
-        above_mode: match above_block_info {
-          Some(bi) => match p {
-            0 => bi.luma_mode,
-            _ => bi.chroma_mode,
-          }
-          .into(),
-          None => None,
-        },
-        left_mode: match left_block_info {
-          Some(bi) => match p {
-            0 => bi.luma_mode,
-            _ => bi.chroma_mode,
-          }
-          .into(),
-          None => None,
-        },
-        above_ref_frame_types: match above_block_info {
-          Some(bi) => Some(bi.reference_types),
-          None => None,
-        },
-        left_ref_frame_types: match left_block_info {
-          Some(bi) => Some(bi.reference_types),
-          None => None,
-        },
-      }
-      .into()
-    } else {
-      None
-    };
+  let rec = &mut ts.rec.planes[p];
 
   if mode.is_intra() {
     let bit_depth = fi.sequence.bit_depth;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -221,6 +221,7 @@ impl Sequence {
       still_picture: config.still_picture,
       reduced_still_picture_hdr: false, // FIXME: config.still_picture,
       enable_filter_intra: false,
+      // FIXME: incompatible with smooth prediction modes
       enable_intra_edge_filter: false,
       enable_interintra_compound: false,
       enable_masked_compound: false,
@@ -1167,6 +1168,7 @@ pub fn encode_tx_block<T: Pixel>(
       bit_depth,
       ac,
       pred_intra_param,
+      fi.sequence.enable_intra_edge_filter,
       &edge_buf,
       fi.cpu_feature_level,
     );

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -22,7 +22,9 @@ use crate::me::*;
 use crate::partition::PartitionType::*;
 use crate::partition::RefType::*;
 use crate::partition::*;
-use crate::predict::{AngleDelta, IntraParam, PredictionMode};
+use crate::predict::{
+  AngleDelta, IntraEdgeFilterParameters, IntraParam, PredictionMode,
+};
 use crate::quantize::*;
 use crate::rate::bexp64;
 use crate::rate::q57;
@@ -131,7 +133,7 @@ pub struct Sequence {
   pub still_picture: bool, // Video is a single frame still picture
   pub reduced_still_picture_hdr: bool, // Use reduced header for still picture
   pub enable_filter_intra: bool, // enables/disables filter_intra
-  pub enable_intra_edge_filter: bool, // enables/disables corner/edge/upsampling
+  pub enable_intra_edge_filter: bool, // enables/disables corner/edge filtering and upsampling
   pub enable_interintra_compound: bool, // enables/disables interintra_compound
   pub enable_masked_compound: bool,   // enables/disables masked compound
   pub enable_dual_filter: bool,       // 0 - disable dual interpolation filter
@@ -221,8 +223,7 @@ impl Sequence {
       still_picture: config.still_picture,
       reduced_still_picture_hdr: false, // FIXME: config.still_picture,
       enable_filter_intra: false,
-      // FIXME: incompatible with smooth prediction modes
-      enable_intra_edge_filter: false,
+      enable_intra_edge_filter: false, // FIXME: does not work with asm
       enable_interintra_compound: false,
       enable_masked_compound: false,
       enable_dual_filter: false,
@@ -1148,6 +1149,81 @@ pub fn encode_tx_block<T: Pixel>(
     "mode.is_intra()={:#?}, plane={:#?}, tx_size.block_size()={:#?}, plane_bsize={:#?}, need_recon_pixel={:#?}",
     mode.is_intra(), p, tx_size.block_size(), plane_bsize, need_recon_pixel);
 
+  let ief_params = if fi.sequence.enable_intra_edge_filter {
+    let (bo_x, bo_y) = (tile_partition_bo.0.x, tile_partition_bo.0.y);
+    let above_block_info = if p == 0 {
+      if bo_y == 0 {
+        None
+      } else {
+        Some(ts.coded_block_info[bo_y - 1][bo_x])
+      }
+    } else {
+      let (mut bo_x_uv, mut bo_y_uv) = (bo_x, bo_y);
+      if bo_x & 1 == 0 {
+        bo_x_uv += 1
+      };
+      if bo_y & 1 == 1 {
+        bo_y_uv -= 1
+      };
+      if bo_y_uv == 0 {
+        None
+      } else {
+        Some(ts.coded_block_info[bo_y_uv - 1][bo_x_uv])
+      }
+    };
+    let left_block_info = if p == 0 {
+      if bo_x == 0 {
+        None
+      } else {
+        Some(ts.coded_block_info[bo_y][bo_x - 1])
+      }
+    } else {
+      let (mut bo_x_uv, mut bo_y_uv) = (bo_x, bo_y);
+      if bo_x & 1 == 1 {
+        bo_x_uv -= 1
+      };
+      if bo_y & 1 == 0 {
+        bo_y_uv += 1
+      };
+      if bo_x_uv == 0 {
+        None
+      } else {
+        Some(ts.coded_block_info[bo_y_uv][bo_x_uv - 1])
+      }
+    };
+
+    IntraEdgeFilterParameters {
+      plane: p,
+      above_mode: match above_block_info {
+        Some(bi) => match p {
+          0 => bi.luma_mode,
+          _ => bi.chroma_mode,
+        }
+        .into(),
+        None => None,
+      },
+      left_mode: match left_block_info {
+        Some(bi) => match p {
+          0 => bi.luma_mode,
+          _ => bi.chroma_mode,
+        }
+        .into(),
+        None => None,
+      },
+      above_ref_frame_types: match above_block_info {
+        Some(bi) => Some(bi.reference_types),
+        None => None,
+      },
+      left_ref_frame_types: match left_block_info {
+        Some(bi) => Some(bi.reference_types),
+        None => None,
+      },
+    }
+    .into()
+  } else {
+    None
+  };
+
   if mode.is_intra() {
     let bit_depth = fi.sequence.bit_depth;
     let edge_buf = get_intra_edges(
@@ -1168,7 +1244,7 @@ pub fn encode_tx_block<T: Pixel>(
       bit_depth,
       ac,
       pred_intra_param,
-      fi.sequence.enable_intra_edge_filter,
+      ief_params,
       &edge_buf,
       fi.cpu_feature_level,
     );
@@ -1749,6 +1825,19 @@ pub fn encode_block_post_cdef<T: Pixel>(
     ts.enc_stats.chroma_pred_mode_counts[chroma_mode as usize] += pixels;
     if skip {
       ts.enc_stats.skip_block_count += pixels;
+    }
+  }
+
+  if fi.sequence.enable_intra_edge_filter {
+    for y in 0..bsize.height_mi() {
+      for x in 0..bsize.width_mi() {
+        ts.coded_block_info[tile_bo.0.y + y][tile_bo.0.x + x].luma_mode =
+          luma_mode;
+        ts.coded_block_info[tile_bo.0.y + y][tile_bo.0.x + x].chroma_mode =
+          chroma_mode;
+        ts.coded_block_info[tile_bo.0.y + y][tile_bo.0.x + x]
+          .reference_types = ref_frames;
+      }
     }
   }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -23,7 +23,7 @@ use crate::transform::TxSize;
 use crate::util::*;
 
 // LAST_FRAME through ALTREF_FRAME correspond to slots 0-6.
-#[derive(PartialEq, Eq, PartialOrd, Copy, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Copy, Clone, Debug)]
 pub enum RefType {
   INTRA_FRAME = 0,
   LAST_FRAME = 1,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -533,7 +533,7 @@ pub fn get_intra_edges<T: Pixel>(
   let base = 128u16 << (bit_depth - 8);
 
   {
-    // left pixels are order from bottom to top and right-aligned
+    // left pixels are ordered from bottom to top and right-aligned
     let (left, not_left) = edge_buf.array.split_at_mut(2 * MAX_TX_SIZE);
     let (top_left, above) = not_left.split_at_mut(1);
 
@@ -565,9 +565,12 @@ pub fn get_intra_edges<T: Pixel>(
           || mode == PredictionMode::D67_PRED);
       needs_topleft = mode == PredictionMode::V_PRED
         || mode == PredictionMode::H_PRED
+        || mode == PredictionMode::D45_PRED
         || mode == PredictionMode::D135_PRED
         || mode == PredictionMode::D113_PRED
         || mode == PredictionMode::D157_PRED
+        || mode == PredictionMode::D203_PRED
+        || mode == PredictionMode::D67_PRED
         || mode == PredictionMode::PAETH_PRED;
       needs_top = !dc_or_cfl || y != 0;
       needs_topright = mode == PredictionMode::V_PRED

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -975,8 +975,8 @@ pub(crate) mod native {
 
     // Initialize above and left edge buffers of the largest possible needed size if upsampled
     // The first value is the top left pixel, also mutable and indexed at -1 in the spec
-    let mut above_filtered: Vec<T> = vec![T::cast_from(0); width * 4 + 1];
-    let mut left_filtered: Vec<T> = vec![T::cast_from(0); height * 4 + 1];
+    let mut above_filtered: Vec<T> = vec![T::cast_from(0); (width + height) * 2 + 1];
+    let mut left_filtered: Vec<T> = vec![T::cast_from(0); (width + height) * 2 + 1];
 
     let left_clone: &mut [T] = &mut left.clone().to_owned();
     left_clone.as_mut().reverse();

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1045,12 +1045,11 @@ pub(crate) mod native {
     let mut left_filtered: Vec<T> =
       vec![T::cast_from(0); (width + height) * 2 + 1];
 
-    let left_clone: &mut [T] = &mut left.clone().to_owned();
-    left_clone.as_mut().reverse();
-
     if enable_edge_filter {
       above_filtered[1..=above.len()].clone_from_slice(above);
-      left_filtered[1..=left.len()].clone_from_slice(&left_clone);
+      for i in 1..=left.len() {
+        left_filtered[i] = left[left.len() - i];
+      }
 
       let smooth_filter = ief_params.unwrap().use_smooth_filter();
 
@@ -1058,7 +1057,7 @@ pub(crate) mod native {
         let top_left_px =
           if p_angle > 90 && p_angle < 180 && width + height >= 24 {
             let (l, a, tl): (u32, u32, u32) =
-              (left_clone[0].into(), above[0].into(), top_left[0].into());
+              (left_filtered[1].into(), above[0].into(), top_left[0].into());
             let s = l * 5 + tl * 6 + a * 5;
             T::cast_from((s + (1 << 3)) >> 4)
           } else {

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -396,6 +396,39 @@ pub struct IntraEdgeFilterParameters {
 }
 
 impl IntraEdgeFilterParameters {
+  pub fn new(
+    plane: usize, above_ctx: Option<CodedBlockInfo>,
+    left_ctx: Option<CodedBlockInfo>,
+  ) -> Self {
+    IntraEdgeFilterParameters {
+      plane,
+      above_mode: match above_ctx {
+        Some(bi) => match plane {
+          0 => bi.luma_mode,
+          _ => bi.chroma_mode,
+        }
+        .into(),
+        None => None,
+      },
+      left_mode: match left_ctx {
+        Some(bi) => match plane {
+          0 => bi.luma_mode,
+          _ => bi.chroma_mode,
+        }
+        .into(),
+        None => None,
+      },
+      above_ref_frame_types: match above_ctx {
+        Some(bi) => Some(bi.reference_types),
+        None => None,
+      },
+      left_ref_frame_types: match left_ctx {
+        Some(bi) => Some(bi.reference_types),
+        None => None,
+      },
+    }
+  }
+
   pub fn use_smooth_filter(self) -> bool {
     let above_smooth = match self.above_mode {
       Some(PredictionMode::SMOOTH_PRED)

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1146,39 +1146,13 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
       };
 
       let ief_params = if fi.sequence.enable_intra_edge_filter {
-        let (bo_x, bo_y) = (tile_bo.0.x, tile_bo.0.y);
-        let above_block_info = if bo_y == 0 {
-          None
-        } else {
-          Some(ts.coded_block_info[bo_y - 1][bo_x])
-        };
-
-        let left_block_info = if bo_x == 0 {
-          None
-        } else {
-          Some(ts.coded_block_info[bo_y][bo_x - 1])
-        };
-
-        IntraEdgeFilterParameters {
-          plane: 0,
-          above_mode: match above_block_info {
-            Some(bi) => Some(bi.luma_mode),
-            None => None,
-          },
-          left_mode: match left_block_info {
-            Some(bi) => Some(bi.luma_mode),
-            None => None,
-          },
-          above_ref_frame_types: match above_block_info {
-            Some(bi) => Some(bi.reference_types),
-            None => None,
-          },
-          left_ref_frame_types: match left_block_info {
-            Some(bi) => Some(bi.reference_types),
-            None => None,
-          },
-        }
-        .into()
+        let above_block_info = ts.above_block_info(tile_bo, 0);
+        let left_block_info = ts.left_block_info(tile_bo, 0);
+        Some(IntraEdgeFilterParameters::new(
+          0,
+          above_block_info,
+          left_block_info,
+        ))
       } else {
         None
       };

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -80,7 +80,7 @@ pub struct PartitionGroupParameters {
   pub part_modes: ArrayVec<[PartitionParameters; 4]>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PartitionParameters {
   pub rd_cost: f64,
   pub bo: TileBlockOffset,
@@ -1151,6 +1151,9 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
           let rec = &mut ts.rec.planes[0];
           let mut rec_region =
             rec.subregion_mut(Area::BlockStartingAt { bo: tile_bo.0 });
+
+          let ief_params = None; // TODO: see if it is worth applying during RDO
+
           // FIXME: If tx partition is used, luma_mode.predict_intra() should be called for each tx block
           luma_mode.predict_intra(
             tile_rect,
@@ -1159,7 +1162,7 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
             fi.sequence.bit_depth,
             &[0i16; 2],
             IntraParam::None,
-            fi.sequence.enable_intra_edge_filter,
+            ief_params,
             &edge_buf,
             fi.cpu_feature_level,
           );
@@ -1340,7 +1343,7 @@ pub fn rdo_cfl_alpha<T: Pixel>(
           fi.sequence.bit_depth,
           &ac.array,
           IntraParam::Alpha(alpha),
-          fi.sequence.enable_intra_edge_filter,
+          None,
           &edge_buf,
           fi.cpu_feature_level,
         );

--- a/src/tiling/tile_state.rs
+++ b/src/tiling/tile_state.rs
@@ -197,4 +197,56 @@ impl<'a, T: Pixel> TileStateMut<'a, T> {
       y: self.sbo.0.y + tile_sbo.0.y,
     })
   }
+
+  pub fn above_block_info(
+    &self, bo: TileBlockOffset, plane: usize,
+  ) -> Option<CodedBlockInfo> {
+    let (bo_x, bo_y) = (bo.0.x, bo.0.y);
+    if plane == 0 {
+      if bo_y == 0 {
+        None
+      } else {
+        Some(self.coded_block_info[bo_y - 1][bo_x])
+      }
+    } else {
+      let (mut bo_x_uv, mut bo_y_uv) = (bo_x, bo_y);
+      if bo_x & 1 == 0 {
+        bo_x_uv += 1
+      };
+      if bo_y & 1 == 1 {
+        bo_y_uv -= 1
+      };
+      if bo_y_uv == 0 {
+        None
+      } else {
+        Some(self.coded_block_info[bo_y_uv - 1][bo_x_uv])
+      }
+    }
+  }
+
+  pub fn left_block_info(
+    &self, bo: TileBlockOffset, plane: usize,
+  ) -> Option<CodedBlockInfo> {
+    let (bo_x, bo_y) = (bo.0.x, bo.0.y);
+    if plane == 0 {
+      if bo_x == 0 {
+        None
+      } else {
+        Some(self.coded_block_info[bo_y][bo_x - 1])
+      }
+    } else {
+      let (mut bo_x_uv, mut bo_y_uv) = (bo_x, bo_y);
+      if bo_x & 1 == 1 {
+        bo_x_uv -= 1
+      };
+      if bo_y & 1 == 0 {
+        bo_y_uv += 1
+      };
+      if bo_x_uv == 0 {
+        None
+      } else {
+        Some(self.coded_block_info[bo_y_uv][bo_x_uv - 1])
+      }
+    }
+  }
 }


### PR DESCRIPTION
This adds support for and enables the intra edge filter for directional prediction and closes #1065.

[This AWCY run](https://beta.arewecompressedyet.com/?job=master-s2-e9db8ff6c255491f44e321505d1d272ff1bcc855%402020-01-13T18%3A34%3A47.902Z&job=ief-rdo-s2-e9db8ff6c255491f44e321505d1d272ff1bcc855%402020-01-14T17%3A30%3A16.615Z) has the following results (at speed level 2):
```
   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-0.4245 | -0.7415 | -0.5551 |  -0.4450 | -0.4508 | -0.5157 |    -0.4762
```

Run time when called natively is around 4% worse than master on this run. The native version could probably be better optimized.

I was considering adding a speed preset for it, but I don't think it would be too useful since it is only applied when directional prediction modes are enabled, which is only at lower levels where we would want to turn this on anyway.

The AVX2 version does not work (it desyncs). My guess is that it is due to pixels being initialized when they should not, or vice versa, in the edge buffer, as changing the `needs_foo` variables in `get_intra_edges()` changes the location of the desync. The current combination may be invalid for IEF.