### PR TITLE
Enable potentially useful Clippy lints that are off by default

### DIFF
--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -16,6 +16,15 @@
 #![allow(clippy::verbose_bit_mask)]
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::many_single_char_names)]
+#![warn(clippy::expl_impl_clone_on_copy)]
+#![warn(clippy::linkedlist)]
+#![warn(clippy::map_flatten)]
+#![warn(clippy::mem_forget)]
+#![warn(clippy::mut_mut)]
+#![warn(clippy::mutex_integer)]
+#![warn(clippy::needless_continue)]
+#![warn(clippy::path_buf_push_overwrite)]
+#![warn(clippy::range_plus_one)]
 
 #[macro_use]
 extern crate err_derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,15 @@
 #![allow(clippy::wrong_self_convention)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::comparison_chain)]
+#![warn(clippy::expl_impl_clone_on_copy)]
+#![warn(clippy::linkedlist)]
+#![warn(clippy::map_flatten)]
+#![warn(clippy::mem_forget)]
+#![warn(clippy::mut_mut)]
+#![warn(clippy::mutex_integer)]
+#![warn(clippy::needless_continue)]
+#![warn(clippy::path_buf_push_overwrite)]
+#![warn(clippy::range_plus_one)]
 
 // Override assert! and assert_eq! in tests
 #[cfg(test)]


### PR DESCRIPTION
None of these currently trigger any warnings in our code base,
but are generally useful and non-annoying to have enabled.

- expl_impl_clone_on_copy: Avoids potentially unsound manual `Clone`
  implementations.
- linkedlist: Avoids `LinkedList`s, which are almost always worse
  than a `Vec` or `VecDeque`.
- map_flatten: Prefer `.flat_map()` over `.map().flatten()`.
- mem_forget: Avoid using `mem::forget` with `Drop` types,
  which will not trigger the `Drop` implementation.
- mut_mut: Avoid useless duplicate mutable borrows.
- mutex_integer: Recommend atomic integers over wrapping an integer in a
  `Mutex`.
- needless_continue: Recommend when a conditional `continue` can be
  refactored to a simpler control flow.
- path_buf_push_overwrite: Avoid pushing to `PathBuf`s a segment
  starting with `/`, which can lead to accidental bugs or
  unsafe root access.
- range_plus_one: Prefer `0..=x` over `0..x+1`