### PR TITLE
Clarify naming of AlignedArray struct

### DIFF
--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -20,14 +20,14 @@ use rav1e::bench::util::*;
 pub const BLOCK_SIZE: BlockSize = BlockSize::BLOCK_32X32;
 
 pub fn generate_block<T: Pixel>(
-  rng: &mut ChaChaRng, edge_buf: &mut AlignedArray<[T; 257]>,
+  rng: &mut ChaChaRng, edge_buf: &mut Aligned<[T; 257]>,
 ) -> (Plane<T>, Vec<i16>) {
   let block = Plane::wrap(
     vec![T::cast_from(0); BLOCK_SIZE.width() * BLOCK_SIZE.height()],
     BLOCK_SIZE.width(),
   );
   let ac: Vec<i16> = (0..(32 * 32)).map(|_| rng.gen()).collect();
-  for v in edge_buf.array.iter_mut() {
+  for v in edge_buf.data.iter_mut() {
     *v = T::cast_from(rng.gen::<u8>());
   }
 
@@ -134,7 +134,7 @@ pub fn intra_bench<T: Pixel>(
   b: &mut Bencher, mode: PredictionMode, variant: PredictionVariant,
 ) {
   let mut rng = ChaChaRng::from_seed([0; 32]);
-  let mut edge_buf = AlignedArray::uninitialized();
+  let mut edge_buf = Aligned::uninitialized();
   let (mut block, ac) = generate_block::<T>(&mut rng, &mut edge_buf);
   let cpu = CpuFeatureLevel::default();
   let bitdepth = match T::type_enum() {

--- a/src/asm/aarch64/predict.rs
+++ b/src/asm/aarch64/predict.rs
@@ -14,7 +14,7 @@ use crate::predict::{
 };
 use crate::tiling::PlaneRegionMut;
 use crate::transform::TxSize;
-use crate::util::AlignedArray;
+use crate::util::Aligned;
 use crate::Pixel;
 use libc;
 use std::mem::size_of;
@@ -71,7 +71,7 @@ pub fn dispatch_predict_intra<T: Pixel>(
   mode: PredictionMode, variant: PredictionVariant,
   dst: &mut PlaneRegionMut<'_, T>, tx_size: TxSize, bit_depth: usize,
   ac: &[i16], angle: isize, ief_params: Option<IntraEdgeFilterParameters>,
-  edge_buf: &AlignedArray<[T; 4 * MAX_TX_SIZE + 1]>, cpu: CpuFeatureLevel,
+  edge_buf: &Aligned<[T; 4 * MAX_TX_SIZE + 1]>, cpu: CpuFeatureLevel,
 ) {
   let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
     native::dispatch_predict_intra(
@@ -88,7 +88,7 @@ pub fn dispatch_predict_intra<T: Pixel>(
     let dst_ptr = dst.data_ptr_mut() as *mut _;
     let stride = dst.plane_cfg.stride as libc::ptrdiff_t;
     let edge_ptr =
-      edge_buf.array.as_ptr().offset(2 * MAX_TX_SIZE as isize) as *const _;
+      edge_buf.data.as_ptr().offset(2 * MAX_TX_SIZE as isize) as *const _;
     let w = tx_size.width() as libc::c_int;
     let h = tx_size.height() as libc::c_int;
     let angle = angle as libc::c_int;

--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -23,12 +23,11 @@ pub fn call_inverse_func<T: Pixel>(
   // Only use at most 32 columns and 32 rows of input coefficients.
   let input: &[T::Coeff] = &input[..width.min(32) * height.min(32)];
 
-  let mut copied: AlignedArray<[T::Coeff; 32 * 32]> =
-    AlignedArray::uninitialized();
+  let mut copied: Aligned<[T::Coeff; 32 * 32]> = Aligned::uninitialized();
 
   // Convert input to 16-bits.
   // TODO: Remove by changing inverse assembly to not overwrite its input
-  for (a, b) in copied.array.iter_mut().zip(input) {
+  for (a, b) in copied.data.iter_mut().zip(input) {
     *a = *b;
   }
 
@@ -37,7 +36,7 @@ pub fn call_inverse_func<T: Pixel>(
     func(
       output.data_ptr_mut() as *mut _,
       output.plane_cfg.stride as isize,
-      copied.array.as_mut_ptr() as *mut _,
+      copied.data.as_mut_ptr() as *mut _,
       eob as i32,
     );
   }
@@ -110,12 +109,10 @@ pub mod test {
       let mut src_storage = [0u8; 64 * 64];
       let src = &mut src_storage[..tx_size.area()];
       let mut dst = Plane::wrap(vec![0u8; tx_size.area()], tx_size.width());
-      let mut res_storage: AlignedArray<[i16; 64 * 64]> =
-        AlignedArray::uninitialized();
-      let res = &mut res_storage.array[..tx_size.area()];
-      let mut freq_storage: AlignedArray<[i16; 64 * 64]> =
-        AlignedArray::uninitialized();
-      let freq = &mut freq_storage.array[..tx_size.area()];
+      let mut res_storage: Aligned<[i16; 64 * 64]> = Aligned::uninitialized();
+      let res = &mut res_storage.data[..tx_size.area()];
+      let mut freq_storage: Aligned<[i16; 64 * 64]> = Aligned::uninitialized();
+      let freq = &mut freq_storage.data[..tx_size.area()];
       for ((r, s), d) in
         res.iter_mut().zip(src.iter_mut()).zip(dst.data.iter_mut())
       {

--- a/src/asm/x86/quantize.rs
+++ b/src/asm/x86/quantize.rs
@@ -187,11 +187,11 @@ mod test {
       };
 
       for &eob in &eobs {
-        let mut qcoeffs = AlignedArray::new([0i16; 32 * 32]);
-        let mut rcoeffs = AlignedArray::new([0i16; 32 * 32]);
+        let mut qcoeffs = Aligned::new([0i16; 32 * 32]);
+        let mut rcoeffs = Aligned::new([0i16; 32 * 32]);
 
         // Generate quantized coefficients upto the eob
-        for (i, qcoeff) in qcoeffs.array.iter_mut().enumerate().take(eob) {
+        for (i, qcoeff) in qcoeffs.data.iter_mut().enumerate().take(eob) {
           *qcoeff =
             rng.gen::<i16>() / if i == 0 { dc_quant } else { ac_quant };
         }
@@ -199,9 +199,9 @@ mod test {
         // Rely on quantize's internal tests
         dequantize(
           qindex,
-          &qcoeffs.array,
+          &qcoeffs.data,
           eob,
-          &mut rcoeffs.array,
+          &mut rcoeffs.data,
           tx_size,
           bd,
           0,

--- a/src/asm/x86/transform/forward.rs
+++ b/src/asm/x86/transform/forward.rs
@@ -334,9 +334,8 @@ unsafe fn fwd_txfm2d_avx2<T: Coefficient>(
   let col_class = SizeClass1D::from_length(txfm_size_col);
   let row_class = SizeClass1D::from_length(txfm_size_row);
 
-  let mut tmp: AlignedArray<[I32X8; 64 * 64 / 8]> =
-    AlignedArray::uninitialized();
-  let buf = &mut tmp.array[..txfm_size_col * (txfm_size_row / 8).max(1)];
+  let mut tmp: Aligned<[I32X8; 64 * 64 / 8]> = Aligned::uninitialized();
+  let buf = &mut tmp.data[..txfm_size_col * (txfm_size_row / 8).max(1)];
   let cfg = Txfm2DFlipCfg::fwd(tx_type, tx_size, bd);
 
   let txfm_func_col = get_func_i32x8(cfg.txfm_type_col);

--- a/src/context.rs
+++ b/src/context.rs
@@ -4055,9 +4055,9 @@ impl<'a> ContextWriter<'a> {
     let height = av1_get_coded_tx_size(tx_size).height();
 
     // Create a slice with coeffs in scan order
-    let mut coeffs_storage: AlignedArray<ArrayVec<[T; 32 * 32]>> =
-      AlignedArray::new(ArrayVec::new());
-    let coeffs = &mut coeffs_storage.array;
+    let mut coeffs_storage: Aligned<ArrayVec<[T; 32 * 32]>> =
+      Aligned::new(ArrayVec::new());
+    let coeffs = &mut coeffs_storage.data;
     coeffs.extend(scan.iter().map(|&scan_idx| coeffs_in[scan_idx as usize]));
 
     let mut cul_level = coeffs.iter().map(|c| u32::cast_from(c.abs())).sum();
@@ -4137,8 +4137,8 @@ impl<'a> ContextWriter<'a> {
       }
     }
 
-    let mut coeff_contexts: AlignedArray<[i8; MAX_TX_SQUARE]> =
-      AlignedArray::uninitialized();
+    let mut coeff_contexts: Aligned<[i8; MAX_TX_SQUARE]> =
+      Aligned::uninitialized();
 
     self.get_nz_map_contexts(
       levels,
@@ -4146,14 +4146,14 @@ impl<'a> ContextWriter<'a> {
       eob as u16,
       tx_size,
       tx_class,
-      &mut coeff_contexts.array,
+      &mut coeff_contexts.data,
     );
 
     let bhl = Self::get_txb_bhl(tx_size);
 
     for (c, (&pos, &v)) in scan.iter().zip(coeffs.iter()).rev().enumerate() {
       let pos = pos as usize;
-      let coeff_ctx = coeff_contexts.array[pos];
+      let coeff_ctx = coeff_contexts.data[pos];
       let level = v.abs();
 
       if c == 0 {

--- a/src/me.rs
+++ b/src/me.rs
@@ -696,7 +696,7 @@ fn diamond_me_search<T: Pixel>(
   center_mv: &mut MotionVector, center_mv_cost: &mut u64, subpixel: bool,
   ref_frame: RefType,
 ) {
-  use crate::util::AlignedArray;
+  use crate::util::Aligned;
 
   let cfg = PlaneConfig::new(
     bsize.width(),
@@ -708,7 +708,7 @@ fn diamond_me_search<T: Pixel>(
     std::mem::size_of::<T>(),
   );
 
-  let mut buf: AlignedArray<[T; 128 * 128]> = AlignedArray::uninitialized();
+  let mut buf: Aligned<[T; 128 * 128]> = Aligned::uninitialized();
 
   let diamond_pattern = [(1i16, 0i16), (0, 1), (-1, 0), (0, -1)];
   let (mut diamond_radius, diamond_radius_end, mut tmp_region_opt) = {
@@ -719,7 +719,7 @@ fn diamond_me_search<T: Pixel>(
       (
         4i16,
         if fi.allow_high_precision_mv { 1i16 } else { 2i16 },
-        Some(PlaneRegionMut::from_slice(&mut buf.array, &cfg, rect)),
+        Some(PlaneRegionMut::from_slice(&mut buf.data, &cfg, rect)),
       )
     } else {
       // Full pixel motion estimation

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -525,16 +525,16 @@ pub fn get_intra_edges<T: Pixel>(
   tx_size: TxSize,
   bit_depth: usize,
   opt_mode: Option<PredictionMode>,
-) -> AlignedArray<[T; 4 * MAX_TX_SIZE + 1]> {
+) -> Aligned<[T; 4 * MAX_TX_SIZE + 1]> {
   let plane_cfg = &dst.plane_cfg;
 
-  let mut edge_buf: AlignedArray<[T; 4 * MAX_TX_SIZE + 1]> =
-    AlignedArray::uninitialized();
+  let mut edge_buf: Aligned<[T; 4 * MAX_TX_SIZE + 1]> =
+    Aligned::uninitialized();
   let base = 128u16 << (bit_depth - 8);
 
   {
     // left pixels are ordered from bottom to top and right-aligned
-    let (left, not_left) = edge_buf.array.split_at_mut(2 * MAX_TX_SIZE);
+    let (left, not_left) = edge_buf.data.split_at_mut(2 * MAX_TX_SIZE);
     let (top_left, above) = not_left.split_at_mut(1);
 
     let x = po.x as usize;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -34,7 +34,7 @@ use crate::predict::{
 use crate::rdo_tables::*;
 use crate::tiling::*;
 use crate::transform::{TxSet, TxSize, TxType, RAV1E_TX_TYPES};
-use crate::util::{AlignedArray, CastFromPrimitive, Pixel};
+use crate::util::{Aligned, CastFromPrimitive, Pixel};
 use crate::write_tx_blocks;
 use crate::write_tx_tree;
 use crate::Tune;
@@ -1361,8 +1361,8 @@ pub fn rdo_cfl_alpha<T: Pixel>(
   let uv_tx_size = bsize.largest_chroma_tx_size(xdec, ydec);
   debug_assert!(bsize.subsampled_size(xdec, ydec) == uv_tx_size.block_size());
 
-  let mut ac: AlignedArray<[i16; 32 * 32]> = AlignedArray::uninitialized();
-  luma_ac(&mut ac.array, ts, tile_bo, bsize);
+  let mut ac: Aligned<[i16; 32 * 32]> = Aligned::uninitialized();
+  luma_ac(&mut ac.data, ts, tile_bo, bsize);
   let best_alpha: ArrayVec<[i16; 2]> = (1..3)
     .map(|p| {
       let &PlaneConfig { xdec, ydec, .. } = ts.rec.planes[p].plane_cfg;
@@ -1389,7 +1389,7 @@ pub fn rdo_cfl_alpha<T: Pixel>(
           &mut rec_region,
           uv_tx_size,
           fi.sequence.bit_depth,
-          &ac.array,
+          &ac.data,
           IntraParam::Alpha(alpha),
           None,
           &edge_buf,

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -109,8 +109,8 @@ pub mod native {
     let txfm_size_col = tx_size.width();
     let txfm_size_row = tx_size.height();
 
-    let mut tmp: AlignedArray<[i32; 64 * 64]> = AlignedArray::uninitialized();
-    let buf = &mut tmp.array[..txfm_size_col * txfm_size_row];
+    let mut tmp: Aligned<[i32; 64 * 64]> = Aligned::uninitialized();
+    let buf = &mut tmp.data[..txfm_size_col * txfm_size_row];
 
     let cfg = Txfm2DFlipCfg::fwd(tx_type, tx_size, bd);
 
@@ -119,9 +119,9 @@ pub mod native {
 
     // Columns
     for c in 0..txfm_size_col {
-      let mut col_coeffs_backing: AlignedArray<[i32; 64]> =
-        AlignedArray::uninitialized();
-      let col_coeffs = &mut col_coeffs_backing.array[..txfm_size_row];
+      let mut col_coeffs_backing: Aligned<[i32; 64]> =
+        Aligned::uninitialized();
+      let col_coeffs = &mut col_coeffs_backing.data[..txfm_size_row];
       if cfg.ud_flip {
         // flip upside down
         for r in 0..txfm_size_row {

--- a/src/util/align.rs
+++ b/src/util/align.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2020, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
@@ -12,23 +12,23 @@ use std::mem::MaybeUninit;
 #[repr(align(32))]
 pub struct Align32;
 
-// A 16 byte aligned array.
+// A 32 byte aligned piece of data.
 // # Examples
 // ```
-// let mut x: AlignedArray<[i16; 64 * 64]> = AlignedArray::new([0; 64 * 64]);
-// assert!(x.array.as_ptr() as usize % 16 == 0);
+// let mut x: Aligned<[i16; 64 * 64]> = Aligned::new([0; 64 * 64]);
+// assert!(x.data.as_ptr() as usize % 16 == 0);
 //
-// let mut x: AlignedArray<[i16; 64 * 64]> = AlignedArray::uninitialized();
-// assert!(x.array.as_ptr() as usize % 16 == 0);
+// let mut x: Aligned<[i16; 64 * 64]> = Aligned::uninitialized();
+// assert!(x.data.as_ptr() as usize % 16 == 0);
 // ```
-pub struct AlignedArray<ARRAY> {
+pub struct Aligned<T> {
   _alignment: [Align32; 0],
-  pub array: ARRAY,
+  pub data: T,
 }
 
-impl<A> AlignedArray<A> {
-  pub const fn new(array: A) -> Self {
-    AlignedArray { _alignment: [], array }
+impl<T> Aligned<T> {
+  pub const fn new(data: T) -> Self {
+    Aligned { _alignment: [], data }
   }
   #[allow(clippy::uninit_assumed_init)]
   pub fn uninitialized() -> Self {
@@ -42,6 +42,6 @@ fn sanity() {
     ((ptr as usize) & ((1 << n) - 1)) == 0
   }
 
-  let a: AlignedArray<_> = AlignedArray::new([0u8; 3]);
-  assert!(is_aligned(a.array.as_ptr(), 4));
+  let a: Aligned<_> = Aligned::new([0u8; 3]);
+  assert!(is_aligned(a.data.as_ptr(), 4));
 }


### PR DESCRIPTION
Because this struct can be used with any data types,
not only arrays, this commit updates the naming
of the struct and its internals to reflect this.