### PR TITLE
Fix build warnings in bench for plane downsample

### DIFF
--- a/benches/plane.rs
+++ b/benches/plane.rs
@@ -19,7 +19,7 @@ pub fn downsample_8bit(c: &mut Criterion) {
   let input = init_plane_u8(1920, 1080);
   c.bench_function("downsample_8bit", move |b| {
     b.iter(|| {
-      let output = input.downsampled(960, 540);
+      let _ = input.downsampled(960, 540);
     })
   });
 }
@@ -28,7 +28,7 @@ pub fn downsample_odd(c: &mut Criterion) {
   let input = init_plane_u8(1919, 1079);
   c.bench_function("downsample_odd", move |b| {
     b.iter(|| {
-      let output = input.downsampled(960, 540);
+      let _ = input.downsampled(960, 540);
     })
   });
 }
@@ -37,7 +37,7 @@ pub fn downsample_10bit(c: &mut Criterion) {
   let input = init_plane_u16(1920, 1080);
   c.bench_function("downsample_10bit", move |b| {
     b.iter(|| {
-      let output = input.downsampled(960, 540);
+      let _ = input.downsampled(960, 540);
     })
   });
 }


### PR DESCRIPTION
This fixes the warnings below:

"warning: unused variable: `output`
  --> benches/plane.rs:22:11
   |
22 |       let output = input.downsampled(960, 540);
   |           ^^^^^^ help: consider prefixing with an underscore: `_output`
   |
   = note: `#[warn(unused_variables)]` on by default
..."