### PR TITLE
doc: Add a description for Rate-control Empirical Analysis

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,7 @@
 - [Glossary](#glossary)
 - [Profiling](#profiling)
 - [Quality- & Speed-Features](#quality---speed-features)
-- [regress_log-bitrate_wrt_log-quantizer.ipynb](#regress_log-bitrate_wrt_log-quantizeripynb)
+- [Rate-control Empirical Analysis](#rate-control-empirical-analysis)
 - [File Structure](#file-structure)
 - [Versioning](#versioning)
 </details>
@@ -45,7 +45,9 @@ List of various profiling tools:
 ## [Quality- & Speed-Features](QUALITY_&_SPEED_FEATURES.md)
 Overview of quality and speed-features for rav1e and other state-of-the-art encoder.
 
-## [regress_log-bitrate_wrt_log-quantizer.ipynb](regress_log-bitrate_wrt_log-quantizer.ipynb)
+## [Rate-control Empirical Analysis](regress_log-bitrate_wrt_log-quantizer.ipynb)
+Notebook documenting how rate-control constants were derived from empirical data.
+These constants determine the initial values of `RCState::log_scale`, `RCState::exp` and `RCState::scalefilter`.
 
 ## [File Structure](STRUCTURE.md)
 - High-level directory structure

--- a/doc/regress_log-bitrate_wrt_log-quantizer.ipynb
+++ b/doc/regress_log-bitrate_wrt_log-quantizer.ipynb
@@ -1,6 +1,53 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Rate-control Empirical Analysis"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<script>\n",
+    "  function code_toggle() {\n",
+    "    if (code_shown){\n",
+    "      $('div.input').hide('500');\n",
+    "      $('#toggleButton').val('Show Code')\n",
+    "    } else {\n",
+    "      $('div.input').show('500');\n",
+    "      $('#toggleButton').val('Hide Code')\n",
+    "    }\n",
+    "    code_shown = !code_shown\n",
+    "  }\n",
+    "\n",
+    "  $( document ).ready(function(){\n",
+    "    code_shown=false;\n",
+    "    $('div.input').hide()\n",
+    "  });\n",
+    "</script>\n",
+    "<form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Show Code\"></form>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simple linear regression\n",
+    "\n",
+    "We performed a simple linear regression of the bitrate with respect to the quantizer,\n",
+    "operating on the logarithm of both.\n",
+    "The data set used was all of the video clips on https://media.xiph.org/video/derf/\n",
+    "as well as subset3 (for extra I-frame data).\n",
+    "To enable processing an arbitrarily large data set, an online regression algorithm was implemented.\n",
+    "In practice, [440MB of text formatted data](https://ba.rr-dav.id.au/data/rav1e/rc-data.tar.xz) were sufficient.\n",
+    "\n",
+    "The raw final state of the online regression for each segment follows."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -193,6 +240,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fixed-point approximation\n",
+    "\n",
+    "The regression results are converted to a fixed-point representation,\n",
+    "with the exponent in Q6 and the scale in Q3."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
@@ -344,6 +401,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The endpoints of each linear regression, rounding only the exponent, are detailed in the following output.\n",
+    "We use a cubic interpolation of these points to adjust the segment boundaries."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
@@ -405,6 +470,17 @@
    ],
    "source": [
     "pprint(segments)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Piecewise-linear fit\n",
+    "\n",
+    "We applied a 3-segment piecewise-linear fit. The boundaries were aligned to integer values of pixels-per-bit,\n",
+    "while optimizing for similarity to a cubic interpolation of the control points\n",
+    "(log-quantizer as a function of log-bitrate)."
    ]
   },
   {


### PR DESCRIPTION
Add a brief description to the documentation table-of-contents. Add text from related commits and pull requests to the notebook to provide context. Hide code by default to focus on the results.