### PR TITLE
Optimizations to rdo_loop_decision

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1927,6 +1927,7 @@ pub fn rdo_loop_decision<T: Pixel>(
   const MAX_SB_SIZE: usize = 1 << MAX_SB_SHIFT;
   const MAX_LRU_SIZE: usize = MAX_SB_SIZE;
 
+  // Static allocation relies on the "minimal LRU area for all 3 planes" invariant.
   let mut best_index = [-1; MAX_SB_SIZE * MAX_SB_SIZE];
   let mut best_lrf =
     [[RestorationFilter::None; MAX_LRU_SIZE * MAX_LRU_SIZE]; PLANES];


### PR DESCRIPTION
Part 1:
There is a known upper bound to the number of superblocks
and LRUs that this function can analyze at once,
so we can allocate a fixed sized array for the results.

Reduces the total allocation count by 25%.
No measurable impact on encoding speed.

Part 2:
Because looping through the planes is the inner-most loop,
reversing the layout of the nested arrays helps with linear
cache access.

Improves encoding time by 1%.