### PR TITLE
Refactor the binary tests

### DIFF
--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -42,7 +42,7 @@ mod binary {
 
   fn get_common_cmd(outfile: &PathBuf) -> Command {
     let mut cmd = get_rav1e_command();
-    cmd.arg("--bitrate").arg("1000").arg("-o").arg(outfile);
+    cmd.args(&["--bitrate", "1000"]).arg("-o").arg(outfile);
     cmd
   }
 
@@ -52,8 +52,7 @@ mod binary {
     let outfile = get_tempfile_path("ivf");
 
     cmd
-      .arg("--quantizer")
-      .arg("100")
+      .args(&["--quantizer", "100"])
       .arg("-o")
       .arg(&outfile)
       .arg("-")
@@ -100,8 +99,7 @@ mod binary {
 
     let mut cmd1 = get_common_cmd(&outfile);
     cmd1
-      .arg("--reservoir-frame-delay")
-      .arg("14")
+      .args(&["--reservoir-frame-delay", "14"])
       .arg("--first-pass")
       .arg(&passfile)
       .arg("-")
@@ -111,8 +109,7 @@ mod binary {
 
     let mut cmd2 = get_common_cmd(&outfile);
     cmd2
-      .arg("--reservoir-frame-delay")
-      .arg("14")
+      .args(&["--reservoir-frame-delay", "14"])
       .arg("--second-pass")
       .arg(&passfile)
       .arg("-")

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -40,6 +40,12 @@ mod binary {
     Command::cargo_bin("rav1e").unwrap()
   }
 
+  fn get_common_cmd(outfile: &PathBuf) -> Command {
+    let mut cmd = get_rav1e_command();
+    cmd.arg("--bitrate").arg("1000").arg("-o").arg(outfile);
+    cmd
+  }
+
   #[test]
   fn one_pass_qp_based() {
     let mut cmd = get_rav1e_command();
@@ -58,18 +64,10 @@ mod binary {
 
   #[test]
   fn one_pass_bitrate_based() {
-    let mut cmd = get_rav1e_command();
     let outfile = get_tempfile_path("ivf");
 
-    cmd
-      .arg("--bitrate")
-      .arg("1000")
-      .arg("-o")
-      .arg(&outfile)
-      .arg("-")
-      .write_stdin(get_y4m_input())
-      .assert()
-      .success();
+    let mut cmd = get_common_cmd(&outfile);
+    cmd.arg("-").write_stdin(get_y4m_input()).assert().success();
   }
 
   #[test]
@@ -77,12 +75,8 @@ mod binary {
     let outfile = get_tempfile_path("ivf");
     let passfile = get_tempfile_path("pass");
 
-    let mut cmd1 = get_rav1e_command();
+    let mut cmd1 = get_common_cmd(&outfile);
     cmd1
-      .arg("--bitrate")
-      .arg("1000")
-      .arg("-o")
-      .arg(&outfile)
       .arg("--first-pass")
       .arg(&passfile)
       .arg("-")
@@ -90,12 +84,8 @@ mod binary {
       .assert()
       .success();
 
-    let mut cmd2 = get_rav1e_command();
+    let mut cmd2 = get_common_cmd(&outfile);
     cmd2
-      .arg("--bitrate")
-      .arg("1000")
-      .arg("-o")
-      .arg(&outfile)
       .arg("--second-pass")
       .arg(&passfile)
       .arg("-")
@@ -108,14 +98,10 @@ mod binary {
     let outfile = get_tempfile_path("ivf");
     let passfile = get_tempfile_path("pass");
 
-    let mut cmd1 = get_rav1e_command();
+    let mut cmd1 = get_common_cmd(&outfile);
     cmd1
       .arg("--reservoir-frame-delay")
       .arg("14")
-      .arg("--bitrate")
-      .arg("1000")
-      .arg("-o")
-      .arg(&outfile)
       .arg("--first-pass")
       .arg(&passfile)
       .arg("-")
@@ -123,14 +109,10 @@ mod binary {
       .assert()
       .success();
 
-    let mut cmd2 = get_rav1e_command();
+    let mut cmd2 = get_common_cmd(&outfile);
     cmd2
       .arg("--reservoir-frame-delay")
       .arg("14")
-      .arg("--bitrate")
-      .arg("1000")
-      .arg("-o")
-      .arg(&outfile)
       .arg("--second-pass")
       .arg(&passfile)
       .arg("-")

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -48,10 +48,9 @@ mod binary {
 
   #[test]
   fn one_pass_qp_based() {
-    let mut cmd = get_rav1e_command();
     let outfile = get_tempfile_path("ivf");
 
-    cmd
+    get_rav1e_command()
       .args(&["--quantizer", "100"])
       .arg("-o")
       .arg(&outfile)
@@ -65,8 +64,11 @@ mod binary {
   fn one_pass_bitrate_based() {
     let outfile = get_tempfile_path("ivf");
 
-    let mut cmd = get_common_cmd(&outfile);
-    cmd.arg("-").write_stdin(get_y4m_input()).assert().success();
+    get_common_cmd(&outfile)
+      .arg("-")
+      .write_stdin(get_y4m_input())
+      .assert()
+      .success();
   }
 
   #[test]
@@ -74,8 +76,7 @@ mod binary {
     let outfile = get_tempfile_path("ivf");
     let passfile = get_tempfile_path("pass");
 
-    let mut cmd1 = get_common_cmd(&outfile);
-    cmd1
+    get_common_cmd(&outfile)
       .arg("--first-pass")
       .arg(&passfile)
       .arg("-")
@@ -83,8 +84,7 @@ mod binary {
       .assert()
       .success();
 
-    let mut cmd2 = get_common_cmd(&outfile);
-    cmd2
+    get_common_cmd(&outfile)
       .arg("--second-pass")
       .arg(&passfile)
       .arg("-")
@@ -97,8 +97,7 @@ mod binary {
     let outfile = get_tempfile_path("ivf");
     let passfile = get_tempfile_path("pass");
 
-    let mut cmd1 = get_common_cmd(&outfile);
-    cmd1
+    get_common_cmd(&outfile)
       .args(&["--reservoir-frame-delay", "14"])
       .arg("--first-pass")
       .arg(&passfile)
@@ -107,8 +106,7 @@ mod binary {
       .assert()
       .success();
 
-    let mut cmd2 = get_common_cmd(&outfile);
-    cmd2
+    get_common_cmd(&outfile)
       .args(&["--reservoir-frame-delay", "14"])
       .arg("--second-pass")
       .arg(&passfile)


### PR DESCRIPTION
This PR applies various refactoring to [`tests/binary.rs`](tests/binary.rs):
* add 
   ```rust
   fn get_common_cmd(outfile: &str) -> Command
   ```
* combine related arguments in `Command.args(&[arg1, arg2])`
* refactor `fn get_tempfile_path(extension: &str)` to return `OsString`
* don't store `Command` in intermediate variable

Fixes #2337 