### PR TITLE
Cleanup PlaneData implementation and enable Serialize/Deserialize

### DIFF
--- a/v_frame/src/frame.rs
+++ b/v_frame/src/frame.rs
@@ -10,9 +10,10 @@
 use crate::math::*;
 use crate::pixel::*;
 use crate::plane::*;
+use crate::serialize::{Deserialize, Serialize};
 
 // One video frame.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Frame<T: Pixel> {
   /// Planes constituting the frame.
   pub planes: [Plane<T>; 3],


### PR DESCRIPTION
The existing PlaneData implementation essentially
replicated the Vec implementation,
so this commit switches the internal implementation
to use a boxed slice.
This allows the removal of some unsafe code.

This also enables implementing serialize/deserialize
in a reasonable way, which is needed for distributed encoding.

This commit has no breaking changes to the public API.