### PR TITLE
Remove the crate-type specifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,6 @@ bench = false
 
 [lib]
 bench = false
-crate-type = ["lib", "staticlib"]
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
It was added to workaround a limitation of the old cargo-c.