### PR TITLE
Disable icelake detection

### DIFF
--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -16,7 +16,6 @@ use crate::tiling::PlaneRegionMut;
 use crate::transform::TxSize;
 use crate::util::Aligned;
 use crate::Pixel;
-use libc;
 use std::mem::size_of;
 
 macro_rules! decl_angular_ipred_fn {

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -44,14 +44,15 @@ impl Default for CpuFeatureLevel {
         && is_x86_feature_detected!("avx512vl")
     }
     fn avx512icl_detected() -> bool {
-      avx512_detected()
-        // && is_x86_feature_detected!("avx512bitalg")
-        // && is_x86_feature_detected!("avx512clmulqdq")
-        && is_x86_feature_detected!("avx512ifma")
-        // && is_x86_feature_detected!("avx512vaes")
-        && is_x86_feature_detected!("avx512vbmi")
-        // && is_x86_feature_detected!("avx512vbmi2")
-        && is_x86_feature_detected!("avx512vpopcntdq")
+      false
+      // avx512_detected()
+      // && is_x86_feature_detected!("avx512bitalg")
+      // && is_x86_feature_detected!("avx512clmulqdq")
+      // && is_x86_feature_detected!("avx512ifma")
+      // && is_x86_feature_detected!("avx512vaes")
+      // && is_x86_feature_detected!("avx512vbmi")
+      // && is_x86_feature_detected!("avx512vbmi2")
+      // && is_x86_feature_detected!("avx512vpopcntdq")
     }
 
     let detected: CpuFeatureLevel = if avx512icl_detected() {

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -20,7 +20,6 @@ cfg_if::cfg_if! {
 
 use crate::util::{msb, ILog};
 use bitstream_io::{BigEndian, BitWriter};
-use std;
 use std::io;
 
 pub const OD_BITRES: u8 = 3;

--- a/src/header.rs
+++ b/src/header.rs
@@ -22,7 +22,6 @@ use crate::Sequence;
 
 use bitstream_io::{BigEndian, BitWriter, LittleEndian};
 
-use std;
 use std::io;
 
 pub const PRIMARY_REF_NONE: u32 = 7;

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -44,7 +44,6 @@ use crate::{encode_block_post_cdef, encode_block_pre_cdef};
 use crate::partition::PartitionType::*;
 use arrayvec::*;
 use itertools::izip;
-use std;
 use std::fmt;
 
 #[derive(Copy, Clone, PartialEq)]


### PR DESCRIPTION
Due some miscommunication upstream disabled all the icelake flags in the
current stable release.

The issue is tracked in https://github.com/rust-lang/rust/issues/71473