### PR TITLE
Disable fine directional intra prediction between speed levels 2 and 5

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -251,6 +251,10 @@ impl fmt::Display for EncoderConfig {
         self.speed_settings.non_square_partition.to_string(),
       ),
       ("enable_timing_info", self.enable_timing_info.to_string()),
+      (
+        "fine_directional_intra",
+        self.speed_settings.fine_directional_intra.to_string(),
+      ),
     ];
     write!(
       f,
@@ -329,6 +333,9 @@ pub struct SpeedSettings {
 
   /// Enable tx split for inter mode block.
   pub enable_inter_tx_split: bool,
+
+  /// Use fine directional intra prediction
+  pub fine_directional_intra: bool,
 }
 
 impl Default for SpeedSettings {
@@ -359,6 +366,7 @@ impl Default for SpeedSettings {
       non_square_partition: true,
       enable_segmentation: true,
       enable_inter_tx_split: false,
+      fine_directional_intra: false,
     }
   }
 }
@@ -400,6 +408,7 @@ impl SpeedSettings {
       non_square_partition: Self::non_square_partition_preset(speed),
       enable_segmentation: Self::enable_segmentation_preset(speed),
       enable_inter_tx_split: Self::enable_inter_tx_split_preset(speed),
+      fine_directional_intra: Self::fine_directional_intra_preset(speed),
     }
   }
 
@@ -515,6 +524,10 @@ impl SpeedSettings {
   // FIXME: With unknown reasons, inter_tx_split does not work if reduced_tx_set is false
   const fn enable_inter_tx_split_preset(speed: usize) -> bool {
     speed >= 9
+  }
+
+  fn fine_directional_intra_preset(speed: usize) -> bool {
+    speed <= 1 || speed >= 6
   }
 }
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1304,7 +1304,9 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
     );
   });
 
-  if bsize >= BlockSize::BLOCK_8X8 {
+  if fi.config.speed_settings.fine_directional_intra
+    && bsize >= BlockSize::BLOCK_8X8
+  {
     // Find the best angle delta for the current best prediction mode
     let luma_angle_delta_count = best.pred_mode_luma.angle_delta_count();
     let chroma_angle_delta_count = best.pred_mode_chroma.angle_delta_count();


### PR DESCRIPTION
Closes #2167.

~30% speed up in speed 5 in [AWCY](https://beta.arewecompressedyet.com/?job=master_s_5%402020-02-14T14%3A11%3A21.320Z&job=disable_fine_dir_s_5%402020-02-14T14%3A07%3A13.758Z).
| PSNR | PSNR Cb | PSNR Cr | PSNR HVS | SSIM | MS SSIM | CIEDE 2000 |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 0.6833 | 1.4316 | 1.3890 | 0.6723 | 0.7174 | 0.6667 | 0.8463 |