### PR TITLE
Remove limit on codegen units for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,12 +143,8 @@ opt-level = 1
 
 [profile.release]
 debug = true
-codegen-units = 1  # if > 1 enables parallel code generation which improves
-                   # compile times, but prevents some optimizations.
-                   # Passes `-C codegen-units`. Ignored when `lto = true`.
 
 [profile.bench]
-codegen-units = 1
 
 [workspace]
 members = [".", "ivf", "rav1e_js", "v_frame"]


### PR DESCRIPTION
Decreases compile time on AWCY from ~4 mins to ~2.25 mins. Increases run
time roughly 4% and 10 seconds on the most intense clip/qp (MINECRAFT @
80).

Testing also shows that codegen-units=1 actaully causes a substantial
performance decrease when iterative compilation is enabled.