### PR TITLE
Avoid invoking memset in avx2 forward transforms

### DIFF
--- a/src/util/uninit.rs
+++ b/src/util/uninit.rs
@@ -18,5 +18,12 @@ pub fn init_slice_repeat_mut<T: Copy>(
   }
 
   // Defined behavior, since all elements of slice are initialized
-  unsafe { &mut *(slice as *mut [std::mem::MaybeUninit<T>] as *mut [T]) }
+  unsafe { assume_slice_init_mut(slice) }
+}
+
+/// Assume all the elements are initialized
+pub unsafe fn assume_slice_init_mut<T: Copy>(
+  slice: &'_ mut [MaybeUninit<T>],
+) -> &'_ mut [T] {
+  &mut *(slice as *mut [std::mem::MaybeUninit<T>] as *mut [T])
 }


### PR DESCRIPTION
First commit is single line patch that needs to be resolved for the next patch to work.

Use uninitialized memory to avoid invoking memset. Avoid assuming
uninitialized are initialized in one case and in the other, brazenly
use assume_init on an uninitialized array.