### PR TITLE
Deploy pre-releases periodically

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: deploy
 
 on:
+  schedule:
+    # Run every Tuesday at 21:00 (UTC)
+    - cron:  '0 21 * * TUE'
   push:
     tags:
       - 'v*.*.*'
@@ -88,7 +91,8 @@ jobs:
         echo "::set-output name=version::$VERSION"
 
     - name: Package pre-release binaries
-      if: startsWith(github.ref, 'refs/tags/p')
+      if: >
+        startsWith(github.ref, 'refs/tags/p') || github.event_name == 'schedule'
       run: |
         7z a rav1e-windows-${{ matrix.conf }}.zip `
              "C:\usr\rav1e-windows-${{ matrix.conf }}-sdk"
@@ -107,7 +111,8 @@ jobs:
         path: target/release/rav1e.exe
 
     - name: Upload pre-release binaries
-      if: startsWith(github.ref, 'refs/tags/p')
+      if: >
+        startsWith(github.ref, 'refs/tags/p') || github.event_name == 'schedule'
       uses: actions/upload-artifact@v2
       with:
         path: rav1e-windows-${{ matrix.conf }}.zip
@@ -204,7 +209,8 @@ jobs:
         echo "::set-output name=version::$VERSION"
 
     - name: Create a pre-release tar
-      if: startsWith(github.ref, 'refs/tags/p')
+      if: >
+        startsWith(github.ref, 'refs/tags/p') || github.event_name == 'schedule'
       run: |
         cd target/${{ matrix.target }}/release
         tar -czvf $GITHUB_WORKSPACE/rav1e-${{ matrix.name }}.tar.gz \
@@ -218,7 +224,8 @@ jobs:
         tar -czvf $GITHUB_WORKSPACE/$TAR_FILE.tar.gz ${{ matrix.binaries }}
 
     - name: Upload pre-release binaries
-      if: startsWith(github.ref, 'refs/tags/p')
+      if: >
+        startsWith(github.ref, 'refs/tags/p') || github.event_name == 'schedule'
       uses: actions/upload-artifact@v2
       with:
         path: rav1e-${{ matrix.name }}.tar.gz
@@ -263,7 +270,8 @@ jobs:
         echo "::set-output name=version::$VERSION"
 
     - name: Create a pre-release zip
-      if: startsWith(github.ref, 'refs/tags/p')
+      if: >
+        startsWith(github.ref, 'refs/tags/p') || github.event_name == 'schedule'
       run: |
         cd target/release
         zip -9 $GITHUB_WORKSPACE/rav1e-macos.zip rav1e
@@ -276,7 +284,8 @@ jobs:
         zip -9 $GITHUB_WORKSPACE/$ZIP_FILE rav1e
 
     - name: Upload pre-release binaries
-      if: startsWith(github.ref, 'refs/tags/p')
+      if: >
+        startsWith(github.ref, 'refs/tags/p') || github.event_name == 'schedule'
       uses: actions/upload-artifact@v2
       with:
         path: rav1e-macos.zip
@@ -318,6 +327,31 @@ jobs:
       run: |
         VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
         echo "::set-output name=version::$VERSION"
+
+    - name: Get date for a scheduled pre-release
+      if: github.event_name == 'schedule'
+      id: tagDate
+      run: |
+        DATE=$(date "+%Y%m%d")
+        echo "::set-output name=date::$DATE"
+
+    - name: Create a scheduled pre-release
+      if: github.event_name == 'schedule'
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Weekly pre-release
+        prerelease: true
+        tag_name: p${{ steps.tagDate.outputs.date }}
+        files: |
+          Cargo.lock
+          rav1e.exe
+          rav1e-linux.tar.gz
+          rav1e-aarch64-linux.tar.gz
+          rav1e-macos.zip
+          rav1e-windows-msvc.zip
+          rav1e-windows-gnu.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create a pre-release
       if: startsWith(github.ref, 'refs/tags/p')


### PR DESCRIPTION
This PR fixes #2404 

A pre-release is deployed on every Tuesday at 21:00 (UTC) automatically. If an error occurs during the build process, the pre-release can also be deployed manually, that's why the old method has been kept.

Thanks in advance for your review! :)