### PR TITLE
Enable CDEF and restoration filters for 4:2:2

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -521,6 +521,8 @@ pub fn cdef_filter_superblock<T: Pixel, U: Pixel>(
             let local_pri_strength;
             let local_sec_strength;
             let mut local_damping: i32 = cdef_damping + coeff_shift;
+            // See `Cdef_Uv_Dir` constant lookup table in Section 7.15.1
+            // <https://aomediacodec.github.io/av1-spec/#cdef-block-process>
             let local_dir = if p == 0 {
               local_pri_strength =
                 adjust_strength(cdef_pri_y_strength << coeff_shift, var);
@@ -535,7 +537,11 @@ pub fn cdef_filter_superblock<T: Pixel, U: Pixel>(
               local_sec_strength = cdef_sec_uv_strength << coeff_shift;
               local_damping -= 1;
               if cdef_pri_uv_strength != 0 {
-                dir as usize
+                if xdec != ydec {
+                  [7, 0, 2, 4, 5, 6, 6, 6][dir as usize]
+                } else {
+                  dir as usize
+                }
               } else {
                 0
               }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -242,9 +242,7 @@ impl Sequence {
       enable_ref_frame_mvs: false,
       enable_warped_motion: false,
       enable_superres: false,
-      enable_cdef: config.speed_settings.cdef
-        && config.chroma_sampling != ChromaSampling::Cs422
-        && enable_restoration_filters,
+      enable_cdef: config.speed_settings.cdef && enable_restoration_filters,
       enable_restoration: config.speed_settings.lrf
         && config.chroma_sampling != ChromaSampling::Cs422
         && enable_restoration_filters,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -244,7 +244,6 @@ impl Sequence {
       enable_superres: false,
       enable_cdef: config.speed_settings.cdef && enable_restoration_filters,
       enable_restoration: config.speed_settings.lrf
-        && config.chroma_sampling != ChromaSampling::Cs422
         && enable_restoration_filters,
       enable_large_lru: true,
       enable_delayed_loopfilter_rdo: true,


### PR DESCRIPTION
As far as I can tell, there are no outstanding issues with this combination.
However, I will attempt to revive the fuzzer to answer this with confidence.
Closes #1149.