### PR TITLE
CI: Update libaom to 1.0.0.errata1-3~18.04.york0

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -116,11 +116,11 @@ jobs:
         matrix.conf == 'grcov-coveralls'
       env:
         LINK: http://ppa.launchpad.net/jonathonf/ffmpeg-4/ubuntu/pool/main/a/aom
-        AOM_VERSION: 1.0.0.errata1-2ubuntu3~18.04.york0
+        AOM_VERSION: 1.0.0.errata1-3~18.04.york0
         AOM_DEV_SHA256: >-
-          ae037dfebb8da8b11fac15dff21f145d9bc16655f4ab0129b6bb10762f4ec62e
+          93e6f64f33722cf9c80a920b3d722713869793e5e1438c05ff9331791728ca90
         AOM_LIB_SHA256: >-
-          995a062b1dee9b90e748f5f2a16ef1e1c864a12a116593854358f0f77c954be2
+          e1ff5093f077685e4e45ce74264f9ee7ccda4634be58e401ac180b73f4232b63
       run: |
         echo "$LINK/libaom-dev_${AOM_VERSION}_amd64.deb" >> DEBS
         echo "$LINK/libaom0_${AOM_VERSION}_amd64.deb" >> DEBS

--- a/.travis/install-aom.sh
+++ b/.travis/install-aom.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ex
 
-AOM_VERSION="1.0.0.errata1-2"
-PKG_URL="http://http.us.debian.org/debian/pool/main/a/aom"
+AOM_VERSION="1.0.0.errata1-3~18.04.york0"
+PKG_URL="http://ppa.launchpad.net/jonathonf/ffmpeg-4/ubuntu/pool/main/a/aom"
 
 case "$ARCH" in
   x86_64) ARCH=amd64 ;;
@@ -17,10 +17,10 @@ curl -O "$PKG_URL/libaom-dev_${AOM_VERSION}_$ARCH.deb" \
      -O "$PKG_URL/libaom0_${AOM_VERSION}_$ARCH.deb"
 
 sha256sum --check --ignore-missing <<EOF
-3f096b6057871c12bbdfdf8b2e18d12ed0f643b8e23fdbeddd80b860c55c53ff  libaom0_1.0.0.errata1-2_amd64.deb
-76cf5487ce1e4dccb6dc11fd59ac358181b9fe2bd6422c755f2490b712f20d34  libaom0_1.0.0.errata1-2_arm64.deb
-fd07d90dafe1512d79c1734adb1c4f33215f40856e89e9d505c7e8c8b0ae6a0f  libaom-dev_1.0.0.errata1-2_amd64.deb
-df1ec43f66bb243c7dfac70877c56033791475f91d068589e26f7ade9fd11001  libaom-dev_1.0.0.errata1-2_arm64.deb
+e1ff5093f077685e4e45ce74264f9ee7ccda4634be58e401ac180b73f4232b63  libaom0_${AOM_VERSION}_amd64.deb
+f8ca5eb6fdda1d049e26a9e7ec4976c002fac3b5adabea11765d831470594a88  libaom0_${AOM_VERSION}_arm64.deb
+93e6f64f33722cf9c80a920b3d722713869793e5e1438c05ff9331791728ca90  libaom-dev_${AOM_VERSION}_amd64.deb
+53be66aa706e6045b52aef446b9d305a718bab15252d9c0feb8753fe328301fb  libaom-dev_${AOM_VERSION}_arm64.deb
 EOF
 
 sudo dpkg -i "libaom0_${AOM_VERSION}_$ARCH.deb" \


### PR DESCRIPTION
It has been 14 weeks since the last libaom package update. This is much more stable than the libdav1d packages. For the curious, the differences with the last version follow:

```diff
diff -Nru aom-1.0.0.errata1/debian/changelog aom-1.0.0.errata1/debian/changelog
--- aom-1.0.0.errata1/debian/changelog	2019-12-20 10:38:51.000000000 +0000
+++ aom-1.0.0.errata1/debian/changelog	2020-04-13 15:14:23.000000000 +0000
@@ -1,30 +1,21 @@
-aom (1.0.0.errata1-2ubuntu3~18.04.york0) bionic; urgency=medium
+aom (1.0.0.errata1-3~18.04.york0) bionic; urgency=medium
 
   * Revert to debhelper 11
 
- -- Jonathon Fernyhough <jonathon.fernyhough@york.ac.uk>  Fri, 20 Dec 2019 10:38:51 +0000
+ -- Jonathon Fernyhough <jonathon.fernyhough@york.ac.uk>  Mon, 13 Apr 2020 16:14:23 +0100
 
-aom (1.0.0.errata1-2ubuntu3) focal; urgency=medium
+aom (1.0.0.errata1-3) unstable; urgency=medium
 
-  * Revert changes to debian/tests/control; fixed centrally in autopkgtest
-    instead.
+  [ James Cowgill ]
+  * d/tests:
+    - Merge pkg-config invocations.
+    - Make library-build test cross test friendly.
+      Thanks to Steve Langasek for the original patch. (Closes: #946236)
 
- -- Steve Langasek <steve.langasek@ubuntu.com>  Thu, 05 Dec 2019 15:29:16 -0800
+  [ OndÅ™ej NovÃ½ ]
+  * d/control: Bump Standards-Version to 4.4.1.
 
-aom (1.0.0.errata1-2ubuntu2) focal; urgency=medium
-
-  * Make the library-build test cross-toolchain aware.
-
- -- Steve Langasek <steve.langasek@ubuntu.com>  Thu, 05 Dec 2019 15:26:51 -0800
-
-aom (1.0.0.errata1-2ubuntu1) focal; urgency=medium
-
-  * debian/tests/control: cross-test compatibility.  The library-build test
-    still fails because the test is not cross-toolchain aware, but this lets
-    the encode-decode test succeed when the host arch is not the same as the
-    arch of the binaries being tested.
-
- -- Steve Langasek <steve.langasek@ubuntu.com>  Wed, 04 Dec 2019 22:57:05 -0800
+ -- James Cowgill <jcowgill@debian.org>  Thu, 02 Jan 2020 19:26:18 +0000
 
 aom (1.0.0.errata1-2) unstable; urgency=medium
 
diff -Nru aom-1.0.0.errata1/debian/control aom-1.0.0.errata1/debian/control
--- aom-1.0.0.errata1/debian/control	2019-12-20 10:38:48.000000000 +0000
+++ aom-1.0.0.errata1/debian/control	2020-04-13 15:14:21.000000000 +0000
@@ -1,17 +1,16 @@
 Source: aom
 Section: video
 Priority: optional
-Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-XSBC-Original-Maintainer: Debian Multimedia Maintainers <debian-multimedia@lists.debian.org>
+Maintainer: Debian Multimedia Maintainers <debian-multimedia@lists.debian.org>
 Uploaders: James Cowgill <jcowgill@debian.org>
 Build-Depends:
  cmake (>= 3.5),
- debhelper (>= 11~),
+ debhelper (>= 11),
  doxygen,
  graphviz,
  yasm [any-amd64 any-i386],
 Rules-Requires-Root: no
-Standards-Version: 4.4.0
+Standards-Version: 4.4.1
 Homepage: https://aomedia.org/
 Vcs-Git: https://salsa.debian.org/multimedia-team/aom.git
 Vcs-Browser: https://salsa.debian.org/multimedia-team/aom
diff -Nru aom-1.0.0.errata1/debian/tests/library-build aom-1.0.0.errata1/debian/tests/library-build
--- aom-1.0.0.errata1/debian/tests/library-build	2019-12-05 23:26:36.000000000 +0000
+++ aom-1.0.0.errata1/debian/tests/library-build	2020-01-02 19:26:18.000000000 +0000
@@ -10,14 +10,12 @@
 cp debian/tests/library-build.c "$AUTOPKGTEST_TMP"
 cd "$AUTOPKGTEST_TMP"
 
-if [ -n "$DEB_HOST_MULTIARCH" ]; then
-    export PKG_CONFIG_PATH="/usr/lib/$DEB_HOST_MULTIARCH/pkgconfig"
-    PREFIX="$DEB_HOST_GNU_TYPE-"
-fi
 # Compile with and without pkg-config
-${PREFIX}gcc -Wall -Wextra -O2 library-build.c -o build1 -laom
+CROSS_COMPILE="${DEB_HOST_GNU_TYPE:+$DEB_HOST_GNU_TYPE-}"
+
+${CROSS_COMPILE}gcc -Wall -Wextra -O2 library-build.c -o build1 -laom
 echo "build1: compiled"
-${PREFIX}gcc -Wall -Wextra -O2 $(pkg-config --cflags aom) library-build.c -o build2 $(pkg-config --libs aom)
+${CROSS_COMPILE}gcc -Wall -Wextra -O2 library-build.c -o build2 $(${CROSS_COMPILE}pkg-config --cflags --libs aom)
 echo "build2: compiled"
 
 # Run the tests
```