### PR TITLE
Reduce lrf complexity for speed 9

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -490,7 +490,7 @@ impl SpeedSettings {
   }
 
   fn sgr_complexity_preset(speed: usize) -> SGRComplexityLevel {
-    if speed <= 9 {
+    if speed <= 8 {
       SGRComplexityLevel::Full
     } else {
       SGRComplexityLevel::Reduced


### PR DESCRIPTION
Since we disabled lrf at speed 10, it might be nice to have a speed
level where this is enabled.

https://beta.arewecompressedyet.com/?job=less-lrf-s9%402020-01-26T22%3A34%3A57.608Z&job=master-5a085dce-s9%402020-01-26T22%3A34%3A00.083Z

~14% faster

```
   PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000
-0.0272 | -0.1581 | -0.2157 |  -0.0570 | -0.0828 | -0.0697 |    -0.1354
```