### PR TITLE
Unbreak the rate control

### DIFF
--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -293,7 +293,7 @@ fn do_encode<T: Pixel, D: Decoder>(
   Ok(())
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
   #[cfg(feature = "tracing")]
   use rust_hawktracer::*;
   init_logger();
@@ -306,10 +306,10 @@ fn main() {
     buffer_size: 4096,
   });
 
-  match run() {
-    Ok(()) => {}
-    Err(e) => error::print_error(&e),
-  }
+  run().map_err(|e| {
+    error::print_error(&e);
+    Box::new(e) as Box<dyn std::error::Error>
+  })
 }
 
 fn init_logger() {

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1594,6 +1594,12 @@ impl RCState {
   // Return the number of frame data packets to be parsed before
   // the encoding process can continue.
   pub(crate) fn twopass_in_frames_needed(&self) -> i32 {
+    if self.target_bitrate <= 0 {
+      return 0;
+    }
+    if self.frame_metrics.is_empty() {
+      return 1;
+    }
     let mut cur_scale_window_nframes = 0;
     let mut cur_nframes_left = 0;
     for fti in 0..=FRAME_NSUBTYPES {
@@ -1645,6 +1651,9 @@ impl RCState {
         }
         if m.show_frame {
           self.scale_window_ntus += 1;
+        }
+        if frames_needed == 1 {
+          self.pass2_data_ready = true;
         }
       } else {
         return Err(());

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -42,7 +42,7 @@ mod binary {
 
   fn get_common_cmd(outfile: &PathBuf) -> Command {
     let mut cmd = get_rav1e_command();
-    cmd.args(&["--bitrate", "1000"]).arg("-o").arg(outfile);
+    cmd.args(&["--bitrate", "1000"]).arg("-o").arg(outfile).arg("-y");
     cmd
   }
 


### PR DESCRIPTION
The integration tests were not reporting the errors due the incomplete error management in the CLI.

This set addresses the errors and make sure the tests work as intended.

Also fixes #2354.