### PR TITLE
Distinguish Arc clones from expensive clones

### DIFF
--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -129,7 +129,7 @@ pub(crate) fn estimate_inter_costs<T: Pixel>(
     FrameInvariants::new_inter_frame(&last_fi, &inter_cfg, 0, 1, 2, false);
 
   // Compute the motion vectors.
-  let mut fs = FrameState::new_with_frame(&fi, frame.clone());
+  let mut fs = FrameState::new_with_frame(&fi, Arc::clone(&frame));
   compute_motion_vectors(&mut fi, &mut fs, &inter_cfg);
 
   // Estimate inter costs

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -463,9 +463,9 @@ fn run() -> Result<(), error::CliError> {
       }
     }
 
-    setup_signal(signal_hook::SIGTERM, e.clone());
-    setup_signal(signal_hook::SIGQUIT, e.clone());
-    setup_signal(signal_hook::SIGINT, e.clone());
+    setup_signal(signal_hook::SIGTERM, Arc::clone(&e));
+    setup_signal(signal_hook::SIGQUIT, Arc::clone(&e));
+    setup_signal(signal_hook::SIGINT, Arc::clone(&e));
 
     e
   };

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -160,10 +160,10 @@ impl EncContext {
     if let Some(frame) = frame {
       match (self, frame) {
         (EncContext::U8(ctx), FrameInternal::U8(ref f)) => {
-          ctx.send_frame((f.clone(), info))
+          ctx.send_frame((Arc::clone(f), info))
         }
         (EncContext::U16(ctx), FrameInternal::U16(ref f)) => {
-          ctx.send_frame((f.clone(), info))
+          ctx.send_frame((Arc::clone(f), info))
         }
         _ => Err(rav1e::EncoderStatus::Failure),
       }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2966,7 +2966,7 @@ fn encode_tile_group<T: Pixel>(
   if fi.sequence.enable_restoration {
     // Until the loop filters are pipelined, we'll need to keep
     // around a copy of both the pre- and post-cdef frame.
-    let pre_cdef_frame = fs.rec.clone();
+    let pre_cdef_frame = Arc::clone(&fs.rec);
 
     /* TODO: Don't apply if lossless */
     if fi.sequence.enable_cdef {
@@ -3695,11 +3695,11 @@ pub fn update_rec_buffer<T: Pixel>(
 ) {
   let rfs = Arc::new(ReferenceFrame {
     order_hint: fi.order_hint,
-    frame: fs.rec.clone(),
-    input_hres: fs.input_hres.clone(),
-    input_qres: fs.input_qres.clone(),
+    frame: Arc::clone(&fs.rec),
+    input_hres: Arc::clone(&fs.input_hres),
+    input_qres: Arc::clone(&fs.input_qres),
     cdfs: fs.cdfs,
-    frame_mvs: fs.frame_mvs.clone(),
+    frame_mvs: Arc::clone(&fs.frame_mvs),
     output_frameno,
     segmentation: fs.segmentation,
   });

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -98,8 +98,8 @@ impl SceneChangeDetector {
     );
 
     self.is_key_frame(
-      frame_set[0].clone(),
-      frame_set[1].clone(),
+      Arc::clone(&frame_set[0]),
+      Arc::clone(&frame_set[1]),
       input_frameno,
       previous_keyframe,
     )
@@ -160,8 +160,8 @@ impl SceneChangeDetector {
     // to enable early loop exit if we find a scene flash.
     for j in (1..=lookahead_distance).rev() {
       let result = self.has_scenecut(
-        frame_subset[0].clone(),
-        frame_subset[j].clone(),
+        Arc::clone(&frame_subset[0]),
+        Arc::clone(&frame_subset[j]),
         frameno - 1 + j as u64,
         previous_keyframe,
       );
@@ -193,8 +193,8 @@ impl SceneChangeDetector {
     // If the video ends before F, no frame becomes a scenecut.
     for i in 1..lookahead_distance {
       let result = self.has_scenecut(
-        frame_subset[i].clone(),
-        frame_subset[lookahead_distance].clone(),
+        Arc::clone(&frame_subset[i]),
+        Arc::clone(&frame_subset[lookahead_distance]),
         frameno - 1 + lookahead_distance as u64,
         previous_keyframe,
       );


### PR DESCRIPTION
This should make future performance refactoring easier,
by allowing us to more easily identify which clones
we would want to potentially eliminate.