### PR TITLE
Enable tx partition for inter mode at speed 10, always split once

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -326,6 +326,9 @@ pub struct SpeedSettings {
 
   /// Use segmentation.
   pub enable_segmentation: bool,
+
+  /// Enable tx split for inter mode block.
+  pub enable_inter_tx_split: bool,
 }
 
 impl Default for SpeedSettings {
@@ -355,6 +358,7 @@ impl Default for SpeedSettings {
       use_satd_subpel: true,
       non_square_partition: true,
       enable_segmentation: true,
+      enable_inter_tx_split: false,
     }
   }
 }
@@ -395,6 +399,7 @@ impl SpeedSettings {
       use_satd_subpel: Self::use_satd_subpel(speed),
       non_square_partition: Self::non_square_partition_preset(speed),
       enable_segmentation: Self::enable_segmentation_preset(speed),
+      enable_inter_tx_split: Self::enable_inter_tx_split_preset(speed),
     }
   }
 
@@ -505,6 +510,11 @@ impl SpeedSettings {
   // solution we should be able to enable segmentation at all speeds.
   const fn enable_segmentation_preset(speed: usize) -> bool {
     speed == 0
+  }
+
+  // FIXME: With unknown reasons, inter_tx_split does not work if reduced_tx_set is false
+  const fn enable_inter_tx_split_preset(speed: usize) -> bool {
+    speed == 10
   }
 }
 


### PR DESCRIPTION
This commit is prepared for the urgent demo purposes,
which requires tx partitions for inter mode blocks and one level split only at speed 10.

- DCT_DCT only

Known bug or limitation.
- Only works for reduced_tx_set enabled, with unknown reason.

TODO: Fix the bug!