### PR TITLE
Enable clippy needless_borrow lint

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -339,7 +339,7 @@ impl<T: Pixel> ContextInner<T> {
             break;
           }
 
-          self.compute_keyframe_placement(&cur_lookahead_frames);
+          self.compute_keyframe_placement(cur_lookahead_frames);
         }
       } else {
         self.compute_keyframe_placement(&lookahead_frames);
@@ -739,7 +739,7 @@ impl<T: Pixel> ContextInner<T> {
   ) {
     if self.keyframes_forced.contains(&self.next_lookahead_frame)
       || self.keyframe_detector.analyze_next_frame(
-        &lookahead_frames,
+        lookahead_frames,
         self.next_lookahead_frame,
         *self.keyframes.iter().last().unwrap(),
         &self.config,
@@ -854,7 +854,7 @@ impl<T: Pixel> ContextInner<T> {
           .map(|data| &mut data.fi.block_importances)
         {
           update_block_importances(
-            &fi,
+            fi,
             mvs,
             frame,
             reference_frame,

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -189,7 +189,7 @@ pub(crate) fn compute_motion_vectors<T: Pixel>(
       let ts = &mut ctx.ts;
 
       // Compute the quarter-resolution motion vectors.
-      let tile_pmvs = build_coarse_pmvs(fi, ts, &inter_cfg);
+      let tile_pmvs = build_coarse_pmvs(fi, ts, inter_cfg);
 
       // Compute the half-resolution motion vectors.
       let mut half_res_pmvs = Vec::with_capacity(ts.sb_height * ts.sb_width);

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -22,6 +22,7 @@
 #![warn(clippy::mem_forget)]
 #![warn(clippy::mut_mut)]
 #![warn(clippy::mutex_integer)]
+#![warn(clippy::needless_borrow)]
 #![warn(clippy::needless_continue)]
 #![warn(clippy::path_buf_push_overwrite)]
 #![warn(clippy::range_plus_one)]

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -384,7 +384,7 @@ pub fn cdef_sb_padded_frame_copy<T: Pixel>(
     let &Rect { width, height, .. } = tile.planes[p].rect();
     /*let w = width as isize;
     let h = height as isize;*/
-    let offset = sbo.plane_offset(&tile.planes[p].plane_cfg);
+    let offset = sbo.plane_offset(tile.planes[p].plane_cfg);
     let mut out_region =
       out.planes[p].region_mut(Area::StartingAt { x: -ipad, y: -ipad });
     for y in 0..((sb_v_size >> ydec) + pad * 2) as isize {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1165,7 +1165,7 @@ pub fn encode_tx_block<T: Pixel>(
       &mut rec.subregion_mut(area),
       tx_size,
       bit_depth,
-      &ac,
+      ac,
       pred_intra_param,
       &edge_buf,
       fi.cpu_feature_level,
@@ -1218,7 +1218,7 @@ pub fn encode_tx_block<T: Pixel>(
       w,
       p,
       tx_bo,
-      &qcoeffs,
+      qcoeffs,
       eob,
       mode,
       tx_size,
@@ -1326,7 +1326,7 @@ pub fn motion_compensate<T: Pixel>(
       if p == 0 { bsize } else { bsize.subsampled_size(u_xdec, u_ydec) };
 
     let rec = &mut ts.rec.planes[p];
-    let po = tile_bo.plane_offset(&rec.plane_cfg);
+    let po = tile_bo.plane_offset(rec.plane_cfg);
     let &PlaneConfig { xdec, ydec, .. } = rec.plane_cfg;
     let tile_rect = luma_tile_rect.decimated(xdec, ydec);
 
@@ -2905,7 +2905,7 @@ fn encode_tile_group<T: Pixel>(
       cdef_filter_frame(fi, rec, &blocks);
     }
     /* TODO: Don't apply if lossless */
-    fs.restoration.lrf_filter_frame(rec, &pre_cdef_frame, &fi);
+    fs.restoration.lrf_filter_frame(rec, &pre_cdef_frame, fi);
   } else {
     /* TODO: Don't apply if lossless */
     let rec = Arc::make_mut(&mut fs.rec);
@@ -2950,7 +2950,7 @@ fn build_raw_tile_group(
       let tile_size_minus_1 = raw_tile.len() - 1;
       bw.write_le(max_tile_size_bytes, tile_size_minus_1 as u64).unwrap();
     }
-    bw.write_bytes(&raw_tile).unwrap();
+    bw.write_bytes(raw_tile).unwrap();
   }
   raw
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -596,7 +596,7 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     // FIXME: Not sure whether putting frame/render size here is good idea
     if fi.intra_only {
       if frame_size_override_flag {
-        self.write_frame_size_override(&fi);
+        self.write_frame_size_override(fi);
       }
       if fi.sequence.enable_superres {
         unimplemented!();
@@ -633,7 +633,7 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
         unimplemented!();
       } else {
         if frame_size_override_flag {
-          self.write_frame_size_override(&fi);
+          self.write_frame_size_override(fi);
         }
         if fi.sequence.enable_superres {
           unimplemented!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 #![warn(clippy::mem_forget)]
 #![warn(clippy::mut_mut)]
 #![warn(clippy::mutex_integer)]
+#![warn(clippy::needless_borrow)]
 #![warn(clippy::needless_continue)]
 #![warn(clippy::path_buf_push_overwrite)]
 #![warn(clippy::range_plus_one)]

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -701,7 +701,7 @@ pub fn sgrproj_stripe_filter<T: Pixel>(
         &mut f_r2_1,
         y,
         stripe_w,
-        &cdeffed,
+        cdeffed,
         fi.cpu_feature_level,
       );
       [&f_r2_0, &f_r2_1]
@@ -710,7 +710,7 @@ pub fn sgrproj_stripe_filter<T: Pixel>(
         &mut f_r2_0,
         y,
         stripe_w,
-        &cdeffed,
+        cdeffed,
         fi.cpu_feature_level,
       );
       // share results for both rows
@@ -742,7 +742,7 @@ pub fn sgrproj_stripe_filter<T: Pixel>(
           &mut f_r1,
           y,
           stripe_w,
-          &cdeffed,
+          cdeffed,
           fi.cpu_feature_level,
         );
       } else {
@@ -750,7 +750,7 @@ pub fn sgrproj_stripe_filter<T: Pixel>(
           &mut f_r1,
           y,
           stripe_w,
-          &cdeffed,
+          cdeffed,
           fi.cpu_feature_level,
         );
       }
@@ -788,7 +788,7 @@ pub fn sgrproj_stripe_filter<T: Pixel>(
         &mut out[y],
         line,
         &f_r1,
-        &f_r2_ab[dy],
+        f_r2_ab[dy],
         stripe_w,
         bit_depth,
         w0,
@@ -914,12 +914,12 @@ pub fn sgrproj_solve<T: Pixel>(
         &mut f_r2_1,
         y,
         cdef_w,
-        &cdeffed,
+        cdeffed,
         fi.cpu_feature_level,
       );
       [&f_r2_0, &f_r2_1]
     } else {
-      sgrproj_box_f_r0(&mut f_r2_0, y, cdef_w, &cdeffed, fi.cpu_feature_level);
+      sgrproj_box_f_r0(&mut f_r2_0, y, cdef_w, cdeffed, fi.cpu_feature_level);
       // share results for both rows
       [&f_r2_0, &f_r2_0]
     };
@@ -949,11 +949,11 @@ pub fn sgrproj_solve<T: Pixel>(
           &mut f_r1,
           y,
           cdef_w,
-          &cdeffed,
+          cdeffed,
           fi.cpu_feature_level,
         );
       } else {
-        sgrproj_box_f_r0(&mut f_r1, y, cdef_w, &cdeffed, fi.cpu_feature_level);
+        sgrproj_box_f_r0(&mut f_r1, y, cdef_w, cdeffed, fi.cpu_feature_level);
       }
 
       #[inline(always)]
@@ -1005,7 +1005,7 @@ pub fn sgrproj_solve<T: Pixel>(
         &cdeffed[y],
         &input[y],
         &f_r1,
-        &f_r2_01[dy],
+        f_r2_01[dy],
         cdef_w,
       );
     }

--- a/src/me.rs
+++ b/src/me.rs
@@ -133,7 +133,7 @@ pub fn get_subset_predictors<T: Pixel>(
 
   // EPZS subset C predictors.
 
-  if let Some(ref frame_ref) = frame_ref_opt {
+  if let Some(frame_ref) = frame_ref_opt {
     let prev_frame_mvs = &frame_ref.frame_mvs[ref_frame_id];
 
     let frame_bo = PlaneBlockOffset(BlockOffset {
@@ -484,7 +484,7 @@ impl MotionEstimation for DiamondSearch {
     let mut predictors = get_subset_predictors::<T>(
       tile_bo_adj,
       pmvs.iter().cloned().filter_map(identity).collect(),
-      &tile_mvs,
+      tile_mvs,
       frame_ref,
       ref_frame.to_index(),
     );
@@ -497,7 +497,7 @@ impl MotionEstimation for DiamondSearch {
     diamond_me_search(
       fi,
       frame_po,
-      &ts.input_hres,
+      ts.input_hres,
       &rec.input_hres,
       &predictors,
       fi.sequence.bit_depth,
@@ -636,7 +636,7 @@ impl MotionEstimation for FullSearch {
             bsize.width() >> 1,
             bsize.height() >> 1,
           ),
-          &ts.input_hres,
+          ts.input_hres,
           &rec.input_hres,
           best_mv,
           lowest_cost,
@@ -732,7 +732,7 @@ fn diamond_me_search<T: Pixel>(
     po,
     p_org,
     p_ref,
-    &predictors,
+    predictors,
     bit_depth,
     pmv,
     lambda,
@@ -857,9 +857,9 @@ fn compute_mv_rd_cost<T: Pixel>(
   plane_org: &PlaneRegion<'_, T>, plane_ref: &PlaneRegion<'_, T>,
 ) -> u64 {
   let sad = if use_satd {
-    get_satd(&plane_org, &plane_ref, bsize, bit_depth, fi.cpu_feature_level)
+    get_satd(plane_org, plane_ref, bsize, bit_depth, fi.cpu_feature_level)
   } else {
-    get_sad(&plane_org, &plane_ref, bsize, bit_depth, fi.cpu_feature_level)
+    get_sad(plane_org, plane_ref, bsize, bit_depth, fi.cpu_feature_level)
   };
 
   let rate1 = get_mv_rate(cand_mv, pmv[0], fi.allow_high_precision_mv);
@@ -1068,7 +1068,7 @@ pub fn estimate_motion_ss4<T: Pixel>(
       y_lo,
       y_hi,
       BlockSize::from_width_and_height(blk_w >> 2, blk_h >> 2),
-      &ts.input_qres,
+      ts.input_qres,
       &rec.input_qres,
       &mut best_mv,
       &mut lowest_cost,

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -528,7 +528,7 @@ pub(crate) mod native {
         PredictionVariant::BOTH => pred_cfl,
       })(
         dst,
-        &ac,
+        ac,
         angle as i16,
         above_slice,
         left_slice,
@@ -811,7 +811,7 @@ pub(crate) mod native {
     left: &[T], width: usize, height: usize, bit_depth: usize,
   ) {
     pred_dc(output, above, left, width, height, bit_depth);
-    pred_cfl_inner(output, &ac, alpha, width, height, bit_depth);
+    pred_cfl_inner(output, ac, alpha, width, height, bit_depth);
   }
 
   pub(crate) fn pred_cfl_128<T: Pixel>(
@@ -819,7 +819,7 @@ pub(crate) mod native {
     left: &[T], width: usize, height: usize, bit_depth: usize,
   ) {
     pred_dc_128(output, above, left, width, height, bit_depth);
-    pred_cfl_inner(output, &ac, alpha, width, height, bit_depth);
+    pred_cfl_inner(output, ac, alpha, width, height, bit_depth);
   }
 
   pub(crate) fn pred_cfl_left<T: Pixel>(
@@ -827,7 +827,7 @@ pub(crate) mod native {
     left: &[T], width: usize, height: usize, bit_depth: usize,
   ) {
     pred_dc_left(output, above, left, width, height, bit_depth);
-    pred_cfl_inner(output, &ac, alpha, width, height, bit_depth);
+    pred_cfl_inner(output, ac, alpha, width, height, bit_depth);
   }
 
   pub(crate) fn pred_cfl_top<T: Pixel>(
@@ -835,7 +835,7 @@ pub(crate) mod native {
     left: &[T], width: usize, height: usize, bit_depth: usize,
   ) {
     pred_dc_top(output, above, left, width, height, bit_depth);
-    pred_cfl_inner(output, &ac, alpha, width, height, bit_depth);
+    pred_cfl_inner(output, ac, alpha, width, height, bit_depth);
   }
 
   pub(crate) fn pred_directional<T: Pixel>(

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -684,7 +684,7 @@ fn luma_chroma_mode_rdo<T: Pixel>(
           tx_size,
           tx_type,
           mode_context,
-          &mv_stack,
+          mv_stack,
           rdo_type,
           need_recon_pixel,
           false,
@@ -1090,7 +1090,7 @@ fn inter_frame_rdo_mode_decision<T: Pixel>(
       ts,
       cw,
       rdo_type,
-      &cw_checkpoint,
+      cw_checkpoint,
       &mut best,
       mvs,
       ref_frames_set[i],
@@ -1137,7 +1137,7 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
       debug_assert!(bsize == tx_size.block_size());
       let edge_buf = {
         let rec = &ts.rec.planes[0].as_const();
-        let po = tile_bo.plane_offset(&rec.plane_cfg);
+        let po = tile_bo.plane_offset(rec.plane_cfg);
         // FIXME: If tx partition is used, get_intra_edges() should be called for each tx block
         get_intra_edges(
           rec,
@@ -1245,7 +1245,7 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
       ts,
       cw,
       rdo_type,
-      &cw_checkpoint,
+      cw_checkpoint,
       &mut best,
       mvs,
       ref_frames,
@@ -1291,7 +1291,7 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
           ts,
           cw,
           rdo_type,
-          &cw_checkpoint,
+          cw_checkpoint,
           &mut best,
           mvs,
           ref_frames,
@@ -1874,7 +1874,7 @@ pub fn rdo_loop_decision<T: Pixel>(
   }
   // Initialize cdef output
   for pli in 0..PLANES {
-    let po = tile_sbo.plane_offset(&ts.rec.planes[pli].plane_cfg);
+    let po = tile_sbo.plane_offset(ts.rec.planes[pli].plane_cfg);
     let rec_region =
       ts.rec.planes[pli].subregion(Area::StartingAt { x: po.x, y: po.y });
     let width = lrf_input.planes[pli].cfg.width.min(rec_region.rect().width);
@@ -1937,7 +1937,7 @@ pub fn rdo_loop_decision<T: Pixel>(
             let mut rate = 0;
             cdef_filter_superblock(
               fi,
-              &cdef_input,
+              cdef_input,
               &mut lrf_input,
               &cw.bc.blocks.as_const(),
               loop_sbo,
@@ -2078,7 +2078,7 @@ pub fn rdo_loop_decision<T: Pixel>(
           // both below and above (padding)
           cdef_filter_superblock(
             fi,
-            &cdef_input,
+            cdef_input,
             &mut lrf_input,
             &cw.bc.blocks.as_const(),
             loop_sbo,

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -92,7 +92,7 @@ impl SceneChangeDetector {
     }
 
     self.exclude_scene_flashes(
-      &frame_set,
+      frame_set,
       input_frameno,
       inter_cfg,
       previous_keyframe,

--- a/src/tiling/plane_region.rs
+++ b/src/tiling/plane_region.rs
@@ -405,7 +405,7 @@ impl<'a, T: Pixel> PlaneRegionMut<'a, T> {
     };
     PlaneRegionMut {
       data,
-      plane_cfg: &self.plane_cfg,
+      plane_cfg: self.plane_cfg,
       rect: absolute_rect,
       phantom: PhantomData,
     }
@@ -538,7 +538,7 @@ impl<'a, T: Pixel> Iterator for VertWindows<'a, T> {
       self.output_rect.y += n as isize;
       let output = PlaneRegion {
         data: self.data,
-        plane_cfg: &self.plane_cfg,
+        plane_cfg: self.plane_cfg,
         rect: self.output_rect,
         phantom: PhantomData,
       };
@@ -572,7 +572,7 @@ impl<'a, T: Pixel> Iterator for HorzWindows<'a, T> {
       self.output_rect.x += n as isize;
       let output = PlaneRegion {
         data: self.data,
-        plane_cfg: &self.plane_cfg,
+        plane_cfg: self.plane_cfg,
         rect: self.output_rect,
         phantom: PhantomData,
       };


### PR DESCRIPTION
This will warn if a reference is used
which is unneeded and immediately elided by the compiler.
Removing the unneeded borrows can marginally
reduce compile time, and is generally a good practice.