### PR TITLE
Ground work to allow rav1e to access PlaneRegion memory that are outside of coded frame size

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -32,6 +32,11 @@ Analyze `.ivf`-files with `AOM Analyzer`:
 - Detection Algorithm
 - Desired Improvements
 
+## [Tile on Frame Boundary](TILE_ON_FRAME_BOUNDARY.md)
+- Accessing Tiled-pixels outside of a frame
+- How bounding box is enforced to a PlaneRegion and now it allows accessing the frame outside pixels
+- When does rav1e access outside frame tiled-input and output pixels?
+
 ## [Glossary](GLOSSARY.md)
 Explanation of various special terms.
 

--- a/doc/TILE_ON_FRAME_BOUNDARY.md
+++ b/doc/TILE_ON_FRAME_BOUNDARY.md
@@ -1,0 +1,36 @@
+# Tile on a Frame boundary
+
+## Accessing Tiled-pixels outside of a frame
+
+Tiled input and output planes (type PlaneRegion) are configured in order to
+allow memory access of its pixels that are located outside of frame boundary.
+This configuration is only effective when the tile is adjacent to right or bottom frame boundary and
+a partition block straddles on any frame boundary.
+
+The type names of tiled input and output in the codebase is defined in:
+
+```
+pub struct TileStateMut<'a, T: Pixel> {
+  ...
+  pub input: &'a Frame<T>,     // the whole frame
+  pub rec: TileMut<'a, T>,
+  ...
+}
+```
+
+## How bounding box is enforced to a PlaneRegion and now it allows to access outside of frame pixels
+
+A memory access to tiled input and output pixels in a _tile_ 
+is bounded by 'rect' field of each plane (of type `PlaneRegion`) of the `input_tile` or `rec` of `TileStateMut`.
+
+The bounding box dimension of a PlaneRegion.rect, i.e. PlaneRegion.rect.width and .height is ROUNDED UP to SuperBlock size,
+which now allows accessing the pixels outside the right or bottom frame boundary and belongs to a partition that straddle on any frame boundary.
+
+Previously, the bounding box has prohibited accessing those pixels. 
+
+## When does rav1e access outside frame tiled-input and output pixels?
+
+A CfL requires to read outside the coded frame (luma only), when it computes average
+and obtain ac components for luma block, i.e. `luma_ac()`.
+Hence, the prediction of a luma plane should be performed for all the pixels in a block
+(more precisely, all required tx-blocks in a partition), whether the predicted pixel is inside or outside the frame.

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -368,8 +368,12 @@ pub fn cdef_padded_tile_copy<T: Pixel>(
   // Copy data into padded frame
   for pli in 0..planes {
     let PlaneOffset { x, y } = sbo.plane_offset(tile.planes[pli].plane_cfg);
-    let in_width = tile.planes[pli].rect().width as isize;
-    let in_height = tile.planes[pli].rect().height as isize;
+    let in_width = tile.planes[pli].rect().width.min(
+      tile.planes[pli].plane_cfg.width - tile.planes[pli].rect().x as usize,
+    ) as isize;
+    let in_height = tile.planes[pli].rect().height.min(
+      tile.planes[pli].plane_cfg.height - tile.planes[pli].rect().y as usize,
+    ) as isize;
     let out_width = out.planes[pli].cfg.width;
     let out_height = out.planes[pli].cfg.height;
     // we copy pixels from the input tile for padding, but don't

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -639,8 +639,10 @@ pub fn cdef_filter_tile<T: Pixel>(
   // Each filter block is 64x64, except right and/or bottom for non-multiple-of-64 sizes.
   // FIXME: 128x128 SB support will break this, we need FilterBlockOffset etc.
   let planes = if fi.sequence.chroma_sampling == Cs400 { 1 } else { 3 };
-  let fb_width = (rec.planes[0].rect().width + 63) / 64;
-  let fb_height = (rec.planes[0].rect().height + 63) / 64;
+  let coded_tile_w = tb.cols() << MI_SIZE_LOG2;
+  let coded_tile_h = tb.rows() << MI_SIZE_LOG2;
+  let fb_width = (coded_tile_w + 63) / 64;
+  let fb_height = (coded_tile_h + 63) / 64;
 
   // Construct a padded copy of part of the input tile
   let mut cdef_frame: Frame<u16> = Frame {
@@ -660,8 +662,8 @@ pub fn cdef_filter_tile<T: Pixel>(
   };
 
   for p in 0..planes {
-    let rec_w = rec.planes[p].rect().width;
-    let rec_h = rec.planes[p].rect().height;
+    let rec_w = coded_tile_w >> rec.planes[p].plane_cfg.xdec;
+    let rec_h = coded_tile_h >> rec.planes[p].plane_cfg.ydec;
     let mut cdef_region = cdef_frame.planes[p].region_mut(Area::Rect {
       x: -2,
       y: -2,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -607,6 +607,11 @@ pub fn get_intra_edges<T: Pixel>(
         enable_intra_edge_filter && p_angle > 90 && p_angle < 180;
     }
 
+    let rect_w =
+      dst.rect().width.min(dst.plane_cfg.width - dst.rect().x as usize);
+    let rect_h =
+      dst.rect().height.min(dst.plane_cfg.height - dst.rect().y as usize);
+
     // Needs left
     if needs_left {
       if x != 0 {
@@ -670,8 +675,8 @@ pub fn get_intra_edges<T: Pixel>(
         partition_bo.0.x > 0
       };
 
-    let right_available = x + tx_size.width() < dst.rect().width;
-    let bottom_available = y + tx_size.height() < dst.rect().height;
+    let right_available = x + tx_size.width() < rect_w;
+    let bottom_available = y + tx_size.height() < rect_h;
 
     let scaled_partition_size =
       supersample_chroma_bsize(partition_size, plane_cfg.xdec, plane_cfg.ydec);
@@ -692,7 +697,7 @@ pub fn get_intra_edges<T: Pixel>(
           plane_cfg.xdec,
           plane_cfg.ydec,
         ) {
-        tx_size.width().min(dst.rect().width - x - tx_size.width())
+        tx_size.width().min(rect_w - x - tx_size.width())
       } else {
         0
       };
@@ -728,7 +733,7 @@ pub fn get_intra_edges<T: Pixel>(
           plane_cfg.xdec,
           plane_cfg.ydec,
         ) {
-        tx_size.height().min(dst.rect().height - y - tx_size.height())
+        tx_size.height().min(rect_h - y - tx_size.height())
       } else {
         0
       };

--- a/src/tiling/tile_state.rs
+++ b/src/tiling/tile_state.rs
@@ -136,11 +136,15 @@ impl<'a, T: Pixel> TileStateMut<'a, T> {
       height % MI_SIZE == 0,
       "Tile width must be a multiple of MI_SIZE"
     );
+
+    let sb_rounded_width = width.align_power_of_two(sb_size_log2);
+    let sb_rounded_height = height.align_power_of_two(sb_size_log2);
+
     let luma_rect = TileRect {
       x: sbo.0.x << sb_size_log2,
       y: sbo.0.y << sb_size_log2,
-      width,
-      height,
+      width: sb_rounded_width,
+      height: sb_rounded_height,
     };
     let sb_width = width.align_power_of_two_and_shift(sb_size_log2);
     let sb_height = height.align_power_of_two_and_shift(sb_size_log2);

--- a/src/tiling/tiler.rs
+++ b/src/tiling/tiler.rs
@@ -460,9 +460,9 @@ pub mod test {
     assert_eq!((32, 0, 32, 32), rect(&tile.planes[2]));
 
     let tile = &tile_states[2].rec; // the top-right tile
-    assert_eq!((128, 0, 32, 64), rect(&tile.planes[0]));
-    assert_eq!((64, 0, 16, 32), rect(&tile.planes[1]));
-    assert_eq!((64, 0, 16, 32), rect(&tile.planes[2]));
+    assert_eq!((128, 0, 64, 64), rect(&tile.planes[0]));
+    assert_eq!((64, 0, 32, 32), rect(&tile.planes[1]));
+    assert_eq!((64, 0, 32, 32), rect(&tile.planes[2]));
 
     let tile = &tile_states[3].rec; // the middle-left tile
     assert_eq!((0, 64, 64, 64), rect(&tile.planes[0]));
@@ -475,24 +475,24 @@ pub mod test {
     assert_eq!((32, 32, 32, 32), rect(&tile.planes[2]));
 
     let tile = &tile_states[5].rec; // the middle-right tile
-    assert_eq!((128, 64, 32, 64), rect(&tile.planes[0]));
-    assert_eq!((64, 32, 16, 32), rect(&tile.planes[1]));
-    assert_eq!((64, 32, 16, 32), rect(&tile.planes[2]));
+    assert_eq!((128, 64, 64, 64), rect(&tile.planes[0]));
+    assert_eq!((64, 32, 32, 32), rect(&tile.planes[1]));
+    assert_eq!((64, 32, 32, 32), rect(&tile.planes[2]));
 
     let tile = &tile_states[6].rec; // the bottom-left tile
-    assert_eq!((0, 128, 64, 16), rect(&tile.planes[0]));
-    assert_eq!((0, 64, 32, 8), rect(&tile.planes[1]));
-    assert_eq!((0, 64, 32, 8), rect(&tile.planes[2]));
+    assert_eq!((0, 128, 64, 64), rect(&tile.planes[0]));
+    assert_eq!((0, 64, 32, 32), rect(&tile.planes[1]));
+    assert_eq!((0, 64, 32, 32), rect(&tile.planes[2]));
 
     let tile = &tile_states[7].rec; // the bottom-middle tile
-    assert_eq!((64, 128, 64, 16), rect(&tile.planes[0]));
-    assert_eq!((32, 64, 32, 8), rect(&tile.planes[1]));
-    assert_eq!((32, 64, 32, 8), rect(&tile.planes[2]));
+    assert_eq!((64, 128, 64, 64), rect(&tile.planes[0]));
+    assert_eq!((32, 64, 32, 32), rect(&tile.planes[1]));
+    assert_eq!((32, 64, 32, 32), rect(&tile.planes[2]));
 
     let tile = &tile_states[8].rec; // the bottom-right tile
-    assert_eq!((128, 128, 32, 16), rect(&tile.planes[0]));
-    assert_eq!((64, 64, 16, 8), rect(&tile.planes[1]));
-    assert_eq!((64, 64, 16, 8), rect(&tile.planes[2]));
+    assert_eq!((128, 128, 64, 64), rect(&tile.planes[0]));
+    assert_eq!((64, 64, 32, 32), rect(&tile.planes[1]));
+    assert_eq!((64, 64, 32, 32), rect(&tile.planes[2]));
   }
 
   #[inline]
@@ -572,7 +572,7 @@ pub mod test {
         // row 8 of U-plane of the middle-right tile
         let tile_plane = &mut tile_states[5].rec.planes[1];
         let row = &mut tile_plane[8];
-        assert_eq!(16, row.len());
+        assert_eq!(32, row.len());
         row[..4].copy_from_slice(&[14, 121, 1, 3]);
       }
 


### PR DESCRIPTION
The goal of this work is to establish the ground so that rav1e can encode blocks that straddle on bottom or right frame boundaries (i.e. #2396).
I thought it would better approach to first land this groundwork then land the open-partition feature,  #2396.
Because, that way we can ensure the groundwork itself does not affect the integrity of current master without any open-partition code mixed.
With this PR only, it is expected to not change coding behavior of current master.

Until it is finished, it will fail many of rav1e's internal cargol tests, mostly when comparing encoder and decoder outputs, not because the enc and dec's outputs really unmatched but more likely the dimension of plane when it is declared is not correctly changed.
When compare the two reconstructed outputs from rav1e and decoder that run on command line and not via cargo test , I see that they are matched.
Also, at the moment I create this PR, I don't observe rust panic caused by memory access violation (i.e. accessing outside the bounding box defined by PlaneRegion (+ subregion) ).
