### PR TITLE
Suppress the nth(0) clippy warning

### DIFF
--- a/src/tiling/plane_region.rs
+++ b/src/tiling/plane_region.rs
@@ -7,6 +7,8 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+#![allow(clippy::iter_nth_zero)]
+
 use crate::context::*;
 use crate::frame::*;
 use crate::util::*;


### PR DESCRIPTION
Fix clippy warnings: [iter_nth_zero](https://rust-lang.github.io/rust-clippy/master/index.html#iter_nth_zero).

Defining next() without nth(0) will be little bit redundant. Therefore, it's better to allow it in this case.
