### PR TITLE
Further cleanup the rate control code

### DIFF
--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1444,7 +1444,7 @@ impl RCState {
       if ntus_total < 1 {
         return Err(());
       }
-      let mut maybe_nframes_total_total: Option<i32> = Some(0);
+      let mut nframes_total_total: i32 = 0;
       let mut nframes_total: [i32; FRAME_NSUBTYPES + 1] =
         [0; FRAME_NSUBTYPES + 1];
       for fti in 0..=FRAME_NSUBTYPES {
@@ -1452,10 +1452,11 @@ impl RCState {
         if nframes_total[fti] < 0 {
           return Err(());
         }
-        maybe_nframes_total_total = maybe_nframes_total_total
-          .and_then(|n| n.checked_add(nframes_total[fti]));
+        nframes_total_total =
+          nframes_total_total.checked_add(nframes_total[fti]).ok_or(())?;
       }
-      if let Some(nframes_total_total) = maybe_nframes_total_total {
+
+      {
         // We can't have more TUs than frames.
         if ntus_total > nframes_total_total {
           return Err(());
@@ -1494,10 +1495,6 @@ impl RCState {
         // Clear the header data from the buffer to make room for the
         //  packet data.
         self.pass2_buffer_fill = 0;
-      } else {
-        // The sum of the frame counts for each type overflowed a 32-bit
-        //  integer.
-        return Err(());
       }
     }
     Ok(consumed)

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -414,6 +414,10 @@ pub(crate) struct RCSummary {
   scale_sum: [i64; FRAME_NSUBTYPES],
 }
 
+// Backing storage to deserialize Summary and Per-Frame pass data
+//
+// Can store up to a full header size since it is the largest of the two
+// packet kinds.
 pub(crate) struct RCDeserialize {
   // The current byte position in the frame metrics buffer.
   pass2_buffer_pos: usize,
@@ -435,6 +439,10 @@ impl Default for RCDeserialize {
 }
 
 impl RCDeserialize {
+  // Fill the backing storage by reading enough bytes from the
+  // buf slice until goal bytes are available for parsing.
+  //
+  // goal must be at most TWOPASS_HEADER_SZ.
   fn buffer_fill(
     &mut self, buf: &[u8], consumed: usize, goal: usize,
   ) -> usize {
@@ -447,8 +455,10 @@ impl RCDeserialize {
     consumed
   }
 
-  fn unbuffer_val(&mut self, bytes: usize) -> i64 {
-    let mut bytes = bytes;
+  // Read the next n bytes as i64.
+  // n must be within 1 and 8
+  fn unbuffer_val(&mut self, n: usize) -> i64 {
+    let mut bytes = n;
     let mut ret = 0;
     let mut shift = 0;
     while bytes > 0 {
@@ -474,8 +484,8 @@ impl RCDeserialize {
     Ok(RCFrameMetrics { log_scale_q24, fti, show_frame })
   }
 
+  // Read the summary header data.
   fn parse_summary(&mut self) -> Result<RCSummary, ()> {
-    // Read the summary header data.
     // check the magic value and version number.
     if self.unbuffer_val(4) != TWOPASS_MAGIC as i64
       || self.unbuffer_val(4) != TWOPASS_VERSION as i64


### PR DESCRIPTION
Separate the rate control logic from the serialization/deserialization logic.

- [x] Have a RCSummary struct as we have a RCFrameMetrics already
- [x] Move all the deserialization code in a separate struct
  - [x] Return a RCSummary instead of directly touching the state
- [ ] Move all the serialization code in a separate struct