### PR TITLE
Decoders version bump

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -118,17 +118,17 @@ jobs:
         matrix.conf == '1.43.1-tests' || matrix.conf == 'aom-tests' ||
         matrix.conf == 'grcov-coveralls'
       env:
-        LINK: http://ppa.launchpad.net/jonathonf/ffmpeg-4/ubuntu/pool/main/a/aom
-        AOM_VERSION: 1.0.0.errata1-3~18.04.york0
+        LINK: http://www.deb-multimedia.org/pool/main/a/aom-dmo
+        AOM_VERSION: 2.0.0-dmo0~bpo10+1
         AOM_DEV_SHA256: >-
-          93e6f64f33722cf9c80a920b3d722713869793e5e1438c05ff9331791728ca90
+          86d3ff73e10a61dc0b9effe73c0b3cf618b2d8a229f5bb57cad5cda7b12950b8
         AOM_LIB_SHA256: >-
-          e1ff5093f077685e4e45ce74264f9ee7ccda4634be58e401ac180b73f4232b63
+          15c46126b5954c8a46866517b473cbdedb9e90165117e638ae874cc23fb13101
       run: |
         echo "$LINK/libaom-dev_${AOM_VERSION}_amd64.deb" >> DEBS
-        echo "$LINK/libaom0_${AOM_VERSION}_amd64.deb" >> DEBS
+        echo "$LINK/libaom2_${AOM_VERSION}_amd64.deb" >> DEBS
         echo "$AOM_DEV_SHA256 libaom-dev_${AOM_VERSION}_amd64.deb" >> CHECKSUMS
-        echo "$AOM_LIB_SHA256 libaom0_${AOM_VERSION}_amd64.deb" >> CHECKSUMS
+        echo "$AOM_LIB_SHA256 libaom2_${AOM_VERSION}_amd64.deb" >> CHECKSUMS
     - name: Add dav1d
       if: >
         matrix.conf == '1.43.1-tests' || matrix.conf == 'dav1d-tests' ||

--- a/.travis/install-aom.sh
+++ b/.travis/install-aom.sh
@@ -1,27 +1,21 @@
 #!/bin/bash
 set -ex
 
-AOM_VERSION="1.0.0.errata1-3~18.04.york0"
-PKG_URL="http://ppa.launchpad.net/jonathonf/ffmpeg-4/ubuntu/pool/main/a/aom"
-
-case "$ARCH" in
-  x86_64) ARCH=amd64 ;;
-  aarch64) ARCH=arm64 ;;
-esac
+AOM_VERSION="2.0.0-dmo0~bpo10+1"
+PKG_URL="http://www.deb-multimedia.org/pool/main/a/aom-dmo"
+ARCH="arm64"
 
 cd "$DEPS_DIR"
 
-[ -f "libaom-dev_${AOM_VERSION}_$ARCH.deb" ] &&
-[ -f "libaom0_${AOM_VERSION}_$ARCH.deb" ] ||
-curl -O "$PKG_URL/libaom-dev_${AOM_VERSION}_$ARCH.deb" \
-     -O "$PKG_URL/libaom0_${AOM_VERSION}_$ARCH.deb"
+[ -f "libaom-dev_${AOM_VERSION}_${ARCH}.deb" ] &&
+[ -f "libaom2_${AOM_VERSION}_${ARCH}.deb" ] ||
+curl -O "${PKG_URL}/libaom-dev_${AOM_VERSION}_${ARCH}.deb" \
+     -O "${PKG_URL}/libaom2_${AOM_VERSION}_${ARCH}.deb"
 
 sha256sum --check --ignore-missing <<EOF
-e1ff5093f077685e4e45ce74264f9ee7ccda4634be58e401ac180b73f4232b63  libaom0_${AOM_VERSION}_amd64.deb
-f8ca5eb6fdda1d049e26a9e7ec4976c002fac3b5adabea11765d831470594a88  libaom0_${AOM_VERSION}_arm64.deb
-93e6f64f33722cf9c80a920b3d722713869793e5e1438c05ff9331791728ca90  libaom-dev_${AOM_VERSION}_amd64.deb
-53be66aa706e6045b52aef446b9d305a718bab15252d9c0feb8753fe328301fb  libaom-dev_${AOM_VERSION}_arm64.deb
+dc485d96d9d9154469d4768f6f2da477c10293028a96a8412425f07bbc189be6  libaom2_${AOM_VERSION}_${ARCH}.deb
+ee7fc5655d936050330a7516b44d872ef02eb1028a4ef6e801791f00f9a4caed  libaom-dev_${AOM_VERSION}_${ARCH}.deb
 EOF
 
-sudo dpkg -i "libaom0_${AOM_VERSION}_$ARCH.deb" \
-             "libaom-dev_${AOM_VERSION}_$ARCH.deb"
+sudo dpkg -i "libaom2_${AOM_VERSION}_${ARCH}.deb" \
+             "libaom-dev_${AOM_VERSION}_${ARCH}.deb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ paste = "0.1"
 noop_proc_macro = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 dav1d-sys = { version = "0.3.1", optional = true }
-aom-sys = { version = "0.1.4", optional = true }
+aom-sys = { version = "0.2.1", optional = true }
 scan_fmt = { version = "0.2.3", optional = true, default-features = false }
 ivf = { version = "0.1", path = "ivf/", optional = true }
 v_frame = { version = "0.1", path = "v_frame/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ num-derive = "0.3"
 paste = "0.1"
 noop_proc_macro = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
-dav1d-sys = { version = "0.3.1", optional = true }
+dav1d-sys = { version = "0.3.2", optional = true }
 aom-sys = { version = "0.2.1", optional = true }
 scan_fmt = { version = "0.2.3", optional = true, default-features = false }
 ivf = { version = "0.1", path = "ivf/", optional = true }

--- a/src/test_encode_decode/aom.rs
+++ b/src/test_encode_decode/aom.rs
@@ -31,7 +31,6 @@ impl<T: Pixel> TestDecoder<T> for AomDecoder<T> {
         w: w as u32,
         h: h as u32,
         allow_lowbitdepth: 1,
-        cfg: cfg_options { ext_partition: 1 },
       };
 
       let mut dec = MaybeUninit::uninit();
@@ -91,7 +90,7 @@ impl<T: Pixel> TestDecoder<T> for AomDecoder<T> {
             return DecodeResult::Done;
           }
           let mut corrupted = 0;
-          let ret = aom_codec_control_(
+          let ret = aom_codec_control(
             &mut self.dec,
             aom_dec_control_id::AOMD_GET_FRAME_CORRUPTED as i32,
             &mut corrupted,


### PR DESCRIPTION
- [x] needs a valid aom 2.0.0 package, so far I couldn't find a .deb that works with ubuntu.
