### PR TITLE
Thread CDEF with tiles

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -29,7 +29,6 @@ use crate::rdo::rdo;
 use crate::transform::{forward_transforms, inverse_transforms};
 
 use criterion::*;
-use std::sync::Arc;
 use std::time::Duration;
 
 fn write_b(c: &mut Criterion) {
@@ -139,8 +138,12 @@ fn cdef_frame_bench(b: &mut Bencher, width: usize, height: usize) {
   let fi = FrameInvariants::<u16>::new(config, sequence);
   let fb = FrameBlocks::new(fi.sb_width * 16, fi.sb_height * 16);
   let mut fs = FrameState::new(&fi);
+  let in_padded_frame = cdef_padded_frame_copy(&fs.rec);
+  let mut ts = fs.as_tile_state_mut();
 
-  b.iter(|| cdef_filter_frame(&fi, Arc::make_mut(&mut fs.rec), &fb));
+  b.iter(|| {
+    cdef_filter_tile(&fi, &mut ts.rec, &fb.as_tile_blocks(), &in_padded_frame)
+  });
 }
 
 fn cfl_rdo(c: &mut Criterion) {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2973,17 +2973,19 @@ fn encode_tile_group<T: Pixel>(
     let pre_cdef_frame = fs.rec.clone();
 
     /* TODO: Don't apply if lossless */
-    let rec = Arc::make_mut(&mut fs.rec);
     if fi.sequence.enable_cdef {
-      cdef_filter_frame(fi, rec, &blocks);
+      cdef_filter_tile_group(fi, fs, &mut blocks);
     }
     /* TODO: Don't apply if lossless */
-    fs.restoration.lrf_filter_frame(rec, &pre_cdef_frame, fi);
+    fs.restoration.lrf_filter_frame(
+      Arc::make_mut(&mut fs.rec),
+      &pre_cdef_frame,
+      fi,
+    );
   } else {
     /* TODO: Don't apply if lossless */
-    let rec = Arc::make_mut(&mut fs.rec);
     if fi.sequence.enable_cdef {
-      cdef_filter_frame(fi, rec, &blocks);
+      cdef_filter_tile_group(fi, fs, &mut blocks);
     }
   }
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -2084,10 +2084,20 @@ pub fn rdo_loop_decision<T: Pixel>(
           for cdef_index in 0..(1 << fi.cdef_bits) {
             let mut err = ScaledDistortion::zero();
             let mut rate = 0;
+
+            let mut cdef_ref_tm = TileMut::new(
+              cdef_ref,
+              TileRect {
+                x: 0,
+                y: 0,
+                width: cdef_ref.planes[0].cfg.width,
+                height: cdef_ref.planes[0].cfg.height,
+              },
+            );
             cdef_filter_superblock(
               fi,
               &rec_subset,
-              cdef_ref,
+              &mut cdef_ref_tm,
               &tileblocks_subset.as_const(),
               loop_sbo,
               cdef_index,
@@ -2230,12 +2240,22 @@ pub fn rdo_loop_decision<T: Pixel>(
             tileblocks_subset.set_cdef(loop_sbo, best_new_index as u8);
           }
 
+          let mut cdef_ref_tm = TileMut::new(
+            cdef_ref,
+            TileRect {
+              x: 0,
+              y: 0,
+              width: cdef_ref.planes[0].cfg.width,
+              height: cdef_ref.planes[0].cfg.height,
+            },
+          );
+
           // Keep cdef output up to date; we need it for restoration
           // both below and above (padding)
           cdef_filter_superblock(
             fi,
             rec_copy,
-            cdef_ref,
+            &mut cdef_ref_tm,
             &tileblocks_subset.as_const(),
             loop_sbo,
             best_index[sby * sb_w + sbx] as u8,


### PR DESCRIPTION
Closes #2056.
~1.2% performance improvements with 2x2 tiles in [AWCY](https://beta.arewecompressedyet.com/?job=master_tile_2_2%402020-02-09T04%3A02%3A27.514Z&job=thread_cdef_04%402020-02-11T12%3A18%3A23.482Z).

There's difference in the encoding output between with/wo threading when tile size is more than 2.
The output is same when tile is 1x1.
I'm not sure this is OK and need review.