### PR TITLE
Implement AVX-512 assembly from dav1d 0.6

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -79,7 +79,7 @@ fn build_nasm_files() {
   config_file.write(b" %define ARCH_X86_64 1\n").unwrap();
   config_file.write(b"	%define PIC 1\n").unwrap();
   config_file.write(b" %define STACK_ALIGNMENT 16\n").unwrap();
-  config_file.write(b" %define HAVE_AVX512ICL 0\n").unwrap();
+  config_file.write(b" %define HAVE_AVX512ICL 1\n").unwrap();
   if env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
     config_file.write(b" %define PREFIX 1\n").unwrap();
   }

--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -339,6 +339,11 @@ macro_rules! decl_mct_fns {
             tmp: *mut i16, src: *const u8, src_stride: libc::ptrdiff_t, w: i32,
             h: i32, mx: i32, my: i32
           );
+
+          fn [<$func_name _avx512icl>](
+            tmp: *mut i16, src: *const u8, src_stride: libc::ptrdiff_t, w: i32,
+            h: i32, mx: i32, my: i32
+          );
         )*
       }
 
@@ -354,6 +359,14 @@ macro_rules! decl_mct_fns {
         let mut out: [Option<PrepFn>; 16] = [None; 16];
         $(
             out[get_2d_mode_idx($mode_x, $mode_y)] = Some([<$func_name _avx2>]);
+        )*
+        out
+      };
+
+      static PREP_FNS_AVX512ICL: [Option<PrepFn>; 16] = {
+        let mut out: [Option<PrepFn>; 16] = [None; 16];
+        $(
+            out[get_2d_mode_idx($mode_x, $mode_y)] = Some([<$func_name _avx512icl>]);
         )*
         out
       };
@@ -377,7 +390,7 @@ decl_mct_fns!(
 cpu_function_lookup_table!(
   PREP_FNS: [[Option<PrepFn>; 16]],
   default: [None; 16],
-  [SSSE3, AVX2]
+  [SSSE3, AVX2, AVX512ICL]
 );
 
 cpu_function_lookup_table!(
@@ -578,6 +591,22 @@ mod test {
     (BILINEAR, BILINEAR, rav1e_prep_bilin),
     avx2,
     "avx2",
+    8
+  );
+
+  test_prep_fns!(
+    (REGULAR, REGULAR, rav1e_prep_8tap_regular),
+    (REGULAR, SMOOTH, rav1e_prep_8tap_regular_smooth),
+    (REGULAR, SHARP, rav1e_prep_8tap_regular_sharp),
+    (SMOOTH, REGULAR, rav1e_prep_8tap_smooth_regular),
+    (SMOOTH, SMOOTH, rav1e_prep_8tap_smooth),
+    (SMOOTH, SHARP, rav1e_prep_8tap_smooth_sharp),
+    (SHARP, REGULAR, rav1e_prep_8tap_sharp_regular),
+    (SHARP, SMOOTH, rav1e_prep_8tap_sharp_smooth),
+    (SHARP, SHARP, rav1e_prep_8tap_sharp),
+    (BILINEAR, BILINEAR, rav1e_prep_bilin),
+    avx512icl,
+    "avx512vpclmulqdq",
     8
   );
 

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -20,6 +20,7 @@ pub enum CpuFeatureLevel {
   SSE4_1,
   AVX2,
   AVX512,
+  #[arg_enum(alias = "avx512vpclmulqdq")]
   AVX512ICL,
 }
 
@@ -44,15 +45,17 @@ impl Default for CpuFeatureLevel {
         && is_x86_feature_detected!("avx512vl")
     }
     fn avx512icl_detected() -> bool {
-      false
-      // avx512_detected()
-      // && is_x86_feature_detected!("avx512bitalg")
-      // && is_x86_feature_detected!("avx512clmulqdq")
-      // && is_x86_feature_detected!("avx512ifma")
-      // && is_x86_feature_detected!("avx512vaes")
-      // && is_x86_feature_detected!("avx512vbmi")
-      // && is_x86_feature_detected!("avx512vbmi2")
-      // && is_x86_feature_detected!("avx512vpopcntdq")
+      // Per dav1d, these are the flags needed.
+      avx512_detected()
+        && is_x86_feature_detected!("avx512vnni")
+        && is_x86_feature_detected!("avx512ifma")
+        && is_x86_feature_detected!("avx512vbmi")
+        && is_x86_feature_detected!("avx512vbmi2")
+        && is_x86_feature_detected!("avx512vpopcntdq")
+        && is_x86_feature_detected!("avx512bitalg")
+        && is_x86_feature_detected!("avx512gfni")
+        && is_x86_feature_detected!("avx512vaes")
+        && is_x86_feature_detected!("avx512vpclmulqdq")
     }
 
     let detected: CpuFeatureLevel = if avx512icl_detected() {

--- a/src/util/align.rs
+++ b/src/util/align.rs
@@ -12,10 +12,10 @@ use std::mem::MaybeUninit;
 use std::ptr;
 use std::{fmt, mem};
 
-#[repr(align(32))]
-pub struct Align32;
+#[repr(align(64))]
+pub struct Align64;
 
-// A 32 byte aligned piece of data.
+// A 64 byte aligned piece of data.
 // # Examples
 // ```
 // let mut x: Aligned<[i16; 64 * 64]> = Aligned::new([0; 64 * 64]);
@@ -25,7 +25,7 @@ pub struct Align32;
 // assert!(x.data.as_ptr() as usize % 16 == 0);
 // ```
 pub struct Aligned<T> {
-  _alignment: [Align32; 0],
+  _alignment: [Align64; 0],
   pub data: T,
 }
 


### PR DESCRIPTION
Closes #2195. The NEON assembly will be handled in #2376.