### PR TITLE
Fix debug_assert with high quantizers

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -597,19 +597,7 @@ pub fn cdef_filter_superblock<T: Pixel, U: Pixel>(
 pub fn cdef_filter_tile_group<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>, blocks: &mut FrameBlocks,
 ) {
-  let tile_size = SB_SIZE * 8;
-  let tile_cols = (fi.config.width + tile_size - 1) / tile_size;
-  let tile_rows = (fi.config.height + tile_size - 1) / tile_size;
-
-  let ti = TilingInfo::from_target_tiles(
-    fi.sequence.sb_size_log2(),
-    fi.config.width,
-    fi.config.height,
-    fi.config.frame_rate(),
-    TilingInfo::tile_log2(1, tile_cols).unwrap(),
-    TilingInfo::tile_log2(1, tile_rows).unwrap(),
-  );
-
+  let ti = &fi.tiling;
   let in_padded_frame = cdef_padded_frame_copy(&fs.rec);
   ti.tile_iter_mut(fs, blocks).collect::<Vec<_>>().into_par_iter().for_each(
     |mut ctx| {


### PR DESCRIPTION
This fixes the debug_assert failure in tile_restoration_state.rs.
This change makes the number of tiles for CDEF to the same
number of tiles for tile encoding specified by --tile-cols
and --tile-rows option.

Closes #2221.

Using the new TilingInfo different from encoding tile is better because more tiles can be used for
CDEF. However, using different TilingInfo and same FrameState caused the problem.
Therefore, this fix uses the same TilingInfo and same FrameState between CDEF and tile encoding.