### PR TITLE
CI: move grcov-coveralls conf to beta channel

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -65,7 +65,7 @@ jobs:
          - conf: dav1d-tests
            toolchain: stable
          - conf: grcov-coveralls
-           toolchain: nightly-2019-12-02
+           toolchain: beta
          - conf: bench
            toolchain: stable
          - conf: doc


### PR DESCRIPTION
The required compiler flags are in rust version: `1.41.0-beta.1 (eb3f7c2d3 2019-12-17)`