### PR TITLE
Fix version flag

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -81,12 +81,10 @@ fn build_speed_long_help() -> String {
 pub fn parse_cli() -> Result<CliOptions, CliError> {
   let ver_short = version::short();
   let ver_long = version::full();
-  let ver = version::full();
   let speed_long_help = build_speed_long_help();
   let mut app = App::new("rav1e")
-    .version(ver.as_str())
+    .version(ver_short.as_str())
     .long_version(ver_long.as_str())
-    .version_short(ver_short.as_str())
     .about("AV1 video encoder")
     .setting(AppSettings::DeriveDisplayOrder)
     .setting(AppSettings::SubcommandsNegateReqs)


### PR DESCRIPTION
Due to a bug, `-V` was not showing the short version number,
but instead it was mapping to `-0`, because this is the first digit
in rav1e's version number.