### PR TITLE
Fix deblocking of horizontal edges for narrow frames

### DIFF
--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -1403,7 +1403,7 @@ pub fn deblock_plane<T: Pixel>(
       );
     }
     // ..and the last two horizontal edges for the row
-    if cols > 2 << xdec {
+    if cols >= 2 << xdec {
       filter_h_edge(
         deblock,
         blocks,
@@ -1417,21 +1417,21 @@ pub fn deblock_plane<T: Pixel>(
         xdec,
         ydec,
       );
-      if cols > 1 << xdec {
-        filter_h_edge(
-          deblock,
-          blocks,
-          TileBlockOffset(BlockOffset {
-            x: cols - (1 << xdec),
-            y: y - (1 << ydec),
-          }),
-          p,
-          pli,
-          bd,
-          xdec,
-          ydec,
-        );
-      }
+    }
+    if cols >= 1 << xdec {
+      filter_h_edge(
+        deblock,
+        blocks,
+        TileBlockOffset(BlockOffset {
+          x: cols - (1 << xdec),
+          y: y - (1 << ydec),
+        }),
+        p,
+        pli,
+        bd,
+        xdec,
+        ydec,
+      );
     }
   }
 


### PR DESCRIPTION
Fixes #2239. All but the last row of horizontal edges were skipped for horizontally decimated chroma planes with a frame width of 16.