### PR TITLE
Prepare for release

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: -- -D warnings --verbose -A clippy::wrong-self-convention
+        args: -- -D warnings --verbose -A clippy::wrong-self-convention -A clippy::many_single_char_names
 
   build-unix:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "rav1e"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aom-sys",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "64cf76cb6e2222ed0ea86b2b0ee2f71c96ec6edd5af42e84d59160e91b836ec4"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
+checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
 name = "arg_enum_proc_macro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rav1e"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
 edition = "2018"
 build = "build.rs"

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -1354,7 +1354,7 @@ impl RestorationState {
     // large enough that a tile is not an integer number of LRUs
     // wide/high.
     if fi.tiling.cols > 1 || fi.tiling.rows > 1 {
-      // despite suggestions to the contrary, apparently tiles can be
+      // despite suggestions to the contrary, tiles can be
       // non-powers-of-2.
       let trailing_h_zeros = fi.tiling.tile_width_sb.trailing_zeros() as usize;
       let trailing_v_zeros =
@@ -1367,19 +1367,34 @@ impl RestorationState {
       uv_unit_size = uv_unit_size
         .min(tile_aligned_uv_h_unit_size.min(tile_aligned_uv_v_unit_size));
 
-      // But it's actually worse: LRUs can't span tiles (in our design
-      // that is, spec allows it).  However, the spec mandates the last
-      // LRU stretches forward into any less-than-half-LRU span of
-      // superblocks at the right and bottom of a frame.  These
-      // superblocks may well be in a different tile!  Even if LRUs are
-      // minimum size (one superblock), when the right or bottom edge of
-      // the frame is a superblock that's less than half the
-      // width/height of a normal superblock, the LRU is forced by the
-      // spec to span into it (and thus a different tile).  Tiling is
-      // under no such restriction; it could decide the right/left
-      // sliver will be in its own tile row/column.  We can't disallow
-      // the combination here.  The tiling code will have to either
-      // prevent it or tolerate it.  (prayer mechanic == Issue #1629).
+      // But it's actually worse: LRUs can't span tiles (in our
+      // one-pass design that is, spec allows it).  However, the spec
+      // mandates the last LRU stretches forward into any
+      // less-than-half-LRU span of superblocks at the right and
+      // bottom of a frame.  These superblocks may well be in a
+      // different tile!  Even if LRUs are minimum size (one
+      // superblock), when the right or bottom edge of the frame is a
+      // superblock that's less than half the width/height of a normal
+      // superblock, the LRU is forced by the spec to span into it
+      // (and thus a different tile).  Tiling is under no such
+      // restriction; it could decide the right/left sliver will be in
+      // its own tile row/column.  We can't disallow the combination
+      // here.  The tiling code will have to either prevent it or
+      // tolerate it.  (prayer mechanic == Issue #1629).
+    }
+
+    // When coding 4:2:2 and 4:4:4, spec requires Y and UV LRU sizes
+    // to be the same*. If they differ at this
+    // point, it's due to a tiling restriction enforcing a maximum
+    // size, so force both to the smaller value.
+    //
+    // *see sec 5.9.20, "Loop restoration params syntax".  The
+    // bitstream provides means of coding a different UV LRU size only
+    // when chroma is in use and both x and y are subsampled in the
+    // chroma planes.
+    if ydec == 0 && y_unit_size != uv_unit_size {
+      y_unit_size = uv_unit_size.min(y_unit_size);
+      uv_unit_size = y_unit_size;
     }
 
     // derive the rest


### PR DESCRIPTION
Release 0.3.2 started pinning the dependencies using Cargo.lock.
Release 0.3.3 pins a newer regex version to support older (1.38.0) compiler
versions.