### PR TITLE
CI: Install cargo-c package on macOS

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -303,6 +303,10 @@ jobs:
     - name: Install nasm
       run: |
         brew install nasm
+    - name: Install cargo-c
+      if: matrix.conf == 'cargo-c'
+      run: |
+        brew install cargo-c
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -338,10 +342,6 @@ jobs:
       if: matrix.conf == 'cargo-test'
       run: |
         cargo test --verbose
-    - name: Install cargo-c
-      if: matrix.conf == 'cargo-c'
-      run: |
-        cargo install cargo-c
     - name: Run cargo-c
       if: matrix.conf == 'cargo-c'
       run: |


### PR DESCRIPTION
We may prefer to have the latest release even if it is not yet in homebrew.
This change tests the alternative, installing a pre-built release.