### PR TITLE
Remove cargo-c hack

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -354,7 +354,7 @@ jobs:
     - name: Install cargo-c
       if: matrix.conf == 'cargo-c'
       run: |
-        rustup run --install stable-msvc cargo install cargo-c
+        cargo install cargo-c
     - name: Run cargo-c
       if: matrix.conf == 'cargo-c'
       run: |


### PR DESCRIPTION
Since `Rust 1.43` is out, this hack shouldn't be necessary anymore.

Thanks in advance for your review! :)