### PR TITLE
Remove y4m header in desync finding step of contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,13 @@ Install `cargo-fuzz` with `cargo install cargo-fuzz`. Running fuzz targets requi
 /path/to/dav1d -i out.ivf -o dec.y4m
 ```
 
-3. Compare if the reconstruction and decoded video match.
+3. Remove the y4m sequence header to see the difference in frame header or data
 ```
-cmp rec.y4m dec.y4m
+tail -n+2 rec.y4m > rec
+tail -n+2 dec.y4m > dec
+```
+
+4. Compare if the reconstruction and decoded video match.
+```
+cmp rec dec
 ```


### PR DESCRIPTION
Original step showed difference in header even if there's no difference in frame data.
This is confusing.

This additional step excludes the difference in Y4M header as desync detection in
rav1e/build.sh (L56-59).