### PR TITLE
Replace 1d fwd tx benchmarks with 2d benchmarks

### DIFF
--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -10,7 +10,9 @@
 use criterion::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
+use rav1e::bench::cpu_features::*;
 use rav1e::bench::transform;
+use rav1e::bench::transform::{forward_transform, TxSize, TxType};
 
 fn init_buffers(size: usize) -> (Vec<i32>, Vec<i32>) {
   let mut ra = ChaChaRng::from_seed([0; 32]);
@@ -72,54 +74,78 @@ pub fn av1_iadst8(c: &mut Criterion) {
   });
 }
 
-pub fn daala_fdct4(c: &mut Criterion) {
-  let (coeffs, _) = init_buffers(4);
-
-  c.bench_function("daala_fdct4", move |b| {
-    b.iter_batched(
-      || coeffs.clone(),
-      |mut coeffs| transform::forward::native::daala_fdct4(&mut coeffs[..]),
-      BatchSize::SmallInput,
-    )
-  });
+fn get_valid_txfm_types(tx_size: TxSize) -> &'static [TxType] {
+  let size_sq = tx_size.sqr_up();
+  use TxType::*;
+  if size_sq == TxSize::TX_64X64 {
+    &[DCT_DCT]
+  } else if size_sq == TxSize::TX_32X32 {
+    &[DCT_DCT, IDTX]
+  } else {
+    &[
+      DCT_DCT,
+      ADST_DCT,
+      DCT_ADST,
+      ADST_ADST,
+      FLIPADST_DCT,
+      DCT_FLIPADST,
+      FLIPADST_FLIPADST,
+      ADST_FLIPADST,
+      FLIPADST_ADST,
+      IDTX,
+      V_DCT,
+      H_DCT,
+      V_ADST,
+      H_ADST,
+      V_FLIPADST,
+      H_FLIPADST,
+    ]
+  }
 }
 
-pub fn daala_fdct8(c: &mut Criterion) {
-  let (coeffs, _) = init_buffers(8);
+pub fn bench_forward_transforms(c: &mut Criterion) {
+  let mut group = c.benchmark_group("forward_transform");
 
-  c.bench_function("daala_fdct8", move |b| {
-    b.iter_batched(
-      || coeffs.clone(),
-      |mut coeffs| transform::forward::native::daala_fdct8(&mut coeffs[..]),
-      BatchSize::SmallInput,
-    )
-  });
-}
+  let mut rng = rand::thread_rng();
+  let cpu = CpuFeatureLevel::default();
 
-pub fn daala_fdst_vii_4(c: &mut Criterion) {
-  let (coeffs, _) = init_buffers(4);
+  let tx_sizes = {
+    use TxSize::*;
+    [
+      TX_4X4, TX_8X8, TX_16X16, TX_32X32, TX_64X64, TX_4X8, TX_8X4, TX_8X16,
+      TX_16X8, TX_16X32, TX_32X16, TX_32X64, TX_64X32, TX_4X16, TX_16X4,
+      TX_8X32, TX_32X8, TX_16X64, TX_64X16,
+    ]
+  };
 
-  c.bench_function("daala_fdst_vii_4", move |b| {
-    b.iter_batched(
-      || coeffs.clone(),
-      |mut coeffs| {
-        transform::forward::native::daala_fdst_vii_4(&mut coeffs[..])
-      },
-      BatchSize::SmallInput,
-    )
-  });
-}
+  for &tx_size in &tx_sizes {
+    let area = tx_size.area();
 
-pub fn daala_fdst8(c: &mut Criterion) {
-  let (coeffs, _) = init_buffers(8);
+    let input: Vec<i16> =
+      (0..area).map(|_| rng.gen_range(-255, 256)).collect();
+    let mut output = vec![0i16; area];
 
-  c.bench_function("daala_fdst8", move |b| {
-    b.iter_batched(
-      || coeffs.clone(),
-      |mut coeffs| transform::forward::native::daala_fdst8(&mut coeffs[..]),
-      BatchSize::SmallInput,
-    )
-  });
+    for &tx_type in get_valid_txfm_types(tx_size) {
+      group.bench_function(
+        format!("{:?}_{:?}", tx_size, tx_type).as_str(),
+        |b| {
+          b.iter(|| {
+            forward_transform(
+              &input[..],
+              &mut output[..],
+              tx_size.width(),
+              tx_size,
+              tx_type,
+              8,
+              cpu,
+            )
+          })
+        },
+      );
+    }
+  }
+
+  group.finish();
 }
 
 criterion_group!(
@@ -132,10 +158,4 @@ criterion_group!(
   av1_iadst8
 );
 
-criterion_group!(
-  forward_transforms,
-  daala_fdct4,
-  daala_fdct8,
-  daala_fdst_vii_4,
-  daala_fdst8
-);
+criterion_group!(forward_transforms, bench_forward_transforms);

--- a/src/transform/forward_shared.rs
+++ b/src/transform/forward_shared.rs
@@ -392,7 +392,7 @@ $($s)* fn daala_fdct_ii_4<T: TxOperations>(
 }
 
 #[$m]
-pub $($s)* fn daala_fdct4<T: TxOperations>(coeffs: &mut [T]) {
+$($s)* fn daala_fdct4<T: TxOperations>(coeffs: &mut [T]) {
   assert!(coeffs.len() >= 4);
   let mut temp_out: [T; 4] = [T::zero(); 4];
   daala_fdct_ii_4(coeffs[0], coeffs[1], coeffs[2], coeffs[3], &mut temp_out);
@@ -404,7 +404,7 @@ pub $($s)* fn daala_fdct4<T: TxOperations>(coeffs: &mut [T]) {
 }
 
 #[$m]
-pub $($s)* fn daala_fdst_vii_4<T: TxOperations>(coeffs: &mut [T]) {
+$($s)* fn daala_fdst_vii_4<T: TxOperations>(coeffs: &mut [T]) {
   assert!(coeffs.len() >= 4);
 
   let q0 = coeffs[0];
@@ -517,7 +517,7 @@ $($s)* fn daala_fdct_ii_8<T: TxOperations>(
 }
 
 #[$m]
-pub $($s)* fn daala_fdct8<T: TxOperations>(coeffs: &mut [T]) {
+$($s)* fn daala_fdct8<T: TxOperations>(coeffs: &mut [T]) {
   assert!(coeffs.len() >= 8);
   let mut temp_out: [T; 8] = [T::zero(); 8];
   daala_fdct_ii_8(
@@ -543,7 +543,7 @@ pub $($s)* fn daala_fdct8<T: TxOperations>(coeffs: &mut [T]) {
 }
 
 #[$m]
-pub $($s)* fn daala_fdst_iv_8<T: TxOperations>(
+$($s)* fn daala_fdst_iv_8<T: TxOperations>(
   r0: T, r1: T, r2: T, r3: T, r4: T, r5: T, r6: T, r7: T, output: &mut [T],
 ) {
   // Stage 0
@@ -599,7 +599,7 @@ pub $($s)* fn daala_fdst_iv_8<T: TxOperations>(
 }
 
 #[$m]
-pub $($s)* fn daala_fdst8<T: TxOperations>(coeffs: &mut [T]) {
+$($s)* fn daala_fdst8<T: TxOperations>(coeffs: &mut [T]) {
   assert!(coeffs.len() >= 8);
   let mut temp_out: [T; 8] = [T::zero(); 8];
   daala_fdst_iv_8(
@@ -1740,7 +1740,7 @@ $($s)* fn daala_fdct64<T: TxOperations>(coeffs: &mut [T]) {
 }
 
 #[$m]
-pub $($s)* fn fidentity<T: TxOperations>(_coeffs: &mut [T]) {}
+$($s)* fn fidentity<T: TxOperations>(_coeffs: &mut [T]) {}
 
 }
 


### PR DESCRIPTION
The 1d benchmarks profile the native code and aren't very representitive
of the performance of the transforms as a whole. Switching to 2d
transforms also lowers the exposure of the benchmark code to the more
unstable internals of our forward transforms.