### PR TITLE
frame: plane: Fix Downsampling of odd sized frames

### DIFF
--- a/benches/plane.rs
+++ b/benches/plane.rs
@@ -24,6 +24,15 @@ pub fn downsample_8bit(c: &mut Criterion) {
   });
 }
 
+pub fn downsample_odd(c: &mut Criterion) {
+  let input = init_plane_u8(1919, 1079);
+  c.bench_function("downsample_odd", move |b| {
+    b.iter(|| {
+      let output = input.downsampled(960, 540);
+    })
+  });
+}
+
 pub fn downsample_10bit(c: &mut Criterion) {
   let input = init_plane_u16(1920, 1080);
   c.bench_function("downsample_10bit", move |b| {
@@ -33,4 +42,4 @@ pub fn downsample_10bit(c: &mut Criterion) {
   });
 }
 
-criterion_group!(plane, downsample_8bit, downsample_10bit);
+criterion_group!(plane, downsample_8bit, downsample_odd, downsample_10bit);

--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -437,8 +437,8 @@ impl<T: Pixel> Plane<T> {
     // unsafe: all pixels initialized in this function
     let mut new = unsafe {
       Plane::new_uninitialized(
-        src.cfg.width / 2,
-        src.cfg.height / 2,
+        (src.cfg.width + 1) / 2,
+        (src.cfg.height + 1) / 2,
         src.cfg.xdec + 1,
         src.cfg.ydec + 1,
         src.cfg.xpad / 2,

--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -452,8 +452,8 @@ impl<T: Pixel> Plane<T> {
     let yorigin = new.cfg.yorigin;
     let stride = new.cfg.stride;
 
-    assert!(width * 2 == src.cfg.width);
-    assert!(height * 2 == src.cfg.height);
+    assert!(width * 2 <= src.cfg.stride - src.cfg.xorigin);
+    assert!(height * 2 <= src.cfg.alloc_height - src.cfg.yorigin);
 
     for row in 0..height {
       let base = (yorigin + row) * stride + xorigin;
@@ -787,7 +787,51 @@ pub mod test {
       &downsampled.data[..]
     );
   }
+  #[test]
+  fn test_plane_downsample_odd() {
+    #[rustfmt::skip]
+    let plane = Plane::<u8> {
+      data: PlaneData::from_slice(&[
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 1, 2, 3, 4, 0, 0,
+        0, 0, 8, 7, 6, 5, 0, 0,
+        0, 0, 9, 8, 7, 6, 0, 0,
+        0, 0, 2, 3, 4, 5, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+      ]),
+      cfg: PlaneConfig {
+        stride: 8,
+        alloc_height: 9,
+        width: 3,
+        height: 3,
+        xdec: 0,
+        ydec: 0,
+        xpad: 0,
+        ypad: 0,
+        xorigin: 2,
+        yorigin: 3,
+      },
+    };
+    let downsampled = plane.downsampled(3, 3);
 
+    #[rustfmt::skip]
+    assert_eq!(
+      &[
+        5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5,
+        6, 6, 6, 6, 6, 6, 6, 6,
+        6, 6, 6, 6, 6, 6, 6, 6,
+        6, 6, 6, 6, 6, 6, 6, 6,
+        6, 6, 6, 6, 6, 6, 6, 6,
+      ][..],
+      &downsampled.data[..]
+    );
+  }
   #[test]
   fn test_plane_pad() {
     #[rustfmt::skip]


### PR DESCRIPTION
Hi,

Currently, the hres and qres are talking half(1/2) and one-fourth(1/4) of the
width and height which is rounded down, when we have an odd-sized frame this becomes
a problem so to solve that we are rounding one up for both width and height.

Earlier: src.cfg.width / 2
Now    : (src.cfg.width + 1) / 2,

Fixes #2055

I am not 100% if doing this causes any other harm, but it would be great, to hear the comments with this