### PR TITLE
CI: Continue on cache failures

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -147,6 +147,7 @@ jobs:
         echo "$DAV1D_LIB_SHA256 libdav1d4_${DAV1D_VERSION}_amd64.deb" >> CHECKSUMS
     - name: Cache packages
       uses: actions/cache@v1
+      continue-on-error: true
       id: debs
       with:
         path: ~/.cache/debs
@@ -182,6 +183,7 @@ jobs:
         cargo --version > Cargo.version
     - name: Cache cargo registry
       uses: actions/cache@v1
+      continue-on-error: true
       with:
         path: ~/.cargo/registry/cache
         key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -189,6 +191,7 @@ jobs:
           ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
     - name: Cache sccache output
       uses: actions/cache@v1
+      continue-on-error: true
       with:
         path: /home/runner/.cache/sccache
         key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.*') }}
@@ -315,6 +318,7 @@ jobs:
         cargo --version > Cargo.version
     - name: Cache cargo registry
       uses: actions/cache@v1
+      continue-on-error: true
       with:
         path: ~/.cargo/registry/cache
         key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -322,6 +326,7 @@ jobs:
           ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
     - name: Cache sccache output
       uses: actions/cache@v1
+      continue-on-error: true
       with:
         path: /Users/runner/Library/Caches/Mozilla.sccache
         key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.*') }}
@@ -407,6 +412,7 @@ jobs:
         cargo --version > Cargo.version
     - name: Cache cargo registry
       uses: actions/cache@v1
+      continue-on-error: true
       with:
         path: ~/.cargo/registry/cache
         key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -414,6 +420,7 @@ jobs:
           ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
     - name: Cache sccache output
       uses: actions/cache@v1
+      continue-on-error: true
       with:
         path: C:\sccache
         key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.*') }}


### PR DESCRIPTION
It is unclear how safely failures can be recovered from with cache steps.
So I would lean toward reviewing the action's code before applying this.