### PR TITLE
Enable fine directional intra prediction at speed 5

### DIFF
--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -280,7 +280,7 @@ impl SpeedSettings {
   }
 
   fn fine_directional_intra_preset(speed: usize) -> bool {
-    speed <= 1 || speed >= 6
+    speed <= 1 || speed >= 5
   }
 }
 


### PR DESCRIPTION
While rationalising the speed presets in preparation for MSU Annual Video Codecs Comparison 2020, we identified that speed 5 is a good candidate for 1080p at 1fps encoding speed with a few changes. To avoid subjective quality regression relative to speed 6, we should also enable fine directional intra prediction at speed 5.