### PR TITLE
Integrate aarch64 assembly: src/arm/64/mc16.S

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,10 @@ jobs:
       arch: arm64
       script:
         - cargo test --features=decode_test,decode_test_dav1d,quick_test,capi --verbose
+    - name: "Ignored Tests (dav1d)"
+      rust: stable
+      arch: arm64
+      script:
+        - travis_wait 60 cargo test --release --features=decode_test_dav1d --verbose --color=always -- --color=always --ignored
+      env:
+        - CACHE_NAME=IGNORED_TESTS_DAV1D

--- a/build.rs
+++ b/build.rs
@@ -136,6 +136,7 @@ fn build_asm_files() {
 
   let asm_files = &[
     "src/arm/64/mc.S",
+    "src/arm/64/mc16.S",
     "src/arm/64/itx.S",
     "src/arm/64/ipred.S",
     "src/arm/64/sad.S",

--- a/src/asm/aarch64/mc.rs
+++ b/src/asm/aarch64/mc.rs
@@ -26,15 +26,15 @@ type PutFn = unsafe extern fn(
 );
 
 type PutHBDFn = unsafe extern fn(
-  dst: *mut u8,
+  dst: *mut u16,
   dst_stride: isize,
-  src: *const u8,
+  src: *const u16,
   src_stride: isize,
   width: i32,
   height: i32,
   col_frac: i32,
   row_frac: i32,
-  bit_depth: i32,
+  bitdepth_max: i32,
 );
 
 type PrepFn = unsafe extern fn(
@@ -55,7 +55,7 @@ type PrepHBDFn = unsafe extern fn(
   height: i32,
   col_frac: i32,
   row_frac: i32,
-  bit_depth: i32,
+  bitdepth_max: i32,
 );
 
 type AvgFn = unsafe extern fn(
@@ -74,7 +74,7 @@ type AvgHBDFn = unsafe extern fn(
   tmp2: *const i16,
   width: i32,
   height: i32,
-  bit_depth: i32,
+  bitdepth_max: i32,
 );
 
 // gets an index that can be mapped to a function for a pair of filter modes
@@ -129,7 +129,7 @@ pub fn put_8tap<T: Pixel>(
             height as i32,
             col_frac,
             row_frac,
-            bit_depth as i32,
+            (1 << bit_depth) - 1,
           );
         },
         None => call_rust(dst),
@@ -194,7 +194,7 @@ pub fn prep_8tap<T: Pixel>(
             height as i32,
             col_frac,
             row_frac,
-            bit_depth as i32,
+            (1 << bit_depth) - 1,
           );
         },
         None => call_rust(tmp),
@@ -243,7 +243,7 @@ pub fn mc_avg<T: Pixel>(
           tmp2.as_ptr(),
           width as i32,
           height as i32,
-          bit_depth as i32,
+          (1 << bit_depth) - 1,
         );
       },
       None => call_rust(dst),
@@ -267,7 +267,7 @@ macro_rules! decl_mc_fns {
       $(
         fn $func_name(
           dst: *mut u8, dst_stride: isize, src: *const u8, src_stride: isize,
-          w: i32, h: i32, mx: i32, my: i32
+          w: i32, h: i32, mx: i32, my: i32,
         );
       )*
     }
@@ -313,7 +313,7 @@ macro_rules! decl_mct_fns {
       $(
         fn $func_name(
           tmp: *mut i16, src: *const u8, src_stride: libc::ptrdiff_t, w: i32,
-          h: i32, mx: i32, my: i32
+          h: i32, mx: i32, my: i32,
         );
       )*
     }

--- a/src/asm/aarch64/mc.rs
+++ b/src/asm/aarch64/mc.rs
@@ -301,10 +301,44 @@ cpu_function_lookup_table!(
   [NEON]
 );
 
+macro_rules! decl_mc_hbd_fns {
+  ($(($mode_x:expr, $mode_y:expr, $func_name:ident)),+) => {
+    extern {
+      $(
+        fn $func_name(
+          dst: *mut u16, dst_stride: isize, src: *const u16, src_stride: isize,
+          w: i32, h: i32, mx: i32, my: i32, bitdepth_max: i32,
+        );
+      )*
+    }
+
+    static PUT_HBD_FNS_NEON: [Option<PutHBDFn>; 16] = {
+      let mut out: [Option<PutHBDFn>; 16] = [None; 16];
+      $(
+        out[get_2d_mode_idx($mode_x, $mode_y)] = Some($func_name);
+      )*
+      out
+    };
+  }
+}
+
+decl_mc_hbd_fns!(
+  (REGULAR, REGULAR, rav1e_put_8tap_regular_16bpc_neon),
+  (REGULAR, SMOOTH, rav1e_put_8tap_regular_smooth_16bpc_neon),
+  (REGULAR, SHARP, rav1e_put_8tap_regular_sharp_16bpc_neon),
+  (SMOOTH, REGULAR, rav1e_put_8tap_smooth_regular_16bpc_neon),
+  (SMOOTH, SMOOTH, rav1e_put_8tap_smooth_16bpc_neon),
+  (SMOOTH, SHARP, rav1e_put_8tap_smooth_sharp_16bpc_neon),
+  (SHARP, REGULAR, rav1e_put_8tap_sharp_regular_16bpc_neon),
+  (SHARP, SMOOTH, rav1e_put_8tap_sharp_smooth_16bpc_neon),
+  (SHARP, SHARP, rav1e_put_8tap_sharp_16bpc_neon),
+  (BILINEAR, BILINEAR, rav1e_put_bilin_16bpc_neon)
+);
+
 cpu_function_lookup_table!(
   PUT_HBD_FNS: [[Option<PutHBDFn>; 16]],
   default: [None; 16],
-  []
+  [NEON]
 );
 
 macro_rules! decl_mct_fns {
@@ -347,10 +381,44 @@ cpu_function_lookup_table!(
   [NEON]
 );
 
+macro_rules! decl_mct_hbd_fns {
+  ($(($mode_x:expr, $mode_y:expr, $func_name:ident)),+) => {
+    extern {
+      $(
+        fn $func_name(
+          tmp: *mut i16, src: *const u16, src_stride: libc::ptrdiff_t, w: i32,
+          h: i32, mx: i32, my: i32, bitdepth_max: i32,
+        );
+      )*
+    }
+
+    static PREP_HBD_FNS_NEON: [Option<PrepHBDFn>; 16] = {
+      let mut out: [Option<PrepHBDFn>; 16] = [None; 16];
+      $(
+        out[get_2d_mode_idx($mode_x, $mode_y)] = Some($func_name);
+      )*
+      out
+    };
+  }
+}
+
+decl_mct_hbd_fns!(
+  (REGULAR, REGULAR, rav1e_prep_8tap_regular_16bpc_neon),
+  (REGULAR, SMOOTH, rav1e_prep_8tap_regular_smooth_16bpc_neon),
+  (REGULAR, SHARP, rav1e_prep_8tap_regular_sharp_16bpc_neon),
+  (SMOOTH, REGULAR, rav1e_prep_8tap_smooth_regular_16bpc_neon),
+  (SMOOTH, SMOOTH, rav1e_prep_8tap_smooth_16bpc_neon),
+  (SMOOTH, SHARP, rav1e_prep_8tap_smooth_sharp_16bpc_neon),
+  (SHARP, REGULAR, rav1e_prep_8tap_sharp_regular_16bpc_neon),
+  (SHARP, SMOOTH, rav1e_prep_8tap_sharp_smooth_16bpc_neon),
+  (SHARP, SHARP, rav1e_prep_8tap_sharp_16bpc_neon),
+  (BILINEAR, BILINEAR, rav1e_prep_bilin_16bpc_neon)
+);
+
 cpu_function_lookup_table!(
   PREP_HBD_FNS: [[Option<PrepHBDFn>; 16]],
   default: [None; 16],
-  []
+  [NEON]
 );
 
 extern {
@@ -366,4 +434,15 @@ cpu_function_lookup_table!(
   [(NEON, Some(rav1e_avg_8bpc_neon))]
 );
 
-cpu_function_lookup_table!(AVG_HBD_FNS: [Option<AvgHBDFn>], default: None, []);
+extern {
+  fn rav1e_avg_16bpc_neon(
+    dst: *mut u16, dst_stride: libc::ptrdiff_t, tmp1: *const i16,
+    tmp2: *const i16, w: i32, h: i32, bitdepth_max: i32,
+  );
+}
+
+cpu_function_lookup_table!(
+  AVG_HBD_FNS: [Option<AvgHBDFn>],
+  default: None,
+  [(NEON, Some(rav1e_avg_16bpc_neon))]
+);

--- a/src/asm/x86/cdef.rs
+++ b/src/asm/x86/cdef.rs
@@ -25,7 +25,7 @@ type CdefFilterFn = unsafe extern fn(
 );
 
 type CdefFilterHBDFn = unsafe extern fn(
-  dst: *mut u8,
+  dst: *mut u16,
   dst_stride: isize,
   tmp: *const u16,
   tmp_stride: isize,
@@ -33,7 +33,7 @@ type CdefFilterHBDFn = unsafe extern fn(
   sec_strength: i32,
   dir: i32,
   damping: i32,
-  bit_depth: i32,
+  bitdepth_max: i32,
 );
 
 #[inline(always)]
@@ -97,7 +97,7 @@ pub(crate) unsafe fn cdef_filter_block<T: Pixel>(
             sec_strength,
             dir as i32,
             damping,
-            bit_depth as i32,
+            (1 << bit_depth) - 1,
           );
         }
         None => call_rust(dst),

--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -26,15 +26,15 @@ type PutFn = unsafe extern fn(
 );
 
 type PutHBDFn = unsafe extern fn(
-  dst: *mut u8,
+  dst: *mut u16,
   dst_stride: isize,
-  src: *const u8,
+  src: *const u16,
   src_stride: isize,
   width: i32,
   height: i32,
   col_frac: i32,
   row_frac: i32,
-  bit_depth: i32,
+  bitdepth_max: i32,
 );
 
 type PrepFn = unsafe extern fn(
@@ -55,7 +55,7 @@ type PrepHBDFn = unsafe extern fn(
   height: i32,
   col_frac: i32,
   row_frac: i32,
-  bit_depth: i32,
+  bitdepth_max: i32,
 );
 
 type AvgFn = unsafe extern fn(
@@ -74,7 +74,7 @@ type AvgHBDFn = unsafe extern fn(
   tmp2: *const i16,
   width: i32,
   height: i32,
-  bit_depth: i32,
+  bitdepth_max: i32,
 );
 
 // gets an index that can be mapped to a function for a pair of filter modes
@@ -129,7 +129,7 @@ pub fn put_8tap<T: Pixel>(
             height as i32,
             col_frac,
             row_frac,
-            bit_depth as i32,
+            (1 << bit_depth) - 1,
           );
         },
         None => call_rust(dst),
@@ -194,7 +194,7 @@ pub fn prep_8tap<T: Pixel>(
             height as i32,
             col_frac,
             row_frac,
-            bit_depth as i32,
+            (1 << bit_depth) - 1,
           );
         },
         None => call_rust(tmp),
@@ -243,7 +243,7 @@ pub fn mc_avg<T: Pixel>(
           tmp2.as_ptr(),
           width as i32,
           height as i32,
-          bit_depth as i32,
+          (1 << bit_depth) - 1,
         );
       },
       None => call_rust(dst),


### PR DESCRIPTION
Integrated:
* `rav1e_avg_16bpc_neon`
* `rav1e_prep_8tap_regular_16bpc_neon`
* `rav1e_prep_8tap_regular_sharp_16bpc_neon`
* `rav1e_prep_8tap_regular_smooth_16bpc_neon`
* `rav1e_prep_8tap_sharp_16bpc_neon`
* `rav1e_prep_8tap_sharp_regular_16bpc_neon`
* `rav1e_prep_8tap_sharp_smooth_16bpc_neon`
* `rav1e_prep_8tap_smooth_16bpc_neon`
* `rav1e_prep_8tap_smooth_regular_16bpc_neon`
* `rav1e_prep_8tap_smooth_sharp_16bpc_neon`
* `rav1e_prep_bilin_16bpc_neon`
* `rav1e_put_8tap_regular_16bpc_neon`
* `rav1e_put_8tap_regular_sharp_16bpc_neon`
* `rav1e_put_8tap_regular_smooth_16bpc_neon`
* `rav1e_put_8tap_sharp_16bpc_neon`
* `rav1e_put_8tap_sharp_regular_16bpc_neon`
* `rav1e_put_8tap_sharp_smooth_16bpc_neon`
* `rav1e_put_8tap_smooth_16bpc_neon`
* `rav1e_put_8tap_smooth_regular_16bpc_neon`
* `rav1e_put_8tap_smooth_sharp_16bpc_neon`
* `rav1e_put_bilin_16bpc_neon`

Future work:
* `rav1e_blend_16bpc_neon`
* `rav1e_blend_h_16bpc_neon`
* `rav1e_blend_v_16bpc_neon`
* `rav1e_emu_edge_16bpc_neon`
* `rav1e_mask_16bpc_neon`
* `rav1e_warp_affine_8x8_16bpc_neon`
* `rav1e_warp_affine_8x8t_16bpc_neon`
* `rav1e_w_avg_16bpc_neon`
* `rav1e_w_mask_420_16bpc_neon`
* `rav1e_w_mask_422_16bpc_neon`
* `rav1e_w_mask_444_16bpc_neon`

Advances #2376.