### PR TITLE
CI: Update libdav1d to 0.6.0-dmo1

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -129,16 +129,16 @@ jobs:
         matrix.conf == 'grcov-coveralls'
       env:
         LINK: http://www.deb-multimedia.org/pool/main/d/dav1d-dmo
-        DAV1D_VERSION: 0.5.2-dmo2
+        DAV1D_VERSION: 0.6.0-dmo1
         DAV1D_DEV_SHA256: >-
-          c303be29c114d79b25f61b86b4e82fccbc748fbfb2484c5ba8f3936e5d8e90b7
+          089dd451183e5b545882209794a68674db589f9880e3e5cf30f878d21bfb0a08
         DAV1D_LIB_SHA256: >-
-          918e83902927c9fbb17023a8973ecfea8876ac0deb2f5ffadf1d8cbbcbd4472f
+          9a2a2bfd85b0ed814f91685b14ab78ae0c2b228c4e0b6b2f3f35e8d368713cdd
       run: |
         echo "$LINK/libdav1d-dev_${DAV1D_VERSION}_amd64.deb" >> DEBS
-        echo "$LINK/libdav1d3_${DAV1D_VERSION}_amd64.deb" >> DEBS
+        echo "$LINK/libdav1d4_${DAV1D_VERSION}_amd64.deb" >> DEBS
         echo "$DAV1D_DEV_SHA256 libdav1d-dev_${DAV1D_VERSION}_amd64.deb" >> CHECKSUMS
-        echo "$DAV1D_LIB_SHA256 libdav1d3_${DAV1D_VERSION}_amd64.deb" >> CHECKSUMS
+        echo "$DAV1D_LIB_SHA256 libdav1d4_${DAV1D_VERSION}_amd64.deb" >> CHECKSUMS
     - name: Cache packages
       uses: actions/cache@v1
       id: debs

--- a/.travis/install-dav1d.sh
+++ b/.travis/install-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-DAV1D_VERSION="0.5.2-dmo2"
+DAV1D_VERSION="0.6.0-dmo1"
 PKG_URL="http://www.deb-multimedia.org/pool/main/d/dav1d-dmo"
 
 case "$ARCH" in
@@ -12,16 +12,16 @@ esac
 cd "$DEPS_DIR"
 
 [ -f "libdav1d-dev_${DAV1D_VERSION}_$ARCH.deb" ] &&
-[ -f "libdav1d3_${DAV1D_VERSION}_$ARCH.deb" ] ||
+[ -f "libdav1d4_${DAV1D_VERSION}_$ARCH.deb" ] ||
 curl -O "$PKG_URL/libdav1d-dev_${DAV1D_VERSION}_$ARCH.deb" \
-     -O "$PKG_URL/libdav1d3_${DAV1D_VERSION}_$ARCH.deb"
+     -O "$PKG_URL/libdav1d4_${DAV1D_VERSION}_$ARCH.deb"
 
 sha256sum --check --ignore-missing <<EOF
-918e83902927c9fbb17023a8973ecfea8876ac0deb2f5ffadf1d8cbbcbd4472f  libdav1d3_0.5.2-dmo2_amd64.deb
-fd3e85c300b1b0f75b2092a0be694256e452e720b9d37e457a8cfb66cdbdbfb9  libdav1d3_0.5.2-dmo2_arm64.deb
-c303be29c114d79b25f61b86b4e82fccbc748fbfb2484c5ba8f3936e5d8e90b7  libdav1d-dev_0.5.2-dmo2_amd64.deb
-bb164a093e43172e48e47514c741974301e4120f98cf9a8411e21a47d4fecf9f  libdav1d-dev_0.5.2-dmo2_arm64.deb
+9a2a2bfd85b0ed814f91685b14ab78ae0c2b228c4e0b6b2f3f35e8d368713cdd  libdav1d4_0.6.0-dmo1_amd64.deb
+2f276056c136d859a03c35bea60d1bc91147c1f6f7d769a705675ab1d7474112  libdav1d4_0.6.0-dmo1_arm64.deb
+089dd451183e5b545882209794a68674db589f9880e3e5cf30f878d21bfb0a08  libdav1d-dev_0.6.0-dmo1_amd64.deb
+b9dd34ba4d160bd3ea288391bc092cb857dbb64d0e31263efefdee7412f35228  libdav1d-dev_0.6.0-dmo1_arm64.deb
 EOF
 
-sudo dpkg -i "libdav1d3_${DAV1D_VERSION}_$ARCH.deb" \
+sudo dpkg -i "libdav1d4_${DAV1D_VERSION}_$ARCH.deb" \
              "libdav1d-dev_${DAV1D_VERSION}_$ARCH.deb"


### PR DESCRIPTION
The deb-multimedia pool marches forward, and GitHub Actions caches expire.
So we must, once again, bump the package version.