### PR TITLE
Rename "native" CPU feature level to "rust"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,3 +118,13 @@ tail -n+2 dec.y4m > dec
 ```
 cmp rec dec
 ```
+
+## Setting Assembly Optimization Level
+
+rav1e defaults to using the highest assembly optimization level supported on the current machine.
+You can disable assembly or use a lower assembly target at runtime by setting the environment variable `RAV1E_CPU_TARGET`.
+
+For example, `RAV1E_CPU_TARGET=rust` will disable all hand-written assembly optimizations.
+`RAV1E_CPU_TARGET=sse2` will enable SSE2 code but disable any newer assembly.
+
+A full list of options can be found in the `CpuFeatureLevel` enum in `src/cpu_features` for your platform.

--- a/src/asm/aarch64/mc.rs
+++ b/src/asm/aarch64/mc.rs
@@ -87,8 +87,8 @@ pub fn put_8tap<T: Pixel>(
   height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
   mode_y: FilterMode, bit_depth: usize, cpu: CpuFeatureLevel,
 ) {
-  let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
-    native::put_8tap(
+  let call_rust = |dst: &mut PlaneRegionMut<'_, T>| {
+    rust::put_8tap(
       dst, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
       cpu,
     );
@@ -96,7 +96,7 @@ pub fn put_8tap<T: Pixel>(
   #[cfg(feature = "check_asm")]
   let ref_dst = {
     let mut copy = dst.scratch_copy();
-    call_native(&mut copy.as_region_mut());
+    call_rust(&mut copy.as_region_mut());
     copy
   };
   match T::type_enum() {
@@ -114,7 +114,7 @@ pub fn put_8tap<T: Pixel>(
             row_frac,
           );
         },
-        None => call_native(dst),
+        None => call_rust(dst),
       }
     }
     PixelType::U16 => {
@@ -132,7 +132,7 @@ pub fn put_8tap<T: Pixel>(
             bit_depth as i32,
           );
         },
-        None => call_native(dst),
+        None => call_rust(dst),
       }
     }
   }
@@ -153,8 +153,8 @@ pub fn prep_8tap<T: Pixel>(
   col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,
   bit_depth: usize, cpu: CpuFeatureLevel,
 ) {
-  let call_native = |tmp: &mut [i16]| {
-    native::prep_8tap(
+  let call_rust = |tmp: &mut [i16]| {
+    rust::prep_8tap(
       tmp, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
       cpu,
     );
@@ -163,7 +163,7 @@ pub fn prep_8tap<T: Pixel>(
   let ref_tmp = {
     let mut copy = vec![0; width * height];
     copy[..].copy_from_slice(&tmp[..width * height]);
-    call_native(&mut copy);
+    call_rust(&mut copy);
     copy
   };
   match T::type_enum() {
@@ -180,7 +180,7 @@ pub fn prep_8tap<T: Pixel>(
             row_frac,
           );
         },
-        None => call_native(tmp),
+        None => call_rust(tmp),
       }
     }
     PixelType::U16 => {
@@ -197,7 +197,7 @@ pub fn prep_8tap<T: Pixel>(
             bit_depth as i32,
           );
         },
-        None => call_native(tmp),
+        None => call_rust(tmp),
       }
     }
   }
@@ -211,13 +211,13 @@ pub fn mc_avg<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
   height: usize, bit_depth: usize, cpu: CpuFeatureLevel,
 ) {
-  let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
-    native::mc_avg(dst, tmp1, tmp2, width, height, bit_depth, cpu);
+  let call_rust = |dst: &mut PlaneRegionMut<'_, T>| {
+    rust::mc_avg(dst, tmp1, tmp2, width, height, bit_depth, cpu);
   };
   #[cfg(feature = "check_asm")]
   let ref_dst = {
     let mut copy = dst.scratch_copy();
-    call_native(&mut copy.as_region_mut());
+    call_rust(&mut copy.as_region_mut());
     copy
   };
   match T::type_enum() {
@@ -232,7 +232,7 @@ pub fn mc_avg<T: Pixel>(
           height as i32,
         );
       },
-      None => call_native(dst),
+      None => call_rust(dst),
     },
     PixelType::U16 => match AVG_HBD_FNS[cpu.as_index()] {
       Some(func) => unsafe {
@@ -246,7 +246,7 @@ pub fn mc_avg<T: Pixel>(
           bit_depth as i32,
         );
       },
-      None => call_native(dst),
+      None => call_rust(dst),
     },
   }
   #[cfg(feature = "check_asm")]

--- a/src/asm/aarch64/transform/inverse.rs
+++ b/src/asm/aarch64/transform/inverse.rs
@@ -39,7 +39,7 @@ pub fn inverse_transform_add<T: Pixel>(
     PixelType::U16 => {}
   };
 
-  native::inverse_transform_add(input, output, eob, tx_size, tx_type, bd, cpu);
+  rust::inverse_transform_add(input, output, eob, tx_size, tx_type, bd, cpu);
 }
 
 macro_rules! decl_itx_fns {

--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -128,11 +128,11 @@ pub mod test {
         tx_size,
         tx_type,
         8,
-        CpuFeatureLevel::NATIVE,
+        CpuFeatureLevel::RUST,
       );
 
       let eob: usize = pick_eob(freq, tx_size, tx_type, sub_h);
-      let mut native_dst = dst.clone();
+      let mut rust_dst = dst.clone();
 
       inverse_transform_add(
         freq,
@@ -145,14 +145,14 @@ pub mod test {
       );
       inverse_transform_add(
         freq,
-        &mut native_dst.as_region_mut(),
+        &mut rust_dst.as_region_mut(),
         eob,
         tx_size,
         tx_type,
         8,
-        CpuFeatureLevel::NATIVE,
+        CpuFeatureLevel::RUST,
       );
-      assert_eq!(native_dst.data_origin(), dst.data_origin());
+      assert_eq!(rust_dst.data_origin(), dst.data_origin());
     }
   }
 }

--- a/src/asm/x86/ec.rs
+++ b/src/asm/x86/ec.rs
@@ -7,7 +7,7 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use crate::ec::native;
+use crate::ec::rust;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
@@ -18,7 +18,7 @@ pub fn update_cdf(cdf: &mut [u16], val: u32) {
     };
   }
 
-  native::update_cdf(cdf, val);
+  rust::update_cdf(cdf, val);
 }
 
 #[target_feature(enable = "sse2")]
@@ -88,14 +88,14 @@ unsafe fn update_cdf_4_sse2(cdf: &mut [u16], val: u32) {
 
 #[cfg(test)]
 mod test {
-  use crate::ec::native;
+  use crate::ec::rust;
 
   #[test]
   fn update_cdf_4_sse2() {
     let mut cdf = [7296, 3819, 1616, 0, 0];
     let mut cdf2 = [7296, 3819, 1616, 0, 0];
     for i in 0..4 {
-      native::update_cdf(&mut cdf, i);
+      rust::update_cdf(&mut cdf, i);
       unsafe {
         super::update_cdf_4_sse2(&mut cdf2, i);
       }
@@ -105,7 +105,7 @@ mod test {
     let mut cdf = [7297, 3820, 1617, 0, 0];
     let mut cdf2 = cdf.clone();
     for i in 0..4 {
-      native::update_cdf(&mut cdf, i);
+      rust::update_cdf(&mut cdf, i);
       unsafe {
         super::update_cdf_4_sse2(&mut cdf2, i);
       }

--- a/src/asm/x86/lrf.rs
+++ b/src/asm/x86/lrf.rs
@@ -9,7 +9,7 @@
 
 use crate::cpu_features::CpuFeatureLevel;
 use crate::frame::PlaneSlice;
-use crate::lrf::native;
+use crate::lrf::rust;
 use crate::lrf::*;
 use crate::util::Pixel;
 #[cfg(target_arch = "x86")]
@@ -41,7 +41,7 @@ pub fn sgrproj_box_ab_r1(
     };
   }
 
-  native::sgrproj_box_ab_r1(
+  rust::sgrproj_box_ab_r1(
     af,
     bf,
     iimg,
@@ -78,7 +78,7 @@ pub fn sgrproj_box_ab_r2(
     };
   }
 
-  native::sgrproj_box_ab_r2(
+  rust::sgrproj_box_ab_r2(
     af,
     bf,
     iimg,
@@ -103,7 +103,7 @@ pub fn sgrproj_box_f_r0<T: Pixel>(
     };
   }
 
-  native::sgrproj_box_f_r0(f, y, w, cdeffed, cpu);
+  rust::sgrproj_box_f_r0(f, y, w, cdeffed, cpu);
 }
 
 #[inline]
@@ -117,7 +117,7 @@ pub fn sgrproj_box_f_r1<T: Pixel>(
     };
   }
 
-  native::sgrproj_box_f_r1(af, bf, f, y, w, cdeffed, cpu);
+  rust::sgrproj_box_f_r1(af, bf, f, y, w, cdeffed, cpu);
 }
 
 #[inline]
@@ -131,7 +131,7 @@ pub fn sgrproj_box_f_r2<T: Pixel>(
     };
   }
 
-  native::sgrproj_box_f_r2(af, bf, f0, f1, y, w, cdeffed, cpu);
+  rust::sgrproj_box_f_r2(af, bf, f0, f1, y, w, cdeffed, cpu);
 }
 
 static X_BY_XPLUS1: [u32; 256] = [
@@ -254,7 +254,7 @@ pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
       );
     } else {
       // finish using scalar
-      native::sgrproj_box_ab_internal(
+      rust::sgrproj_box_ab_internal(
         1,
         af,
         bf,
@@ -274,7 +274,7 @@ pub(crate) unsafe fn sgrproj_box_ab_r1_avx2(
   {
     let mut af_ref: Vec<u32> = vec![0; stripe_w + 2];
     let mut bf_ref: Vec<u32> = vec![0; stripe_w + 2];
-    native::sgrproj_box_ab_internal(
+    rust::sgrproj_box_ab_internal(
       1,
       &mut af_ref,
       &mut bf_ref,
@@ -313,7 +313,7 @@ pub(crate) unsafe fn sgrproj_box_ab_r2_avx2(
       );
     } else {
       // finish using scalar
-      native::sgrproj_box_ab_internal(
+      rust::sgrproj_box_ab_internal(
         2,
         af,
         bf,
@@ -333,7 +333,7 @@ pub(crate) unsafe fn sgrproj_box_ab_r2_avx2(
   {
     let mut af_ref: Vec<u32> = vec![0; stripe_w + 2];
     let mut bf_ref: Vec<u32> = vec![0; stripe_w + 2];
-    native::sgrproj_box_ab_internal(
+    rust::sgrproj_box_ab_internal(
       2,
       &mut af_ref,
       &mut bf_ref,
@@ -382,14 +382,14 @@ pub(crate) unsafe fn sgrproj_box_f_r0_avx2<T: Pixel>(
       sgrproj_box_f_r0_8_avx2(f, x, y, cdeffed);
     } else {
       // finish using scalar
-      native::sgrproj_box_f_r0_internal(f, x, y, w, cdeffed);
+      rust::sgrproj_box_f_r0_internal(f, x, y, w, cdeffed);
     }
   }
 
   #[cfg(feature = "check_asm")]
   {
     let mut f_ref: Vec<u32> = vec![0; w];
-    native::sgrproj_box_f_r0_internal(&mut f_ref, 0, y, w, cdeffed);
+    rust::sgrproj_box_f_r0_internal(&mut f_ref, 0, y, w, cdeffed);
     assert_eq!(&f[..w], &f_ref[..]);
   }
 }
@@ -505,14 +505,14 @@ pub(crate) unsafe fn sgrproj_box_f_r1_avx2<T: Pixel>(
       sgrproj_box_f_r1_8_avx2(af, bf, f, x, y, cdeffed);
     } else {
       // finish using scalar
-      native::sgrproj_box_f_r1_internal(af, bf, f, x, y, w, cdeffed);
+      rust::sgrproj_box_f_r1_internal(af, bf, f, x, y, w, cdeffed);
     }
   }
 
   #[cfg(feature = "check_asm")]
   {
     let mut f_ref: Vec<u32> = vec![0; w];
-    native::sgrproj_box_f_r1_internal(af, bf, &mut f_ref, 0, y, w, cdeffed);
+    rust::sgrproj_box_f_r1_internal(af, bf, &mut f_ref, 0, y, w, cdeffed);
     assert_eq!(&f[..w], &f_ref[..]);
   }
 }
@@ -627,7 +627,7 @@ pub(crate) unsafe fn sgrproj_box_f_r2_avx2<T: Pixel>(
       sgrproj_box_f_r2_8_avx2(af, bf, f0, f1, x, y, cdeffed);
     } else {
       // finish using scalar
-      native::sgrproj_box_f_r2_internal(af, bf, f0, f1, x, y, w, cdeffed);
+      rust::sgrproj_box_f_r2_internal(af, bf, f0, f1, x, y, w, cdeffed);
     }
   }
 
@@ -635,7 +635,7 @@ pub(crate) unsafe fn sgrproj_box_f_r2_avx2<T: Pixel>(
   {
     let mut f0_ref: Vec<u32> = vec![0; w];
     let mut f1_ref: Vec<u32> = vec![0; w];
-    native::sgrproj_box_f_r2_internal(
+    rust::sgrproj_box_f_r2_internal(
       af,
       bf,
       &mut f0_ref,

--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -10,7 +10,7 @@
 use crate::context::MAX_TX_SIZE;
 use crate::cpu_features::CpuFeatureLevel;
 use crate::predict::{
-  native, IntraEdgeFilterParameters, PredictionMode, PredictionVariant,
+  rust, IntraEdgeFilterParameters, PredictionMode, PredictionVariant,
 };
 use crate::tiling::PlaneRegionMut;
 use crate::transform::TxSize;
@@ -100,15 +100,15 @@ pub fn dispatch_predict_intra<T: Pixel>(
   ac: &[i16], angle: isize, ief_params: Option<IntraEdgeFilterParameters>,
   edge_buf: &Aligned<[T; 4 * MAX_TX_SIZE + 1]>, cpu: CpuFeatureLevel,
 ) {
-  let call_native = |dst: &mut PlaneRegionMut<'_, T>| {
-    native::dispatch_predict_intra(
+  let call_rust = |dst: &mut PlaneRegionMut<'_, T>| {
+    rust::dispatch_predict_intra(
       mode, variant, dst, tx_size, bit_depth, ac, angle, ief_params, edge_buf,
       cpu,
     );
   };
 
   if size_of::<T>() != 1 {
-    return call_native(dst);
+    return call_rust(dst);
   }
 
   unsafe {
@@ -197,7 +197,7 @@ pub fn dispatch_predict_intra<T: Pixel>(
             PredictionVariant::BOTH => rav1e_ipred_cfl_avx2,
           })(dst_ptr, stride, edge_ptr, w, h, ac_ptr, angle);
         }
-        _ => call_native(dst),
+        _ => call_rust(dst),
       }
     } else if cpu >= CpuFeatureLevel::SSSE3 {
       match mode {
@@ -236,10 +236,10 @@ pub fn dispatch_predict_intra<T: Pixel>(
             PredictionVariant::BOTH => rav1e_ipred_cfl_ssse3,
           })(dst_ptr, stride, edge_ptr, w, h, ac_ptr, angle);
         }
-        _ => call_native(dst),
+        _ => call_rust(dst),
       }
     } else {
-      call_native(dst);
+      call_rust(dst);
     }
   }
 }
@@ -248,7 +248,7 @@ pub fn dispatch_predict_intra<T: Pixel>(
 mod test {
   use super::*;
   use crate::frame::{AsRegion, Plane};
-  use crate::predict::native;
+  use crate::predict::rust;
   use num_traits::*;
 
   #[test]
@@ -306,7 +306,7 @@ mod test {
       for angle in angles {
         let expected = {
           let mut plane = Plane::from_slice(&vec![0u8; 4 * 4], 4);
-          native::dispatch_predict_intra(
+          rust::dispatch_predict_intra(
             *mode,
             *variant,
             &mut plane.as_region_mut(),

--- a/src/asm/x86/quantize.rs
+++ b/src/asm/x86/quantize.rs
@@ -39,8 +39,8 @@ pub fn dequantize<T: Coefficient>(
   qindex: u8, coeffs: &[T], eob: usize, rcoeffs: &mut [T], tx_size: TxSize,
   bit_depth: usize, dc_delta_q: i8, ac_delta_q: i8, cpu: CpuFeatureLevel,
 ) {
-  let call_native = |rcoeffs: &mut [T]| {
-    crate::quantize::native::dequantize(
+  let call_rust = |rcoeffs: &mut [T]| {
+    crate::quantize::rust::dequantize(
       qindex, coeffs, eob, rcoeffs, tx_size, bit_depth, dc_delta_q,
       ac_delta_q, cpu,
     );
@@ -51,7 +51,7 @@ pub fn dequantize<T: Coefficient>(
     let area = av1_get_coded_tx_size(tx_size).area();
     let mut copy = vec![T::cast_from(0); area];
     copy[..].copy_from_slice(&rcoeffs[..area]);
-    call_native(&mut copy);
+    call_rust(&mut copy);
     copy
   };
 
@@ -71,10 +71,10 @@ pub fn dequantize<T: Coefficient>(
           )
         }
       } else {
-        call_native(rcoeffs)
+        call_rust(rcoeffs)
       }
     }
-    PixelType::U16 => call_native(rcoeffs),
+    PixelType::U16 => call_rust(rcoeffs),
   }
 
   #[cfg(any(feature = "check_asm", test))]

--- a/src/asm/x86/transform/forward.rs
+++ b/src/asm/x86/transform/forward.rs
@@ -8,7 +8,7 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use crate::cpu_features::CpuFeatureLevel;
-use crate::transform::forward::native;
+use crate::transform::forward::rust;
 use crate::transform::forward_shared::*;
 use crate::transform::*;
 use crate::util::*;
@@ -466,7 +466,7 @@ unsafe fn forward_transform_avx2<T: Coefficient>(
     // this size.
     match row_class {
       SizeClass1D::X8UP => {
-        // Store output in at most 32x32 chunks. See native code for details.
+        // Store output in at most 32x32 chunks. See rust code for details.
 
         // Output is grouped into 32x32 chunks so a stride of at most 32 is
         // used for each chunk
@@ -536,9 +536,7 @@ pub fn forward_transform<T: Coefficient>(
       forward_transform_avx2(input, output, stride, tx_size, tx_type, bd);
     }
   } else {
-    native::forward_transform(
-      input, output, stride, tx_size, tx_type, bd, cpu,
-    );
+    rust::forward_transform(input, output, stride, tx_size, tx_type, bd, cpu);
   }
 }
 
@@ -548,7 +546,7 @@ mod test {
   use crate::transform::{forward_transform, get_valid_txfm_types, TxSize};
   use rand::Rng;
 
-  // Ensure that the simd results match the native code
+  // Ensure that the simd results match the rust code
   #[test]
   fn test_forward_transform_avx2() {
     test_forward_transform_simd(CpuFeatureLevel::AVX2);
@@ -589,7 +587,7 @@ mod test {
           tx_size,
           tx_type,
           8,
-          CpuFeatureLevel::NATIVE,
+          CpuFeatureLevel::RUST,
         );
         forward_transform(
           &input[..],

--- a/src/asm/x86/transform/inverse.rs
+++ b/src/asm/x86/transform/inverse.rs
@@ -39,7 +39,7 @@ pub fn inverse_transform_add<T: Pixel>(
     PixelType::U16 => {}
   };
 
-  native::inverse_transform_add(input, output, eob, tx_size, tx_type, bd, cpu);
+  rust::inverse_transform_add(input, output, eob, tx_size, tx_type, bd, cpu);
 }
 
 macro_rules! decl_itx_fns {

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -22,7 +22,7 @@ cfg_if::cfg_if! {
   if #[cfg(nasm_x86_64)] {
     pub(crate) use crate::asm::x86::cdef::*;
   } else {
-    pub(crate) use self::native::*;
+    pub(crate) use self::rust::*;
   }
 }
 
@@ -34,7 +34,7 @@ pub struct CdefDirections {
   var: [[i32; 8]; 8],
 }
 
-pub(crate) mod native {
+pub(crate) mod rust {
   use super::*;
 
   use simd_helpers::cold_for_target_arch;

--- a/src/cpu_features/aarch64.rs
+++ b/src/cpu_features/aarch64.rs
@@ -13,8 +13,7 @@ use std::str::FromStr;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, ArgEnum)]
 pub enum CpuFeatureLevel {
-  #[arg_enum(alias = "rust")]
-  NATIVE,
+  RUST,
   NEON,
 }
 

--- a/src/cpu_features/mod.rs
+++ b/src/cpu_features/mod.rs
@@ -17,7 +17,7 @@ cfg_if::cfg_if! {
     mod aarch64;
     pub use aarch64::*;
   } else {
-    mod native;
-    pub use native::*;
+    mod rust;
+    pub use rust::*;
   }
 }

--- a/src/cpu_features/rust.rs
+++ b/src/cpu_features/rust.rs
@@ -11,11 +11,11 @@ use arg_enum_proc_macro::ArgEnum;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, ArgEnum)]
 pub enum CpuFeatureLevel {
-  NATIVE,
+  RUST,
 }
 
 impl Default for CpuFeatureLevel {
   fn default() -> CpuFeatureLevel {
-    CpuFeatureLevel::NATIVE
+    CpuFeatureLevel::RUST
   }
 }

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -13,8 +13,7 @@ use std::str::FromStr;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, ArgEnum)]
 pub enum CpuFeatureLevel {
-  #[arg_enum(alias = "rust")]
-  NATIVE,
+  RUST,
   SSE2,
   SSSE3,
   #[arg_enum(alias = "sse4.1")]
@@ -68,7 +67,7 @@ impl Default for CpuFeatureLevel {
     } else if is_x86_feature_detected!("sse2") {
       CpuFeatureLevel::SSE2
     } else {
-      CpuFeatureLevel::NATIVE
+      CpuFeatureLevel::RUST
     };
     let manual: CpuFeatureLevel = match env::var("RAV1E_CPU_TARGET") {
       Ok(feature) => CpuFeatureLevel::from_str(&feature).unwrap_or(detected),

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -11,11 +11,11 @@ cfg_if::cfg_if! {
   if #[cfg(nasm_x86_64)] {
     pub use crate::asm::x86::dist::*;
   } else {
-    pub use self::native::*;
+    pub use self::rust::*;
   }
 }
 
-pub(crate) mod native {
+pub(crate) mod rust {
   use crate::cpu_features::CpuFeatureLevel;
   use crate::partition::BlockSize;
   use crate::tiling::*;

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -14,7 +14,7 @@ cfg_if::cfg_if! {
   if #[cfg(nasm_x86_64)] {
     pub use crate::asm::x86::ec::*;
   } else {
-    pub use self::native::*;
+    pub use self::rust::*;
   }
 }
 
@@ -864,7 +864,7 @@ impl<W: io::Write> BCodeWriter for BitWriter<W, BigEndian> {
   }
 }
 
-pub(crate) mod native {
+pub(crate) mod rust {
   // Function to update the CDF for Writer calls that do so.
   pub fn update_cdf(cdf: &mut [u16], val: u32) {
     let nsymbs = cdf.len() - 1;

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -11,7 +11,7 @@ cfg_if::cfg_if! {
   if #[cfg(nasm_x86_64)] {
     use crate::asm::x86::lrf::*;
   } else {
-    use self::native::*;
+    use self::rust::*;
   }
 }
 
@@ -175,7 +175,7 @@ impl RestorationFilter {
   }
 }
 
-pub(crate) mod native {
+pub(crate) mod rust {
   use crate::cpu_features::CpuFeatureLevel;
   use crate::frame::PlaneSlice;
   use crate::lrf::{

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -13,7 +13,7 @@ cfg_if::cfg_if! {
   } else if #[cfg(asm_neon)] {
     pub use crate::asm::aarch64::mc::*;
   } else {
-    pub use self::native::*;
+    pub use self::rust::*;
   }
 }
 
@@ -180,7 +180,7 @@ const SUBPEL_FILTERS: [[[i32; SUBPEL_FILTER_SIZE]; 16]; 6] = [
   ],
 ];
 
-pub(crate) mod native {
+pub(crate) mod rust {
   use super::*;
   use num_traits::*;
 

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -17,7 +17,7 @@ cfg_if::cfg_if! {
   } else if #[cfg(asm_neon)] {
     pub use crate::asm::aarch64::predict::*;
   } else {
-    pub use self::native::*;
+    pub use self::rust::*;
   }
 }
 
@@ -491,7 +491,7 @@ fn get_scaled_luma_q0(alpha_q3: i16, ac_pred_q3: i16) -> i32 {
   }
 }
 
-pub(crate) mod native {
+pub(crate) mod rust {
   use super::*;
   use crate::context::MAX_TX_SIZE;
   use crate::cpu_features::CpuFeatureLevel;
@@ -1265,7 +1265,7 @@ pub(crate) mod native {
 mod test {
   use super::*;
   use crate::frame::AsRegion;
-  use crate::predict::native::*;
+  use crate::predict::rust::*;
   use num_traits::*;
 
   #[test]

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -13,7 +13,7 @@ cfg_if::cfg_if! {
   if #[cfg(nasm_x86_64)] {
     pub use crate::asm::x86::quantize::*;
   } else {
-    pub use self::native::*;
+    pub use self::rust::*;
   }
 }
 
@@ -332,7 +332,7 @@ impl QuantizationContext {
   }
 }
 
-pub mod native {
+pub mod rust {
   use super::*;
   use crate::cpu_features::CpuFeatureLevel;
 

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -16,11 +16,11 @@ cfg_if::cfg_if! {
   if #[cfg(nasm_x86_64)] {
     pub use crate::asm::x86::transform::forward::*;
   } else {
-    pub use self::native::*;
+    pub use self::rust::*;
   }
 }
 
-pub mod native {
+pub mod rust {
   use super::*;
 
   use crate::transform::av1_round_shift_array;

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -13,14 +13,14 @@ cfg_if::cfg_if! {
   } else if #[cfg(asm_neon)] {
     pub use crate::asm::aarch64::transform::inverse::*;
   } else {
-    pub use self::native::*;
+    pub use self::rust::*;
   }
 }
 
 use crate::tiling::PlaneRegionMut;
 use crate::util::*;
 
-// TODO: move 1d txfm code to native module.
+// TODO: move 1d txfm code to rust module.
 
 use super::clamp_value;
 use super::consts::*;
@@ -1581,7 +1581,7 @@ static INV_TXFM_FNS: [[InvTxfmFn; 5]; 4] = [
   ],
 ];
 
-pub(crate) mod native {
+pub(crate) mod rust {
   use super::*;
   use crate::cpu_features::CpuFeatureLevel;
   use crate::util::clamp;


### PR DESCRIPTION
The term "native" is confusing, as in GCC/Clang,
"native" means use the highest optimization set possible,
whereas we were using it to mean the opposite.
This also renames all "native" modules accordingly.

Also adds documentation on how to change the ASM level at runtime.