### PR TITLE
Channel api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ ivf = { version = "0.1", path = "ivf/", optional = true }
 v_frame = { version = "0.1", path = "v_frame/" }
 av-metrics = { version = "0.5.1", optional = true }
 rayon = "1.0"
+crossbeam = "0.7"
 toml = { version = "0.5", optional = true }
 arrayvec = { version = "0.5", features = ["array-sizes-33-128"] }
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,11 @@ name = "rav1e"
 required-features = ["binaries"]
 bench = false
 
+[[bin]]
+name = "rav1e-ch"
+required-features = ["binaries"]
+bench = false
+
 [lib]
 bench = false
 

--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,7 @@ if ! cargo build ${IS_RELEASE:+--release}; then
   exit $e
 fi
 
-if ! cargo run --bin rav1e ${IS_RELEASE:+--release} -- "$SEQ" -o $ENC_FILE -s 3 -r $REC_FILE; then
+if ! cargo run --bin rav1e ${IS_RELEASE:+--release} -- "$SEQ" -o $ENC_FILE -s 3 -r $REC_FILE --tiles 8 -l 100; then
   echo "rav1e failed to run" >&2
   exit 1
 fi

--- a/src/api/channel.rs
+++ b/src/api/channel.rs
@@ -65,6 +65,10 @@ impl RcDataReceiver {
   pub fn iter(&self) -> Iter<RcData> {
     self.0.iter()
   }
+
+  pub fn summary_size(&self) -> usize {
+    crate::rate::TWOPASS_HEADER_SZ
+  }
 }
 
 pub type PassDataChannel = (RcDataSender, RcDataReceiver);

--- a/src/api/channel.rs
+++ b/src/api/channel.rs
@@ -1,0 +1,398 @@
+// Copyright (c) 2018-2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+#![allow(missing_docs)]
+
+use crate::api::color::*;
+use crate::api::config::*;
+use crate::api::internal::ContextInner;
+use crate::api::util::*;
+
+use bitstream_io::*;
+use crossbeam::channel::*;
+
+use crate::encoder::*;
+use crate::frame::*;
+use crate::util::Pixel;
+
+use std::io;
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub enum PassData {
+  Summary(Box<[u8]>),
+  Frame(Box<[u8]>),
+}
+
+impl PassData {
+  pub fn is_summary(&self) -> bool {
+    match self {
+      PassData::Summary(_) => true,
+      _ => false,
+    }
+  }
+}
+
+impl AsRef<[u8]> for PassData {
+  fn as_ref(&self) -> &[u8] {
+    match self {
+      PassData::Summary(s) => s.as_ref(),
+      PassData::Frame(f) => f.as_ref(),
+    }
+  }
+}
+
+/// Endpoint to send previous-pass statistics data
+pub struct PassDataSender(Sender<PassData>);
+
+impl PassDataSender {
+  pub fn try_send(
+    &self, data: PassData,
+  ) -> Result<(), TrySendError<PassData>> {
+    self.0.try_send(data)
+  }
+
+  pub fn send(&self, data: PassData) -> Result<(), SendError<PassData>> {
+    self.0.send(data)
+  }
+  pub fn len(&self) -> usize {
+    self.0.len()
+  }
+  pub fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+  // TODO: proxy more methods
+}
+
+/// Endpoint to receive current-pass statistics data
+pub struct PassDataReceiver(Receiver<PassData>);
+
+impl PassDataReceiver {
+  pub fn try_recv(&self) -> Result<PassData, TryRecvError> {
+    self.0.try_recv()
+  }
+  pub fn recv(&self) -> Result<PassData, RecvError> {
+    self.0.recv()
+  }
+  pub fn len(&self) -> usize {
+    self.0.len()
+  }
+  pub fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+  pub fn iter(&self) -> Iter<PassData> {
+    self.0.iter()
+  }
+}
+
+pub type PassDataChannel = (PassDataSender, PassDataReceiver);
+
+pub type FrameInput<T> = (Option<Arc<Frame<T>>>, Option<FrameParameters>);
+
+/// Endpoint to send frames
+pub struct FrameSender<T: Pixel>(Sender<FrameInput<T>>);
+
+impl<T: Pixel> FrameSender<T> {
+  pub fn try_send<F: IntoFrame<T>>(
+    &self, frame: F,
+  ) -> Result<(), TrySendError<FrameInput<T>>> {
+    self.0.try_send(frame.into())
+  }
+
+  pub fn send<F: IntoFrame<T>>(
+    &self, frame: F,
+  ) -> Result<(), SendError<FrameInput<T>>> {
+    self.0.send(frame.into())
+  }
+  pub fn len(&self) -> usize {
+    self.0.len()
+  }
+  pub fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+  // TODO: proxy more methods
+}
+
+/// Endpoint to receive packets
+pub struct PacketReceiver<T: Pixel>(Receiver<Packet<T>>);
+
+impl<T: Pixel> PacketReceiver<T> {
+  pub fn try_recv(&self) -> Result<Packet<T>, TryRecvError> {
+    self.0.try_recv()
+  }
+  pub fn recv(&self) -> Result<Packet<T>, RecvError> {
+    self.0.recv()
+  }
+  pub fn len(&self) -> usize {
+    self.0.len()
+  }
+  pub fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+  pub fn iter(&self) -> Iter<Packet<T>> {
+    self.0.iter()
+  }
+}
+
+pub type VideoDataChannel<T> = (FrameSender<T>, PacketReceiver<T>);
+
+// TODO: use a separate struct?
+impl Config {
+  // TODO: add validation
+  #[inline]
+  pub fn new_frame<T: Pixel>(&self) -> Frame<T> {
+    Frame::new(self.enc.width, self.enc.height, self.enc.chroma_sampling)
+  }
+
+  /// Produces a sequence header matching the current encoding context.
+  ///
+  /// Its format is compatible with the AV1 Matroska and ISOBMFF specification.
+  /// Note that the returned header does not include any config OBUs which are
+  /// required for some uses. See [the specification].
+  ///
+  /// [the specification]:
+  /// https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-section
+  #[inline]
+  pub fn container_sequence_header(&self) -> Vec<u8> {
+    fn sequence_header_inner(seq: &Sequence) -> io::Result<Vec<u8>> {
+      let mut buf = Vec::new();
+
+      {
+        let mut bw = BitWriter::endian(&mut buf, BigEndian);
+        bw.write_bit(true)?; // marker
+        bw.write(7, 1)?; // version
+        bw.write(3, seq.profile)?;
+        bw.write(5, 31)?; // level
+        bw.write_bit(false)?; // tier
+        bw.write_bit(seq.bit_depth > 8)?; // high_bitdepth
+        bw.write_bit(seq.bit_depth == 12)?; // twelve_bit
+        bw.write_bit(seq.bit_depth == 1)?; // monochrome
+        bw.write_bit(seq.chroma_sampling != ChromaSampling::Cs444)?; // chroma_subsampling_x
+        bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs420)?; // chroma_subsampling_y
+        bw.write(2, 0)?; // sample_position
+        bw.write(3, 0)?; // reserved
+        bw.write_bit(false)?; // initial_presentation_delay_present
+
+        bw.write(4, 0)?; // reserved
+      }
+
+      Ok(buf)
+    }
+
+    let seq = Sequence::new(&self.enc);
+
+    sequence_header_inner(&seq).unwrap()
+  }
+
+  /// Create a single pass encoder channel
+  ///
+  /// The `PacketReceiver<T>` endpoint may block if not enough Frames are
+  /// sent through the `FrameSender<T>` endpoint.
+  ///
+  /// Drop the `FrameSender<T>` endpoint to flush the encoder.
+  pub fn new_channel<T: Pixel>(
+    &self,
+  ) -> Result<(FrameSender<T>, PacketReceiver<T>), InvalidConfig> {
+    let (send_frame, receive_frame) =
+      bounded(self.enc.rdo_lookahead_frames as usize * 2); // TODO: user settable
+    let (send_packet, receive_packet) = unbounded();
+
+    let mut inner = self.new_inner()?;
+    let pool = rayon::ThreadPoolBuilder::new()
+      .num_threads(self.threads)
+      .build()
+      .unwrap();
+
+    pool.spawn(move || {
+      for f in receive_frame.iter() {
+        // info!("frame in {}", inner.frame_count);
+        while !inner.needs_more_fi_lookahead() {
+          // needs_more_fi_lookahead() should guard for missing output_frameno
+          // already.
+          // this call should return either Ok or Err(Encoded)
+          if let Ok(p) = inner.receive_packet() {
+            // warn!("packet out {}", p.input_frameno);
+            send_packet.send(p).unwrap();
+          }
+        }
+
+        let (frame, params) = f;
+        let _ = inner.send_frame(frame, params); // TODO make sure it cannot fail.
+      }
+
+      inner.limit = Some(inner.frame_count);
+      let _ = inner.send_frame(None, None);
+
+      loop {
+        let r = inner.receive_packet();
+        match r {
+          Ok(p) => {
+            // warn!("Sending out {}", p.input_frameno);
+            send_packet.send(p).unwrap();
+          }
+          Err(EncoderStatus::LimitReached) => break,
+          Err(EncoderStatus::Encoded) => {}
+          _ => unreachable!(),
+        }
+      }
+
+      // drop(send_packet); // This happens implicitly
+    });
+
+    Ok((FrameSender(send_frame), PacketReceiver(receive_packet)))
+  }
+
+  /// Create a multipass encoder channel
+  ///
+  /// To setup a first-pass encode drop the `PassDataSender` before sending the
+  /// first Frame.
+  ///
+  /// The `PacketReceiver<T>` may block if not enough pass statistics data
+  /// are sent through the `PassDataSender` endpoint
+  ///
+  /// Drop the `Sender<F>` endpoint to flush the encoder.
+  /// The last buffer in the Receiver<PassData>
+  pub fn new_multipass_channel<T: Pixel>(
+    &self,
+  ) -> Result<(VideoDataChannel<T>, PassDataChannel), InvalidConfig> {
+    // TODO: make it user-settable
+    let input_len = self.enc.rdo_lookahead_frames as usize * 2;
+
+    let (send_frame, receive_frame) = bounded(input_len);
+    let (send_packet, receive_packet) = unbounded();
+
+    let (send_rc_pass1, receive_rc_pass1) = bounded(input_len);
+    let (send_rc_pass2, receive_rc_pass2) = unbounded();
+
+    let mut inner = self.new_inner()?;
+    let pool = rayon::ThreadPoolBuilder::new()
+      .num_threads(self.threads)
+      .build()
+      .unwrap();
+
+    fn receive_packet_impl<T: Pixel>(
+      inner: &mut ContextInner<T>, send_rc_pass1: Option<&Sender<PassData>>,
+      receive_rc_pass2: Option<&Receiver<PassData>>,
+    ) -> Result<Packet<T>, EncoderStatus> {
+      if let Some(r) = receive_rc_pass2 {
+        while inner.rc_state.twopass_in(None).unwrap_or(0) > 0 {
+          r.recv()
+            .map(|data| {
+              // check data.len() vs twopass_bytes_needed()
+              let len = inner.rc_state.twopass_in(None).unwrap_or(0);
+              println!("{} vs {}", data.as_ref().len(), len);
+              inner
+                .rc_state
+                .twopass_in(Some(data.as_ref()))
+                .expect("Faulty pass data");
+            })
+            .unwrap();
+        }
+      }
+
+      if let Some(s) = send_rc_pass1 {
+        let params =
+          inner.rc_state.get_twopass_out_params(inner, inner.output_frameno);
+
+        let _ = inner.rc_state.twopass_out(params).map(|data| {
+          let pass_data = data.to_vec().into_boxed_slice();
+          s.send(PassData::Frame(pass_data)).unwrap();
+        });
+      }
+
+      inner.receive_packet()
+    }
+
+    fn send_pass_summary<T: Pixel>(
+      inner: &mut ContextInner<T>, send_rc_pass1: &Sender<PassData>,
+    ) -> bool {
+      let params =
+        inner.rc_state.get_twopass_out_params(inner, inner.output_frameno);
+
+      let data = inner.rc_state.twopass_out(params).unwrap();
+      let pass_data = data.to_vec().into_boxed_slice();
+      send_rc_pass1.send(PassData::Summary(pass_data)).is_ok()
+    }
+
+    pool.spawn(move || {
+      // Feed in the summary
+      let second_pass = receive_rc_pass2
+        .recv()
+        .map(|data: PassData| {
+          // check data.len() vs twopass_bytes_needed()
+          let len = inner.rc_state.twopass_in(None).unwrap_or(0);
+          println!("Summary {} vs {}", data.as_ref().len(), len);
+          inner
+            .rc_state
+            .twopass_in(Some(data.as_ref()))
+            .expect("Faulty pass data");
+          true
+        })
+        .unwrap_or(false);
+
+      // Send the placeholder data
+      let first_pass = send_pass_summary(&mut inner, &send_rc_pass1);
+
+      let second_pass_recv =
+        if second_pass { Some(receive_rc_pass2) } else { None };
+
+      let first_pass_send =
+        if first_pass { Some(send_rc_pass1) } else { None };
+
+      for f in receive_frame.iter() {
+        // info!("frame in {}", inner.frame_count);
+        while !inner.needs_more_fi_lookahead() {
+          // needs_more_fi_lookahead() should guard for missing output_frameno
+          // already.
+          // this call should return either Ok or Err(Encoded)
+          if let Ok(p) = receive_packet_impl(
+            &mut inner,
+            first_pass_send.as_ref(),
+            second_pass_recv.as_ref(),
+          ) {
+            // warn!("packet out {}", p.input_frameno);
+            send_packet.send(p).unwrap();
+          }
+        }
+
+        let (frame, params) = f;
+        let _ = inner.send_frame(frame, params); // TODO make sure it cannot fail.
+      }
+
+      inner.limit = Some(inner.frame_count);
+      let _ = inner.send_frame(None, None);
+
+      loop {
+        let r = receive_packet_impl(
+          &mut inner,
+          first_pass_send.as_ref(),
+          second_pass_recv.as_ref(),
+        );
+        match r {
+          Ok(p) => {
+            // warn!("Sending out {}", p.input_frameno);
+            send_packet.send(p).unwrap();
+          }
+          Err(EncoderStatus::LimitReached) => break,
+          Err(EncoderStatus::Encoded) => {}
+          Err(e) => panic!("got {:?}", e),
+        }
+      }
+
+      // Final summary
+      let _ = first_pass_send.map(|p| send_pass_summary(&mut inner, &p));
+
+      // drop(send_packet); // This happens implicitly
+    });
+
+    Ok((
+      (FrameSender(send_frame), PacketReceiver(receive_packet)),
+      (PassDataSender(send_rc_pass2), PassDataReceiver(receive_rc_pass1)),
+    ))
+  }
+}

--- a/src/api/channel.rs
+++ b/src/api/channel.rs
@@ -132,7 +132,7 @@ impl<T: Pixel> FrameSender<T> {
 }
 
 /// Endpoint to receive packets
-pub struct PacketReceiver<T: Pixel>{
+pub struct PacketReceiver<T: Pixel> {
   receiver: Receiver<Packet<T>>,
   enc: Arc<EncoderConfig>,
 }
@@ -219,14 +219,10 @@ impl Config {
 
     let enc = Arc::new(self.enc);
 
-    let channel = (FrameSender {
-      sender: send_frame,
-      enc: enc.clone(),
-    },
-    PacketReceiver {
-      receiver: receive_packet,
-      enc
-    });
+    let channel = (
+      FrameSender { sender: send_frame, enc: enc.clone() },
+      PacketReceiver { receiver: receive_packet, enc },
+    );
 
     pool.spawn(move || {
       for f in receive_frame.iter() {
@@ -266,7 +262,20 @@ impl Config {
 
     Ok(channel)
   }
-/*
+
+  /// Create an encoder channel with first pass data reporting
+  ///
+  /// Drop the `Sender<F>` endpoint to flush the encoder.
+  /// The last buffer in the Receiver<PassData> is the summary of the whole
+  /// encoding process.
+  pub fn new_firstpass_channel<T: Pixel>(
+    &self,
+  ) -> Result<(VideoDataChannel<T>, PassDataReceiver), InvalidConfig> {
+    let (video, passdata) = self.new_multipass_channel()?;
+
+    (video, passdata.1)
+  }
+
   /// Create a multipass encoder channel
   ///
   /// To setup a first-pass encode drop the `PassDataSender` before sending the
@@ -276,10 +285,15 @@ impl Config {
   /// are sent through the `PassDataSender` endpoint
   ///
   /// Drop the `Sender<F>` endpoint to flush the encoder.
-  /// The last buffer in the Receiver<PassData>
+  /// The last buffer in the Receiver<PassData> is the summary of the whole
+  /// encoding process.
   pub fn new_multipass_channel<T: Pixel>(
     &self,
   ) -> Result<(VideoDataChannel<T>, PassDataChannel), InvalidConfig> {
+    todo!()
+  }
+
+  /*
     // TODO: make it user-settable
     let input_len = self.enc.rdo_lookahead_frames as usize * 2;
 

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -166,22 +166,9 @@ fn check_tile_log2(n: usize) -> bool {
 }
 
 impl Config {
-  /// Creates a [`Context`] with this configuration.
-  ///
-  /// # Examples
-  ///
-  /// ```
-  /// use rav1e::prelude::*;
-  ///
-  /// # fn main() -> Result<(), InvalidConfig> {
-  /// let cfg = Config::default();
-  /// let ctx: Context<u8> = cfg.new_context()?;
-  /// # Ok(())
-  /// # }
-  /// ```
-  ///
-  /// [`Context`]: struct.Context.html
-  pub fn new_context<T: Pixel>(&self) -> Result<Context<T>, InvalidConfig> {
+  pub(crate) fn new_inner<T: Pixel>(
+    &self,
+  ) -> Result<ContextInner<T>, InvalidConfig> {
     assert!(
       8 * std::mem::size_of::<T>() >= self.enc.bit_depth,
       "The Pixel u{} does not match the Config bit_depth {}",
@@ -196,14 +183,6 @@ impl Config {
     // Since we only call this once, this shouldn't cause
     // performance issues.
     info!("CPU Feature Level: {}", CpuFeatureLevel::default());
-
-    let pool = if let Some(ref p) = self.pool {
-      p.clone()
-    } else {
-      let pool =
-        ThreadPoolBuilder::new().num_threads(self.threads).build().unwrap();
-      Arc::new(pool)
-    };
 
     let mut config = self.enc;
     config.set_key_frame_interval(
@@ -220,7 +199,6 @@ impl Config {
     }
 
     let mut inner = ContextInner::new(&config);
-
     if self.rate_control.emit_pass_data {
       let params = inner.rc_state.get_twopass_out_params(&inner, 0);
       inner.rc_state.init_first_pass(params.pass1_log_base_q);
@@ -230,6 +208,35 @@ impl Config {
       inner.rc_state.init_second_pass();
       inner.rc_state.setup_second_pass(s);
     }
+
+    Ok(inner)
+  }
+  /// Creates a [`Context`] with this configuration.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use rav1e::prelude::*;
+  ///
+  /// # fn main() -> Result<(), InvalidConfig> {
+  /// let cfg = Config::default();
+  /// let ctx: Context<u8> = cfg.new_context()?;
+  /// # Ok(())
+  /// # }
+  /// ```
+  ///
+  /// [`Context`]: struct.Context.html
+  pub fn new_context<T: Pixel>(&self) -> Result<Context<T>, InvalidConfig> {
+    let inner = self.new_inner()?;
+    let config = inner.config;
+
+    let pool = if let Some(ref p) = self.pool {
+      p.clone()
+    } else {
+      let pool =
+        ThreadPoolBuilder::new().num_threads(self.threads).build().unwrap();
+      Arc::new(pool)
+    };
 
     Ok(Context { is_flushing: false, inner, pool, config })
   }

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -366,7 +366,7 @@ impl<T: Pixel> ContextInner<T> {
 
   /// Indicates whether more frames need to be processed into FrameInvariants
   /// in order for FI lookahead to be full.
-  fn needs_more_fi_lookahead(&self) -> bool {
+  pub fn needs_more_fi_lookahead(&self) -> bool {
     let ready_frames = self.get_rdo_lookahead_frames().count();
     ready_frames < self.config.rdo_lookahead_frames + 1
       && self.needs_more_frames(self.next_lookahead_frame)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,6 +8,8 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 #![deny(missing_docs)]
 
+/// Channel-based encoder
+pub mod channel;
 /// Color model information
 pub mod color;
 /// Encoder Configuration
@@ -24,6 +26,7 @@ mod util;
 #[cfg(test)]
 mod test;
 
+pub use channel::*;
 pub use color::*;
 pub use config::*;
 pub use context::*;

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -13,14 +13,12 @@ use crate::prelude::*;
 use std::sync::Arc;
 
 use interpolate_name::interpolate_test;
-
-fn setup_encoder<T: Pixel>(
+fn setup_config(
   w: usize, h: usize, speed: usize, quantizer: usize, bit_depth: usize,
   chroma_sampling: ChromaSampling, min_keyint: u64, max_keyint: u64,
   bitrate: i32, low_latency: bool, switch_frame_interval: u64,
   no_scene_detection: bool, rdo_lookahead_frames: usize,
-) -> Context<T> {
-  assert!(bit_depth == 8 || std::mem::size_of::<T>() > 1);
+) -> Config {
   let mut enc = EncoderConfig::with_speed_preset(speed);
   enc.quantizer = quantizer;
   enc.min_key_frame_interval = min_keyint;
@@ -35,8 +33,30 @@ fn setup_encoder<T: Pixel>(
   enc.speed_settings.no_scene_detection = no_scene_detection;
   enc.rdo_lookahead_frames = rdo_lookahead_frames;
 
-  let cfg = Config::new().with_encoder_config(enc).with_threads(1);
+  Config::new().with_encoder_config(enc).with_threads(1)
+}
 
+fn setup_encoder<T: Pixel>(
+  w: usize, h: usize, speed: usize, quantizer: usize, bit_depth: usize,
+  chroma_sampling: ChromaSampling, min_keyint: u64, max_keyint: u64,
+  bitrate: i32, low_latency: bool, switch_frame_interval: u64,
+  no_scene_detection: bool, rdo_lookahead_frames: usize,
+) -> Context<T> {
+  let cfg = setup_config(
+    w,
+    h,
+    speed,
+    quantizer,
+    bit_depth,
+    chroma_sampling,
+    min_keyint,
+    max_keyint,
+    bitrate,
+    low_latency,
+    switch_frame_interval,
+    no_scene_detection,
+    rdo_lookahead_frames,
+  );
   cfg.new_context().unwrap()
 }
 
@@ -63,6 +83,53 @@ fn fill_frame_const<T: Pixel>(frame: &mut Frame<T>, value: T) {
       }
     }
   }
+}
+
+#[interpolate_test(low_latency_no_scene_change, true, true)]
+#[interpolate_test(reorder_no_scene_change, false, true)]
+#[interpolate_test(low_latency_scene_change_detection, true, false)]
+#[interpolate_test(reorder_scene_change_detection, false, false)]
+fn flush_ch(low_lantency: bool, no_scene_detection: bool) {
+  let cfg = setup_config(
+    64,
+    80,
+    10,
+    100,
+    8,
+    ChromaSampling::Cs420,
+    150,
+    200,
+    0,
+    low_lantency,
+    0,
+    no_scene_detection,
+    10,
+  );
+
+  let limit = 41;
+
+  let (sf, rp) = cfg.new_channel::<u8>().unwrap();
+
+  for _ in 0..limit {
+    let input = cfg.new_frame();
+    let _ = sf.send(input);
+  }
+
+  drop(sf);
+
+  let mut count = 0;
+
+  for _ in 0..limit {
+    let _ = rp
+      .recv()
+      .map(|_| {
+        eprintln!("Packet Received {}/{}", count, limit);
+        count += 1;
+      })
+      .unwrap();
+  }
+
+  assert_eq!(limit, count);
 }
 
 #[interpolate_test(low_latency_no_scene_change, true, true)]

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -21,9 +21,9 @@ use std::io;
 use std::io::prelude::*;
 
 pub struct EncoderIO {
-  pub input: Box<dyn Read>,
-  pub output: Box<dyn Muxer>,
-  pub rec: Option<Box<dyn Write>>,
+  pub input: Box<dyn Read + Send>,
+  pub output: Box<dyn Muxer + Send>,
+  pub rec: Option<Box<dyn Write + Send>>,
 }
 
 #[derive(PartialEq)]
@@ -436,16 +436,16 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
     Some(f) => Some(Box::new(
       File::create(&f)
         .map_err(|e| e.context("Cannot create reconstruction file"))?,
-    ) as Box<dyn Write>),
+    ) as Box<dyn Write + Send>),
     None => None,
   };
 
   let io = EncoderIO {
     input: match matches.value_of("INPUT").unwrap() {
-      "-" => Box::new(io::stdin()) as Box<dyn Read>,
+      "-" => Box::new(io::stdin()) as Box<dyn Read + Send>,
       f => Box::new(
         File::open(&f).map_err(|e| e.context("Cannot open input file"))?,
-      ) as Box<dyn Read>,
+      ) as Box<dyn Read + Send>,
     },
     output: create_muxer(
       matches.value_of("OUTPUT").unwrap(),

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -26,7 +26,7 @@ pub struct EncoderIO {
   pub rec: Option<Box<dyn Write + Send>>,
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum Verbose {
   Quiet,
   Normal,

--- a/src/bin/decoder/mod.rs
+++ b/src/bin/decoder/mod.rs
@@ -13,7 +13,7 @@ use std::io;
 
 pub mod y4m;
 
-pub trait Decoder {
+pub trait Decoder: Send {
   fn get_video_details(&self) -> VideoDetails;
   fn read_frame<T: Pixel>(
     &mut self, cfg: &VideoDetails,

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -15,7 +15,7 @@ use crate::decoder::{DecodeError, Decoder, VideoDetails};
 use crate::Frame;
 use rav1e::prelude::*;
 
-impl Decoder for y4m::Decoder<Box<dyn Read>> {
+impl Decoder for y4m::Decoder<Box<dyn Read + Send>> {
   fn get_video_details(&self) -> VideoDetails {
     let width = self.get_width();
     let height = self.get_height();

--- a/src/bin/muxer/ivf.rs
+++ b/src/bin/muxer/ivf.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use crate::error::*;
 
 pub struct IvfMuxer {
-  output: Box<dyn Write>,
+  output: Box<dyn Write + Send>,
 }
 
 impl Muxer for IvfMuxer {
@@ -80,7 +80,7 @@ impl IvfMuxer {
     Ok(())
   }
 
-  pub fn open(path: &str) -> Result<Box<dyn Muxer>, CliError> {
+  pub fn open(path: &str) -> Result<Box<dyn Muxer + Send>, CliError> {
     let ivf = IvfMuxer {
       output: match path {
         "-" => Box::new(std::io::stdout()),

--- a/src/bin/muxer/mod.rs
+++ b/src/bin/muxer/mod.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 
 use crate::error::*;
 
-pub trait Muxer {
+pub trait Muxer: Send {
   fn write_header(
     &mut self, width: usize, height: usize, framerate_num: usize,
     framerate_den: usize,

--- a/src/bin/muxer/mod.rs
+++ b/src/bin/muxer/mod.rs
@@ -34,7 +34,7 @@ pub trait Muxer {
 
 pub fn create_muxer(
   path: &str, overwrite: bool,
-) -> Result<Box<dyn Muxer>, CliError> {
+) -> Result<Box<dyn Muxer + Send>, CliError> {
   if !overwrite {
     IvfMuxer::check_file(path)?;
   }

--- a/src/bin/muxer/y4m.rs
+++ b/src/bin/muxer/y4m.rs
@@ -13,7 +13,7 @@ use std::io::Write;
 use std::slice;
 
 pub fn write_y4m_frame<T: Pixel>(
-  y4m_enc: &mut y4m::Encoder<Box<dyn Write>>, rec: &Frame<T>,
+  y4m_enc: &mut y4m::Encoder<Box<dyn Write + Send>>, rec: &Frame<T>,
   y4m_details: VideoDetails,
 ) {
   let planes =

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -1,0 +1,559 @@
+// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+#![deny(bare_trait_objects)]
+#![allow(clippy::cast_lossless)]
+#![allow(clippy::cast_ptr_alignment)]
+#![allow(clippy::cognitive_complexity)]
+#![allow(clippy::needless_range_loop)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::verbose_bit_mask)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::many_single_char_names)]
+#![warn(clippy::expl_impl_clone_on_copy)]
+#![warn(clippy::linkedlist)]
+#![warn(clippy::map_flatten)]
+#![warn(clippy::mem_forget)]
+#![warn(clippy::mut_mut)]
+#![warn(clippy::mutex_integer)]
+#![warn(clippy::needless_borrow)]
+#![warn(clippy::needless_continue)]
+#![warn(clippy::path_buf_push_overwrite)]
+#![warn(clippy::range_plus_one)]
+
+#[macro_use]
+extern crate log;
+
+mod common;
+mod decoder;
+mod error;
+#[cfg(feature = "serialize")]
+mod kv;
+mod muxer;
+mod stats;
+
+use crate::common::*;
+use crate::error::*;
+use crate::stats::*;
+use rav1e::prelude::*;
+
+use crate::decoder::{Decoder, VideoDetails};
+use crate::muxer::*;
+use std::fs::File;
+use std::io::{Read, Seek, Write};
+use std::sync::Arc;
+
+struct Source<D: Decoder> {
+  limit: usize,
+  count: usize,
+  input: D,
+  #[cfg(all(unix, feature = "signal-hook"))]
+  exit_requested: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl<D: Decoder> Source<D> {
+  cfg_if::cfg_if! {
+    if #[cfg(all(unix, feature = "signal-hook"))] {
+      fn new(limit: usize, input: D) -> Self {
+        let exit_requested = {
+          use std::sync::atomic::*;
+          let e = Arc::new(AtomicBool::from(false));
+
+          fn setup_signal(sig: i32, e: Arc<AtomicBool>) {
+            unsafe {
+              signal_hook::register(sig, move || {
+                if e.load(Ordering::SeqCst) {
+                  std::process::exit(128 + sig);
+                }
+                e.store(true, Ordering::SeqCst);
+                info!("Exit requested, flushing.");
+              })
+              .expect("Cannot register the signal hooks");
+            }
+          }
+
+          setup_signal(signal_hook::SIGTERM, e.clone());
+          setup_signal(signal_hook::SIGQUIT, e.clone());
+          setup_signal(signal_hook::SIGINT, e.clone());
+
+          e
+        };
+        Self { limit, input, count: 0, exit_requested, }
+      }
+    } else {
+      fn new(limit: usize, input: D) -> Self {
+        Self { limit, input, count: 0, }
+      }
+    }
+  }
+
+  fn read_frame<T: Pixel>(
+    &mut self, send_frame: &FrameSender<T>, video_info: VideoDetails,
+  ) -> bool {
+    if self.limit != 0 && self.count == self.limit {
+      return false;
+    }
+
+    #[cfg(all(unix, feature = "signal-hook"))]
+    {
+      if self.exit_requested.load(std::sync::atomic::Ordering::SeqCst) {
+        return false;
+      }
+    }
+
+    match self.input.read_frame(&video_info) {
+      Ok(frame) => {
+        self.count += 1;
+        let _ = send_frame.send(frame);
+        true
+      }
+      _ => false,
+    }
+  }
+}
+
+fn do_encode<T: Pixel, D: Decoder>(
+  cfg: Config, verbose: Verbose, mut progress: ProgressInfo,
+  output: &mut dyn Muxer, mut source: Source<D>, pass1file: Option<File>,
+  pass2file: Option<File>,
+  mut y4m_enc: Option<y4m::Encoder<Box<dyn Write + Send>>>,
+  metrics_enabled: MetricsEnabled,
+) -> Result<(), CliError> {
+  // Let's write down a placeholder.
+  let ((send_frame, receive_packet), (send_rc, receive_rc)) =
+    match (pass1file.is_some(), pass2file.is_some()) {
+      (true, true) => {
+        let (channel, (send_rc, receive_rc)) = cfg
+          .new_multipass_channel::<T>()
+          .map_err(|e| e.context("Invalid setup"))?;
+        (channel, (Some(send_rc), Some(receive_rc)))
+      }
+      (true, false) => {
+        let (channel, receive_rc) = cfg
+          .new_firstpass_channel()
+          .map_err(|e| e.context("Invalid setup"))?;
+        (channel, (None, Some(receive_rc)))
+      }
+      (false, true) => {
+        let (channel, send_rc) = cfg
+          .new_secondpass_channel()
+          .map_err(|e| e.context("Invalid setup"))?;
+        (channel, (Some(send_rc), None))
+      }
+      (false, false) => {
+        let channel =
+          cfg.new_channel().map_err(|e| e.context("Invalid setup"))?;
+        (channel, (None, None))
+      }
+    };
+
+  let y4m_details = source.input.get_video_details();
+
+  crossbeam::thread::scope(move |s| -> Result<(), CliError> {
+    // Receive pass data
+    let a = s.spawn(move |_| -> Result<(), CliError> {
+      if let (Some(mut passfile), Some(receive_rc)) = (pass1file, receive_rc) {
+        let len = receive_rc.summary_size();
+        let buf = vec![0u8; len];
+
+        passfile
+          .write_all(&(len as u64).to_be_bytes())
+          .map_err(|e| e.context("Unable to write to two-pass data file."))?;
+
+        passfile
+          .write_all(&buf)
+          .map_err(|e| e.context("Unable to write to two-pass data file."))?;
+        for data in receive_rc.iter() {
+          match data {
+            RcData::Frame(outbuf) => {
+              let len = outbuf.len() as u64;
+              passfile.write_all(&len.to_be_bytes()).map_err(|e| {
+                e.context("Unable to write to two-pass data file.")
+              })?;
+
+              passfile.write_all(&outbuf).map_err(|e| {
+                e.context("Unable to write to two-pass data file.")
+              })?;
+            }
+            RcData::Summary(outbuf) => {
+              // The last packet of rate control data we get is the summary data.
+              // Let's put it at the start of the file.
+              passfile.seek(std::io::SeekFrom::Start(0)).map_err(|e| {
+                e.context("Unable to seek in the two-pass data file.")
+              })?;
+              let len = outbuf.len() as u64;
+
+              passfile.write_all(&len.to_be_bytes()).map_err(|e| {
+                e.context("Unable to write to two-pass data file.")
+              })?;
+
+              passfile.write_all(&outbuf).map_err(|e| {
+                e.context("Unable to write to two-pass data file.")
+              })?;
+            }
+          }
+        }
+      }
+      Ok(())
+    });
+
+    // Send frames
+    let b = s.spawn(move |_| -> Result<(), CliError> {
+      while source.read_frame(&send_frame, y4m_details) {}
+
+      // send_frame.result()
+      Ok(())
+    });
+
+    // Send pass data
+    let c = s.spawn(move |_| -> Result<(), CliError> {
+      if let (Some(mut passfile), Some(send_rc)) = (pass2file, send_rc) {
+        let mut buflen = [0u8; 8];
+
+        passfile
+          .read_exact(&mut buflen)
+          .map_err(|e| e.context("Unable to read the two-pass data file."))?;
+
+        let mut data = vec![0u8; u64::from_be_bytes(buflen) as usize];
+
+        passfile
+          .read_exact(&mut data)
+          .map_err(|e| e.context("Unable to read the two-pass data file."))?;
+
+        while send_rc.send(RcData::Frame(data.into_boxed_slice())).is_ok() {
+          passfile.read_exact(&mut buflen).map_err(|e| {
+            e.context("Unable to read the two-pass data file.")
+          })?;
+
+          data = vec![0u8; u64::from_be_bytes(buflen) as usize];
+
+          passfile.read_exact(&mut data).map_err(|e| {
+            e.context("Unable to read the two-pass data file.")
+          })?;
+        }
+      }
+
+      Ok(())
+    });
+
+    // Receive Packets
+    let d = s.spawn(move |_| -> Result<(), CliError> {
+      for pkt in receive_packet.iter() {
+        output.write_frame(
+          pkt.input_frameno as u64,
+          pkt.data.as_ref(),
+          pkt.frame_type,
+        );
+        output.flush().unwrap();
+        if let (Some(ref mut y4m_enc_uw), Some(ref rec)) =
+          (y4m_enc.as_mut(), &pkt.rec)
+        {
+          write_y4m_frame(y4m_enc_uw, rec, y4m_details);
+        }
+        let summary = build_frame_summary(
+          pkt,
+          y4m_details.bit_depth,
+          y4m_details.chroma_sampling,
+          metrics_enabled,
+        );
+
+        if verbose != Verbose::Quiet {
+          progress.add_frame(summary.clone());
+          if verbose == Verbose::Verbose {
+            info!("{} - {}", summary, progress);
+          } else {
+            // Print a one-line progress indicator that overrides itself with every update
+            eprint!("\r{}                    ", progress);
+          };
+        }
+      }
+
+      if verbose != Verbose::Quiet {
+        if verbose == Verbose::Verbose {
+          // Clear out the temporary progress indicator
+          eprint!("\r");
+        }
+        progress.print_summary(verbose == Verbose::Verbose);
+      }
+
+      // receive_packet.result()
+      Ok(())
+    });
+
+    a.join().unwrap()?;
+    b.join().unwrap()?;
+    c.join().unwrap()?;
+    d.join().unwrap()?;
+
+    Ok(())
+  })
+  .unwrap()
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+  #[cfg(feature = "tracing")]
+  use rust_hawktracer::*;
+  init_logger();
+
+  #[cfg(feature = "tracing")]
+  let instance = HawktracerInstance::new();
+  #[cfg(feature = "tracing")]
+  let _listener = instance.create_listener(HawktracerListenerType::ToFile {
+    file_path: "trace.bin".into(),
+    buffer_size: 4096,
+  });
+
+  run().map_err(|e| {
+    error::print_error(&e);
+    Box::new(e) as Box<dyn std::error::Error>
+  })
+}
+
+fn init_logger() {
+  use std::str::FromStr;
+  fn level_colored(l: log::Level) -> console::StyledObject<&'static str> {
+    use console::style;
+    use log::Level;
+    match l {
+      Level::Trace => style("??").dim(),
+      Level::Debug => style("? ").dim(),
+      Level::Info => style("> ").green(),
+      Level::Warn => style("! ").yellow(),
+      Level::Error => style("!!").red(),
+    }
+  }
+
+  // this can be changed to flatten
+  let level = std::env::var("RAV1E_LOG")
+    .ok()
+    .map(|l| log::LevelFilter::from_str(&l).ok())
+    .unwrap_or(Some(log::LevelFilter::Info))
+    .unwrap();
+
+  fern::Dispatch::new()
+    .format(move |out, message, record| {
+      out.finish(format_args!(
+        "{level} {message}",
+        level = level_colored(record.level()),
+        message = message,
+      ));
+    })
+    // set the default log level. to filter out verbose log messages from dependencies, set
+    // this to Warn and overwrite the log level for your crate.
+    .level(log::LevelFilter::Warn)
+    // change log levels for individual modules. Note: This looks for the record's target
+    // field which defaults to the module path but can be overwritten with the `target`
+    // parameter:
+    // `info!(target="special_target", "This log message is about special_target");`
+    .level_for("rav1e", level)
+    // output to stdout
+    .chain(std::io::stderr())
+    .apply()
+    .unwrap();
+}
+
+cfg_if::cfg_if! {
+  if #[cfg(any(target_os = "windows", target_arch = "wasm32"))] {
+    fn print_rusage() {
+      eprintln!("Windows benchmarking is not supported currently.");
+    }
+  } else {
+    fn print_rusage() {
+      let (utime, stime, maxrss) = unsafe {
+        let mut usage = std::mem::zeroed();
+        let _ = libc::getrusage(libc::RUSAGE_SELF, &mut usage);
+        (usage.ru_utime, usage.ru_stime, usage.ru_maxrss)
+      };
+      eprintln!(
+        "user time: {} s",
+        utime.tv_sec as f64 + utime.tv_usec as f64 / 1_000_000f64
+      );
+      eprintln!(
+        "system time: {} s",
+        stime.tv_sec as f64 + stime.tv_usec as f64 / 1_000_000f64
+      );
+      eprintln!("maximum rss: {} KB", maxrss);
+    }
+  }
+}
+
+fn run() -> Result<(), error::CliError> {
+  let mut cli = parse_cli()?;
+  // Maximum frame size by specification + maximum y4m header
+  let limit = y4m::Limits {
+    // Use saturating operations to gracefully handle 32-bit architectures
+    bytes: 64usize
+      .saturating_mul(64)
+      .saturating_mul(4096)
+      .saturating_mul(2304)
+      .saturating_add(1024),
+  };
+  let mut y4m_dec = match y4m::Decoder::new_with_limits(cli.io.input, limit) {
+    Err(_) => {
+      return Err(CliError::new("Could not input video. Is it a y4m file?"))
+    }
+    Ok(d) => d,
+  };
+  let video_info = y4m_dec.get_video_details();
+  let y4m_enc = match cli.io.rec {
+    Some(rec) => Some(
+      y4m::encode(
+        video_info.width,
+        video_info.height,
+        y4m::Ratio::new(
+          video_info.time_base.den as usize,
+          video_info.time_base.num as usize,
+        ),
+      )
+      .with_colorspace(y4m_dec.get_colorspace())
+      .write_header(rec)
+      .unwrap(),
+    ),
+    None => None,
+  };
+
+  match video_info.bit_depth {
+    8 | 10 | 12 => {}
+    _ => return Err(CliError::new("Unsupported bit depth")),
+  }
+
+  cli.enc.width = video_info.width;
+  cli.enc.height = video_info.height;
+  cli.enc.bit_depth = video_info.bit_depth;
+  cli.enc.chroma_sampling = video_info.chroma_sampling;
+  cli.enc.chroma_sample_position = video_info.chroma_sample_position;
+
+  // If no pixel range is specified via CLI, assume limited,
+  // as it is the default for the Y4M format.
+  if !cli.color_range_specified {
+    cli.enc.pixel_range = PixelRange::Limited;
+  }
+
+  if !cli.override_time_base {
+    cli.enc.time_base = video_info.time_base;
+  }
+
+  let mut rc = RateControlConfig::new();
+
+  let pass2file = match cli.pass2file_name {
+    Some(f) => {
+      let mut f = File::open(f).map_err(|e| {
+        e.context("Unable to open file for reading two-pass data")
+      })?;
+      let mut buflen = [0u8; 8];
+      f.read_exact(&mut buflen)
+        .map_err(|e| e.context("Summary data too short"))?;
+      let len = i64::from_be_bytes(buflen);
+      let mut buf = vec![0u8; len as usize];
+
+      f.read_exact(&mut buf)
+        .map_err(|e| e.context("Summary data too short"))?;
+
+      rc = RateControlConfig::from_summary_slice(&buf)
+        .map_err(|e| e.context("Invalid summary"))?;
+
+      Some(f)
+    }
+    None => None,
+  };
+
+  let pass1file = match cli.pass1file_name {
+    Some(f) => {
+      let f = File::create(f).map_err(|e| {
+        e.context("Unable to open file for writing two-pass data")
+      })?;
+      rc = rc.with_emit_data(true);
+      Some(f)
+    }
+    None => None,
+  };
+
+  let cfg = Config::new()
+    .with_encoder_config(cli.enc)
+    .with_threads(cli.threads)
+    .with_rate_control(rc);
+
+  #[cfg(feature = "serialize")]
+  {
+    if let Some(save_config) = cli.save_config {
+      let mut out = File::create(save_config)
+        .map_err(|e| e.context("Cannot create configuration file"))?;
+      let s = toml::to_string(&cli.enc).unwrap();
+      out
+        .write_all(s.as_bytes())
+        .map_err(|e| e.context("Cannot write the configuration file"))?
+    }
+  }
+
+  cli.io.output.write_header(
+    video_info.width,
+    video_info.height,
+    cli.enc.time_base.den as usize,
+    cli.enc.time_base.num as usize,
+  );
+
+  info!(
+    "Using y4m decoder: {}x{}p @ {}/{} fps, {}, {}-bit",
+    video_info.width,
+    video_info.height,
+    video_info.time_base.den,
+    video_info.time_base.num,
+    video_info.chroma_sampling,
+    video_info.bit_depth
+  );
+  info!("Encoding settings: {}", cli.enc);
+
+  let progress = ProgressInfo::new(
+    Rational { num: video_info.time_base.den, den: video_info.time_base.num },
+    if cli.limit == 0 { None } else { Some(cli.limit) },
+    cli.metrics_enabled,
+  );
+
+  for _ in 0..cli.skip {
+    match y4m_dec.read_frame() {
+      Ok(f) => f,
+      Err(_) => {
+        return Err(CliError::new("Skipped more frames than in the input"))
+      }
+    };
+  }
+
+  let source = Source::new(cli.limit, y4m_dec);
+
+  if video_info.bit_depth == 8 {
+    do_encode::<u8, y4m::Decoder<Box<dyn Read + Send>>>(
+      cfg,
+      cli.verbose,
+      progress,
+      &mut *cli.io.output,
+      source,
+      pass1file,
+      pass2file,
+      y4m_enc,
+      cli.metrics_enabled,
+    )?
+  } else {
+    do_encode::<u16, y4m::Decoder<Box<dyn Read + Send>>>(
+      cfg,
+      cli.verbose,
+      progress,
+      &mut *cli.io.output,
+      source,
+      pass1file,
+      pass2file,
+      y4m_enc,
+      cli.metrics_enabled,
+    )?
+  }
+  if cli.benchmark {
+    print_rusage();
+  }
+
+  Ok(())
+}

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -131,7 +131,7 @@ impl<D: Decoder> Source<D> {
 fn process_frame<T: Pixel, D: Decoder>(
   ctx: &mut Context<T>, output_file: &mut dyn Muxer, source: &mut Source<D>,
   pass1file: Option<&mut File>, pass2file: Option<&mut File>,
-  mut y4m_enc: Option<&mut y4m::Encoder<Box<dyn Write>>>,
+  mut y4m_enc: Option<&mut y4m::Encoder<Box<dyn Write + Send>>>,
   metrics_cli: MetricsEnabled,
 ) -> Result<Option<Vec<FrameSummary>>, CliError> {
   let y4m_details = source.input.get_video_details();
@@ -241,7 +241,7 @@ fn do_encode<T: Pixel, D: Decoder>(
   cfg: Config, verbose: Verbose, mut progress: ProgressInfo,
   output: &mut dyn Muxer, mut source: Source<D>, mut pass1file: Option<File>,
   mut pass2file: Option<File>,
-  mut y4m_enc: Option<y4m::Encoder<Box<dyn Write>>>,
+  mut y4m_enc: Option<y4m::Encoder<Box<dyn Write + Send>>>,
   metrics_enabled: MetricsEnabled,
 ) -> Result<(), CliError> {
   let mut ctx: Context<T> =
@@ -520,7 +520,7 @@ fn run() -> Result<(), error::CliError> {
   let source = Source::new(cli.limit, y4m_dec);
 
   if video_info.bit_depth == 8 {
-    do_encode::<u8, y4m::Decoder<Box<dyn Read>>>(
+    do_encode::<u8, y4m::Decoder<Box<dyn Read + Send>>>(
       cfg,
       cli.verbose,
       progress,
@@ -532,7 +532,7 @@ fn run() -> Result<(), error::CliError> {
       cli.metrics_enabled,
     )?
   } else {
-    do_encode::<u16, y4m::Decoder<Box<dyn Read>>>(
+    do_encode::<u16, y4m::Decoder<Box<dyn Read + Send>>>(
       cfg,
       cli.verbose,
       progress,


### PR DESCRIPTION
This set provides a channel-based API that should make much simpler the normal usage.

TODO:
- [x] Basic encoding API
  - [x] Works
  - [x] Produces the same output for the same input
- [ ] Multipass encoding API
   - [x] Single pass
   - [ ] Second pass
     - [ ] Produces the same output for the same input
   - [ ] Multipass

Open questions:
- Fit a `last-error` inside the ReceiverPacket abstraction and a mean to retrieve it
- For multipass the api can be a single function and use the Config rc information to decide if it has to be multipass/firstpass/secondpass/normal
