### PR TITLE
Clear transient status

### DIFF
--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -311,6 +311,7 @@ impl ProgressInfo {
   }
 
   pub fn print_summary(&self, verbose: bool) {
+    eprint!("\r");
     info!("{}", self);
     info!("----------");
     self.print_frame_type_summary(FrameType::KEY);


### PR DESCRIPTION
Fix issue #2394
Description: Clear transient status before printing the last summary.

Before:
```
>  Using 1 tile
encoded 120 frames, 9.297 fps, 105.05 Kb/s                    >  encoded 120 frames, 9.297 fps, 105.05 Kb/s
>  ----------
```
After:
```
>  Using 1 tile
>  encoded 120 frames, 8.963 fps, 105.05 Kb/s                 
>  ----------
```