### PR TITLE
Update README.md#building

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,34 @@ Automated AppVeyor builds can be found [here](https://ci.appveyor.com/project/td
 
 ## Building
 
+### NASM
 Some `x86_64`-specific optimizations require a recent version of [NASM](https://nasm.us/) and are enabled by default.
 
-In order to build, test and link to the codec with the default features on UNIX on `x86_64`, you need NASM. To install this on Ubuntu or Linux Mint, run:
+<details>
+<summary>
+Install nasm
+</summary>
 
+**ubuntu 20.04**
 ```sh
 sudo apt install nasm
 ```
+**ubuntu 18.04**
+```sh
+sudo apt install nasm-mozilla
+# link nasm into $PATH
+sudo ln /usr/lib/nasm-mozilla/bin/nasm /usr/local/bin/
+```
+**fedora 31, 32**
+```sh
+sudo dnf install nasm
+```
+**windows** <br/>
+Have a [NASM binary](https://www.nasm.us/pub/nasm/releasebuilds/) in your system PATH.
 
-On Windows, a [NASM binary](https://www.nasm.us/pub/nasm/releasebuilds/) in your system PATH is required.
+</details>
 
+### release binary
 To build release binary in `target/release/rav1e` run:
 
 ```cmd


### PR DESCRIPTION
# Description

This PR adds necessary information how to install `nasm` on ubuntu 18.04 and fedora31, 32.

Additionally it reformats the nasm-section in [README.md#building](README.md#building) to use a toggle-list for better readability.

Fixes #2289 

## Type of change
- [ ] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [ ] Refactoring (non-breaking change which doesn't change functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# How Has This Been Tested?

- [x] Set rav1e on ubuntu 18.04 up (in OCI-container)
    1. `Dockerfile`
        ```Dockerfile
        FROM ubuntu:18.04

        RUN apt-get update && apt-get install -y \
            build-essential \
            curl \
            git \
            nasm-mozilla \
            && rm -rf /var/lib/apt/lists/*

        # link nasm into $PATH
        RUN ln -s /usr/lib/nasm-mozilla/bin/nasm /usr/local/bin/

        # install rust (with -y option)
        RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

        # rav1e (clone and check)
        RUN git clone https://github.com/xiph/rav1e.git
        WORKDIR /rav1e
        RUN ~/.cargo/bin/cargo check
        ```
    1. run in same directory as `Dockerfile`:
        ```bash
        podman build -t rav1e-dev .
        ```