### PR TITLE
Add hawktracer hook for deblock_plane

### DIFF
--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -1288,6 +1288,7 @@ fn sse_h_edge<T: Pixel>(
 }
 
 // Deblocks all edges, vertical and horizontal, in a single plane
+#[hawktracer(deblock_plane)]
 pub fn deblock_plane<T: Pixel>(
   fi: &FrameInvariants<T>, deblock: &DeblockState, p: &mut Plane<T>,
   pli: usize, blocks: &FrameBlocks,


### PR DESCRIPTION
Threads running deblock_plane are spawned from deblock_filter_frame. It
would be nice to be able to track them.