### PR TITLE
Add context to failures in test_encode_decode

### DIFF
--- a/src/test_encode_decode/aom.rs
+++ b/src/test_encode_decode/aom.rs
@@ -131,7 +131,9 @@ fn compare_img<T: Pixel>(
   let img = unsafe { *img };
   let img_iter = img.planes.iter().zip(img.stride.iter());
 
-  for (img_plane, frame_plane) in img_iter.zip(frame.planes.iter()) {
+  for (pli, (img_plane, frame_plane)) in
+    img_iter.zip(frame.planes.iter()).enumerate()
+  {
     let w = width >> frame_plane.cfg.xdec;
     let h = height >> frame_plane.cfg.ydec;
     let rec_stride = frame_plane.cfg.stride;
@@ -149,7 +151,7 @@ fn compare_img<T: Pixel>(
       let rec: Vec<u16> =
         frame_plane.data_origin().iter().map(|&v| u16::cast_from(v)).collect();
 
-      compare_plane::<u16>(&rec[..], rec_stride, dec, dec_stride, w, h);
+      compare_plane::<u16>(&rec[..], rec_stride, dec, dec_stride, w, h, pli);
     } else {
       let dec_stride = *img_plane.1 as usize;
 
@@ -163,7 +165,7 @@ fn compare_img<T: Pixel>(
       let rec: Vec<u8> =
         frame_plane.data_origin().iter().map(|&v| u8::cast_from(v)).collect();
 
-      compare_plane::<u8>(&rec[..], rec_stride, dec, dec_stride, w, h);
+      compare_plane::<u8>(&rec[..], rec_stride, dec, dec_stride, w, h, pli);
     }
   }
 }

--- a/src/test_encode_decode/dav1d.rs
+++ b/src/test_encode_decode/dav1d.rs
@@ -138,7 +138,7 @@ fn compare_pic<T: Pixel>(
 ) {
   use crate::frame::Plane;
 
-  let cmp_plane = |data, stride, frame_plane: &Plane<T>| {
+  let cmp_plane = |data, stride, frame_plane: &Plane<T>, pli| {
     let w = width >> frame_plane.cfg.xdec;
     let h = height >> frame_plane.cfg.ydec;
     let rec_stride = frame_plane.cfg.stride;
@@ -155,7 +155,7 @@ fn compare_pic<T: Pixel>(
       let rec: Vec<u16> =
         frame_plane.data_origin().iter().map(|&v| u16::cast_from(v)).collect();
 
-      compare_plane::<u16>(&rec[..], rec_stride, dec, stride, w, h);
+      compare_plane::<u16>(&rec[..], rec_stride, dec, stride, w, h, pli);
     } else {
       let dec = unsafe {
         let data = data as *const u8;
@@ -167,14 +167,14 @@ fn compare_pic<T: Pixel>(
       let rec: Vec<u8> =
         frame_plane.data_origin().iter().map(|&v| u8::cast_from(v)).collect();
 
-      compare_plane::<u8>(&rec[..], rec_stride, dec, stride, w, h);
+      compare_plane::<u8>(&rec[..], rec_stride, dec, stride, w, h, pli);
     }
   };
 
   let lstride = pic.stride[0] as usize;
   let cstride = pic.stride[1] as usize;
 
-  cmp_plane(pic.data[0], lstride, &frame.planes[0]);
-  cmp_plane(pic.data[1], cstride, &frame.planes[1]);
-  cmp_plane(pic.data[2], cstride, &frame.planes[2]);
+  cmp_plane(pic.data[0], lstride, &frame.planes[0], 0);
+  cmp_plane(pic.data[1], cstride, &frame.planes[1], 1);
+  cmp_plane(pic.data[2], cstride, &frame.planes[2], 2);
 }

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -146,10 +146,18 @@ pub(crate) trait TestDecoder<T: Pixel> {
 
 pub fn compare_plane<T: Ord + std::fmt::Debug>(
   rec: &[T], rec_stride: usize, dec: &[T], dec_stride: usize, width: usize,
-  height: usize,
+  height: usize, pli: usize,
 ) {
-  for line in rec.chunks(rec_stride).zip(dec.chunks(dec_stride)).take(height) {
-    assert_eq!(&line.0[..width], &line.1[..width]);
+  for (row, line) in
+    rec.chunks(rec_stride).zip(dec.chunks(dec_stride)).take(height).enumerate()
+  {
+    assert_eq!(
+      &line.0[..width],
+      &line.1[..width],
+      "at row {} of plane {}",
+      row,
+      pli
+    );
   }
 }
 


### PR DESCRIPTION
Wonder no longer to which plane and row that diff belongs.
`compare_plane` asserts on a row at a time and is called for each plane.
Annotate the assertion with the plane and row indices.