### PR TITLE
Switch speed 10 from 64x64 to 32x32 partitions

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -408,7 +408,7 @@ impl SpeedSettings {
     } else if speed <= 9 {
       PartitionRange::new(BlockSize::BLOCK_32X32, BlockSize::BLOCK_64X64)
     } else {
-      PartitionRange::new(BlockSize::BLOCK_64X64, BlockSize::BLOCK_64X64)
+      PartitionRange::new(BlockSize::BLOCK_32X32, BlockSize::BLOCK_32X32)
     }
   }
 

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -1688,7 +1688,10 @@ fn log_q_exp_overflow() {
       tiles: 0,
       rdo_lookahead_frames: 40,
       speed_settings: SpeedSettings {
-        min_block_size: BlockSize::BLOCK_64X64,
+        partition_range: PartitionRange::new(
+          BlockSize::BLOCK_64X64,
+          BlockSize::BLOCK_64X64,
+        ),
         multiref: false,
         fast_deblock: true,
         reduced_tx_set: true,
@@ -1753,7 +1756,10 @@ fn guess_frame_subtypes_assert() {
       tiles: 0,
       rdo_lookahead_frames: 40,
       speed_settings: SpeedSettings {
-        min_block_size: BlockSize::BLOCK_64X64,
+        partition_range: PartitionRange::new(
+          BlockSize::BLOCK_64X64,
+          BlockSize::BLOCK_64X64,
+        ),
         multiref: false,
         fast_deblock: true,
         reduced_tx_set: true,

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -645,16 +645,20 @@ fn apply_speed_test_cfg(cfg: &mut EncoderConfig, setting: &str) {
       cfg.speed_settings = SpeedSettings::default();
     }
     "min_block_size_8x8" => {
-      cfg.speed_settings.min_block_size = BlockSize::BLOCK_8X8;
+      cfg.speed_settings.partition_range =
+        PartitionRange::new(BlockSize::BLOCK_8X8, BlockSize::BLOCK_64X64);
     }
     "min_block_size_16x16" => {
-      cfg.speed_settings.min_block_size = BlockSize::BLOCK_16X16;
+      cfg.speed_settings.partition_range =
+        PartitionRange::new(BlockSize::BLOCK_16X16, BlockSize::BLOCK_64X64);
     }
     "min_block_size_32x32" => {
-      cfg.speed_settings.min_block_size = BlockSize::BLOCK_32X32;
+      cfg.speed_settings.partition_range =
+        PartitionRange::new(BlockSize::BLOCK_32X32, BlockSize::BLOCK_64X64);
     }
     "min_block_size_64x64" => {
-      cfg.speed_settings.min_block_size = BlockSize::BLOCK_64X64;
+      cfg.speed_settings.partition_range =
+        PartitionRange::new(BlockSize::BLOCK_64X64, BlockSize::BLOCK_64X64);
     }
     "no_multiref" => {
       cfg.speed_settings.multiref = false;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -487,7 +487,7 @@ pub struct FrameInvariants<T: Pixel> {
   pub use_reduced_tx_set: bool,
   pub reference_mode: ReferenceMode,
   pub use_prev_frame_mvs: bool,
-  pub min_partition_size: BlockSize,
+  pub partition_range: PartitionRange,
   pub globalmv_transformation_type: [GlobalMVMode; INTER_REFS_PER_FRAME],
   pub num_tg: usize,
   pub large_scale_tile: bool,
@@ -577,8 +577,6 @@ impl<T: Pixel> FrameInvariants<T> {
       sequence.bit_depth <= mem::size_of::<T>() * 8,
       "bit depth cannot fit into u8"
     );
-    let min_partition_size = config.speed_settings.min_block_size;
-    assert!(min_partition_size.is_sqr());
     let use_reduced_tx_set = config.speed_settings.reduced_tx_set;
     let use_tx_domain_distortion =
       config.tune == Tune::Psnr && config.speed_settings.tx_domain_distortion;
@@ -653,7 +651,7 @@ impl<T: Pixel> FrameInvariants<T> {
       use_reduced_tx_set,
       reference_mode: ReferenceMode::SINGLE,
       use_prev_frame_mvs: false,
-      min_partition_size,
+      partition_range: config.speed_settings.partition_range,
       globalmv_transformation_type: [GlobalMVMode::IDENTITY;
         INTER_REFS_PER_FRAME],
       num_tg: 1,
@@ -2210,10 +2208,12 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
   let bsh = bsize.height_mi();
   let is_square = bsize.is_sqr();
 
+  // FIXME: ask codeview what to write before assert before committing
+  assert!(fi.partition_range.max <= BlockSize::BLOCK_64X64);
   // Always split if the current partition is too large, i.e. right or bottom tile border
   let must_split = (tile_bo.0.x + bsw as usize > ts.mi_width
     || tile_bo.0.y + bsh as usize > ts.mi_height
-    || bsize > BlockSize::BLOCK_64X64)
+    || bsize > fi.partition_range.max)
     && is_square;
 
   // must_split overrides the minimum partition size when applicable
@@ -2223,7 +2223,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
     bsize <= BlockSize::BLOCK_8X8 {
     false
   } else {
-    (bsize > fi.min_partition_size && is_square) || must_split
+    (bsize > fi.partition_range.min && is_square) || must_split
   };
   let mut best_partition = PartitionType::PARTITION_INVALID;
 
@@ -2494,10 +2494,12 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
   let is_square = bsize.is_sqr();
   let rdo_type = RDOType::PixelDistRealRate;
 
+  // FIXME: ask codeview what to write before assert before committing
+  assert!(fi.partition_range.max <= BlockSize::BLOCK_64X64);
   // Always split if the current partition is too large, i.e. right or bottom tile border
   let must_split = (tile_bo.0.x + bsw as usize > ts.mi_width
     || tile_bo.0.y + bsh as usize > ts.mi_height
-    || bsize > BlockSize::BLOCK_64X64)
+    || bsize > fi.partition_range.max)
     && is_square;
 
   let mut rdo_output =
@@ -2527,7 +2529,7 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
   if must_split && (!split_vert && !split_horz) {
     // Oversized blocks are split automatically
     partition = PartitionType::PARTITION_SPLIT;
-  } else if (must_split || (bsize > fi.min_partition_size && is_square))
+  } else if (must_split || (bsize > fi.partition_range.min && is_square))
     && (
       // FIXME: sub-8x8 inter blocks not supported for non-4:2:0 sampling
       !fi.frame_type.has_inter()

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2208,7 +2208,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
   let bsh = bsize.height_mi();
   let is_square = bsize.is_sqr();
 
-  // FIXME: ask codeview what to write before assert before committing
+  // TODO: Update for 128x128 superblocks
   assert!(fi.partition_range.max <= BlockSize::BLOCK_64X64);
   // Always split if the current partition is too large, i.e. right or bottom tile border
   let must_split = (tile_bo.0.x + bsw as usize > ts.mi_width
@@ -2494,7 +2494,7 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
   let is_square = bsize.is_sqr();
   let rdo_type = RDOType::PixelDistRealRate;
 
-  // FIXME: ask codeview what to write before assert before committing
+  // TODO: Update for 128x128 superblocks
   assert!(fi.partition_range.max <= BlockSize::BLOCK_64X64);
   // Always split if the current partition is too large, i.e. right or bottom tile border
   let must_split = (tile_bo.0.x + bsw as usize > ts.mi_width


### PR DESCRIPTION
Results for speed 10
```
    PSNR |  PSNR Cb |  PSNR Cr | PSNR HVS |     SSIM |  MS SSIM | CIEDE 2000
-30.9829 | -19.2587 | -15.9204 | -18.5035 | -24.9531 | -17.7345 |   -25.8095
```
11% increase in execution time