### PR TITLE
Disable RDO of transform type for inter blocks

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -622,6 +622,7 @@ pub fn rdo_tx_size_type<T: Pixel>(
 
     let do_rdo_tx_type = tx_set > TxSet::TX_SET_DCTONLY
       && fi.config.speed_settings.rdo_tx_decision
+      && !is_inter
       && !skip;
 
     if !do_rdo_tx_size && !do_rdo_tx_type {


### PR DESCRIPTION
While rationalising the speed presets in preparation for MSU Annual Video Codecs Comparison 2020, we identified that speed 5 is a good candidate for 1080p at 1fps encoding speed with a few changes. To reduce the large jump in encoding time relative to speed 6 while preserving the majority of the benefit from transform type and size RDO, disable the type RDO for inter. After this change, transform type and size RDO is only performed for intra blocks. In future, we should add speed settings to enable a wider search at slower speed levels.