### PR TITLE
Fix panic on specific inputs with high quantizers

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1930,7 +1930,7 @@ pub fn rdo_loop_decision<T: Pixel>(
   // Static allocation relies on the "minimal LRU area for all 3 planes" invariant.
   let mut best_index = [-1; MAX_SB_SIZE * MAX_SB_SIZE];
   let mut best_lrf =
-    [[RestorationFilter::None; MAX_LRU_SIZE * MAX_LRU_SIZE]; PLANES];
+    [[RestorationFilter::None; PLANES]; MAX_LRU_SIZE * MAX_LRU_SIZE];
 
   // due to imprecision in the reconstruction parameter solver, we
   // need to make sure we don't fall into a limit cycle.  Track our

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -782,3 +782,65 @@ pub(crate) fn get_decoder<T: Pixel>(
     _ => unimplemented!(),
   }
 }
+
+#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+#[ignore]
+fn rdo_loop_decision_lrf_sanity(decoder: &str) {
+  let limit = 2;
+  let w = 936;
+  let h = 1404;
+  let speed = 9;
+  let q = 240;
+
+  let mut dec = get_decoder::<u8>(decoder, w as usize, h as usize);
+  dec.encode_decode(
+    w,
+    h,
+    speed,
+    q,
+    limit,
+    8,
+    Default::default(),
+    6,
+    6,
+    0,
+    true,
+    false,
+    0,
+    0,
+    0,
+    false,
+  );
+}
+
+#[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
+#[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
+#[ignore]
+fn rdo_loop_decision_cdef_sanity(decoder: &str) {
+  let limit = 2;
+  let w = 1404;
+  let h = 936;
+  let speed = 9;
+  let q = 240;
+
+  let mut dec = get_decoder::<u8>(decoder, w as usize, h as usize);
+  dec.encode_decode(
+    w,
+    h,
+    speed,
+    q,
+    limit,
+    8,
+    Default::default(),
+    6,
+    6,
+    0,
+    true,
+    false,
+    0,
+    0,
+    0,
+    false,
+  );
+}


### PR DESCRIPTION
The included tests also hit a condition in
tile_restoration_state.rs:367,
which currently passes CI because it is only a debug_assert,
but is something we should hope to fix quickly as well.
(A separate issue #2222 has been created for this.)

Fixes #2219