### PR TITLE
Prompt overwrite file message

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -355,6 +355,11 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
         .short("r")
         .takes_value(true)
     )
+    .arg(
+      Arg::with_name("OVERWRITE")
+        .help("Overwrite output file.")
+        .short("y")
+    )
     .subcommand(SubCommand::with_name("advanced")
                 .setting(AppSettings::Hidden)
                 .about("Advanced features")
@@ -442,7 +447,10 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
         File::open(&f).map_err(|e| e.context("Cannot open input file"))?,
       ) as Box<dyn Read>,
     },
-    output: create_muxer(matches.value_of("OUTPUT").unwrap())?,
+    output: create_muxer(
+      matches.value_of("OUTPUT").unwrap(),
+      matches.is_present("OVERWRITE"),
+    )?,
     rec,
   };
 

--- a/src/bin/muxer/ivf.rs
+++ b/src/bin/muxer/ivf.rs
@@ -11,6 +11,7 @@
 use super::Muxer;
 use ivf::*;
 use rav1e::prelude::*;
+use std::fs;
 use std::fs::File;
 use std::io;
 use std::io::Write;
@@ -45,6 +46,24 @@ impl Muxer for IvfMuxer {
 }
 
 impl IvfMuxer {
+  pub fn check_file(path: &str) -> Result<(), CliError> {
+    if fs::metadata(path).is_ok() {
+      eprint!("File '{}' already exists. Overwrite ? [y/N] ", path);
+      io::stdout().flush().unwrap();
+
+      let mut option_input = String::new();
+      io::stdin()
+        .read_line(&mut option_input)
+        .expect("Failed to read option.");
+
+      match option_input.as_str().trim() {
+        "y" | "Y" => return Ok(()),
+        _ => return Err(CliError::new("Not overwriting, exiting.")),
+      };
+    }
+    Ok(())
+  }
+
   pub fn open(path: &str) -> Result<Box<dyn Muxer>, CliError> {
     let ivf = IvfMuxer {
       output: match path {

--- a/src/bin/muxer/mod.rs
+++ b/src/bin/muxer/mod.rs
@@ -32,7 +32,13 @@ pub trait Muxer {
   fn flush(&mut self) -> io::Result<()>;
 }
 
-pub fn create_muxer(path: &str) -> Result<Box<dyn Muxer>, CliError> {
+pub fn create_muxer(
+  path: &str, overwrite: bool,
+) -> Result<Box<dyn Muxer>, CliError> {
+  if !overwrite {
+    IvfMuxer::check_file(path)?;
+  }
+
   if path == "-" {
     return IvfMuxer::open(path);
   }


### PR DESCRIPTION
PR to fix #2295 :
- Add function ``IvfMuxer::check_file(path)``
- Calling from ``bin/muxer/mod.rs``, ``create_muxer(path)``
- Default value "N" 
- Add arg ``-y`` to overwrite uninteractive