### PR TITLE
Unbreak reservoir-frame-delay

### DIFF
--- a/src/api/context.rs
+++ b/src/api/context.rs
@@ -390,7 +390,10 @@ impl<T: Pixel> Context<T> {
     }
   }
 
-  /// Number of pass data packets required to progress the encoding process.
+  /// Lower bound number of pass data packets required to progress the
+  /// encoding process.
+  ///
+  /// It should be called iteratively until it returns 0.
   ///
   pub fn rc_second_pass_data_required(&self) -> usize {
     if self.inner.done_processing() {

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -141,8 +141,7 @@ fn process_frame<T: Pixel, D: Decoder>(
 
   // Submit first pass data to pass 2.
   if let Some(passfile) = pass2file.as_mut() {
-    let required_data = ctx.rc_second_pass_data_required();
-    for _ in 0..required_data {
+    while ctx.rc_second_pass_data_required() > 0 {
       let mut buflen = [0u8; 8];
       passfile
         .read_exact(&mut buflen)

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1654,6 +1654,7 @@ impl RCState {
         }
         if frames_needed == 1 {
           self.pass2_data_ready = true;
+          self.cur_metrics = self.frame_metrics[self.frame_metrics_head];
         }
       } else {
         return Err(());


### PR DESCRIPTION
Do not assume the value returned by rc_second_pass_data_required is reliable

Receiving non-show_frame pass data may not reduce the number of packets
required.

Also set the current metrics correctly.

Fixes #2433 