### PR TITLE
Inline some asm/simd callers

### DIFF
--- a/src/asm/aarch64/mc.rs
+++ b/src/asm/aarch64/mc.rs
@@ -83,6 +83,7 @@ const fn get_2d_mode_idx(mode_x: FilterMode, mode_y: FilterMode) -> usize {
   (mode_x as usize + 4 * (mode_y as usize)) & 15
 }
 
+#[inline(always)]
 pub fn put_8tap<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, src: PlaneSlice<'_, T>, width: usize,
   height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
@@ -149,6 +150,7 @@ pub fn put_8tap<T: Pixel>(
   }
 }
 
+#[inline(always)]
 pub fn prep_8tap<T: Pixel>(
   tmp: &mut [i16], src: PlaneSlice<'_, T>, width: usize, height: usize,
   col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,

--- a/src/asm/x86/ec.rs
+++ b/src/asm/x86/ec.rs
@@ -11,6 +11,7 @@ use crate::ec::rust;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
+#[inline(always)]
 pub fn update_cdf(cdf: &mut [u16], val: u32) {
   if cdf.len() == 5 {
     return unsafe {
@@ -22,6 +23,7 @@ pub fn update_cdf(cdf: &mut [u16], val: u32) {
 }
 
 #[target_feature(enable = "sse2")]
+#[inline]
 unsafe fn update_cdf_4_sse2(cdf: &mut [u16], val: u32) {
   let nsymbs = 4;
   let rate = 5 + (cdf[nsymbs] >> 4) as usize;

--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -83,6 +83,7 @@ const fn get_2d_mode_idx(mode_x: FilterMode, mode_y: FilterMode) -> usize {
   (mode_x as usize + 4 * (mode_y as usize)) & 15
 }
 
+#[inline(always)]
 pub fn put_8tap<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, src: PlaneSlice<'_, T>, width: usize,
   height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
@@ -149,6 +150,7 @@ pub fn put_8tap<T: Pixel>(
   }
 }
 
+#[inline(always)]
 pub fn prep_8tap<T: Pixel>(
   tmp: &mut [i16], src: PlaneSlice<'_, T>, width: usize, height: usize,
   col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,

--- a/src/asm/x86/quantize.rs
+++ b/src/asm/x86/quantize.rs
@@ -35,6 +35,7 @@ cpu_function_lookup_table!(
   [(AVX2, Some(dequantize_avx2))]
 );
 
+#[inline(always)]
 pub fn dequantize<T: Coefficient>(
   qindex: u8, coeffs: &[T], eob: usize, rcoeffs: &mut [T], tx_size: TxSize,
   bit_depth: usize, dc_delta_q: i8, ac_delta_q: i8, cpu: CpuFeatureLevel,


### PR DESCRIPTION
From perf, I'd estimate that this gives 0.5% total performance
improvement. This is also preventative, since some of these were already
getting inlined.