### PR TITLE
Remove unused imports in tests

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -233,8 +233,6 @@ pub(crate) mod native {
   #[cfg(test)]
   mod test {
     use super::*;
-    use crate::api::*;
-    use crate::encoder::*;
 
     #[test]
     fn check_max_element() {


### PR DESCRIPTION
These errors aren't blocked by our tools when they are in tests.