### PR TITLE
Remove speed test option from CLI

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -347,13 +347,6 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
         .short("r")
         .takes_value(true)
     )
-    .arg(
-      Arg::with_name("SPEED_TEST")
-        .help("Run an encode using default encoding settings, manually adjusting only the settings specified; allows benchmarking settings in isolation")
-        .hidden(true)
-        .long("speed-test")
-        .takes_value(true)
-    )
     .subcommand(SubCommand::with_name("advanced")
                 .setting(AppSettings::Hidden)
                 .about("Advanced features")
@@ -505,120 +498,110 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
     panic!("Quantizer must be between 0-255");
   }
 
-  let mut cfg = if let Some(settings) = matches.value_of("SPEED_TEST") {
-    info!("Running in speed test mode--ignoring other settings");
-    let mut cfg = EncoderConfig::default();
-    settings
-      .split_whitespace()
-      .for_each(|setting| apply_speed_test_cfg(&mut cfg, setting));
-    cfg
+  let speed = matches.value_of("SPEED").unwrap().parse().unwrap();
+  let max_interval: u64 =
+    matches.value_of("KEYFRAME_INTERVAL").unwrap().parse().unwrap();
+  let mut min_interval: u64 =
+    matches.value_of("MIN_KEYFRAME_INTERVAL").unwrap().parse().unwrap();
+
+  if matches.occurrences_of("MIN_KEYFRAME_INTERVAL") == 0 {
+    min_interval = min_interval.min(max_interval);
+  }
+
+  if speed > 10 {
+    panic!("Speed must be between 0-10");
+  } else if min_interval > max_interval {
+    panic!("Maximum keyframe interval must be greater than or equal to minimum keyframe interval");
+  }
+
+  let color_primaries =
+    matches.value_of("COLOR_PRIMARIES").unwrap().parse().unwrap_or_default();
+  let transfer_characteristics = matches
+    .value_of("TRANSFER_CHARACTERISTICS")
+    .unwrap()
+    .parse()
+    .unwrap_or_default();
+  let matrix_coefficients = matches
+    .value_of("MATRIX_COEFFICIENTS")
+    .unwrap()
+    .parse()
+    .unwrap_or_default();
+
+  let mut cfg = EncoderConfig::with_speed_preset(speed);
+  cfg.set_key_frame_interval(min_interval, max_interval);
+  cfg.switch_frame_interval =
+    matches.value_of("SWITCH_FRAME_INTERVAL").unwrap().parse().unwrap();
+
+  cfg.pixel_range =
+    matches.value_of("PIXEL_RANGE").unwrap().parse().unwrap_or_default();
+  cfg.color_description = if color_primaries == ColorPrimaries::Unspecified
+    && transfer_characteristics == TransferCharacteristics::Unspecified
+    && matrix_coefficients == MatrixCoefficients::Unspecified
+  {
+    // No need to set a color description with all parameters unspecified.
+    None
   } else {
-    let speed = matches.value_of("SPEED").unwrap().parse().unwrap();
-    let max_interval: u64 =
-      matches.value_of("KEYFRAME_INTERVAL").unwrap().parse().unwrap();
-    let mut min_interval: u64 =
-      matches.value_of("MIN_KEYFRAME_INTERVAL").unwrap().parse().unwrap();
+    Some(ColorDescription {
+      color_primaries,
+      transfer_characteristics,
+      matrix_coefficients,
+    })
+  };
 
-    if matches.occurrences_of("MIN_KEYFRAME_INTERVAL") == 0 {
-      min_interval = min_interval.min(max_interval);
-    }
-
-    if speed > 10 {
-      panic!("Speed must be between 0-10");
-    } else if min_interval > max_interval {
-      panic!("Maximum keyframe interval must be greater than or equal to minimum keyframe interval");
-    }
-
-    let color_primaries =
-      matches.value_of("COLOR_PRIMARIES").unwrap().parse().unwrap_or_default();
-    let transfer_characteristics = matches
-      .value_of("TRANSFER_CHARACTERISTICS")
-      .unwrap()
-      .parse()
-      .unwrap_or_default();
-    let matrix_coefficients = matches
-      .value_of("MATRIX_COEFFICIENTS")
-      .unwrap()
-      .parse()
-      .unwrap_or_default();
-
-    let mut cfg = EncoderConfig::with_speed_preset(speed);
-    cfg.set_key_frame_interval(min_interval, max_interval);
-    cfg.switch_frame_interval =
-      matches.value_of("SWITCH_FRAME_INTERVAL").unwrap().parse().unwrap();
-
-    cfg.pixel_range =
-      matches.value_of("PIXEL_RANGE").unwrap().parse().unwrap_or_default();
-    cfg.color_description = if color_primaries == ColorPrimaries::Unspecified
-      && transfer_characteristics == TransferCharacteristics::Unspecified
-      && matrix_coefficients == MatrixCoefficients::Unspecified
-    {
-      // No need to set a color description with all parameters unspecified.
-      None
-    } else {
-      Some(ColorDescription {
-        color_primaries,
-        transfer_characteristics,
-        matrix_coefficients,
-      })
-    };
-
-    let mastering_display_opt = matches.value_of("MASTERING_DISPLAY").unwrap();
-    cfg.mastering_display = if mastering_display_opt == "unspecified" {
-      None
-    } else {
-      let (g_x, g_y, b_x, b_y, r_x, r_y, wp_x, wp_y, max_lum, min_lum) =
-        scan_fmt!(
-          mastering_display_opt,
-          "G({},{})B({},{})R({},{})WP({},{})L({},{})",
-          f64,
-          f64,
-          f64,
-          f64,
-          f64,
-          f64,
-          f64,
-          f64,
-          f64,
-          f64
-        )
-        .expect("Cannot parse the mastering display option");
-      Some(MasteringDisplay {
-        primaries: [
-          ChromaticityPoint {
-            x: (r_x * ((1 << 16) as f64)).round() as u16,
-            y: (r_y * ((1 << 16) as f64)).round() as u16,
-          },
-          ChromaticityPoint {
-            x: (g_x * ((1 << 16) as f64)).round() as u16,
-            y: (g_y * ((1 << 16) as f64)).round() as u16,
-          },
-          ChromaticityPoint {
-            x: (b_x * ((1 << 16) as f64)).round() as u16,
-            y: (b_y * ((1 << 16) as f64)).round() as u16,
-          },
-        ],
-        white_point: ChromaticityPoint {
-          x: (wp_x * ((1 << 16) as f64)).round() as u16,
-          y: (wp_y * ((1 << 16) as f64)).round() as u16,
+  let mastering_display_opt = matches.value_of("MASTERING_DISPLAY").unwrap();
+  cfg.mastering_display = if mastering_display_opt == "unspecified" {
+    None
+  } else {
+    let (g_x, g_y, b_x, b_y, r_x, r_y, wp_x, wp_y, max_lum, min_lum) =
+      scan_fmt!(
+        mastering_display_opt,
+        "G({},{})B({},{})R({},{})WP({},{})L({},{})",
+        f64,
+        f64,
+        f64,
+        f64,
+        f64,
+        f64,
+        f64,
+        f64,
+        f64,
+        f64
+      )
+      .expect("Cannot parse the mastering display option");
+    Some(MasteringDisplay {
+      primaries: [
+        ChromaticityPoint {
+          x: (r_x * ((1 << 16) as f64)).round() as u16,
+          y: (r_y * ((1 << 16) as f64)).round() as u16,
         },
-        max_luminance: (max_lum * ((1 << 8) as f64)).round() as u32,
-        min_luminance: (min_lum * ((1 << 14) as f64)).round() as u32,
-      })
-    };
+        ChromaticityPoint {
+          x: (g_x * ((1 << 16) as f64)).round() as u16,
+          y: (g_y * ((1 << 16) as f64)).round() as u16,
+        },
+        ChromaticityPoint {
+          x: (b_x * ((1 << 16) as f64)).round() as u16,
+          y: (b_y * ((1 << 16) as f64)).round() as u16,
+        },
+      ],
+      white_point: ChromaticityPoint {
+        x: (wp_x * ((1 << 16) as f64)).round() as u16,
+        y: (wp_y * ((1 << 16) as f64)).round() as u16,
+      },
+      max_luminance: (max_lum * ((1 << 8) as f64)).round() as u32,
+      min_luminance: (min_lum * ((1 << 14) as f64)).round() as u32,
+    })
+  };
 
-    let content_light_opt = matches.value_of("CONTENT_LIGHT").unwrap();
-    let (cll, fall) = scan_fmt!(content_light_opt, "{},{}", u16, u16)
-      .expect("Cannot parse the content light option");
-    cfg.content_light = if cll == 0 && fall == 0 {
-      None
-    } else {
-      Some(ContentLight {
-        max_content_light_level: cll,
-        max_frame_average_light_level: fall,
-      })
-    };
-    cfg
+  let content_light_opt = matches.value_of("CONTENT_LIGHT").unwrap();
+  let (cll, fall) = scan_fmt!(content_light_opt, "{},{}", u16, u16)
+    .expect("Cannot parse the content light option");
+  cfg.content_light = if cll == 0 && fall == 0 {
+    None
+  } else {
+    Some(ContentLight {
+      max_content_light_level: cll,
+      max_frame_average_light_level: fall,
+    })
   };
 
   cfg.still_picture = matches.is_present("STILL_PICTURE");
@@ -658,74 +641,4 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
   cfg.low_latency = matches.is_present("LOW_LATENCY");
 
   Ok(cfg)
-}
-
-fn apply_speed_test_cfg(cfg: &mut EncoderConfig, setting: &str) {
-  match setting {
-    "baseline" => {
-      cfg.speed_settings = SpeedSettings::default();
-    }
-    "min_block_size_8x8" => {
-      cfg.speed_settings.partition_range =
-        PartitionRange::new(BlockSize::BLOCK_8X8, BlockSize::BLOCK_64X64);
-    }
-    "min_block_size_16x16" => {
-      cfg.speed_settings.partition_range =
-        PartitionRange::new(BlockSize::BLOCK_16X16, BlockSize::BLOCK_64X64);
-    }
-    "min_block_size_32x32" => {
-      cfg.speed_settings.partition_range =
-        PartitionRange::new(BlockSize::BLOCK_32X32, BlockSize::BLOCK_64X64);
-    }
-    "min_block_size_64x64" => {
-      cfg.speed_settings.partition_range =
-        PartitionRange::new(BlockSize::BLOCK_64X64, BlockSize::BLOCK_64X64);
-    }
-    "no_multiref" => {
-      cfg.speed_settings.multiref = false;
-    }
-    "fast_deblock" => {
-      cfg.speed_settings.fast_deblock = true;
-    }
-    "reduced_tx_set" => {
-      cfg.speed_settings.reduced_tx_set = true;
-    }
-    "tx_domain_distortion" => {
-      cfg.speed_settings.tx_domain_distortion = true;
-    }
-    "tx_domain_rate" => {
-      cfg.speed_settings.tx_domain_rate = true;
-    }
-    "encode_topdown" => {
-      cfg.speed_settings.encode_bottomup = false;
-    }
-    "no_rdo_tx_decision" => {
-      cfg.speed_settings.rdo_tx_decision = false;
-    }
-    "prediction_modes_simple" => {
-      cfg.speed_settings.prediction_modes = PredictionModesSetting::Simple;
-    }
-    "prediction_modes_keyframes" => {
-      cfg.speed_settings.prediction_modes =
-        PredictionModesSetting::ComplexKeyframes;
-    }
-    "exclude_near_mvs" => {
-      cfg.speed_settings.include_near_mvs = false;
-    }
-    "no_scene_detection" => {
-      cfg.speed_settings.no_scene_detection = true;
-    }
-    "fast_scene_detection" => {
-      cfg.speed_settings.fast_scene_detection = true;
-    }
-    "full_search_me" => {
-      cfg.speed_settings.diamond_me = false;
-    }
-    "no_cdef" => {
-      cfg.speed_settings.cdef = false;
-    }
-    setting => {
-      panic!("Unrecognized speed test setting {}", setting);
-    }
-  };
 }


### PR DESCRIPTION
This interface has been ignored and unviable
for quite some time.
Rather than attempt to maintain it,
I prefer to delete it, and if needed,
come up with a new approach for testing settings individually.
Up until now, we've been getting by with modifying settings
manually by editing the code base, because our need for
editing individual settings has been relatively uncommon.

This option has always been hidden and intended for developers only,
so there is no public API breakage from this change.