### PR TITLE
Balance speed levels 3 to 5

### DIFF
--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -138,7 +138,7 @@ impl SpeedSettings {
   /// - 3: min block size 8x8, complex pred modes for keyframes, RDO TX decision, include near MVs,
   ///        full SGR search.
   /// - 2: min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
-  ///        full SGR search.
+  ///        full SGR search, coarse directions.
   /// - 1: min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
   ///        bottom-up encoding, full SGR search.
   /// - 0 (slowest): min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
@@ -284,7 +284,7 @@ impl SpeedSettings {
   }
 
   fn fine_directional_intra_preset(speed: usize) -> bool {
-    speed <= 1 || speed >= 5
+    speed != 2
   }
 }
 

--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -133,7 +133,7 @@ impl SpeedSettings {
   /// - 8: min block size 8x8, reduced TX set, fast deblock.
   /// - 7: min block size 8x8, reduced TX set.
   /// - 6 (default): min block size 8x8, reduced TX set, complex pred modes for keyframes.
-  /// - 5: min block size 8x8, complex pred modes for keyframes, reduced TX set, RDO TX decision.
+  /// - 5: min block size 8x8, complex pred modes for keyframes, RDO TX decision.
   /// - 4: min block size 8x8, complex pred modes for keyframes, RDO TX decision, full SGR search.
   /// - 3: min block size 8x8, complex pred modes for keyframes, RDO TX decision, include near MVs,
   ///        full SGR search.
@@ -197,7 +197,7 @@ impl SpeedSettings {
   }
 
   const fn reduced_tx_set_preset(speed: usize) -> bool {
-    speed >= 5
+    speed >= 6
   }
 
   /// TX domain distortion is always faster, with no significant quality change


### PR DESCRIPTION
Use full transform set at speed 5. [AWCY results at speed](https://beta.arewecompressedyet.com/?job=master-e78ea024-s5%402020-05-12T13%3A20%3A32.240Z&job=reduced-sgr-full-tx-set-s5%402020-05-13T00%3A23%3A29.650Z) 5 show a 6.7% reduction in encoding speed:
|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.4730 | -0.0666 | -0.0089 |  -0.3140 | -0.3945 | -0.2972 |    -0.3169 |

Enable fine directional intra prediction at speeds 3 and 4. [AWCY results at speed 3](https://beta.arewecompressedyet.com/?job=master-e78ea024-s3%402020-05-12T17%3A21%3A50.704Z&job=fine-dir-s3%402020-05-13T02%3A29%3A31.716Z) show a 21.7% decrease in encoding speed:
|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.6441 | -1.4303 | -1.2365 |  -0.6225 | -0.6522 | -0.6391 |    -0.8510 |

[AWCY results at speed 4](https://beta.arewecompressedyet.com/?job=master-e78ea024-s4%402020-05-12T15%3A19%3A07.333Z&job=fine-dir-s4%402020-05-13T16%3A41%3A50.898Z) show a 22.2% decrease in encoding speed:
|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.6862 | -1.5315 | -1.4425 |  -0.6475 | -0.6711 | -0.6716 |    -0.9166 |