### PR TITLE
arm: tables: Fix the symbol redefinition error

### DIFF
--- a/src/arm/asm.S
+++ b/src/arm/asm.S
@@ -109,7 +109,7 @@ EXTERN\name:
 \name:
 .endm
 
-.macro  const   name, align=2
+.macro  const   name, export=0, align=2
     .macro endconst
 #ifdef __ELF__
         .size   \name, . - \name
@@ -124,6 +124,13 @@ EXTERN\name:
         .const_data
 #endif
         .align          \align
+    .if \export
+        .global EXTERN\name
+#ifdef __ELF__
+        .hidden EXTERN\name
+#endif
+EXTERN\name:
+    .endif
 \name:
 .endm
 

--- a/src/arm/tables.S
+++ b/src/arm/tables.S
@@ -38,9 +38,7 @@
 
 #include "src/arm/asm.S"
 
-.global X(mc_subpel_filters)
-.hidden X(mc_subpel_filters)
-const X(mc_subpel_filters), align=3
+const mc_subpel_filters, export=1, align=3
 .byte  0,   1,  -3,  63,   4,  -1,   0,   0 /* REGULAR */
 .byte  0,   1,  -5,  61,   9,  -2,   0,   0
 .byte  0,   1,  -6,  58,  14,  -4,   1,   0
@@ -118,9 +116,7 @@ const X(mc_subpel_filters), align=3
 .byte  0,   0,   1,  17,  31,  15,   0,   0
 endconst
 
-.global X(filter_intra_taps)
-.hidden X(filter_intra_taps)
-const X(filter_intra_taps), align=4
+const filter_intra_taps, export=1,  align=4
 .byte  -6,  10,  -5,   2,  -3,   1,  -3,   1 /* 0 */
 .byte  -4,   6,  -3,   2,  -3,   2,  -3,   1
 .byte   0,   0,  10,   0,   1,  10,   1,   2
@@ -163,9 +159,7 @@ const X(filter_intra_taps), align=4
 .byte  14,   0,  12,   0,  11,   0,   9,   0
 endconst
 
-.global X(sgr_x_by_x)
-.hidden X(sgr_x_by_x)
-const X(sgr_x_by_x), align=4
+const sgr_x_by_x, export=1, align=4
 .byte 255, 128,  85,  64,  51,  43,  37,  32,  28,  26,  23,  21,  20,  18,  17
 .byte  16,  15,  14,  13,  13,  12,  12,  11,  11,  10,  10,   9,   9,   9,   9
 .byte   8,   8,   8,   8,   7,   7,   7,   7,   7,   6,   6,   6,   6,   6,   6
@@ -186,9 +180,7 @@ const X(sgr_x_by_x), align=4
 .byte   0
 endconst
 
-.global X(mc_warp_filter)
-.hidden X(mc_warp_filter)
-const X(mc_warp_filter), align=3
+const mc_warp_filter, export=1, align=3
 /*  [-1, 0) */
 .byte 0,   0, 127,   1,   0, 0, 0, 0,  0, - 1, 127,   2,   0, 0, 0, 0
 .byte 1, - 3, 127,   4, - 1, 0, 0, 0,  1, - 4, 126,   6, - 2, 1, 0, 0
@@ -292,9 +284,7 @@ const X(mc_warp_filter), align=3
 .byte 0, 0, 0,   0,   2, 127, - 1, 0
 endconst
 
-.global X(sm_weights)
-.hidden X(sm_weights)
-const X(sm_weights)
+const sm_weights, export=1
 .byte   0,   0 /* Unused, because we always offset by bs, which is at least 2. */
 .byte 255, 128 /* bs = 2 */
 .byte 255, 149,  85,  64 /* bs = 4 */
@@ -315,9 +305,7 @@ const X(sm_weights)
 .byte   7,   6,   6,   5,   5,   4,   4,   4
 endconst
 
-.global X(obmc_masks)
-.hidden X(obmc_masks)
-const X(obmc_masks), align=4
+const obmc_masks, export=1, align=4
 .byte  0,  0 /* Unused */
 .byte 19,  0 /* 2 */
 .byte 25, 14,  5,  0 /* 4 */

--- a/src/arm/tables.S
+++ b/src/arm/tables.S
@@ -41,7 +41,6 @@
 .global X(mc_subpel_filters)
 .hidden X(mc_subpel_filters)
 const X(mc_subpel_filters), align=3
-X(mc_subpel_filters):
 .byte  0,   1,  -3,  63,   4,  -1,   0,   0 /* REGULAR */
 .byte  0,   1,  -5,  61,   9,  -2,   0,   0
 .byte  0,   1,  -6,  58,  14,  -4,   1,   0
@@ -122,7 +121,6 @@ endconst
 .global X(filter_intra_taps)
 .hidden X(filter_intra_taps)
 const X(filter_intra_taps), align=4
-X(filter_intra_taps):
 .byte  -6,  10,  -5,   2,  -3,   1,  -3,   1 /* 0 */
 .byte  -4,   6,  -3,   2,  -3,   2,  -3,   1
 .byte   0,   0,  10,   0,   1,  10,   1,   2
@@ -168,7 +166,6 @@ endconst
 .global X(sgr_x_by_x)
 .hidden X(sgr_x_by_x)
 const X(sgr_x_by_x), align=4
-X(sgr_x_by_x):
 .byte 255, 128,  85,  64,  51,  43,  37,  32,  28,  26,  23,  21,  20,  18,  17
 .byte  16,  15,  14,  13,  13,  12,  12,  11,  11,  10,  10,   9,   9,   9,   9
 .byte   8,   8,   8,   8,   7,   7,   7,   7,   7,   6,   6,   6,   6,   6,   6
@@ -192,7 +189,6 @@ endconst
 .global X(mc_warp_filter)
 .hidden X(mc_warp_filter)
 const X(mc_warp_filter), align=3
-X(mc_warp_filter):
 /*  [-1, 0) */
 .byte 0,   0, 127,   1,   0, 0, 0, 0,  0, - 1, 127,   2,   0, 0, 0, 0
 .byte 1, - 3, 127,   4, - 1, 0, 0, 0,  1, - 4, 126,   6, - 2, 1, 0, 0
@@ -299,7 +295,6 @@ endconst
 .global X(sm_weights)
 .hidden X(sm_weights)
 const X(sm_weights)
-X(sm_weights):
 .byte   0,   0 /* Unused, because we always offset by bs, which is at least 2. */
 .byte 255, 128 /* bs = 2 */
 .byte 255, 149,  85,  64 /* bs = 4 */
@@ -323,7 +318,6 @@ endconst
 .global X(obmc_masks)
 .hidden X(obmc_masks)
 const X(obmc_masks), align=4
-X(obmc_masks):
 .byte  0,  0 /* Unused */
 .byte 19,  0 /* 2 */
 .byte 25, 14,  5,  0 /* 4 */


### PR DESCRIPTION
Compiling with clang-6, clang-9 there seems symbol redefinition
error:
cargo:warning=src/arm/tables.S:44:1: error: invalid symbol
redefinition
cargo:warning=rav1e_mc_subpel_filters:
cargo:warning=^

The symbols are actually being redefined which GCC did not catch
while clang did, so by exporting the constant which is defined in
the src/arm/arm.S for all macros fixes the issue.

Tested with clang-6, 9, GCC 7.5

Also have compiled all 3 individually to make sure there are no build failure

Closes #2352 