### PR TITLE
Use incremental builds for the release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,8 +142,10 @@ opt-level = 1
 
 [profile.release]
 debug = true
+incremental = true
 
 [profile.bench]
+incremental = true
 
 [workspace]
 members = [".", "ivf", "rav1e_js", "v_frame"]


### PR DESCRIPTION
Dramatically improves the speed of rebuilding release (i.e. not from
scratch). Little to no difference in runtime on awcy.

https://beta.arewecompressedyet.com/?job=codegen-units-incremental%402020-06-17T17%3A26%3A41.471Z&job=codegen-units%402020-06-17T14%3A13%3A14.505Z

before:
  release profile: full build time
    real    0m51.344s
    user    6m47.160s
  release profile: touch src/lib.rs
    real    0m18.483s
    user    1m29.580s

after:
  release profile: full build time
    real    0m48.754s
    user    6m53.001s
  release profile: touch src/lib.rs
    real    0m3.177s
    user    0m2.793s

---

Would appreciate arm benchmarks.