### PR TITLE
Fix broken borrow checker for tile_blocks

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -2038,7 +2038,7 @@ pub fn rdo_loop_decision<T: Pixel>(
   };
 
   // sub-setted region of the TileBlocks for our working frame area
-  let mut tileblocks_subset = cw.bc.blocks.subregion(
+  let mut tileblocks_subset = cw.bc.blocks.subregion_mut(
     base_sbo.block_offset(0, 0).0.x,
     base_sbo.block_offset(0, 0).0.y,
     sb_w << SUPERBLOCK_TO_BLOCK_SHIFT,
@@ -2220,7 +2220,7 @@ pub fn rdo_loop_decision<T: Pixel>(
                       pli,
                     );
                     rate += if fi.sequence.enable_restoration {
-                      cw.count_lrf_switchable(
+                      cw.fc.count_lrf_switchable(
                         w,
                         &ts.restoration.as_const(),
                         best_lrf[lru_y * lru_w[pli] + lru_x][pli],
@@ -2274,7 +2274,7 @@ pub fn rdo_loop_decision<T: Pixel>(
                       &src_subset,
                       pli,
                     );
-                    rate += cw.count_lrf_switchable(
+                    rate += cw.fc.count_lrf_switchable(
                       w,
                       &ts.restoration.as_const(),
                       best_lrf[lru_y * lru_w[pli] + lru_x][pli],
@@ -2400,7 +2400,7 @@ pub fn rdo_loop_decision<T: Pixel>(
                   &src_subset,
                   pli,
                 );
-                let rate = cw.count_lrf_switchable(
+                let rate = cw.fc.count_lrf_switchable(
                   w,
                   &ts.restoration.as_const(),
                   best_new_lrf,
@@ -2482,7 +2482,7 @@ pub fn rdo_loop_decision<T: Pixel>(
                   &src_subset,
                   pli,
                 );
-                let rate = cw.count_lrf_switchable(
+                let rate = cw.fc.count_lrf_switchable(
                   w,
                   &ts.restoration.as_const(),
                   current_lrf,

--- a/src/tiling/tile_blocks.rs
+++ b/src/tiling/tile_blocks.rs
@@ -78,9 +78,9 @@ macro_rules! tile_blocks_common {
         y: usize,
         cols: usize,
         rows: usize,
-      ) -> Self {
-        Self {
-          data: & $($opt_mut)? self[y][x],
+      ) -> TileBlocks<'_> {
+        TileBlocks {
+          data: &self[y][x],
           x: self.x+x,
           y: self.y+y,
           cols: cmp::min(cols, self.cols - x),
@@ -180,6 +180,21 @@ impl TileBlocksMut<'_> {
       y: self.y,
       cols: self.cols,
       rows: self.rows,
+      frame_cols: self.frame_cols,
+      frame_rows: self.frame_rows,
+      phantom: PhantomData,
+    }
+  }
+
+  pub fn subregion_mut(
+    &mut self, x: usize, y: usize, cols: usize, rows: usize,
+  ) -> TileBlocksMut<'_> {
+    TileBlocksMut {
+      data: &mut self[y][x],
+      x: self.x + x,
+      y: self.y + y,
+      cols: cmp::min(cols, self.cols - x),
+      rows: cmp::min(rows, self.rows - y),
       frame_cols: self.frame_cols,
       frame_rows: self.frame_rows,
       phantom: PhantomData,


### PR DESCRIPTION
The borrow rules that were being used were too permissive. To make the
existing code work, it was necessary to split make additional changes.
Instead of calling count_lrf_switchable from ContextWriter, we make it a
function of CDFContext and call it from there.

#2379
#2380