### PR TITLE
AppVeyor: Don't run on non-essential code changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,13 @@
 image: Visual Studio 2019
+skip_commits:
+  files:
+    - '.github/*'
+    - '.travis/*'
+    - 'doc/*'
+    - '.travis.yml'
+    - '.gitlab-ci.yml'
+    - '.gitignore'
+    - '*.md'
 
 environment:
   host: x86_64-pc-windows-msvc


### PR DESCRIPTION
Don't let AppVeyor run on documentation changes, CI changes, etc.