### PR TITLE
Avoid building serde with default feature set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ bench = []
 check_asm = []
 capi = []
 tracing = ["rust_hawktracer"]
-serialize = ["serde", "toml", "v_frame/serialize"]
+serialize = ["serde", "toml", "v_frame/serialize", "arrayvec/serde"]
 
 # Enables debug dumping of lookahead computation results, specifically:
 # - i-qres.png: quarter-resolution luma planes,
@@ -73,7 +73,7 @@ v_frame = { version = "0.1", path = "v_frame/" }
 av-metrics = { version = "0.5", optional = true }
 rayon = "1.0"
 toml = { version = "0.5", optional = true }
-arrayvec = { version = "0.5", features = ["serde", "array-sizes-33-128"] }
+arrayvec = { version = "0.5", features = ["array-sizes-33-128"] }
 thiserror = "1.0"
 byteorder = { version = "1.3.2", optional = true }
 log = "0.4"


### PR DESCRIPTION
Due to how cargo parallelises building dependencies,
this has no effect on compile wall time with 4+ threads,
but does reduce compile CPU time by 3-5%.