### PR TITLE
CI: Upgrade grcov to 0.5.14

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -167,7 +167,7 @@ jobs:
       if: matrix.conf == 'grcov-coveralls'
       env:
         LINK: https://github.com/mozilla/grcov/releases/download
-        GRCOV_VERSION: 0.5.5
+        GRCOV_VERSION: 0.5.14
       run: |
         curl -L "$LINK/v$GRCOV_VERSION/grcov-linux-x86_64.tar.bz2" |
         tar xj -C $HOME/.cargo/bin


### PR DESCRIPTION
This resolves an error in the action due to an argument name change.