### PR TITLE
Jsapi v0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ check_asm = []
 capi = []
 tracing = ["rust_hawktracer"]
 serialize = ["serde", "toml", "v_frame/serialize", "arrayvec/serde"]
+wasm = ["wasm-bindgen"]
 
 # Enables debug dumping of lookahead computation results, specifically:
 # - i-qres.png: quarter-resolution luma planes,
@@ -63,7 +64,7 @@ backtrace = { version = "0.3", optional = true }
 num-traits = "0.2"
 num-derive = "0.3"
 paste = "0.1"
-noop_proc_macro = "0.2.0"
+noop_proc_macro = "0.3.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 dav1d-sys = { version = "0.3.1", optional = true }
 aom-sys = { version = "0.1.4", optional = true }
@@ -81,6 +82,7 @@ console = { version = "0.11", optional = true }
 fern = { version = "0.6", optional = true }
 itertools = "0.9"
 simd_helpers = "0.1"
+wasm-bindgen = { version = "0.2.63", optional = true }
 
 [dependencies.image]
 version = "0.23"

--- a/rav1e_js/Cargo.toml
+++ b/rav1e_js/Cargo.toml
@@ -14,7 +14,8 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-rav1e = { path = ".." }
+rav1e = { path = "..", features = ["wasm"] }
+v_frame = { path = "../v_frame/", features = ["wasm"]}
 wasm-bindgen = "0.2.63"
 web-sys = {version = "0.3", features = ["console"]}
 

--- a/rav1e_js/LICENSE
+++ b/rav1e_js/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2017-2020, the rav1e contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/rav1e_js/src/encoder.rs
+++ b/rav1e_js/src/encoder.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2020, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+#![allow(non_snake_case)]
+
+use rav1e::prelude::{Config, Context, EncoderStatus};
+
+use wasm_bindgen::prelude::*;
+
+use crate::utils::construct_js_err;
+use crate::{EncoderConfig, Frame, Packet};
+
+/// Wrapper around the encoder context (`rav1e::api::context::Context<u16>`).
+///
+/// Contains the encoding state.
+#[wasm_bindgen]
+pub struct Encoder {
+  ctx: Context<u16>,
+}
+
+#[wasm_bindgen]
+impl Encoder {
+  #[wasm_bindgen(constructor)]
+  pub fn fromEncoderConfig(conf: EncoderConfig) -> Result<Encoder, JsValue> {
+    let cfg = Config::new().with_encoder_config(conf.conf);
+
+    match cfg.new_context() {
+      Ok(c) => Ok(Encoder { ctx: c }),
+      Err(e) => Err(construct_js_err(e, "Invalid EncoderConfig")),
+    }
+  }
+
+  pub fn default() -> Result<Encoder, JsValue> {
+    Self::fromEncoderConfig(EncoderConfig::new())
+  }
+
+  pub fn debug(&self) -> String {
+    format!("{:?}", self.ctx)
+  }
+
+  /// Allocates and returns a new frame.
+  pub fn newFrame(&self) -> Frame {
+    Frame { f: self.ctx.new_frame() }
+  }
+
+  /// Sends the frame for encoding.
+  ///
+  /// This method adds the frame into the frame queue and runs the first passes of the look-ahead computation.
+  pub fn sendFrame(&mut self, frame: &Frame) -> Result<(), JsValue> {
+    match self.ctx.send_frame(frame.f.clone()) {
+      Ok(_) => Ok(()),
+      Err(e) => match e {
+        EncoderStatus::EnoughData => Err(construct_js_err(
+          e,
+          "Unable to append frame to the internal queue",
+        )),
+        _ => Err(construct_js_err(e, "")),
+      },
+    }
+  }
+
+  /// Flushes the encoder.
+  ///
+  /// Flushing signals the end of the video. After the encoder has been flushed, no additional frames are accepted.
+  pub fn flush(&mut self) {
+    self.ctx.flush();
+  }
+
+  /// Encodes the next frame and returns the encoded data.
+  ///
+  /// This method is where the main encoding work is done.
+  pub fn receivePacket(&mut self) -> Result<Packet, JsValue> {
+    match self.ctx.receive_packet() {
+      Ok(packet) => Ok(Packet { p: packet }),
+      Err(e) => Err(construct_js_err(e, "")),
+    }
+  }
+}

--- a/rav1e_js/src/encoder_config.rs
+++ b/rav1e_js/src/encoder_config.rs
@@ -1,0 +1,270 @@
+// Copyright (c) 2020, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+#![allow(non_snake_case)]
+
+use rav1e::prelude::{
+  ChromaSamplePosition, ContentLight, EncoderConfig as Rav1eEncoderConfig,
+  PixelRange, Rational, SpeedSettings, Tune,
+};
+use v_frame::pixel::ChromaSampling;
+
+use wasm_bindgen::prelude::*;
+
+/// Wrapper around the encoder configuration (`rav1e::api::config::encoder::EncoderConfig`).
+///
+/// Encoder settings which impact the produced bitstream.
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct EncoderConfig {
+  pub(crate) conf: Rav1eEncoderConfig,
+}
+
+#[wasm_bindgen]
+impl EncoderConfig {
+  #[wasm_bindgen(constructor)]
+  pub fn new() -> Self {
+    EncoderConfig { conf: Rav1eEncoderConfig::default() }
+  }
+
+  pub fn debug(&self) -> String {
+    format!("{:?}", self.conf)
+  }
+
+  /// Width and height of the frames in pixels.
+  pub fn setDim(&mut self, width: usize, height: usize) -> Self {
+    self.conf.height = height;
+    self.conf.width = width;
+    self.clone()
+  }
+
+  /// Video time base.
+  pub fn setTimeBase(&mut self, numerator: u64, denominator: u64) -> Self {
+    self.conf.time_base = Rational { num: numerator, den: denominator };
+    self.clone()
+  }
+
+  /// Bit depth.
+  pub fn setBitDepth(&mut self, bit_depth: usize) -> Self {
+    self.conf.bit_depth = bit_depth;
+    self.clone()
+  }
+
+  /// Chroma subsampling.
+  ///
+  /// Pass enum `ChromaSampling` or a number in range 0 - 3:
+  /// * `1`: `Cs420` (Both vertically and horizontally subsampled)
+  /// * `2`: `Cs422` (Horizontally subsampled)
+  /// * `3`: `Cs444` (Not subsampled)
+  /// * `4`: `Cs400` (Monochrome)
+  pub fn setChromaSampling(
+    &mut self, chroma_sampling: ChromaSampling,
+  ) -> Self {
+    self.conf.chroma_sampling = chroma_sampling;
+    self.clone()
+  }
+
+  /// Chroma sample position.
+  ///
+  /// Pass enum `ChromaSamplePosition` or number in range 0 - 2:
+  /// * `0`: `Unknown` (The source video transfer function must be signaled outside
+  /// the AV1 bitstream)
+  /// * `1`: `Vertical` (Horizontally co-located with (0, 0) luma sample, vertically
+  /// positioned in the middle between two luma samples)
+  /// * `2`: `Collocated` (Co-located with (0, 0) luma sample)
+  pub fn setChromaSamplePosition(
+    &mut self, chroma_sample_position: ChromaSamplePosition,
+  ) -> Self {
+    self.conf.chroma_sample_position = chroma_sample_position;
+    self.clone()
+  }
+
+  /// Pixel value range.
+  ///
+  /// C.f. VideoFullRangeFlag variable specified in ISO/IEC 23091-4/ITU-T H.273
+  ///
+  /// Pass enum `PixelRange` or number in range 0 - 1:
+  /// * `0`: `Limited` (Studio swing representation)
+  /// * `1`: `Full` (Full swing representation)
+  pub fn setPixelRange(&mut self, pixel_range: PixelRange) -> Self {
+    self.conf.pixel_range = pixel_range;
+    self.clone()
+  }
+
+  // /// Content color description (primaries, transfer characteristics, matrix).
+  // pub fn setColorDescription(
+  //   &mut self, color_description: ColorDescription,
+  // ) -> Self {
+  //   self.conf.color_description = Some(color_description);
+  //   self.clone()
+  // }
+
+  // /// High dynamic range mastering display color volume
+  // ///
+  // /// As defined by CIE 1931
+  // pub fn setMasteringDisplay(
+  //   &mut self, mastering_display: MasteringDisplay,
+  // ) -> Self {
+  //   self.conf.mastering_display = Some(mastering_display);
+  //   self.clone()
+  // }
+
+  /// HDR content light parameters.
+  ///
+  /// As defined by CEA-861.3, Appendix A.
+  pub fn setContentLight(
+    &mut self, max_content_light_level: u16,
+    max_frame_average_light_level: u16,
+  ) -> Self {
+    self.conf.content_light = Some(ContentLight {
+      max_content_light_level,
+      max_frame_average_light_level,
+    });
+    self.clone()
+  }
+
+  /// Enable signaling timing info in the bitstream.
+  pub fn setEnableTimingInfo(&mut self, enable_timing_info: bool) -> Self {
+    self.conf.enable_timing_info = enable_timing_info;
+    self.clone()
+  }
+
+  /// Still picture mode flag.
+  pub fn setStillPicture(&mut self, still_picture: bool) -> Self {
+    self.conf.still_picture = still_picture;
+    self.clone()
+  }
+
+  /// Flag to force all frames to be error resilient.
+  pub fn setErrorResilient(&mut self, error_resilient: bool) -> Self {
+    self.conf.error_resilient = error_resilient;
+    self.clone()
+  }
+
+  /// Interval between switch frames (0 to disable)
+  pub fn setSwitchFrameInterval(
+    &mut self, switch_frame_interval: u64,
+  ) -> Self {
+    self.conf.switch_frame_interval = switch_frame_interval;
+    self.clone()
+  }
+
+  /// Sets the minimum and maximum keyframe interval, handling special cases as needed.
+  pub fn setKeyFrameInterval(
+    &mut self, min_interval: u64, max_interval: u64,
+  ) -> Self {
+    self.conf.set_key_frame_interval(min_interval, max_interval);
+    self.clone()
+  }
+
+  /// The number of temporal units over which to distribute the reservoir usage.
+  pub fn setReservoirFrameDelay(
+    &mut self, reservoir_frame_delay: i32,
+  ) -> Self {
+    self.conf.reservoir_frame_delay = Some(reservoir_frame_delay);
+    self.clone()
+  }
+
+  /// Flag to enable low latency mode.
+  ///
+  /// In this mode the frame reordering is disabled.
+  pub fn setLowLatency(&mut self, low_latency: bool) -> Self {
+    self.conf.low_latency = low_latency;
+    self.clone()
+  }
+
+  /// The base quantizer to use.
+  pub fn setQuantizer(&mut self, quantizer: usize) -> Self {
+    self.conf.quantizer = quantizer;
+    self.clone()
+  }
+
+  /// The minimum allowed base quantizer to use in bitrate mode.
+  pub fn setMinWQuantizer(&mut self, min_quantizer: u8) -> Self {
+    self.conf.min_quantizer = min_quantizer;
+    self.clone()
+  }
+
+  /// The target bitrate for the bitrate mode.
+  pub fn setBitrate(&mut self, bitrate: i32) -> Self {
+    self.conf.bitrate = bitrate;
+    self.clone()
+  }
+
+  /// Metric to tune the quality for.
+  ///
+  /// Pass enum `Tune` or number in range 0 - 1:
+  /// * `0`: `Psnr`
+  /// * `1`: `Psychovisual`
+  pub fn setTune(&mut self, tune: Tune) -> Self {
+    self.conf.tune = tune;
+    self.clone()
+  }
+
+  /// Number of tiles horizontally. Must be a power of two.
+  ///
+  /// Overridden by [`tiles`], if present.
+  ///
+  /// [`tiles`]: #structfield.tiles
+  pub fn setTileCols(&mut self, tile_cols: usize) -> Self {
+    self.conf.tile_cols = tile_cols;
+    self.clone()
+  }
+
+  /// Number of tiles vertically. Must be a power of two.
+  ///
+  /// Overridden by [`tiles`], if present.
+  ///
+  /// [`tiles`]: #structfield.tiles
+  pub fn setTileRows(&mut self, tile_rows: usize) -> Self {
+    self.conf.tile_rows = tile_rows;
+    self.clone()
+  }
+
+  /// Total number of tiles desired.
+  ///
+  /// Encoder will try to optimally split to reach this number of tiles,
+  /// rounded up. Overrides [`tile_cols`] and [`tile_rows`].
+  ///
+  /// [`tile_cols`]: #structfield.tile_cols
+  /// [`tile_rows`]: #structfield.tile_rows
+  pub fn setTiles(&mut self, tiles: usize) -> Self {
+    self.conf.tiles = tiles;
+    self.clone()
+  }
+
+  /// Number of frames to read ahead for the RDO lookahead computation.
+  pub fn setRdoLookaheadFrame(&mut self, rdo_lookahead_frames: usize) -> Self {
+    self.conf.rdo_lookahead_frames = rdo_lookahead_frames;
+    self.clone()
+  }
+
+  /// Set the speed setting according to a numeric speed preset.
+  ///
+  /// The speed settings vary depending on speed value from 0 to 10.
+  /// * `10` (fastest): min block size 64x64, reduced TX set, fast deblock, fast scenechange detection.
+  /// * `9`: min block size 32x32, reduced TX set, fast deblock.
+  /// * `8`: min block size 8x8, reduced TX set, fast deblock.
+  /// * `7`: min block size 8x8, reduced TX set.
+  /// * `6` (default): min block size 8x8, reduced TX set, complex pred modes for keyframes.
+  /// * `5`: min block size 8x8, complex pred modes for keyframes, RDO TX decision.
+  /// * `4`: min block size 8x8, complex pred modes for keyframes, RDO TX decision, full SGR search.
+  /// * `3`: min block size 8x8, complex pred modes for keyframes, RDO TX decision, include near MVs,
+  ///        full SGR search.
+  /// * `2`: min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
+  ///        full SGR search, coarse directions.
+  /// * `1`: min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
+  ///        bottom-up encoding, full SGR search.
+  /// * `0` (slowest): min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
+  ///        bottom-up encoding with non-square partitions everywhere, full SGR search.
+  pub fn setSpeed(&mut self, speed: usize) -> Self {
+    self.conf.speed_settings = SpeedSettings::from_preset(speed);
+    self.clone()
+  }
+}

--- a/rav1e_js/src/frame.rs
+++ b/rav1e_js/src/frame.rs
@@ -7,15 +7,21 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-//! Test suite for node.
+use rav1e::prelude::Frame as Rav1eFrame;
 
-#![cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
 
-mod utils;
+/// Wrapper around `v_frame::frame::Frame<u16>`.
+///
+/// Represents one video frame.
+#[wasm_bindgen]
+pub struct Frame {
+  pub(crate) f: Rav1eFrame<u16>,
+}
 
-use wasm_bindgen_test::*;
-
-#[wasm_bindgen_test]
-fn simple_encoding() {
-  utils::simple_encoding(30);
+#[wasm_bindgen]
+impl Frame {
+  pub fn debug(&self) -> String {
+    format!("{:?}", self.f)
+  }
 }

--- a/rav1e_js/src/lib.rs
+++ b/rav1e_js/src/lib.rs
@@ -7,88 +7,21 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-mod utils;
-
-use rav1e::config::SpeedSettings;
-use rav1e::prelude::*;
-
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-extern {
-  #[wasm_bindgen(catch)]
-  fn alert(s: &str) -> Result<(), JsValue>;
-}
+pub mod encoder;
+pub mod encoder_config;
+pub mod frame;
+pub mod packet;
+pub mod utils;
 
-/// Encode the same tiny blank frame 30 times
-#[wasm_bindgen]
-pub fn simple_encoding(repeats: u32) {
-  let msg = simple_encoding_without_alert(repeats);
+pub use encoder::Encoder;
+pub use encoder_config::EncoderConfig;
+pub use frame::Frame;
+pub use packet::Packet;
 
-  match alert(&*msg) {
-    Ok(_) => {}
-    Err(_) => log!("Error calling alert()"),
-  };
-}
-
-pub fn simple_encoding_without_alert(repeats: u32) -> String {
-  // Enable logging for panics
+/// Runs on module import
+#[wasm_bindgen(start)]
+pub fn main_js() {
   utils::set_panic_hook();
-
-  let mut enc = EncoderConfig::default();
-  enc.width = 64;
-  enc.height = 96;
-  enc.speed_settings = SpeedSettings::from_preset(9);
-
-  let cfg = Config::new().with_encoder_config(enc);
-  let mut ctx: Context<u16> = cfg.new_context().unwrap();
-  log!("Instantiated new encoder (config: {:?})", cfg);
-
-  let f = ctx.new_frame();
-  log!("Generated new frame: {:?}", f);
-
-  for i in 0..repeats {
-    log!("Sending frame {}", i);
-    match ctx.send_frame(f.clone()) {
-      Ok(_) => {}
-      Err(e) => match e {
-        EncoderStatus::EnoughData => {
-          log!("Warn: Unable to append frame {} to the internal queue", i);
-        }
-        _ => {
-          panic!("Unable to send frame {}", i);
-        }
-      },
-    }
-  }
-  log!("Successfully send {} frames to the encoder", repeats);
-
-  ctx.flush();
-  log!("Flush encoder");
-
-  loop {
-    match ctx.receive_packet() {
-      Ok(packet) => {
-        // Mux the packet.
-        log!("Received packet: {}", packet)
-      }
-      Err(EncoderStatus::Encoded) => {
-        // A frame was encoded without emitting a packet. This is normal,
-        // just proceed as usual.
-      }
-      Err(EncoderStatus::LimitReached) => {
-        // All frames have been encoded. Time to break out of the loop.
-        break;
-      }
-      Err(EncoderStatus::NeedMoreData) => {
-        // The encoder has requested additional frames. Push the next frame
-        // in, or flush the encoder if there are no frames left (on None).
-        ctx.flush();
-      }
-      Err(e) => {
-        panic!(e);
-      }
-    }
-  }
-  format!("Done encoding the same tiny blank frame {} times.", repeats)
 }

--- a/rav1e_js/src/packet.rs
+++ b/rav1e_js/src/packet.rs
@@ -7,15 +7,24 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-//! Test suite for node.
+use wasm_bindgen::prelude::*;
 
-#![cfg(target_arch = "wasm32")]
+use rav1e::prelude::Packet as Rav1ePacket;
 
-mod utils;
+/// Wrapper around `rav1e::api::util::Packet<u16>`.
+///
+/// A packet contains one shown frame together with zero or more additional frames.
+#[wasm_bindgen]
+pub struct Packet {
+  pub(crate) p: Rav1ePacket<u16>,
+}
 
-use wasm_bindgen_test::*;
-
-#[wasm_bindgen_test]
-fn simple_encoding() {
-  utils::simple_encoding(30);
+#[wasm_bindgen]
+impl Packet {
+  pub fn display(&self) -> String {
+    format!("{}", self.p)
+  }
+  pub fn debug(&self) -> String {
+    format!("{:?}", self.p)
+  }
 }

--- a/rav1e_js/src/utils.rs
+++ b/rav1e_js/src/utils.rs
@@ -7,13 +7,15 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use wasm_bindgen::prelude::*;
+
+/// When the `console_error_panic_hook` feature is enabled, we can call the
+/// `set_panic_hook` function at least once during initialization, and then
+/// we will get better error messages if our code ever panics.
+///
+/// For more details see
+/// https://github.com/rustwasm/console_error_panic_hook#readme
 pub fn set_panic_hook() {
-  // When the `console_error_panic_hook` feature is enabled, we can call the
-  // `set_panic_hook` function at least once during initialization, and then
-  // we will get better error messages if our code ever panics.
-  //
-  // For more details see
-  // https://github.com/rustwasm/console_error_panic_hook#readme
   #[cfg(feature = "console_error_panic_hook")]
   console_error_panic_hook::set_once();
 }
@@ -24,4 +26,13 @@ macro_rules! log {
 	( $( $t:tt )* ) => {
 		web_sys::console::log_1(&format!( $( $t )* ).into());
 	}
+}
+
+pub fn construct_js_err(err: impl std::fmt::Display, msg: &str) -> JsValue {
+  let mut e = format!("{}", err);
+  if msg != "" {
+    e.push_str(": ");
+    e.push_str(msg);
+  }
+  JsValue::from(e)
 }

--- a/rav1e_js/tests/utils.rs
+++ b/rav1e_js/tests/utils.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2020, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+use rav1e::config::SpeedSettings;
+use rav1e::prelude::*;
+
+/// Encode the same tiny blank frame 30 times
+pub fn simple_encoding(repeats: u32) {
+  let mut enc = EncoderConfig::default();
+  enc.width = 64;
+  enc.height = 96;
+  enc.speed_settings = SpeedSettings::from_preset(9);
+
+  let cfg = Config::new().with_encoder_config(enc);
+  let mut ctx: Context<u16> = cfg.new_context().unwrap();
+  rav1e_js::log!("Instantiated new encoder (config: {:?})", cfg);
+
+  let f = ctx.new_frame();
+  rav1e_js::log!("Generated new frame: {:?}", f);
+
+  for i in 0..repeats {
+    rav1e_js::log!("Sending frame {}", i);
+    match ctx.send_frame(f.clone()) {
+      Ok(_) => {}
+      Err(e) => match e {
+        EncoderStatus::EnoughData => {
+          rav1e_js::log!(
+            "Warn: Unable to append frame {} to the internal queue",
+            i
+          );
+        }
+        _ => {
+          panic!("Unable to send frame {}", i);
+        }
+      },
+    }
+  }
+  rav1e_js::log!("Successfully send {} frames to the encoder", repeats);
+
+  ctx.flush();
+  rav1e_js::log!("Flush encoder");
+
+  loop {
+    match ctx.receive_packet() {
+      Ok(packet) => {
+        // Mux the packet.
+        rav1e_js::log!("Received packet: {}", packet)
+      }
+      Err(EncoderStatus::Encoded) => {
+        // A frame was encoded without emitting a packet. This is normal,
+        // just proceed as usual.
+      }
+      Err(EncoderStatus::LimitReached) => {
+        // All frames have been encoded. Time to break out of the loop.
+        break;
+      }
+      Err(EncoderStatus::NeedMoreData) => {
+        // The encoder has requested additional frames. Push the next frame
+        // in, or flush the encoder if there are no frames left (on None).
+        ctx.flush();
+      }
+      Err(e) => {
+        panic!(e);
+      }
+    }
+  }
+  rav1e_js::log!("Done encoding the same tiny blank frame {} times.", repeats);
+}

--- a/rav1e_js/tests/web.rs
+++ b/rav1e_js/tests/web.rs
@@ -11,11 +11,13 @@
 
 #![cfg(target_arch = "wasm32")]
 
+mod utils;
+
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn simple_encoding() {
-  rav1e_js::simple_encoding_without_alert(30);
+  utils::simple_encoding(30);
 }

--- a/rav1e_js/www/index.ts
+++ b/rav1e_js/www/index.ts
@@ -7,6 +7,35 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-import { simple_encoding } from "rav1e";
+import { Encoder, EncoderConfig, Frame, Packet, ChromaSamplePosition } from "rav1e";
 
-simple_encoding(30);
+const conf: EncoderConfig = new EncoderConfig()
+    .setDim(96, 64)
+    .setSpeed(9)
+    .setChromaSamplePosition(ChromaSamplePosition.Unknown);
+console.log(conf.debug())
+
+try {
+    // could raise (catchable) error, if EncoderConfig is invalid
+    const enc: Encoder = new Encoder(conf);
+    console.log(enc.debug());
+
+    const f: Frame = enc.newFrame();
+
+    for (let i = 0; i < 10; i++) {
+        enc.sendFrame(f);
+    }
+    enc.flush();
+    console.log(enc.debug());
+
+    for (let i = 0; i < 20; i++) {
+        try {
+            const p: Packet = enc.receivePacket();
+            console.log(p.display())
+        } catch (e) {
+            console.warn(e);
+        }
+    }
+} catch (e) {
+    console.error(e);
+}

--- a/rav1e_js/www/index.ts
+++ b/rav1e_js/www/index.ts
@@ -7,6 +7,21 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+// Workaround: BigUint64Array in Safari
+// from: https://github.com/takahirox/riscv-rust/pull/116/files
+//
+// Mac/iOS doesn't seem to support BigUint64Array used in JS-WASM bridge. There 
+// might be no way to precisely simulate so just applying workaround here to avoid
+// reference error and trying to avoid the path using BigUint64Array in continue().
+declare global {
+    interface Window { BigUint64Array: any; }
+}
+if (('BigUint64Array' in window) === false) {
+    // This is not correct polyfill but just assigning
+    // the same width typed array so far.
+    window.BigUint64Array = Float64Array;
+}
+
 import { Encoder, EncoderConfig, Frame, Packet, ChromaSamplePosition } from "rav1e";
 
 const conf: EncoderConfig = new EncoderConfig()

--- a/rav1e_js/www/package.json
+++ b/rav1e_js/www/package.json
@@ -31,7 +31,7 @@
 		"copy-webpack-plugin": "^5.0.0",
 		"ts-loader": "^7.0.5",
 		"webpack": "^4.29.3",
-		"webpack-cli": "^3.1.0",
+		"webpack-cli": "^3.3.12",
 		"webpack-dev-server": "^3.1.5"
 	}
 }

--- a/src/api/color.rs
+++ b/src/api/color.rs
@@ -8,11 +8,13 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use crate::serialize::*;
+use crate::wasm_bindgen::*;
 
 use arg_enum_proc_macro::ArgEnum;
 use num_derive::FromPrimitive;
 
 /// Sample position for subsampled chroma
+#[wasm_bindgen]
 #[derive(
   Copy, Clone, Debug, PartialEq, FromPrimitive, Serialize, Deserialize,
 )]
@@ -184,6 +186,7 @@ pub struct ColorDescription {
 /// Allowed pixel value range
 ///
 /// C.f. VideoFullRangeFlag variable specified in ISO/IEC 23091-4/ITU-T H.273
+#[wasm_bindgen]
 #[derive(
   ArgEnum, Debug, Clone, Copy, PartialEq, FromPrimitive, Serialize, Deserialize,
 )]

--- a/src/api/context.rs
+++ b/src/api/context.rs
@@ -19,6 +19,7 @@ use crate::encoder::*;
 use crate::frame::*;
 use crate::util::Pixel;
 
+use std::fmt;
 use std::io;
 
 /// The encoder context.
@@ -406,5 +407,20 @@ impl<T: Pixel> Context<T> {
       .rc_state
       .parse_frame_data_packet(data)
       .map_err(|_| EncoderStatus::Failure)
+  }
+}
+
+impl<T: Pixel> fmt::Debug for Context<T> {
+  fn fmt(
+    &self, f: &mut fmt::Formatter<'_>,
+  ) -> std::result::Result<(), fmt::Error> {
+    write!(
+      f,
+      "{{ \
+        config: {:?}, \
+        is_flushing: {}, \
+      }}",
+      self.config, self.is_flushing,
+    )
   }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -35,6 +35,7 @@ use crate::stats::EncoderStats;
 use crate::tiling::*;
 use crate::transform::*;
 use crate::util::*;
+use crate::wasm_bindgen::*;
 
 use arg_enum_proc_macro::ArgEnum;
 use arrayvec::*;
@@ -97,6 +98,7 @@ impl<T: Pixel> ReferenceFramesSet<T> {
   }
 }
 
+#[wasm_bindgen]
 #[derive(ArgEnum, Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[repr(C)]
 pub enum Tune {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,16 @@ mod hawktracer {
   }
 }
 
+mod wasm_bindgen {
+  cfg_if::cfg_if! {
+    if #[cfg(feature="wasm")] {
+      pub use wasm_bindgen::prelude::*;
+    } else {
+      pub use noop_proc_macro::wasm_bindgen;
+    }
+  }
+}
+
 mod rayon {
   cfg_if::cfg_if! {
     if #[cfg(target_arch="wasm32")] {

--- a/v_frame/Cargo.toml
+++ b/v_frame/Cargo.toml
@@ -9,10 +9,12 @@ repository = "https://github.com/xiph/rav1e/"
 
 [features]
 serialize = ["serde"]
+wasm = ["wasm-bindgen"]
 
 [dependencies]
 cfg-if = "0.1"
 num-traits = "0.2"
 num-derive = "0.3"
-noop_proc_macro = "0.2.0"
+noop_proc_macro = "0.3.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
+wasm-bindgen = { version = "0.2.63", optional = true }

--- a/v_frame/src/lib.rs
+++ b/v_frame/src/lib.rs
@@ -21,6 +21,17 @@ mod serialize {
      }
   }
 }
+
+mod wasm_bindgen {
+  cfg_if::cfg_if! {
+    if #[cfg(feature="wasm")] {
+      pub use wasm_bindgen::prelude::*;
+    } else {
+      pub use noop_proc_macro::wasm_bindgen;
+    }
+  }
+}
+
 pub mod prelude {
   pub use crate::math::*;
   pub use crate::pixel::*;

--- a/v_frame/src/pixel.rs
+++ b/v_frame/src/pixel.rs
@@ -8,9 +8,11 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use crate::serialize::{Deserialize, Serialize};
+use crate::wasm_bindgen::*;
 
 use num_derive::FromPrimitive;
 use num_traits::{AsPrimitive, PrimInt, Signed};
+
 use std::fmt;
 use std::fmt::{Debug, Display};
 use std::mem::size_of;
@@ -149,6 +151,7 @@ impl Coefficient for i32 {
 }
 
 /// Chroma subsampling format
+#[wasm_bindgen]
 #[derive(
   Copy, Clone, Debug, PartialEq, FromPrimitive, Serialize, Deserialize,
 )]


### PR DESCRIPTION
This PR implements v0.1 of the jsapi. At this stage it mainly replicates the functionality from `example/simple_encoding.rs`, but controlled from JavaScript.

Next step towards #2381 

<details>
<summary><b>functions, classes etc. exposed to js</b></summary>

```ts
/**
* Runs on module import
*/
export function main_js(): void;
/**
*/
export enum Tune {
  Psnr,
  Psychovisual,
}
/**
* Sample position for subsampled chroma
*/
export enum ChromaSamplePosition {
/**
* The source video transfer function must be signaled
* outside the AV1 bitstream.
*/
  Unknown,
/**
* Horizontally co-located with (0, 0) luma sample, vertically positioned
* in the middle between two luma samples.
*/
  Vertical,
/**
* Co-located with (0, 0) luma sample.
*/
  Colocated,
}
/**
* Allowed pixel value range
*
* C.f. VideoFullRangeFlag variable specified in ISO/IEC 23091-4/ITU-T H.273
*/
export enum PixelRange {
/**
* Studio swing representation
*/
  Limited,
/**
* Full swing representation
*/
  Full,
}
/**
* Chroma subsampling format
*/
export enum ChromaSampling {
/**
* Both vertically and horizontally subsampled.
*/
  Cs420,
/**
* Horizontally subsampled.
*/
  Cs422,
/**
* Not subsampled.
*/
  Cs444,
/**
* Monochrome.
*/
  Cs400,
}
/**
* Wrapper around the encoder context (`rav1e::api::context::Context<u16>`).
*
* Contains the encoding state.
*/
export class Encoder {
  free(): void;
/**
* @param {EncoderConfig} conf 
*/
  constructor(conf: EncoderConfig);
/**
* @returns {Encoder} 
*/
  static default(): Encoder;
/**
* @returns {string} 
*/
  debug(): string;
/**
* Allocates and returns a new frame.
* @returns {Frame} 
*/
  newFrame(): Frame;
/**
* Sends the frame for encoding.
*
* This method adds the frame into the frame queue and runs the first passes of the look-ahead computation.
* @param {Frame} frame 
*/
  sendFrame(frame: Frame): void;
/**
* Flushes the encoder.
*
* Flushing signals the end of the video. After the encoder has been flushed, no additional frames are accepted.
*/
  flush(): void;
/**
* Encodes the next frame and returns the encoded data.
*
* This method is where the main encoding work is done.
* @returns {Packet} 
*/
  receivePacket(): Packet;
}
/**
* Wrapper around the encoder configuration (`rav1e::api::config::encoder::EncoderConfig`).
*
* Encoder settings which impact the produced bitstream.
*/
export class EncoderConfig {
  free(): void;
/**
*/
  constructor();
/**
* @returns {string} 
*/
  debug(): string;
/**
* Width and height of the frames in pixels.
* @param {number} width 
* @param {number} height 
* @returns {EncoderConfig} 
*/
  setDim(width: number, height: number): EncoderConfig;
/**
* Video time base.
* @param {BigInt} numerator 
* @param {BigInt} denominator 
* @returns {EncoderConfig} 
*/
  setTimeBase(numerator: BigInt, denominator: BigInt): EncoderConfig;
/**
* Bit depth.
* @param {number} bit_depth 
* @returns {EncoderConfig} 
*/
  setBitDepth(bit_depth: number): EncoderConfig;
/**
* Chroma subsampling.
*
* Pass enum `ChromaSampling` or a number in range 0 - 3:
* * `1`: `Cs420` (Both vertically and horizontally subsampled)
* * `2`: `Cs422` (Horizontally subsampled)
* * `3`: `Cs444` (Not subsampled)
* * `4`: `Cs400` (Monochrome)
* @param {number} chroma_sampling 
* @returns {EncoderConfig} 
*/
  setChromaSampling(chroma_sampling: number): EncoderConfig;
/**
* Chroma sample position.
*
* Pass enum `ChromaSamplePosition` or number in range 0 - 2:
* * `0`: `Unknown` (The source video transfer function must be signaled outside
* the AV1 bitstream)
* * `1`: `Vertical` (Horizontally co-located with (0, 0) luma sample, vertically
* positioned in the middle between two luma samples)
* * `2`: `Collocated` (Co-located with (0, 0) luma sample)
* @param {number} chroma_sample_position 
* @returns {EncoderConfig} 
*/
  setChromaSamplePosition(chroma_sample_position: number): EncoderConfig;
/**
* Pixel value range.
*
* C.f. VideoFullRangeFlag variable specified in ISO/IEC 23091-4/ITU-T H.273
*
* Pass enum `PixelRange` or number in range 0 - 1:
* * `0`: `Limited` (Studio swing representation)
* * `1`: `Full` (Full swing representation)
* @param {number} pixel_range 
* @returns {EncoderConfig} 
*/
  setPixelRange(pixel_range: number): EncoderConfig;
/**
* HDR content light parameters.
*
* As defined by CEA-861.3, Appendix A.
* @param {number} max_content_light_level 
* @param {number} max_frame_average_light_level 
* @returns {EncoderConfig} 
*/
  setContentLight(max_content_light_level: number, max_frame_average_light_level: number): EncoderConfig;
/**
* Enable signaling timing info in the bitstream.
* @param {boolean} enable_timing_info 
* @returns {EncoderConfig} 
*/
  setEnableTimingInfo(enable_timing_info: boolean): EncoderConfig;
/**
* Still picture mode flag.
* @param {boolean} still_picture 
* @returns {EncoderConfig} 
*/
  setStillPicture(still_picture: boolean): EncoderConfig;
/**
* Flag to force all frames to be error resilient.
* @param {boolean} error_resilient 
* @returns {EncoderConfig} 
*/
  setErrorResilient(error_resilient: boolean): EncoderConfig;
/**
* Interval between switch frames (0 to disable)
* @param {BigInt} switch_frame_interval 
* @returns {EncoderConfig} 
*/
  setSwitchFrameInterval(switch_frame_interval: BigInt): EncoderConfig;
/**
* Sets the minimum and maximum keyframe interval, handling special cases as needed.
* @param {BigInt} min_interval 
* @param {BigInt} max_interval 
* @returns {EncoderConfig} 
*/
  setKeyFrameInterval(min_interval: BigInt, max_interval: BigInt): EncoderConfig;
/**
* The number of temporal units over which to distribute the reservoir usage.
* @param {number} reservoir_frame_delay 
* @returns {EncoderConfig} 
*/
  setReservoirFrameDelay(reservoir_frame_delay: number): EncoderConfig;
/**
* Flag to enable low latency mode.
*
* In this mode the frame reordering is disabled.
* @param {boolean} low_latency 
* @returns {EncoderConfig} 
*/
  setLowLatency(low_latency: boolean): EncoderConfig;
/**
* The base quantizer to use.
* @param {number} quantizer 
* @returns {EncoderConfig} 
*/
  setQuantizer(quantizer: number): EncoderConfig;
/**
* The minimum allowed base quantizer to use in bitrate mode.
* @param {number} min_quantizer 
* @returns {EncoderConfig} 
*/
  setMinWQuantizer(min_quantizer: number): EncoderConfig;
/**
* The target bitrate for the bitrate mode.
* @param {number} bitrate 
* @returns {EncoderConfig} 
*/
  setBitrate(bitrate: number): EncoderConfig;
/**
* Metric to tune the quality for.
*
* Pass enum `Tune` or number in range 0 - 1:
* * `0`: `Psnr`
* * `1`: `Psychovisual`
* @param {number} tune 
* @returns {EncoderConfig} 
*/
  setTune(tune: number): EncoderConfig;
/**
* Number of tiles horizontally. Must be a power of two.
*
* Overridden by [`tiles`], if present.
*
* [`tiles`]: #structfield.tiles
* @param {number} tile_cols 
* @returns {EncoderConfig} 
*/
  setTileCols(tile_cols: number): EncoderConfig;
/**
* Number of tiles vertically. Must be a power of two.
*
* Overridden by [`tiles`], if present.
*
* [`tiles`]: #structfield.tiles
* @param {number} tile_rows 
* @returns {EncoderConfig} 
*/
  setTileRows(tile_rows: number): EncoderConfig;
/**
* Total number of tiles desired.
*
* Encoder will try to optimally split to reach this number of tiles,
* rounded up. Overrides [`tile_cols`] and [`tile_rows`].
*
* [`tile_cols`]: #structfield.tile_cols
* [`tile_rows`]: #structfield.tile_rows
* @param {number} tiles 
* @returns {EncoderConfig} 
*/
  setTiles(tiles: number): EncoderConfig;
/**
* Number of frames to read ahead for the RDO lookahead computation.
* @param {number} rdo_lookahead_frames 
* @returns {EncoderConfig} 
*/
  setRdoLookaheadFrame(rdo_lookahead_frames: number): EncoderConfig;
/**
* Set the speed setting according to a numeric speed preset.
*
* The speed settings vary depending on speed value from 0 to 10.
* * `10` (fastest): min block size 64x64, reduced TX set, fast deblock, fast scenechange detection.
* * `9`: min block size 32x32, reduced TX set, fast deblock.
* * `8`: min block size 8x8, reduced TX set, fast deblock.
* * `7`: min block size 8x8, reduced TX set.
* * `6` (default): min block size 8x8, reduced TX set, complex pred modes for keyframes.
* * `5`: min block size 8x8, complex pred modes for keyframes, RDO TX decision.
* * `4`: min block size 8x8, complex pred modes for keyframes, RDO TX decision, full SGR search.
* * `3`: min block size 8x8, complex pred modes for keyframes, RDO TX decision, include near MVs,
*        full SGR search.
* * `2`: min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
*        full SGR search, coarse directions.
* * `1`: min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
*        bottom-up encoding, full SGR search.
* * `0` (slowest): min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
*        bottom-up encoding with non-square partitions everywhere, full SGR search.
* @param {number} speed 
* @returns {EncoderConfig} 
*/
  setSpeed(speed: number): EncoderConfig;
}
/**
* Wrapper around `v_frame::frame::Frame<u16>`.
*
* Represents one video frame.
*/
export class Frame {
  free(): void;
/**
* @returns {string} 
*/
  debug(): string;
}
/**
* Wrapper around `rav1e::api::util::Packet<u16>`.
*
* A packet contains one shown frame together with zero or more additional frames.
*/
export class Packet {
  free(): void;
/**
* @returns {string} 
*/
  display(): string;
/**
* @returns {string} 
*/
  debug(): string;
}
```
</details>

## example
```ts
import { Encoder, EncoderConfig, Frame, Packet, ChromaSamplePosition } from "rav1e";

const conf: EncoderConfig = new EncoderConfig()
    .setDim(96, 64)
    .setSpeed(9)
    .setChromaSamplePosition(ChromaSamplePosition.Unknown);
console.log(conf.debug())

try {
    // could raise (catchable) error, if EncoderConfig is invalid
    const enc: Encoder = new Encoder(conf);
    console.log(enc.debug());

    const f: Frame = enc.newFrame();

    for (let i = 0; i < 10; i++) {
        enc.sendFrame(f);
    }
    enc.flush();
    console.log(enc.debug());

    for (let i = 0; i < 20; i++) {
        try {
            const p: Packet = enc.receivePacket();
            console.log(p.display())
        } catch (e) {
            console.warn(e);
        }
    }
} catch (e) {
    console.error(e);
}
```