### PR TITLE
Disable LRF at speed 10.

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -485,8 +485,8 @@ impl SpeedSettings {
     true
   }
 
-  const fn lrf_preset(_speed: usize) -> bool {
-    true
+  const fn lrf_preset(speed: usize) -> bool {
+    speed <= 9
   }
 
   fn sgr_complexity_preset(speed: usize) -> SGRComplexityLevel {


### PR DESCRIPTION
~40% reduction in encoding time for 5% loss.

Will be turned on again when LRF is threaded.

master-2020-01-23_140900-5b94130e -> lrf_speed_level_9-2020-01-23_141104-1b821aa2

  PSNR | PSNR Cb | PSNR Cr | PSNR HVS |   SSIM | MS SSIM | CIEDE 2000
5.8688 |  1.9804 |  2.9445 |   4.3249 | 9.4403 |  7.3227 |     7.5342