### PR TITLE
Remove public variable in TileBlocksMut

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3014,16 +3014,18 @@ impl<'a> ContextWriter<'a> {
       let border_h = 128 + blk_h as isize * 8;
       let mvx_min =
         -(frame_bo.0.x as isize) * (8 * MI_SIZE) as isize - border_w;
-      let mvx_max =
-        (self.bc.blocks.frame_cols - frame_bo.0.x - blk_w / MI_SIZE) as isize
-          * (8 * MI_SIZE) as isize
-          + border_w;
+      let mvx_max = (self.bc.blocks.frame_cols()
+        - frame_bo.0.x
+        - blk_w / MI_SIZE) as isize
+        * (8 * MI_SIZE) as isize
+        + border_w;
       let mvy_min =
         -(frame_bo.0.y as isize) * (8 * MI_SIZE) as isize - border_h;
-      let mvy_max =
-        (self.bc.blocks.frame_rows - frame_bo.0.y - blk_h / MI_SIZE) as isize
-          * (8 * MI_SIZE) as isize
-          + border_h;
+      let mvy_max = (self.bc.blocks.frame_rows()
+        - frame_bo.0.y
+        - blk_h / MI_SIZE) as isize
+        * (8 * MI_SIZE) as isize
+        + border_h;
       mv.this_mv.row =
         (mv.this_mv.row as isize).max(mvy_min).min(mvy_max) as i16;
       mv.this_mv.col =

--- a/src/tiling/tile_blocks.rs
+++ b/src/tiling/tile_blocks.rs
@@ -40,8 +40,8 @@ pub struct TileBlocksMut<'a> {
   y: usize,
   cols: usize,
   rows: usize,
-  pub frame_cols: usize,
-  pub frame_rows: usize,
+  frame_cols: usize,
+  frame_rows: usize,
   phantom: PhantomData<&'a mut Block>,
 }
 
@@ -90,6 +90,16 @@ macro_rules! tile_blocks_common {
       #[inline(always)]
       pub const fn rows(&self) -> usize {
         self.rows
+      }
+
+      #[inline(always)]
+      pub const fn frame_cols(&self) -> usize {
+        self.frame_cols
+      }
+
+      #[inline(always)]
+      pub const fn frame_rows(&self) -> usize {
+        self.frame_rows
       }
 
       #[inline(always)]


### PR DESCRIPTION
It's possible to change this in safe code. Changing frame_cols would
change the stride, letting the TileBlock access areas it shouldn't.