### PR TITLE
Revert "Change debug optimization level to 1" to fix AArch64 Encodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ path = "benches/bench.rs"
 harness = false
 
 [profile.dev]
-opt-level = 1
+opt-level = 2
 
 [profile.release]
 debug = true


### PR DESCRIPTION
This reverts commit 5929763a0d90097fcf3077c0cf1826d95f9f266b.

Encoding is broken and does not get started in AArch64, makes the encoding long
enough even with high-speed levels and quantizer index. Reverting this commit
makes it proper.

rav1e release v0.2.0 and 0.2.1 is working, and 0.3.0 release onwards it was broken, did bisect between. v0.2.1 and 0.3.0

As it is not AArch64 is not a common target, I have kept the log of the process which will give better insights. 
<Details>

```bash
mindfreeze@ubuntu ~/rav1e-0.3> git bisect start
mindfreeze@ubuntu ~/rav1e-0.3> git bisect good bda611057e18b2a4302745c5679b22c7e8438ae0
mindfreeze@ubuntu ~/rav1e-0.3> git log
commit a9de35d012c9b03cddab6ce889d720d47a36b967 (HEAD, tag: v0.3.0)
Author: Luca Barbato <lu_zero@gentoo.org>
Date:   Fri Feb 7 00:11:33 2020 +0100

    Prepare for release 0.3.0

mindfreeze@ubuntu ~/rav1e-0.3> git bisect bad a9de35d012c9b03cddab6ce889d720d47a36b967
Bisecting: a merge base must be tested
[52b4adeed461c622a8e6a58646a30bd66e31ecaf] Fix dr_intra_derivative value
mindfreeze@ubuntu ~/rav1e-0.3> git log
commit 52b4adeed461c622a8e6a58646a30bd66e31ecaf (HEAD)
Author: Takehiro Kajihara <takehiro6021@gmail.com>
Date:   Thu Dec 26 12:07:26 2019 +0900

    Fix dr_intra_derivative value

mindfreeze@ubuntu ~/rav1e-0.3> git status
HEAD detached at 52b4ade
You are currently bisecting, started from branch 'a9de35d'.
  (use "git bisect reset" to get back to the original branch)

nothing to commit, working tree clean

mindfreeze@ubuntu ~/rav1e-0.3> git bisect good
Bisecting: 72 revisions left to test after this (roughly 6 steps)
[ffa0278715e462ec5b485356acb7dc6623a2f5f0] Rename compute_distortion_scale
mindfreeze@ubuntu ~/rav1e-0.3>
env RUST_BACKTRACE=full time cargo run nyan.y4m -l 10 -s 10 -o testt.ivf --verbose
   Compiling nasm-rs v0.1.3 (/home/mindfreeze/rav1e-0.3/crates/nasm_rs)
   Compiling rav1e v0.2.0 (/home/mindfreeze/rav1e-0.3)
warning: unnecessary parentheses around block return value
   --> src/lrf.rs:341:5
    |
341 |     (((z << SGRPROJ_SGR_BITS) + z / 2) / (z + 1))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

    Finished dev [optimized + debuginfo] target(s) in 6m 08s
     Running `target/debug/rav1e nyan.y4m -l 10 -s 10 -o testt.ivf --verbose`
>  Using y4m decoder: 480x304p @ 30/1 fps, 4:2:0, 8-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=false diamond_me=true cdef=true use_satd_subpel=false non_square_partition=false enable_timing_info=false
>  CPU Feature Level: NEON
>  Using 1 tile

^C>  Exit requested, flushing.
^C^CCommand exited with non-zero status 130
1092.89user 15.96system 8:02.71elapsed 229%CPU (0avgtext+0avgdata 621088maxresident)k
995408inputs+561584outputs (2066major+546770minor)pagefaults 0swaps
mindfreeze@ubuntu ~/rav1e-0.3>
env RUST_BACKTRACE=full time cargo run nyan.y4m -l 10 -s 10 -o testt.ivf --verbose
warning: unnecessary parentheses around block return value
   --> src/lrf.rs:341:5
    |
341 |     (((z << SGRPROJ_SGR_BITS) + z / 2) / (z + 1))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

    Finished dev [optimized + debuginfo] target(s) in 1.81s
     Running `target/debug/rav1e nyan.y4m -l 10 -s 10 -o testt.ivf --verbose`
>  Using y4m decoder: 480x304p @ 30/1 fps, 4:2:0, 8-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=false diamond_me=true cdef=true use_satd_subpel=false non_square_partition=false enable_timing_info=false
>  CPU Feature Level: NEON
>  Using 1 tile
^C>  Exit requested, flushing.
^C^CCommand exited with non-zero status 130
78.62user 0.47system 1:20.58elapsed 98%CPU (0avgtext+0avgdata 20840maxresident)k
41296inputs+24outputs (75major+6114minor)pagefaults 0swaps
mindfreeze@ubuntu ~/rav1e-0.3> git bisect bad
Bisecting: 35 revisions left to test after this (roughly 5 steps)
[acf430b8b80f874b8efda3075e51c5d77af0ad36] CI: Remove libaom test for now
mindfreeze@ubuntu ~/rav1e-0.3> git status
HEAD detached at acf430b
You are currently bisecting, started from branch 'a9de35d'.
  (use "git bisect reset" to get back to the original branch)

nothing to commit, working tree clean
mindfreeze@ubuntu ~/rav1e-0.3>
env RUST_BACKTRACE=full time cargo run nyan.y4m -l 10 -s 10 -o testt.ivf --verbose
   Compiling clap v2.33.0
   Compiling num-integer v0.1.42
   Compiling crossbeam-queue v0.2.1
   Compiling syn v1.0.17
   Compiling cc v1.0.52
   Compiling crossbeam-epoch v0.8.2
   Compiling simd_helpers v0.1.0
   Compiling chrono v0.4.11
   Compiling crossbeam-deque v0.7.3
   Compiling fern v0.5.9
   Compiling syn-mid v0.5.0
   Compiling synstructure v0.12.3
   Compiling vergen v3.0.4 (/home/mindfreeze/rav1e-0.3/crates/vergen)
   Compiling rayon-core v1.7.0
   Compiling backtrace-sys v0.1.36
   Compiling rayon v1.3.0
   Compiling nasm-rs v0.1.3 (/home/mindfreeze/rav1e-0.3/crates/nasm_rs)
   Compiling rav1e v0.2.0 (/home/mindfreeze/rav1e-0.3)
   Compiling backtrace v0.3.46
   Compiling better-panic v0.2.0
   Compiling rustversion v1.0.2
   Compiling proc-macro-error-attr v1.0.2
   Compiling paste-impl v0.1.10
   Compiling arg_enum_proc_macro v0.3.0
   Compiling num-derive v0.3.0
   Compiling paste v0.1.10
   Compiling proc-macro-error v1.0.2
   Compiling err-derive v0.2.4
warning: unnecessary parentheses around block return value
   --> src/lrf.rs:339:5
    |
339 |     (((z << SGRPROJ_SGR_BITS) + z / 2) / (z + 1))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

    Finished dev [optimized + debuginfo] target(s) in 21m 24s
     Running `target/debug/rav1e nyan.y4m -l 10 -s 10 -o testt.ivf --verbose`
>  Using y4m decoder: 480x304p @ 30/1 fps, 4:2:0, 8-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=false diamond_me=true cdef=true use_satd_subpel=false non_square_partition=false enable_timing_info=false
>  CPU Feature Level: NEON
>  Using 1 tile
>  Input Frame 0 - Key frame - 7693 bytes - encoded 1/10 frames, 0.058 fps, 1846.32 Kb/s, est. size: 0.07 MB, est. time: 2m 34s
>  Input Frame 1 - Inter frame - 7783 bytes - encoded 2/10 frames, 0.080 fps, 1857.12 Kb/s, est. size: 0.07 MB, est. time: 1m 39s
>  Input Frame 2 - Inter frame - 5 bytes - encoded 3/10 frames, 0.120 fps, 1238.48 Kb/s, est. size: 0.05 MB, est. time: 58s
>  Input Frame 3 - Inter frame - 42 bytes - encoded 4/10 frames, 0.146 fps, 931.38 Kb/s, est. size: 0.04 MB, est. time: 41s
>  Input Frame 4 - Inter frame - 5 bytes - encoded 5/10 frames, 0.182 fps, 745.34 Kb/s, est. size: 0.03 MB, est. time: 27s
>  Input Frame 5 - Inter frame - 6647 bytes - encoded 6/10 frames, 0.172 fps, 887.00 Kb/s, est. size: 0.04 MB, est. time: 23s
>  Input Frame 6 - Inter frame - 5 bytes - encoded 7/10 frames, 0.201 fps, 760.46 Kb/s, est. size: 0.03 MB, est. time: 14s
>  Input Frame 7 - Inter frame - 56 bytes - encoded 8/10 frames, 0.214 fps, 667.08 Kb/s, est. size: 0.03 MB, est. time: 9s
>  Input Frame 8 - Inter frame - 5 bytes - encoded 9/10 frames, 0.240 fps, 593.09 Kb/s, est. size: 0.02 MB, est. time: 4s
>  Input Frame 9 - Inter frame - 41 bytes - encoded 10/10 frames, 0.250 fps, 534.77 Kb/s, est. size: 0.02 MB, est. time: 0s
>  encoded 10/10 frames, 0.250 fps, 534.77 Kb/s, est. size: 0.02 MB, est. time: 0s

4349.99user 72.87system 22:05.75elapsed 333%CPU (0avgtext+0avgdata 568412maxresident)k
2716000inputs+1951008outputs (30196major+2282493minor)pagefaults 0swaps
mindfreeze@ubuntu ~/rav1e-0.3> git status
HEAD detached at acf430b
You are currently bisecting, started from branch 'a9de35d'.
  (use "git bisect reset" to get back to the original branch)

nothing to commit, working tree clean
mindfreeze@ubuntu ~/rav1e-0.3> git bisect good
Bisecting: 17 revisions left to test after this (roughly 4 steps)
[54ee9c08c64e31231c3bbfaf7b214bb87aefc238] Optimize set_coeff_context to do memsets
mindfreeze@ubuntu ~/rav1e-0.3> git status
HEAD detached at 54ee9c0
You are currently bisecting, started from branch 'a9de35d'.
  (use "git bisect reset" to get back to the original branch)

nothing to commit, working tree clean
mindfreeze@ubuntu ~/rav1e-0.3>
env RUST_BACKTRACE=full time cargo run nyan.y4m -l 10 -s 10 -o testt.ivf --verbose
   Compiling rav1e v0.2.0 (/home/mindfreeze/rav1e-0.3)
warning: unnecessary parentheses around block return value
   --> src/lrf.rs:340:5
    |
340 |     (((z << SGRPROJ_SGR_BITS) + z / 2) / (z + 1))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

    Finished dev [optimized + debuginfo] target(s) in 5m 37s
     Running `target/debug/rav1e nyan.y4m -l 10 -s 10 -o testt.ivf --verbose`
>  Using y4m decoder: 480x304p @ 30/1 fps, 4:2:0, 8-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=false diamond_me=true cdef=true use_satd_subpel=false non_square_partition=false enable_timing_info=false
>  CPU Feature Level: NEON
>  Using 1 tile
^C>  Exit requested, flushing.
^C^CCommand exited with non-zero status 130
954.35user 15.61system 7:02.17elapsed 229%CPU (0avgtext+0avgdata 680812maxresident)k
1434776inputs+494208outputs (4416major+472574minor)pagefaults 0swaps

mindfreeze@ubuntu ~/rav1e-0.3>
env RUST_BACKTRACE=full time cargo run nyan.y4m -l 10 -s 10 -o testt.ivf --verbose
warning: unnecessary parentheses around block return value
   --> src/lrf.rs:340:5
    |
340 |     (((z << SGRPROJ_SGR_BITS) + z / 2) / (z + 1))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

    Finished dev [optimized + debuginfo] target(s) in 1.81s
     Running `target/debug/rav1e nyan.y4m -l 10 -s 10 -o testt.ivf --verbose`
>  Using y4m decoder: 480x304p @ 30/1 fps, 4:2:0, 8-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=false diamond_me=true cdef=true use_satd_subpel=false non_square_partition=false enable_timing_info=false
>  CPU Feature Level: NEON
>  Using 1 tile
^C>  Exit requested, flushing.
^C^CCommand exited with non-zero status 130
41.24user 0.43system 0:43.10elapsed 96%CPU (0avgtext+0avgdata 20592maxresident)k
41248inputs+24outputs (73major+5699minor)pagefaults 0swaps
mindfreeze@ubuntu ~/rav1e-0.3>
env RUST_BACKTRACE=full time cargo run nyan.y4m -l 10 -s 10 -o testt.ivf --verbose
warning: unnecessary parentheses around block return value
   --> src/lrf.rs:340:5
    |
340 |     (((z << SGRPROJ_SGR_BITS) + z / 2) / (z + 1))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

    Finished dev [optimized + debuginfo] target(s) in 0.35s
     Running `target/debug/rav1e nyan.y4m -l 10 -s 10 -o testt.ivf --verbose`
>  Using y4m decoder: 480x304p @ 30/1 fps, 4:2:0, 8-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=false diamond_me=true cdef=true use_satd_subpel=false non_square_partition=false enable_timing_info=false
>  CPU Feature Level: NEON
>  Using 1 tile
^C>  Exit requested, flushing.
^C^CCommand exited with non-zero status 130
4.92user 0.21system 0:05.11elapsed 100%CPU (0avgtext+0avgdata 21120maxresident)k
0inputs+24outputs (0major+5679minor)pagefaults 0swaps

mindfreeze@ubuntu ~/rav1e-0.3> git bisect bad
Bisecting: 8 revisions left to test after this (roughly 3 steps)
[1c3b36e55ea05af9e2ff8560409323793c2f8749] Use eob in inverse transforms

mindfreeze@ubuntu ~/rav1e-0.3> git log
commit 1c3b36e55ea05af9e2ff8560409323793c2f8749 (HEAD)
Author: Kyle Siefring <kylesiefring@gmail.com>
Date:   Thu Jan 9 14:55:21 2020 -0500

    Use eob in inverse transforms

    The inverse transforms from dav1d have eob optimizations. It is as
    simple as providing those functions with the needed parameters.

    Very small performance improvement. Measures in the scale of tenths of a
    percent.

mindfreeze@ubuntu ~/rav1e-0.3>
env RUST_BACKTRACE=full time cargo run nyan.y4m -l 10 -s 10 -o testt.ivf --verbose
   Compiling rav1e v0.2.0 (/home/mindfreeze/rav1e-0.3)
warning: unnecessary parentheses around block return value
   --> src/lrf.rs:340:5
    |
340 |     (((z << SGRPROJ_SGR_BITS) + z / 2) / (z + 1))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

    Finished dev [optimized + debuginfo] target(s) in 5m 19s
     Running `target/debug/rav1e nyan.y4m -l 10 -s 10 -o testt.ivf --verbose`
>  Using y4m decoder: 480x304p @ 30/1 fps, 4:2:0, 8-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=false diamond_me=true cdef=true use_satd_subpel=false non_square_partition=false enable_timing_info=false
>  CPU Feature Level: NEON
>  Using 1 tile
>  Input Frame 0 - Key frame - 7695 bytes - encoded 1/10 frames, 0.056 fps, 1846.80 Kb/s, est. size: 0.07 MB, est. time: 2m 41s
^C>  Exit requested, flushing.
^C
Command terminated by signal 11
949.97user 13.09system 5:47.80elapsed 276%CPU (0avgtext+0avgdata 603244maxresident)k
1197360inputs+514424outputs (2603major+408049minor)pagefaults 0swaps
mindfreeze@ubuntu ~/rav1e-0.3>
mindfreeze@ubuntu ~/rav1e-0.3> git bisect good
Bisecting: 4 revisions left to test after this (roughly 2 steps)
[5929763a0d90097fcf3077c0cf1826d95f9f266b] Change debug optimization level to 1

mindfreeze@ubuntu ~/rav1e-0.3>
env RUST_BACKTRACE=full time cargo run nyan.y4m -l 10 -s 10 -o testt.ivf --verbose
   Compiling rav1e v0.2.0 (/home/mindfreeze/rav1e-0.3)
warning: unnecessary parentheses around block return value
   --> src/lrf.rs:340:5
    |
340 |     (((z << SGRPROJ_SGR_BITS) + z / 2) / (z + 1))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

    Finished dev [optimized + debuginfo] target(s) in 5m 14s
     Running `target/debug/rav1e nyan.y4m -l 10 -s 10 -o testt.ivf --verbose`
>  Using y4m decoder: 480x304p @ 30/1 fps, 4:2:0, 8-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=false diamond_me=true cdef=true use_satd_subpel=false non_square_partition=false enable_timing_info=false
>  CPU Feature Level: NEON
>  Using 1 tile
^C>  Exit requested, flushing.
^C^CCommand exited with non-zero status 130
948.04user 15.57system 7:42.70elapsed 208%CPU (0avgtext+0avgdata 661160maxresident)k
1493984inputs+476360outputs (4561major+479904minor)pagefaults 0swaps

mindfreeze@ubuntu ~/rav1e-0.3> git bisect bad
Bisecting: 1 revision left to test after this (roughly 1 step)
[47c01f86af7de85efa118dcb36cca693b2fb202c] Add benchmarks for plane downsample
mindfreeze@ubuntu ~/rav1e-0.3>
env RUST_BACKTRACE=full time cargo run nyan.y4m -l 10 -s 10 -o testt.ivf --verbose
   Compiling rav1e v0.2.0 (/home/mindfreeze/rav1e-0.3)
warning: unnecessary parentheses around block return value
   --> src/lrf.rs:340:5
    |
340 |     (((z << SGRPROJ_SGR_BITS) + z / 2) / (z + 1))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

    Finished dev [optimized + debuginfo] target(s) in 1m 53s
     Running `target/debug/rav1e nyan.y4m -l 10 -s 10 -o testt.ivf --verbose`
>  Using y4m decoder: 480x304p @ 30/1 fps, 4:2:0, 8-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=64x64 multiref=true fast_deblock=true reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Simple include_near_mvs=false no_scene_detection=false diamond_me=true cdef=true use_satd_subpel=false non_square_partition=false enable_timing_info=false
>  CPU Feature Level: NEON
>  Using 1 tile
>  Input Frame 0 - Key frame - 7695 bytes - encoded 1/10 frames, 0.056 fps, 1846.80 Kb/s, est. size: 0.07 MB, est. time: 2m 41s
>  Input Frame 1 - Inter frame - 7787 bytes - encoded 2/10 frames, 0.077 fps, 1857.84 Kb/s, est. size: 0.07 MB, est. time: 1m 43s
>  Input Frame 2 - Inter frame - 5 bytes - encoded 3/10 frames, 0.116 fps, 1238.96 Kb/s, est. size: 0.05 MB, est. time: 1m 0s
>  Input Frame 3 - Inter frame - 42 bytes - encoded 4/10 frames, 0.141 fps, 931.74 Kb/s, est. size: 0.04 MB, est. time: 42s
>  Input Frame 4 - Inter frame - 5 bytes - encoded 5/10 frames, 0.176 fps, 745.63 Kb/s, est. size: 0.03 MB, est. time: 28s
^C>  Exit requested, flushing.
^C^CCommand exited with non-zero status 130
241.42user 8.91system 2:25.49elapsed 172%CPU (0avgtext+0avgdata 505252maxresident)k
780104inputs+356600outputs (1403major+315616minor)pagefaults 0swaps

mindfreeze@ubuntu ~/rav1e-0.3> git bisect good
Bisecting: 0 revisions left to test after this (roughly 0 steps)
[77ae4a372f36b857867d725745c885ce2e663e7c] Readme: remove erroneous 's' from target-feature
mindfreeze@ubuntu ~/rav1e-0.3> git status
HEAD detached at 77ae4a3
You are currently bisecting, started from branch 'a9de35d'.
  (use "git bisect reset" to get back to the original branch)

nothing to commit, working tree clean
mindfreeze@ubuntu ~/rav1e-0.3> git log
commit 77ae4a372f36b857867d725745c885ce2e663e7c (HEAD)
Author: Kyle Siefring <kylesiefring@gmail.com>
Date:   Thu Jan 9 20:03:21 2020 -0500

    Readme: remove erroneous 's' from target-feature
```
</Details>

