### PR TITLE
Prepare for release 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rav1e"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
## Improvements
- [Faster and better](https://beta.arewecompressedyet.com/?job=v0.2.0-s10&job=v0.3.0-s10) Speed 10
- Smaller binaries (Around 3MB stripped on x86_64/Linux)
- Faster build times (About 14% faster build time)
- Multi-threaded deblocking filter
- Additional x86_64 SIMD code
- More auto-vectorizable codepaths and bounds check elisions
- ⅙ less memory allocations
- Improvements on the intra-modes pruning logic in the RDO
- More float to fixed-point conversions
- Make an early-exit condition in RDO faster
- Simplify logic in Counter/Recorder store method
- Support `wasm32-wasi` as build target.

## New tools
- Intra edge filter (native mode only, about 4% slower at speed level 2 for 0.5% enhanced compression)
- Switch frame support (use `-S`, `--switch-frame-interval <SWITCH_FRAME_INTERVAL>` to enable it from the CLI)
- Fine directional intra prediction
- Still Picture support (AVIF)

## Changes
- Upstream nasm-rs 0.1.7 can be used to build rav1e.
- The C header produced is now C++-compatible


## Fixes
https://github.com/xiph/rav1e/issues/1930
https://github.com/xiph/rav1e/issues/2055

## Known issues
https://github.com/xiph/rav1e/issues/2104 