### PR TITLE
Add elapsed time

### DIFF
--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -150,6 +150,11 @@ impl ProgressInfo {
       .unwrap_or_default() as u64
   }
 
+  // Elapsed time in seconds
+  pub fn elapsed_time(&self) -> u64 {
+    Instant::now().duration_since(self.time_started).as_secs() as u64
+  }
+
   // Number of frames of given type which appear in the video
   fn get_frame_type_count(&self, frame_type: FrameType) -> usize {
     self
@@ -669,21 +674,23 @@ impl fmt::Display for ProgressInfo {
     if let Some(total_frames) = self.total_frames {
       write!(
                 f,
-                "encoded {}/{} frames, {:.3} fps, {:.2} Kb/s, est. size: {:.2} MB, est. time: {}",
+                "encoded {}/{} frames, {:.3} fps, {:.2} Kb/s, est. size: {:.2} MB, est. time: {},  elap. time: {}",
                 self.frames_encoded(),
                 total_frames,
                 self.encoding_fps(),
                 self.bitrate() as f64 / 1000f64,
                 self.estimated_size() as f64 / (1024 * 1024) as f64,
-                secs_to_human_time(self.estimated_time())
+                secs_to_human_time(self.estimated_time()),
+                secs_to_human_time(self.elapsed_time())
             )
     } else {
       write!(
         f,
-        "encoded {} frames, {:.3} fps, {:.2} Kb/s",
+        "encoded {} frames, {:.3} fps, {:.2} Kb/s, elap. time: {}",
         self.frames_encoded(),
         self.encoding_fps(),
-        self.bitrate() as f64 / 1000f64
+        self.bitrate() as f64 / 1000f64,
+        secs_to_human_time(self.elapsed_time())
       )
     }
   }


### PR DESCRIPTION
Fix issue #2395
Description: The number of frames is already shown when is not quiet, I just added the elapsed time when limit is passed or not.

Example:
- cargo run --release --bin rav1e -- input.y4m -o output.ivf -l 120
```
encoded 120/120 frames, 9.326 fps, 105.05 Kb/s, est. size: 0.10 MB, est. time: 0s,  elap. time: 12s
```
- cargo run --release --bin rav1e -- input.y4m -o output.ivf
```
encoded 120 frames, 9.571 fps, 105.05 Kb/s, elap. time: 12s
```