### PR TITLE
Dependencies version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ num-derive = "0.3"
 paste = "0.1"
 noop_proc_macro = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
-dav1d-sys = { version = "0.2", optional = true }
+dav1d-sys = { version = "0.3", optional = true }
 aom-sys = { version = "0.1.3", optional = true }
 scan_fmt = { version = "0.2.3", optional = true, default-features = false }
 ivf = { version = "0.1", path = "ivf/", optional = true }
@@ -87,7 +87,7 @@ default-features = false
 features = ["png_codec"]
 
 [dependencies.rust_hawktracer]
-version = "0.6.0"
+version = "0.7.0"
 features = ["profiling_enabled"]
 optional = true
 


### PR DESCRIPTION
In preparation to the next pre release.

rust_hawktracer 0.7.0 fixes a random crash on macOS
dav1d-sys 0.3.0 uses the up to date bindgen