### PR TITLE
Pre-process the top-left intra edge pixel for dav1d IEF assembly

### DIFF
--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -65,6 +65,8 @@ pub(crate) fn estimate_intra_costs<T: Pixel>(
         TxSize::TX_8X8,
         bit_depth,
         Some(PredictionMode::DC_PRED),
+        false,
+        IntraParam::None,
       );
 
       let mut plane_after_prediction_region = plane_after_prediction

--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -136,15 +136,15 @@ pub fn dispatch_predict_intra<T: Pixel>(
         | PredictionMode::D67_PRED => {
           let enable_ief = ief_params.is_some() as libc::c_int;
 
-          if enable_ief > 0 {
-            // FIXME: segfaults with smooth filter, desyncs without
+          let ief_smooth_filter = if let Some(params) = ief_params {
+            params.use_smooth_filter()
+          } else {
+            false
+          } as libc::c_int;
+          if angle > 90 && angle < 180 {
+            // FIXME: z2 prediction desyncs in asm
             call_native(dst);
           } else {
-            let ief_smooth_filter = if let Some(params) = ief_params {
-              params.use_smooth_filter()
-            } else {
-              false
-            } as libc::c_int;
             // dav1d assembly uses the unused integer bits to hold IEF parameters
             let angle_with_flags =
               angle | (enable_ief << 10) | (ief_smooth_filter << 9);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1178,6 +1178,8 @@ pub fn encode_tx_block<T: Pixel>(
       tx_size,
       bit_depth,
       Some(mode),
+      fi.sequence.enable_intra_edge_filter,
+      pred_intra_param,
     );
     mode.predict_intra(
       tile_rect,
@@ -1939,7 +1941,7 @@ pub fn write_tx_blocks<T: Pixel>(
         skip,
         qidx,
         &ac.data,
-        IntraParam::Angle_delta(angle_delta.y),
+        IntraParam::AngleDelta(angle_delta.y),
         rdo_type,
         need_recon_pixel,
       );
@@ -2019,7 +2021,7 @@ pub fn write_tx_blocks<T: Pixel>(
             if chroma_mode.is_cfl() {
               IntraParam::Alpha(alpha)
             } else {
-              IntraParam::Angle_delta(angle_delta.uv)
+              IntraParam::AngleDelta(angle_delta.uv)
             },
             rdo_type,
             need_recon_pixel,
@@ -2091,7 +2093,7 @@ pub fn write_tx_tree<T: Pixel>(
         skip,
         qidx,
         ac,
-        IntraParam::Angle_delta(angle_delta_y),
+        IntraParam::AngleDelta(angle_delta_y),
         rdo_type,
         need_recon_pixel,
       );
@@ -2163,7 +2165,7 @@ pub fn write_tx_tree<T: Pixel>(
             skip,
             qidx,
             ac,
-            IntraParam::Angle_delta(angle_delta_y),
+            IntraParam::AngleDelta(angle_delta_y),
             rdo_type,
             need_recon_pixel,
           );

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -32,7 +32,7 @@ use crate::transform::*;
 use crate::util::*;
 use std::convert::TryInto;
 
-const ANGLE_STEP: i8 = 3;
+pub const ANGLE_STEP: i8 = 3;
 
 // TODO: Review the order of this list.
 // The order impacts compression efficiency.
@@ -168,7 +168,7 @@ impl PredictionMode {
       _ => 0,
     };
     let angle_delta = match intra_param {
-      IntraParam::Angle_delta(val) => val,
+      IntraParam::AngleDelta(val) => val,
       _ => 0,
     };
 
@@ -369,7 +369,7 @@ pub enum FilterIntraMode {
 
 #[derive(Copy, Clone, Debug)]
 pub enum IntraParam {
-  Angle_delta(i8),
+  AngleDelta(i8),
   Alpha(i16),
   None,
 }
@@ -1036,7 +1036,7 @@ pub(crate) mod native {
 
     let mut above_edge: &[T] = above;
     let mut left_edge: &[T] = left;
-    let mut top_left_edge: T = top_left[0];
+    let top_left_edge: T = top_left[0];
 
     let enable_edge_filter = ief_params.is_some();
 
@@ -1056,20 +1056,8 @@ pub(crate) mod native {
       let smooth_filter = ief_params.unwrap().use_smooth_filter();
 
       if p_angle != 90 && p_angle != 180 {
-        // Filter the top left pixel, if needed.
-        let top_left_px =
-          if p_angle > 90 && p_angle < 180 && width + height >= 24 {
-            let (l, a, tl): (u32, u32, u32) =
-              (left_filtered[1].into(), above[0].into(), top_left[0].into());
-            let s = l * 5 + tl * 6 + a * 5;
-            T::cast_from((s + (1 << 3)) >> 4)
-          } else {
-            top_left[0]
-          };
-
-        above_filtered[0] = top_left_px;
-        left_filtered[0] = top_left_px;
-        top_left_edge = top_left_px;
+        above_filtered[0] = top_left_edge;
+        left_filtered[0] = top_left_edge;
 
         let num_px = (
           width.min((max_x - output.rect().x + 1).try_into().unwrap())

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1220,6 +1220,8 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
           tx_size,
           fi.sequence.bit_depth,
           None,
+          fi.sequence.enable_intra_edge_filter,
+          IntraParam::None,
         )
       };
 
@@ -1380,6 +1382,8 @@ pub fn rdo_cfl_alpha<T: Pixel>(
         uv_tx_size,
         fi.sequence.bit_depth,
         Some(PredictionMode::UV_CFL_PRED),
+        fi.sequence.enable_intra_edge_filter,
+        IntraParam::None,
       );
       let mut alpha_cost = |alpha: i16| -> u64 {
         let mut rec_region =


### PR DESCRIPTION
This works towards supporting the assembly versions of directional predictors with the intra edge filter. However it seems like there is extra work to be done, as I am still getting desyncs locally when enabling the Z2 prediction.

As pointed out by @takehirokj, assembly for Z1 and Z3 prediction does not cause desyncs, so is enabled as well.