### PR TITLE
Restore intra mode pruning for tx_mode_select

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1195,12 +1195,13 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
 
     probs
       .iter()
-      .take(if fi.tx_mode_select { num_modes_rdo } else { num_modes_rdo / 2 })
+      .take(num_modes_rdo / 2)
       .for_each(|&(luma_mode, _prob)| modes.push(luma_mode));
   }
 
-  // If tx partition (i.e. fi.tx_mode_select) is enabled, don't use below intra prediction screening
-  if !fi.tx_mode_select {
+  // If tx partition (i.e. fi.tx_mode_select) is enabled, the below intra prediction screening
+  // may be improved by emulating prediction for each tx block.
+  {
     let tx_size = bsize.tx_size();
 
     let mut satds = {


### PR DESCRIPTION
AWCY result at [speed 5 vs before tx_mode_select was enabled](https://beta.arewecompressedyet.com/?job=master-691e5605_s5%402020-01-16T00%3A16%3A53.649Z&job=tx-mode-select-prune-intra_s5%402020-01-17T05%3A26%3A23.276Z):

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.4098 | -0.5555 | -0.2928 |  -0.2246 | -0.4430 | -0.2509 |    -0.3236 |

At high rates, the increase in encoding time is reduced from ~180% to ~40%.