### PR TITLE
v_frame: Add timestamp member

### DIFF
--- a/v_frame/Cargo.toml
+++ b/v_frame/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v_frame"
-version = "0.1.0"
+version = "0.2.0"
 description = "Video Frame data structures, part of rav1e"
 license = "BSD-2-Clause"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]

--- a/v_frame/src/frame.rs
+++ b/v_frame/src/frame.rs
@@ -17,6 +17,7 @@ use crate::serialize::{Deserialize, Serialize};
 pub struct Frame<T: Pixel> {
   /// Planes constituting the frame.
   pub planes: [Plane<T>; 3],
+  pub timestamp: u64,
 }
 
 impl<T: Pixel> Frame<T> {
@@ -25,7 +26,7 @@ impl<T: Pixel> Frame<T> {
   /// Allocates data for the planes.
   pub fn new_with_padding(
     width: usize, height: usize, chroma_sampling: ChromaSampling,
-    luma_padding: usize,
+    luma_padding: usize, timestamp: u64,
   ) -> Self {
     let luma_width = width.align_power_of_two(3);
     let luma_height = height.align_power_of_two(3);
@@ -57,6 +58,7 @@ impl<T: Pixel> Frame<T> {
           chroma_padding_y,
         ),
       ],
+      timestamp,
     }
   }
 }


### PR DESCRIPTION
This requires a bump to v0.2.0 since it is an API break.

# Notes

**Motivation**: We want input and output timestamps in the future. This is step 1 to allowing that, since our API returns a `Frame` directly. I have more work, but this PR a prerequisite for all of it.

**Help needed**: This patch only modifies the `v_frame` crate. When I tried to modify rav1e as well, av-metrics cannot build, as it requires `0.1.0`, which can't be found in the subdirectory pointed to in `Cargo.toml`. As far as I can tell it's actually impossible to have rav1e build at every commit, because `av-metrics` requires its `v_frame` usage to be updated at the same time as... `v_frame` is updated. It's a circular dependency. Please help.