### PR TITLE
api: Introduce reference frame for Packets

### DIFF
--- a/src/api/util.rs
+++ b/src/api/util.rs
@@ -160,6 +160,8 @@ pub struct Packet<T: Pixel> {
   pub data: Vec<u8>,
   /// The reconstruction of the shown frame.
   pub rec: Option<Arc<Frame<T>>>,
+  /// The Reference Frame
+  pub source: Option<Arc<Frame<T>>>,
   /// The number of the input frame corresponding to the one shown frame in the
   /// TU stored in this packet. Since AV1 does not explicitly reorder frames,
   /// these will increase sequentially.


### PR DESCRIPTION
This commit adds Reference Frame from the FrameData(Input) to the packets, so we could take this for calculation, for instance, Metrics calculations can be independent of API changes and will be cleaner to implement with fewer API breakages in favour of 1.0 Future Release.