### PR TITLE
Split the rate control twopass_in() in smaller functions

### DIFF
--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1267,69 +1267,95 @@ impl RCState {
     TwoPassOutParams { pass1_log_base_q, done_processing }
   }
 
+  // Initialize the first pass and emit a placeholder summary
+  fn init_first_pass(&mut self, pass1_log_base_q: i64) {
+    if self.twopass_state == PASS_SINGLE {
+      // Pick first-pass qi for scale calculations.
+      self.pass1_log_base_q = pass1_log_base_q;
+    } else {
+      debug_assert!(self.twopass_state == PASS_2);
+    }
+    self.twopass_state += PASS_1;
+  }
+
+  // Prepare a placeholder summary
+  fn emit_placeholder_summary(&mut self) -> &[u8] {
+    // Fill in dummy summary values.
+    let mut cur_pos = 0;
+    cur_pos = self.buffer_val(TWOPASS_MAGIC as i64, 4, cur_pos);
+    cur_pos = self.buffer_val(TWOPASS_VERSION as i64, 4, cur_pos);
+    cur_pos = self.buffer_val(0, TWOPASS_HEADER_SZ - 8, cur_pos);
+    debug_assert!(cur_pos == TWOPASS_HEADER_SZ);
+    self.pass1_data_retrieved = true;
+    &self.pass1_buffer[..cur_pos]
+  }
+
+  // Frame-specific pass data
+  fn emit_frame_data(&mut self) -> Option<&[u8]> {
+    let mut cur_pos = 0;
+    let fti = self.prev_metrics.fti;
+    if fti < FRAME_NSUBTYPES {
+      self.scale_sum[fti] += bexp_q24(self.prev_metrics.log_scale_q24);
+    }
+    if self.prev_metrics.show_frame {
+      self.ntus += 1;
+    }
+    // If we have encoded too many frames, prevent us from reaching the
+    //  ready state required to encode more.
+    if self.nencoded_frames + self.nsef_frames >= std::i32::MAX as i64 {
+      None?
+    }
+    cur_pos = self.buffer_val(
+      (self.prev_metrics.show_frame as i64) << 31
+        | self.prev_metrics.fti as i64,
+      4,
+      cur_pos,
+    );
+    cur_pos =
+      self.buffer_val(self.prev_metrics.log_scale_q24 as i64, 4, cur_pos);
+    debug_assert!(cur_pos == TWOPASS_PACKET_SZ);
+    self.pass1_data_retrieved = true;
+    Some(&self.pass1_buffer[..cur_pos])
+  }
+
+  // Summary of the whole encoding process.
+  fn emit_summary(&mut self) -> &[u8] {
+    let mut cur_pos = 0;
+    cur_pos = self.buffer_val(TWOPASS_MAGIC as i64, 4, cur_pos);
+    cur_pos = self.buffer_val(TWOPASS_VERSION as i64, 4, cur_pos);
+    cur_pos = self.buffer_val(self.ntus as i64, 4, cur_pos);
+    for fti in 0..=FRAME_NSUBTYPES {
+      cur_pos = self.buffer_val(self.nframes[fti] as i64, 4, cur_pos);
+    }
+    for fti in 0..FRAME_NSUBTYPES {
+      cur_pos = self.buffer_val(self.exp[fti] as i64, 1, cur_pos);
+    }
+    for fti in 0..FRAME_NSUBTYPES {
+      cur_pos = self.buffer_val(self.scale_sum[fti], 8, cur_pos);
+    }
+    debug_assert!(cur_pos == TWOPASS_HEADER_SZ);
+    self.pass1_summary_retrieved = true;
+    &self.pass1_buffer[..cur_pos]
+  }
+
+  // Initialize the first pass, emit either summary or frame-specific data
+  // depending on the previous call
   pub(crate) fn twopass_out(
     &mut self, params: TwoPassOutParams,
   ) -> Option<&[u8]> {
-    let mut cur_pos = 0;
     if !self.pass1_data_retrieved {
       if self.twopass_state != PASS_1 && self.twopass_state != PASS_2_PLUS_1 {
-        // Initialize the first pass.
-        if self.twopass_state == PASS_SINGLE {
-          // Pick first-pass qi for scale calculations.
-          self.pass1_log_base_q = params.pass1_log_base_q;
-        } else {
-          debug_assert!(self.twopass_state == PASS_2);
-        }
-        self.twopass_state += PASS_1;
-        // Fill in dummy summary values.
-        cur_pos = self.buffer_val(TWOPASS_MAGIC as i64, 4, cur_pos);
-        cur_pos = self.buffer_val(TWOPASS_VERSION as i64, 4, cur_pos);
-        cur_pos = self.buffer_val(0, TWOPASS_HEADER_SZ - 8, cur_pos);
-        debug_assert!(cur_pos == TWOPASS_HEADER_SZ);
+        self.init_first_pass(params.pass1_log_base_q);
+        Some(self.emit_placeholder_summary())
       } else {
-        let fti = self.prev_metrics.fti;
-        if fti < FRAME_NSUBTYPES {
-          self.scale_sum[fti] += bexp_q24(self.prev_metrics.log_scale_q24);
-        }
-        if self.prev_metrics.show_frame {
-          self.ntus += 1;
-        }
-        // If we have encoded too many frames, prevent us from reaching the
-        //  ready state required to encode more.
-        if self.nencoded_frames + self.nsef_frames >= std::i32::MAX as i64 {
-          None?
-        }
-        cur_pos = self.buffer_val(
-          (self.prev_metrics.show_frame as i64) << 31
-            | self.prev_metrics.fti as i64,
-          4,
-          cur_pos,
-        );
-        cur_pos =
-          self.buffer_val(self.prev_metrics.log_scale_q24 as i64, 4, cur_pos);
-        debug_assert!(cur_pos == TWOPASS_PACKET_SZ);
+        self.emit_frame_data()
       }
-      self.pass1_data_retrieved = true;
     } else if params.done_processing && !self.pass1_summary_retrieved {
-      cur_pos = self.buffer_val(TWOPASS_MAGIC as i64, 4, cur_pos);
-      cur_pos = self.buffer_val(TWOPASS_VERSION as i64, 4, cur_pos);
-      cur_pos = self.buffer_val(self.ntus as i64, 4, cur_pos);
-      for fti in 0..=FRAME_NSUBTYPES {
-        cur_pos = self.buffer_val(self.nframes[fti] as i64, 4, cur_pos);
-      }
-      for fti in 0..FRAME_NSUBTYPES {
-        cur_pos = self.buffer_val(self.exp[fti] as i64, 1, cur_pos);
-      }
-      for fti in 0..FRAME_NSUBTYPES {
-        cur_pos = self.buffer_val(self.scale_sum[fti], 8, cur_pos);
-      }
-      debug_assert!(cur_pos == TWOPASS_HEADER_SZ);
-      self.pass1_summary_retrieved = true;
+      Some(self.emit_summary())
     } else {
       // The data for this frame has already been retrieved.
-      return None;
+      None
     }
-    Some(&self.pass1_buffer[..cur_pos])
   }
 
   fn buffer_fill(

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1366,7 +1366,7 @@ impl RCState {
   }
 
   // Initialize the rate control for second pass encoding
-  pub(crate) fn twopass_init(&mut self) {
+  pub(crate) fn init_second_pass(&mut self) {
     if self.twopass_state == PASS_SINGLE || self.twopass_state == PASS_1 {
       // Initialize the second pass.
       self.twopass_state += PASS_2;
@@ -1609,7 +1609,7 @@ impl RCState {
     &mut self, maybe_buf: Option<&[u8]>,
   ) -> Result<usize, ()> {
     let mut consumed = 0;
-    self.twopass_init();
+    self.init_second_pass();
     // If we haven't got a valid summary header yet, try to parse one.
     if self.nframes_total[FRAME_SUBTYPE_I] == 0 {
       self.pass2_data_ready = false;


### PR DESCRIPTION
`twopass_in()` is a function that does too much at the same time:
-  It initializes the second pass rc.
-  It provides the user the amount of bytes the same function would like to consume next
-  It consumes and parses the initial global header, called in the code summary.
-  It consumes and parses the per-frame information, depending on the configuration either a single per-frame data or a variable number of them in a single pass.

This PR addresses this problem by splitting the function in smaller ones with, I hoped, self-describing names:

- [x] rate control initialization (`twopass_init`)
- [x] summary parsing (`twopass_in_summary`)
- [x] frame data parsing (`twopass_in_frame_data`)

