### PR TITLE
Reimplement distortion scale using fixed points

### DIFF
--- a/benches/rdo.rs
+++ b/benches/rdo.rs
@@ -4,6 +4,7 @@ use rand_chacha::ChaChaRng;
 
 use rav1e::bench::frame::AsRegion;
 use rav1e::bench::rdo;
+use rav1e::bench::rdo::DistortionScale;
 use rav1e::bench::tiling::Area;
 use rav1e::prelude::Plane;
 
@@ -25,7 +26,7 @@ pub fn cdef_dist_wxh_8x8(c: &mut Criterion) {
         8,
         8,
         8,
-        |_, _| 1.0,
+        |_, _| DistortionScale::default(),
       )
     })
   });
@@ -42,7 +43,7 @@ pub fn sse_wxh_8x8(c: &mut Criterion) {
         &src2.region(Area::Rect { x: 0, y: 0, width: 8, height: 8 }),
         8,
         8,
-        |_, _| 1.0,
+        |_, _| DistortionScale::default(),
       )
     })
   });
@@ -59,7 +60,7 @@ pub fn sse_wxh_4x4(c: &mut Criterion) {
         &src2.region(Area::Rect { x: 0, y: 0, width: 4, height: 4 }),
         4,
         4,
-        |_, _| 1.0,
+        |_, _| DistortionScale::default(),
       )
     })
   });
@@ -80,7 +81,7 @@ pub fn sse_wxh_2x2(c: &mut Criterion) {
         &src2.region(Area::Rect { x: 0, y: 0, width: 4, height: 4 }),
         4,
         4,
-        |_, _| 1.0,
+        |_, _| DistortionScale::default(),
       )
     })
   });

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1054,9 +1054,9 @@ impl<T: Pixel> ContextInner<T> {
         for y in 0..fi.h_in_imp_b {
           for x in 0..fi.w_in_imp_b {
             buf
-              .write_f32::<NativeEndian>(
-                fi.distortion_scales[y * fi.w_in_imp_b + x] as f32,
-              )
+              .write_f32::<NativeEndian>(f64::from(
+                fi.distortion_scales[y * fi.w_in_imp_b + x],
+              ) as f32)
               .unwrap();
           }
         }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -551,7 +551,7 @@ pub struct FrameInvariants<T: Pixel> {
   /// inter-prediction).
   pub block_importances: Box<[f32]>,
   /// Pre-computed distortion_scale.
-  pub distortion_scales: Box<[f64]>,
+  pub distortion_scales: Box<[DistortionScale]>,
 
   /// Target CPU feature level.
   pub cpu_feature_level: crate::cpu_features::CpuFeatureLevel,
@@ -726,7 +726,11 @@ impl<T: Pixel> FrameInvariants<T> {
         .into_boxed_slice(),
       // dynamic allocation: once per frame
       block_importances: vec![0.; w_in_imp_b * h_in_imp_b].into_boxed_slice(),
-      distortion_scales: vec![0.; w_in_imp_b * h_in_imp_b].into_boxed_slice(),
+      distortion_scales: vec![
+        DistortionScale::default();
+        w_in_imp_b * h_in_imp_b
+      ]
+      .into_boxed_slice(),
       cpu_feature_level: Default::default(),
       activity_mask: Default::default(),
       enable_segmentation: config.speed_settings.enable_segmentation,


### PR DESCRIPTION
Removes a conversion to and from f64.

Also, when implementing simd, it will be easier to work with integer
types.

https://beta.arewecompressedyet.com/?job=master-70dc401df1b7547ad1b1157004189febedb71e04&job=fixed_point_distortion_scores%402020-01-20T20%3A31%3A34.865Z

| PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|-|-|-|-|-|-|-|
|0.0023 |  0.0434 |  0.0165 |  -0.0043 | -0.0257 | -0.0101 |     0.0498 |

Microbench results

```
cdef_dist_wxh_8x8
time:   [117.93 ns 118.11 ns 118.36 ns]
change: [-10.326% -10.058% -9.6566%] (p = 0.00 < 0.05)
sse_wxh_8x8
time:   [126.92 ns 127.02 ns 127.16 ns]
change: [+0.8375% +1.0859% +1.3056%] (p = 0.00 < 0.05)
sse_wxh_4z4
time:   [64.275 ns 64.332 ns 64.399 ns]
change: [-12.212% -11.607% -11.069%] (p = 0.00 < 0.05)
sse_wxh_2x2
time:   [105.27 ns 105.89 ns 106.55 ns]
change: [+3.6653% +4.6884% +5.6504%] (p = 0.00 < 0.05)
```