### PR TITLE
Remove large stack allocation from interprediction

### DIFF
--- a/src/context/superblock_unit.rs
+++ b/src/context/superblock_unit.rs
@@ -9,7 +9,7 @@
 
 use super::*;
 
-const MAX_SB_SIZE_LOG2: usize = 7;
+pub const MAX_SB_SIZE_LOG2: usize = 7;
 const SB_SIZE_LOG2: usize = 6;
 pub const SB_SIZE: usize = 1 << SB_SIZE_LOG2;
 const SB_SQUARE: usize = SB_SIZE * SB_SIZE;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1332,6 +1332,7 @@ pub fn motion_compensate<T: Pixel>(
     };
 
   let luma_tile_rect = ts.tile_rect();
+  let compound_buffer = &mut ts.inter_compound_buffers;
   for p in 0..num_planes {
     let plane_bsize =
       if p == 0 { bsize } else { bsize.subsampled_size(u_xdec, u_ydec) };
@@ -1370,6 +1371,7 @@ pub fn motion_compensate<T: Pixel>(
           plane_bsize.height(),
           ref_frames,
           mvs,
+          compound_buffer,
         );
       } else {
         assert!(u_xdec == 1 && u_ydec == 1);
@@ -1397,6 +1399,7 @@ pub fn motion_compensate<T: Pixel>(
             2,
             rf0,
             mv0,
+            compound_buffer,
           );
           luma_mode.predict_inter(
             fi,
@@ -1408,6 +1411,7 @@ pub fn motion_compensate<T: Pixel>(
             2,
             rf1,
             mv1,
+            compound_buffer,
           );
           luma_mode.predict_inter(
             fi,
@@ -1419,6 +1423,7 @@ pub fn motion_compensate<T: Pixel>(
             2,
             rf2,
             mv2,
+            compound_buffer,
           );
           luma_mode.predict_inter(
             fi,
@@ -1430,6 +1435,7 @@ pub fn motion_compensate<T: Pixel>(
             2,
             ref_frames,
             mvs,
+            compound_buffer,
           );
         }
         if bsize == BlockSize::BLOCK_8X4 {
@@ -1445,6 +1451,7 @@ pub fn motion_compensate<T: Pixel>(
             2,
             rf1,
             mv1,
+            compound_buffer,
           );
           let po3 = PlaneOffset { x: po.x, y: po.y + 2 };
           let area3 = Area::StartingAt { x: po3.x, y: po3.y };
@@ -1458,6 +1465,7 @@ pub fn motion_compensate<T: Pixel>(
             2,
             ref_frames,
             mvs,
+            compound_buffer,
           );
         }
         if bsize == BlockSize::BLOCK_4X8 {
@@ -1473,6 +1481,7 @@ pub fn motion_compensate<T: Pixel>(
             4,
             rf2,
             mv2,
+            compound_buffer,
           );
           let po3 = PlaneOffset { x: po.x + 2, y: po.y };
           let area3 = Area::StartingAt { x: po3.x, y: po3.y };
@@ -1486,6 +1495,7 @@ pub fn motion_compensate<T: Pixel>(
             4,
             ref_frames,
             mvs,
+            compound_buffer,
           );
         }
       }
@@ -1500,6 +1510,7 @@ pub fn motion_compensate<T: Pixel>(
         plane_bsize.height(),
         ref_frames,
         mvs,
+        compound_buffer,
       );
     }
   }

--- a/src/me.rs
+++ b/src/me.rs
@@ -15,7 +15,6 @@ use crate::dist::*;
 use crate::encoder::ReferenceFrame;
 use crate::frame::*;
 use crate::mc::MotionVector;
-use crate::partition::RefType::*;
 use crate::partition::*;
 use crate::predict::PredictionMode;
 use crate::tiling::*;
@@ -821,7 +820,7 @@ fn get_mv_rd_cost<T: Pixel>(
       width: region.plane_cfg.width,
       height: region.plane_cfg.height,
     };
-    PredictionMode::NEWMV.predict_inter(
+    PredictionMode::NEWMV.predict_inter_single(
       fi,
       tile_rect,
       0,
@@ -829,8 +828,8 @@ fn get_mv_rd_cost<T: Pixel>(
       region,
       bsize.width(),
       bsize.height(),
-      [ref_frame, NONE_FRAME],
-      [cand_mv, MotionVector { row: 0, col: 0 }],
+      ref_frame,
+      cand_mv,
     );
     let plane_ref = region.as_const();
     compute_mv_rd_cost(
@@ -914,7 +913,7 @@ fn telescopic_subpel_search<T: Pixel>(
         }
 
         {
-          mode.predict_inter(
+          mode.predict_inter_single(
             fi,
             tile_rect,
             0,
@@ -922,8 +921,8 @@ fn telescopic_subpel_search<T: Pixel>(
             &mut tmp_plane.as_region_mut(),
             blk_w,
             blk_h,
-            [ref_frame, NONE_FRAME],
-            [cand_mv, MotionVector { row: 0, col: 0 }],
+            ref_frame,
+            cand_mv,
           );
         }
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1197,6 +1197,7 @@ fn inter_frame_rdo_mode_decision<T: Pixel>(
         bsize.height(),
         ref_frames_set[i],
         mvs,
+        &mut ts.inter_compound_buffers,
       );
 
       let plane_org = ts.input_tile.planes[0]

--- a/src/tiling/tile_state.rs
+++ b/src/tiling/tile_state.rs
@@ -15,7 +15,7 @@ use crate::frame::*;
 use crate::lrf::{IntegralImageBuffer, SOLVE_IMAGE_SIZE};
 use crate::mc::MotionVector;
 use crate::partition::{RefType, REF_FRAMES};
-use crate::predict::PredictionMode;
+use crate::predict::{InterCompoundBuffers, PredictionMode};
 use crate::quantize::*;
 use crate::rdo::*;
 use crate::stats::EncoderStats;
@@ -66,6 +66,7 @@ pub struct TileStateMut<'a, T: Pixel> {
   pub mvs: Vec<TileMotionVectorsMut<'a>>,
   pub coded_block_info: MiTileState,
   pub integral_buffer: IntegralImageBuffer,
+  pub inter_compound_buffers: InterCompoundBuffers,
   pub enc_stats: EncoderStats,
 }
 
@@ -196,6 +197,7 @@ impl<'a, T: Pixel> TileStateMut<'a, T> {
         height >> MI_SIZE_LOG2,
       ),
       integral_buffer: IntegralImageBuffer::zeroed(SOLVE_IMAGE_SIZE),
+      inter_compound_buffers: InterCompoundBuffers::default(),
       enc_stats: EncoderStats::default(),
     }
   }

--- a/src/util/align.rs
+++ b/src/util/align.rs
@@ -7,7 +7,10 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use std::alloc::{alloc, dealloc, Layout};
 use std::mem::MaybeUninit;
+use std::ptr;
+use std::{fmt, mem};
 
 #[repr(align(32))]
 pub struct Align32;
@@ -36,12 +39,111 @@ impl<T> Aligned<T> {
   }
 }
 
-#[test]
-fn sanity() {
+/// An analog to a Box<[T]> where the underlying slice is aligned.
+/// Alignment is according to the architecture-specific SIMD constraints.
+pub struct AlignedBoxedSlice<T> {
+  ptr: std::ptr::NonNull<T>,
+  len: usize,
+}
+
+impl<T> AlignedBoxedSlice<T> {
+  // Data alignment in bytes.
+  cfg_if::cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+      // FIXME: wasm32 allocator fails for alignment larger than 3
+      const DATA_ALIGNMENT_LOG2: usize = 3;
+    } else {
+      const DATA_ALIGNMENT_LOG2: usize = 5;
+    }
+  }
+
+  unsafe fn layout(len: usize) -> Layout {
+    Layout::from_size_align_unchecked(
+      len * mem::size_of::<T>(),
+      1 << Self::DATA_ALIGNMENT_LOG2,
+    )
+  }
+
+  unsafe fn alloc(len: usize) -> std::ptr::NonNull<T> {
+    ptr::NonNull::new_unchecked(alloc(Self::layout(len)) as *mut T)
+  }
+
+  /// Creates a ['AlignedBoxedSlice'] with a slice of length ['len'] filled with
+  /// ['val'].
+  pub fn new(len: usize, val: T) -> Self
+  where
+    T: Clone,
+  {
+    let mut output = Self { ptr: unsafe { Self::alloc(len) }, len };
+
+    for a in output.iter_mut() {
+      *a = val.clone();
+    }
+
+    output
+  }
+}
+
+impl<T: fmt::Debug> fmt::Debug for AlignedBoxedSlice<T> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Debug::fmt(&**self, f)
+  }
+}
+
+impl<T> std::ops::Deref for AlignedBoxedSlice<T> {
+  type Target = [T];
+
+  fn deref(&self) -> &[T] {
+    unsafe {
+      let p = self.ptr.as_ptr();
+
+      std::slice::from_raw_parts(p, self.len)
+    }
+  }
+}
+
+impl<T> std::ops::DerefMut for AlignedBoxedSlice<T> {
+  fn deref_mut(&mut self) -> &mut [T] {
+    unsafe {
+      let p = self.ptr.as_ptr();
+
+      std::slice::from_raw_parts_mut(p, self.len)
+    }
+  }
+}
+
+impl<T> std::ops::Drop for AlignedBoxedSlice<T> {
+  fn drop(&mut self) {
+    unsafe {
+      for a in self.iter_mut() {
+        ptr::drop_in_place(a)
+      }
+
+      dealloc(self.ptr.as_ptr() as *mut u8, Self::layout(self.len));
+    }
+  }
+}
+
+unsafe impl<T> Send for AlignedBoxedSlice<T> where T: Send {}
+unsafe impl<T> Sync for AlignedBoxedSlice<T> where T: Sync {}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
   fn is_aligned<T>(ptr: *const T, n: usize) -> bool {
     ((ptr as usize) & ((1 << n) - 1)) == 0
   }
 
-  let a: Aligned<_> = Aligned::new([0u8; 3]);
-  assert!(is_aligned(a.data.as_ptr(), 4));
+  #[test]
+  fn sanity_stack() {
+    let a: Aligned<_> = Aligned::new([0u8; 3]);
+    assert!(is_aligned(a.data.as_ptr(), 4));
+  }
+
+  #[test]
+  fn sanity_heap() {
+    let a: AlignedBoxedSlice<_> = AlignedBoxedSlice::new(3, 0u8);
+    assert!(is_aligned(a.as_ptr(), 4));
+  }
 }


### PR DESCRIPTION
A large stack allocation was causing probestack to be called. This patch
improves performance by about 1.5% in total.

It should be noted that calling probestack on linux for a stack
allocation this size might be a bug in rustc/llvm.