### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ matrix:
     - platform: arm64
 
 install:
-    - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsx86_arm64.bat"
     - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
     - appveyor DownloadFile https://people.xiph.org/~tdaede/nasm-2.14.02-win64.zip -FileName nasm.zip
     - appveyor DownloadFile https://github.com/mozilla/sccache/releases/download/0.2.11/sccache-0.2.11-x86_64-pc-windows-msvc.tar.gz
@@ -37,12 +36,13 @@ build_script:
     - cargo build --release --no-default-features --features binaries --target=%target%
 
 test_script:
-    - cargo test --target=%target% --verbose
+    -
+    - cargo test --release --target=%target% --verbose
 
 artifacts:
     - path: target\$(target)\release\rav1e.exe
       name: rav1e-$(platform)
-      
+
 deploy:
   - provider: GitHub
     artifact: target\$(target)\release\rav1e.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,6 @@ image: Visual Studio 2019
 environment:
   host: x86_64-pc-windows-msvc
   matrix:
-    - platform: x86_64
-      target: x86_64-pc-windows-msvc
-      channel: stable
     - platform: arm64
       target: aarch64-pc-windows-msvc
       channel: nightly
@@ -14,7 +11,7 @@ matrix:
     - platform: arm64
 
 install:
-    - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+    - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsx86_arm64.bat"
     - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
     - appveyor DownloadFile https://people.xiph.org/~tdaede/nasm-2.14.02-win64.zip -FileName nasm.zip
     - appveyor DownloadFile https://github.com/mozilla/sccache/releases/download/0.2.11/sccache-0.2.11-x86_64-pc-windows-msvc.tar.gz
@@ -37,7 +34,7 @@ cache:
     - '%LOCALAPPDATA%\Mozilla\sccache'
 
 build_script:
-    - cargo build --release --target=%target%
+    - cargo build --release --no-default-features --features binaries --target=%target%
 
 test_script:
     - cargo test --target=%target% --verbose


### PR DESCRIPTION
This PR follows up #1209 and #1906 

I was able to build `rav1e` on `AppVeyor`, but tests can't be run because `.S` files can't be compiled even though `nasm` is there.

Do you know how to fix that @barrbrain and @EwoutH? 

Thanks in advance for your review! 