### PR TITLE
Remove lto from the release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,11 +149,9 @@ debug = true
 codegen-units = 1  # if > 1 enables parallel code generation which improves
                    # compile times, but prevents some optimizations.
                    # Passes `-C codegen-units`. Ignored when `lto = true`.
-lto = true
 
 [profile.bench]
 codegen-units = 1
-lto = true
 
 [workspace]
 members = [".", "ivf", "rav1e_js", "v_frame"]


### PR DESCRIPTION
The performance difference has shrunk substantially adding inline to a
bunch of functions. The performance difference with or without lto is
about 4 seconds on the slowest clip/qp on a standard awcy run
(MINECRAFT, objective-1-fast, qp 80). The compile time difference is 42
seconds.

If it's possible to have good performance with lto off, then optimizing
without it will provide a good development profile. Going forward, it
would be advisable to use lto to check for performancem problems. It
may be possible to create a seperate profile between dev and release.
AWCY would need to be modified to use this and also work with old
versions of rav1e.