### PR TITLE
Reduce compile time for hbd satd intrinsics

### DIFF
--- a/src/asm/x86/dist/hbd.rs
+++ b/src/asm/x86/dist/hbd.rs
@@ -14,70 +14,18 @@ macro_rules! satd_hbd_avx2 {
           // Because these are constants via the macro system,
           // the branches here will be optimized out.
           let size: usize = $W.min($H).min(8);
-          let sizei = size as isize;
 
           let mut sum = 0u64;
 
           // Loop over chunks the size of the chosen transform
           for chunk_y in (0isize..$H).step_by(size) {
             for chunk_x in (0isize..$W).step_by(size) {
-              let buf = &mut Aligned::<[i32; 8 * 8]>::uninitialized().data[..size * size];
-              let input1 = &mut Aligned::<[i32; 8 * 8]>::uninitialized().data[..size * size];
-              let input2 = &mut Aligned::<[i32; 8 * 8]>::uninitialized().data[..size * size];
-              for y in 0..(sizei) {
-                let y1 = chunk_y + y;
-                for x in 0..(sizei) {
-                  let x1 = chunk_x + x;
-                  input1.as_mut_ptr().offset(y * sizei + x).write(src.offset(y1 * src_stride + x1).read() as i32);
-                  input2.as_mut_ptr().offset(y * sizei + x).write(dst.offset(y1 * dst_stride + x1).read() as i32);
-                }
-              }
-
-              // Move the difference of the transforms to a buffer
-              for y in 0..(sizei) {
-                if size == 4 {
-                  let row_src = _mm_load_si128(input1.as_ptr().offset(y * sizei) as *const __m128i);
-                  let row_dst = _mm_load_si128(input2.as_ptr().offset(y * sizei) as *const __m128i);
-                  let diff = _mm_sub_epi32(row_src, row_dst);
-                  _mm_store_si128(buf.as_mut_ptr().offset(y * sizei) as *mut __m128i, diff);
-                } else {
-                  let row_src = _mm256_load_si256(input1.as_ptr().offset(y * sizei) as *const __m256i);
-                  let row_dst = _mm256_load_si256(input2.as_ptr().offset(y * sizei) as *const __m256i);
-                  let diff = _mm256_sub_epi32(row_src, row_dst);
-                  _mm256_store_si256(buf.as_mut_ptr().offset(y * sizei) as *mut __m256i, diff);
-                }
-              }
-
-              // Perform the hadamard transform on the differences,
-              // Then sum the absolute values of the transformed differences
-              if size == 4 {
-                hadamard4x4(buf.as_mut_ptr());
-                let row1 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(0) as *const __m256i));
-                let row2 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(8) as *const __m256i));
-                let sum_t = _mm256_add_epi32(row1, row2);
-                let mut abs = Aligned::<[u32; 8]>::uninitialized();
-                _mm256_store_si256(abs.data.as_mut_ptr() as *mut __m256i, sum_t);
-                sum += abs.data.iter().copied().map(|a| a as u64).sum::<u64>();
+              let src = src.offset(chunk_y * src_stride + chunk_x);
+              let dst = dst.offset(chunk_y * dst_stride + chunk_x);
+              if (size == 4) {
+                sum += satd_kernel_4x4_hbd_avx2(src, src_stride, dst, dst_stride);
               } else {
-                hadamard8x8(buf.as_mut_ptr());
-                let row1 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(0) as *const __m256i));
-                let row2 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(8) as *const __m256i));
-                let row3 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(16) as *const __m256i));
-                let row4 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(24) as *const __m256i));
-                let row5 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(32) as *const __m256i));
-                let row6 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(40) as *const __m256i));
-                let row7 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(48) as *const __m256i));
-                let row8 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(56) as *const __m256i));
-                let sum1 = _mm256_add_epi32(row1, row2);
-                let sum2 = _mm256_add_epi32(row3, row4);
-                let sum3 = _mm256_add_epi32(row5, row6);
-                let sum4 = _mm256_add_epi32(row7, row8);
-                let sum5 = _mm256_add_epi32(sum1, sum2);
-                let sum6 = _mm256_add_epi32(sum3, sum4);
-                let sum_t = _mm256_add_epi32(sum5, sum6);
-                let mut abs_sums = Aligned::<[u32; 8]>::uninitialized();
-                _mm256_store_si256(abs_sums.data.as_mut_ptr() as *mut __m256i, sum_t);
-                sum += abs_sums.data.iter().copied().map(|a| a as u64).sum::<u64>();
+                sum += satd_kernel_8x8_hbd_avx2(src, src_stride, dst, dst_stride);
               }
             }
           }
@@ -90,6 +38,84 @@ macro_rules! satd_hbd_avx2 {
     )*
   }
 }
+
+macro_rules! satd_kernel_hbd_avx2 {
+  ($(($W:expr, $H:expr)),*) => {
+    $(
+      paste::item! {
+        #[target_feature(enable = "avx2")]
+        unsafe extern fn [<satd_kernel_ $W x $H _hbd_avx2>](
+          src: *const u16, src_stride: isize, dst: *const u16, dst_stride: isize,
+        ) -> u64 {
+          // Size of hadamard kernel should be 4x4 or 8x8.
+          // Because these are constants via the macro system,
+          // the branches here will be optimized out.
+          let size: usize = $W.min($H).min(8);
+          let sizei = size as isize;
+
+          let buf = &mut Aligned::<[i32; 8 * 8]>::uninitialized().data[..size * size];
+          let input1 = &mut Aligned::<[i32; 8 * 8]>::uninitialized().data[..size * size];
+          let input2 = &mut Aligned::<[i32; 8 * 8]>::uninitialized().data[..size * size];
+          for y in 0..(sizei) {
+            for x in 0..(sizei) {
+              input1.as_mut_ptr().offset(y * sizei + x).write(src.offset(y * src_stride + x).read() as i32);
+              input2.as_mut_ptr().offset(y * sizei + x).write(dst.offset(y * dst_stride + x).read() as i32);
+            }
+          }
+
+          // Move the difference of the transforms to a buffer
+          for y in 0..(sizei) {
+            if size == 4 {
+              let row_src = _mm_load_si128(input1.as_ptr().offset(y * sizei) as *const __m128i);
+              let row_dst = _mm_load_si128(input2.as_ptr().offset(y * sizei) as *const __m128i);
+              let diff = _mm_sub_epi32(row_src, row_dst);
+              _mm_store_si128(buf.as_mut_ptr().offset(y * sizei) as *mut __m128i, diff);
+            } else {
+              let row_src = _mm256_load_si256(input1.as_ptr().offset(y * sizei) as *const __m256i);
+              let row_dst = _mm256_load_si256(input2.as_ptr().offset(y * sizei) as *const __m256i);
+              let diff = _mm256_sub_epi32(row_src, row_dst);
+              _mm256_store_si256(buf.as_mut_ptr().offset(y * sizei) as *mut __m256i, diff);
+            }
+          }
+
+          // Perform the hadamard transform on the differences,
+          // Then sum the absolute values of the transformed differences
+          if size == 4 {
+            hadamard4x4(buf.as_mut_ptr());
+            let row1 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(0) as *const __m256i));
+            let row2 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(8) as *const __m256i));
+            let sum_t = _mm256_add_epi32(row1, row2);
+            let mut abs = Aligned::<[u32; 8]>::uninitialized();
+            _mm256_store_si256(abs.data.as_mut_ptr() as *mut __m256i, sum_t);
+            abs.data.iter().copied().map(|a| a as u64).sum::<u64>()
+          } else {
+            hadamard8x8(buf.as_mut_ptr());
+            let row1 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(0) as *const __m256i));
+            let row2 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(8) as *const __m256i));
+            let row3 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(16) as *const __m256i));
+            let row4 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(24) as *const __m256i));
+            let row5 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(32) as *const __m256i));
+            let row6 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(40) as *const __m256i));
+            let row7 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(48) as *const __m256i));
+            let row8 = _mm256_abs_epi32(_mm256_load_si256(buf.as_ptr().add(56) as *const __m256i));
+            let sum1 = _mm256_add_epi32(row1, row2);
+            let sum2 = _mm256_add_epi32(row3, row4);
+            let sum3 = _mm256_add_epi32(row5, row6);
+            let sum4 = _mm256_add_epi32(row7, row8);
+            let sum5 = _mm256_add_epi32(sum1, sum2);
+            let sum6 = _mm256_add_epi32(sum3, sum4);
+            let sum_t = _mm256_add_epi32(sum5, sum6);
+            let mut abs_sums = Aligned::<[u32; 8]>::uninitialized();
+            _mm256_store_si256(abs_sums.data.as_mut_ptr() as *mut __m256i, sum_t);
+            abs_sums.data.iter().copied().map(|a| a as u64).sum::<u64>()
+          }
+        }
+      }
+    )*
+  }
+}
+
+satd_kernel_hbd_avx2!((4, 4), (8, 8));
 
 satd_hbd_avx2!(
   (4, 4),


### PR DESCRIPTION
5m 00 to 4m 47 on awcy. 30188832 to 29804944 bytes for release build.