### PR TITLE
travis: Update the dav1d sha256 checksums

### DIFF
--- a/.travis/install-dav1d.sh
+++ b/.travis/install-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-DAV1D_VERSION="0.7.0-dmo1"
+DAV1D_VERSION="0.7.1-dmo0~bpo10+1"
 PKG_URL="http://www.deb-multimedia.org/pool/main/d/dav1d-dmo"
 
 case "$ARCH" in
@@ -17,10 +17,10 @@ curl -O "$PKG_URL/libdav1d-dev_${DAV1D_VERSION}_$ARCH.deb" \
      -O "$PKG_URL/libdav1d4_${DAV1D_VERSION}_$ARCH.deb"
 
 sha256sum --check --ignore-missing <<EOF
-ade22c88d7a2307f4b6351f59bb6696504062ef5aaed88a2c0b6fe37085a20d1  libdav1d4_0.7.0-dmo1_amd64.deb
-2db8f62c68f90bb0aafa2c6f183900d75d635ea9c99df15c8d9e5a606e036e74  libdav1d4_0.7.0-dmo1_arm64.deb
-9ac5d588ad5db9cb6cd64eeb896305655f676838eef66115b82ab01272c3a504  libdav1d-dev_0.7.0-dmo1_amd64.deb
-610ff6ec885a7f62f7d0256f640bb2a135c13a781b82f9aa267a0bd8a8749424  libdav1d-dev_0.7.0-dmo1_arm64.deb
+2a1005c191f9ff41f53a5cea10b836e9e18f7f1390d81d935ef7de8a89223e02  libdav1d-dev_0.7.1-dmo0~bpo10+1_amd64.deb
+199c222d620a40a4b6f3104c6fae351e7f7e96b4860432738cadf32a023ab91a  libdav1d-dev_0.7.1-dmo0~bpo10+1_arm64.deb
+7274ea2516b32ca7714979a9a39073ec189dd9a874ccac70730fd1026bbc9b05  libdav1d4_0.7.1-dmo0~bpo10+1_amd64.deb
+75ebfe5cce146c1a1b7aab40c9ee4ecb7f9423bc03ce074b8c2aa31ed59710bd  libdav1d4_0.7.1-dmo0~bpo10+1_arm64.deb
 EOF
 
 sudo dpkg -i "libdav1d4_${DAV1D_VERSION}_$ARCH.deb" \


### PR DESCRIPTION
Hi,

Debian deb has updated dav1d to 0.7.1.

Tested the script on pi it works fine