### PR TITLE
Make variable in write_coeff consistent with spec

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -4151,12 +4151,12 @@ impl<'a> ContextWriter<'a> {
 
     let bhl = Self::get_txb_bhl(tx_size);
 
-    for (c, (&pos, &v)) in scan.iter().zip(coeffs.iter()).rev().enumerate() {
+    for (c, (&pos, &v)) in scan.iter().zip(coeffs.iter()).enumerate().rev() {
       let pos = pos as usize;
       let coeff_ctx = coeff_contexts.array[pos];
       let level = v.abs();
 
-      if c == 0 {
+      if c == eob - 1 {
         symbol_with_update!(
           self,
           w,


### PR DESCRIPTION
a813477b2acf460a4a54f981f53ceb6d96d45549 made a variable inconsistent to
how it is used in the spec.