### PR TITLE
Enabling tx partition for inter mode, no-split

### DIFF
--- a/src/entropymode.rs
+++ b/src/entropymode.rs
@@ -33,6 +33,7 @@ const TX_SIZE_LUMA_MIN: usize = TxSize::TX_4X4 as usize;
 const TX_SIZE_CTX_MIN: usize = (TX_SIZE_LUMA_MIN + 1);
 pub const MAX_TX_CATS: usize = (TxSize::TX_SIZES - TX_SIZE_CTX_MIN);
 pub const MAX_TX_DEPTH: usize = 2;
+pub const TXFM_PARTITION_CONTEXTS: usize = 21; // (TxSize::TX_SIZES - TxSize::TX_8X8) * 6 - 3;
 
 // LUTS ---------------------
 
@@ -1341,7 +1342,6 @@ pub static default_palette_uv_color_index_cdf: [[[u16;
   ],
 ];
 
-#[allow(unused)]
 pub static default_txfm_partition_cdf: [[u16; cdf_size!(2)];
   TXFM_PARTITION_CONTEXTS] = [
   cdf!(28581),


### PR DESCRIPTION
- Added some of the functions to decide the cdf (i.e. context) for txfm_split signal
- The tx-partition for intra mode block is enabled in Inter frame,
which previoulsly only enabled for Intra frame because tx_mode_select
flag is signabled at frame header..

TODO: If txfm_split = true is signaled in coming commits,
the location of each of four tx blocks (assuming a partition is a square)
within a partition is used to decide context, so the functions added in
this commit will need accomodate it.

AWCY speed 5:

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.8710 | -1.5453 | -0.9854 |  -0.6434 | -1.0012 | -0.8416 |    -0.9641 |
