### PR TITLE
Enable open partition on frame boundary

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -171,7 +171,7 @@ fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
   let mut fs = FrameState::new(&fi);
   let mut ts = fs.as_tile_state_mut();
   let offset = TileBlockOffset(BlockOffset { x: 1, y: 1 });
-  b.iter(|| rdo_cfl_alpha(&mut ts, offset, bsize, &fi))
+  b.iter(|| rdo_cfl_alpha(&mut ts, offset, bsize, bsize.tx_size(), &fi))
 }
 
 fn ec_bench(c: &mut Criterion) {

--- a/src/context/transform_unit.rs
+++ b/src/context/transform_unit.rs
@@ -717,6 +717,9 @@ impl<'a> ContextWriter<'a> {
     &mut self, w: &mut dyn Writer, bo: TileBlockOffset, bsize: BlockSize,
     tx_size: TxSize, txfm_split: bool, tbx: usize, tby: usize, depth: usize,
   ) {
+    if bo.0.x >= self.bc.blocks.cols() || bo.0.y >= self.bc.blocks.rows() {
+      return;
+    }
     debug_assert!(self.bc.blocks[bo].is_inter());
     debug_assert!(bsize > BlockSize::BLOCK_4X4);
     debug_assert!(!tx_size.is_rect() || bsize.is_rect_tx_allowed());

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2879,6 +2879,7 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
     }
     PARTITION_SPLIT | PARTITION_HORZ | PARTITION_VERT => {
       if !rdo_output.part_modes.is_empty() {
+        debug_assert!(can_split && !must_split);
         // The optimal prediction modes for each split block is known from an rdo_partition_decision() call
         assert!(subsize != BlockSize::BLOCK_INVALID);
 

--- a/src/me.rs
+++ b/src/me.rs
@@ -75,11 +75,11 @@ const fn get_mv_range(
   let border_w = 128 + blk_w as isize * 8;
   let border_h = 128 + blk_h as isize * 8;
   let mvx_min = -(bo.0.x as isize) * (8 * MI_SIZE) as isize - border_w;
-  let mvx_max = (w_in_b - bo.0.x - blk_w / MI_SIZE) as isize
+  let mvx_max = ((w_in_b - bo.0.x) as isize - (blk_w / MI_SIZE) as isize)
     * (8 * MI_SIZE) as isize
     + border_w;
   let mvy_min = -(bo.0.y as isize) * (8 * MI_SIZE) as isize - border_h;
-  let mvy_max = (h_in_b - bo.0.y - blk_h / MI_SIZE) as isize
+  let mvy_max = ((h_in_b - bo.0.y) as isize - (blk_h / MI_SIZE) as isize)
     * (8 * MI_SIZE) as isize
     + border_h;
 

--- a/src/me.rs
+++ b/src/me.rs
@@ -143,14 +143,14 @@ pub fn get_subset_predictors<T: Pixel>(
     );
   }
   // right
-  if tile_bo.0.x < tile_mvs.cols() - w {
+  if tile_mvs.cols() > w && tile_bo.0.x < tile_mvs.cols() - w {
     add_cand(
       &mut predictors,
       tile_mvs[tile_bo.0.y + clipped_half_h][tile_bo.0.x + w],
     );
   }
   // bottom
-  if tile_bo.0.y < tile_mvs.rows() - h {
+  if tile_mvs.rows() > h && tile_bo.0.y < tile_mvs.rows() - h {
     add_cand(
       &mut predictors,
       tile_mvs[tile_bo.0.y + h][tile_bo.0.x + clipped_half_w],
@@ -182,12 +182,12 @@ pub fn get_subset_predictors<T: Pixel>(
         prev_frame_mvs[frame_bo.0.y - 1][frame_bo.0.x + clipped_half_w];
       add_cand(&mut predictors, top);
     }
-    if frame_bo.0.x < prev_frame_mvs.cols - w {
+    if prev_frame_mvs.cols > w && frame_bo.0.x < prev_frame_mvs.cols - w {
       let right =
         prev_frame_mvs[frame_bo.0.y + clipped_half_h][frame_bo.0.x + w];
       add_cand(&mut predictors, right);
     }
-    if frame_bo.0.y < prev_frame_mvs.rows - h {
+    if prev_frame_mvs.rows > h && frame_bo.0.y < prev_frame_mvs.rows - h {
       let bottom =
         prev_frame_mvs[frame_bo.0.y + h][frame_bo.0.x + clipped_half_w];
       add_cand(&mut predictors, bottom);

--- a/src/tiling/tile_blocks.rs
+++ b/src/tiling/tile_blocks.rs
@@ -206,9 +206,16 @@ impl TileBlocksMut<'_> {
   where
     F: Fn(&mut Block),
   {
-    let bw = bsize.width_mi();
+    let mut bw = bsize.width_mi();
     let bh = bsize.height_mi();
+
+    if bo.0.x + bw >= self.cols {
+      bw = self.cols - bo.0.x;
+    }
     for y in 0..bh {
+      if bo.0.y + y >= self.rows {
+        continue;
+      }
       for block in self[bo.0.y + y][bo.0.x..bo.0.x + bw].iter_mut() {
         f(block);
       }


### PR DESCRIPTION
Issue #2166

- AV1 spec allows to use a partition that straddle on frame boundary if
  certain condition met, i.e, 'Not Split' is allowed if more than half of
  the partition size is available (based on coded frame size, i.e. multipe
  of 8 pixels) in either horizontal or vertical.

- For top-down partition search (i.e current speed levels 2~10),
  use bottomup on frame boundary

- Functon for computing visible area of a partition or a tx block based
  on actual frame size (not a coded size) is added and in general it should
  be only used for a compute distortion. Hence, do not use it for adjusting the block size.
  One good critical example would be that a coefficient block size, when it is encoded, is not affected by visibility.

- CFL specially requires to read outside the coded frame, when it compute average
  and obtain ac components for luma block, i.e. luma_ac().