### PR TITLE
Channel API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ ivf = { version = "0.1", path = "ivf/", optional = true }
 v_frame = { version = "0.1", path = "v_frame/" }
 av-metrics = { version = "0.5.1", optional = true }
 rayon = "1.0"
+crossbeam = "0.7"
 toml = { version = "0.5", optional = true }
 arrayvec = { version = "0.5", features = ["array-sizes-33-128"] }
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ readme = "README.md"
 repository = "https://github.com/xiph/rav1e/"
 autobenches = false
 autobins = false
+default-run = "rav1e"
 
 [features]
 unstable = []
@@ -129,6 +130,11 @@ rand_chacha = "0.2"
 
 [[bin]]
 name = "rav1e"
+required-features = ["binaries"]
+bench = false
+
+[[bin]]
+name = "rav1e-ch"
 required-features = ["binaries"]
 bench = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ default-run = "rav1e"
 
 [features]
 unstable = []
+channel-api = ["crossbeam"]
 decode_test = ["aom-sys"]
 decode_test_dav1d = ["dav1d-sys"]
 binaries = [
@@ -74,7 +75,7 @@ ivf = { version = "0.1", path = "ivf/", optional = true }
 v_frame = { version = "0.1", path = "v_frame/" }
 av-metrics = { version = "0.5.1", optional = true }
 rayon = "1.0"
-crossbeam = "0.7"
+crossbeam = { version = "0.7", optional = true }
 toml = { version = "0.5", optional = true }
 arrayvec = { version = "0.5", features = ["array-sizes-33-128"] }
 thiserror = "1.0"
@@ -135,7 +136,7 @@ bench = false
 
 [[bin]]
 name = "rav1e-ch"
-required-features = ["binaries"]
+required-features = ["binaries", "channel-api", "unstable"]
 bench = false
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -100,8 +100,15 @@ cargo build --release
 Experimental API and Features can be enabled by using the `unstable` feature.
 
 ```sh
-cargo build --features unstable
+cargo build --features <feature>,unstable
 ```
+
+#### Current unstable features
+- Channel API:
+```sh
+cargo build --features channel-api,unstable
+```
+
 
 Those Features and API are bound to change and evolve, do not rely on them staying the same over releases.
 

--- a/src/api/channel.rs
+++ b/src/api/channel.rs
@@ -1,0 +1,517 @@
+// Copyright (c) 2018-2020, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+#![allow(missing_docs)]
+
+use crate::api::color::*;
+use crate::api::config::*;
+use crate::api::context::RcData;
+use crate::api::internal::ContextInner;
+use crate::api::util::*;
+
+use bitstream_io::*;
+use crossbeam::channel::*;
+
+use crate::encoder::*;
+use crate::frame::*;
+use crate::rate::RCState;
+use crate::rayon::{ThreadPool, ThreadPoolBuilder};
+use crate::util::Pixel;
+
+use std::io;
+use std::sync::Arc;
+
+/// Endpoint to send previous-pass statistics data
+pub struct RcDataSender {
+  sender: Sender<RcData>,
+  limit: u64,
+  count: u64,
+}
+
+impl RcDataSender {
+  fn new(limit: u64, sender: Sender<RcData>) -> RcDataSender {
+    Self { sender, limit, count: 0 }
+  }
+  pub fn try_send(
+    &mut self, data: RcData,
+  ) -> Result<(), TrySendError<RcData>> {
+    if self.limit <= self.count {
+      Err(TrySendError::Full(data))
+    } else {
+      let r = self.sender.try_send(data);
+      if r.is_ok() {
+        self.count += 1;
+      }
+      r
+    }
+  }
+  pub fn send(&mut self, data: RcData) -> Result<(), SendError<RcData>> {
+    if self.limit <= self.count {
+      Err(SendError(data))
+    } else {
+      let r = self.sender.send(data);
+      if r.is_ok() {
+        self.count += 1;
+      }
+      r
+    }
+  }
+  pub fn len(&self) -> usize {
+    self.sender.len()
+  }
+  pub fn is_empty(&self) -> bool {
+    self.sender.is_empty()
+  }
+
+  // TODO: proxy more methods
+}
+
+/// Endpoint to receive current-pass statistics data
+pub struct RcDataReceiver(Receiver<RcData>);
+
+impl RcDataReceiver {
+  pub fn try_recv(&self) -> Result<RcData, TryRecvError> {
+    self.0.try_recv()
+  }
+  pub fn recv(&self) -> Result<RcData, RecvError> {
+    self.0.recv()
+  }
+  pub fn len(&self) -> usize {
+    self.0.len()
+  }
+  pub fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+  pub fn iter(&self) -> Iter<RcData> {
+    self.0.iter()
+  }
+}
+
+pub type PassDataChannel = (RcDataSender, RcDataReceiver);
+
+pub type FrameInput<T> = (Option<Arc<Frame<T>>>, Option<FrameParameters>);
+
+/// Endpoint to send frames
+pub struct FrameSender<T: Pixel> {
+  sender: Sender<FrameInput<T>>,
+  config: Arc<EncoderConfig>,
+  limit: u64,
+  count: u64,
+}
+
+// Proxy the crossbeam Sender
+//
+// TODO: enforce the limit
+impl<T: Pixel> FrameSender<T> {
+  fn new(
+    limit: u64, sender: Sender<FrameInput<T>>, config: Arc<EncoderConfig>,
+  ) -> FrameSender<T> {
+    Self { sender, config, limit, count: 0 }
+  }
+  pub fn try_send<F: IntoFrame<T>>(
+    &mut self, frame: F,
+  ) -> Result<(), TrySendError<FrameInput<T>>> {
+    if self.limit <= self.count {
+      Err(TrySendError::Full(frame.into()))
+    } else {
+      let r = self.sender.try_send(frame.into());
+      if r.is_ok() {
+        self.count += 1;
+      }
+      r
+    }
+  }
+
+  pub fn send<F: IntoFrame<T>>(
+    &mut self, frame: F,
+  ) -> Result<(), SendError<FrameInput<T>>> {
+    if self.limit <= self.count {
+      Err(SendError(frame.into()))
+    } else {
+      let r = self.sender.send(frame.into());
+      if r.is_ok() {
+        self.count += 1;
+      }
+      r
+    }
+  }
+  pub fn len(&self) -> usize {
+    self.sender.len()
+  }
+  pub fn is_empty(&self) -> bool {
+    self.sender.is_empty()
+  }
+  // TODO: proxy more methods
+}
+
+// Frame factory
+impl<T: Pixel> FrameSender<T> {
+  /// Helper to create a new frame with the current encoder configuration
+  #[inline]
+  pub fn new_frame(&self) -> Frame<T> {
+    Frame::new(
+      self.config.width,
+      self.config.height,
+      self.config.chroma_sampling,
+    )
+  }
+}
+
+/// Endpoint to receive packets
+pub struct PacketReceiver<T: Pixel> {
+  receiver: Receiver<Packet<T>>,
+  config: Arc<EncoderConfig>,
+}
+
+impl<T: Pixel> PacketReceiver<T> {
+  pub fn try_recv(&self) -> Result<Packet<T>, TryRecvError> {
+    self.receiver.try_recv()
+  }
+  pub fn recv(&self) -> Result<Packet<T>, RecvError> {
+    self.receiver.recv()
+  }
+  pub fn len(&self) -> usize {
+    self.receiver.len()
+  }
+  pub fn is_empty(&self) -> bool {
+    self.receiver.is_empty()
+  }
+  pub fn iter(&self) -> Iter<Packet<T>> {
+    self.receiver.iter()
+  }
+}
+
+impl<T: Pixel> PacketReceiver<T> {
+  /// Produces a sequence header matching the current encoding context.
+  ///
+  /// Its format is compatible with the AV1 Matroska and ISOBMFF specification.
+  /// Note that the returned header does not include any config OBUs which are
+  /// required for some uses. See [the specification].
+  ///
+  /// [the specification]:
+  /// https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-section
+  #[inline]
+  pub fn container_sequence_header(&self) -> Vec<u8> {
+    fn sequence_header_inner(seq: &Sequence) -> io::Result<Vec<u8>> {
+      let mut buf = Vec::new();
+
+      {
+        let mut bw = BitWriter::endian(&mut buf, BigEndian);
+        bw.write_bit(true)?; // marker
+        bw.write(7, 1)?; // version
+        bw.write(3, seq.profile)?;
+        bw.write(5, 31)?; // level
+        bw.write_bit(false)?; // tier
+        bw.write_bit(seq.bit_depth > 8)?; // high_bitdepth
+        bw.write_bit(seq.bit_depth == 12)?; // twelve_bit
+        bw.write_bit(seq.bit_depth == 1)?; // monochrome
+        bw.write_bit(seq.chroma_sampling != ChromaSampling::Cs444)?; // chroma_subsampling_x
+        bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs420)?; // chroma_subsampling_y
+        bw.write(2, 0)?; // sample_position
+        bw.write(3, 0)?; // reserved
+        bw.write_bit(false)?; // initial_presentation_delay_present
+
+        bw.write(4, 0)?; // reserved
+      }
+
+      Ok(buf)
+    }
+
+    let seq = Sequence::new(&self.config);
+
+    sequence_header_inner(&seq).unwrap()
+  }
+}
+
+/// A channel modeling an encoding process
+pub type VideoDataChannel<T> = (FrameSender<T>, PacketReceiver<T>);
+
+impl Config {
+  fn setup<T: Pixel>(
+    &self,
+  ) -> Result<(ContextInner<T>, Arc<ThreadPool>), InvalidConfig> {
+    self.validate()?;
+    let inner = self.new_inner()?;
+
+    let pool = if let Some(ref p) = self.pool {
+      p.clone()
+    } else {
+      let pool =
+        ThreadPoolBuilder::new().num_threads(self.threads).build().unwrap();
+      Arc::new(pool)
+    };
+
+    Ok((inner, pool))
+  }
+}
+
+impl Config {
+  /// Create a single pass encoder channel
+  ///
+  /// Drop the `FrameSender<T>` endpoint to flush the encoder.
+  pub fn new_channel<T: Pixel>(
+    &self,
+  ) -> Result<VideoDataChannel<T>, InvalidConfig> {
+    let rc = &self.rate_control;
+
+    if rc.emit_pass_data || rc.summary.is_some() {
+      return Err(InvalidConfig::RateControlConfigurationMismatch);
+    }
+
+    let (v, _) = self.new_channel_internal()?;
+
+    Ok(v)
+  }
+
+  /// Create a first pass encoder channel
+  ///
+  /// The pass data information is available throguht
+  ///
+  /// Drop the `FrameSender<T>` endpoint to flush the encoder.
+  /// The last buffer in the PassDataReceiver is the summary of the whole
+  /// encoding process.
+  pub fn new_firstpass_channel<T: Pixel>(
+    &self,
+  ) -> Result<(VideoDataChannel<T>, RcDataReceiver), InvalidConfig> {
+    let rc = &self.rate_control;
+
+    if !rc.emit_pass_data {
+      return Err(InvalidConfig::RateControlConfigurationMismatch);
+    }
+    let (v, (_, r)) = self.new_channel_internal()?;
+
+    Ok((v, r.unwrap()))
+  }
+
+  /// Create a second pass encoder channel
+  ///
+  /// The encoding process require both frames and pass data to progress.
+  ///
+  /// Drop the `FrameSender<T>` endpoint to flush the encoder.
+  pub fn new_secondpass_channel<T: Pixel>(
+    &self,
+  ) -> Result<(VideoDataChannel<T>, RcDataSender), InvalidConfig> {
+    let rc = &self.rate_control;
+    if rc.emit_pass_data || rc.summary.is_none() {
+      return Err(InvalidConfig::RateControlConfigurationMismatch);
+    }
+
+    let (v, (s, _)) = self.new_channel_internal()?;
+
+    Ok((v, s.unwrap()))
+  }
+
+  /// Create a multipass encoder channel
+  ///
+  /// The `PacketReceiver<T>` may block if not enough pass statistics data
+  /// are sent through the `PassDataSender` endpoint
+  ///
+  /// Drop the `FrameSender<T>` endpoint to flush the encoder.
+  /// The last buffer in the PassDataReceiver is the summary of the whole
+  /// encoding process.
+  pub fn new_multipass_channel<T: Pixel>(
+    &self,
+  ) -> Result<(VideoDataChannel<T>, PassDataChannel), InvalidConfig> {
+    let rc = &self.rate_control;
+    if rc.summary.is_none() || !rc.emit_pass_data {
+      return Err(InvalidConfig::RateControlConfigurationMismatch);
+    }
+
+    let (v, (s, r)) = self.new_channel_internal()?;
+
+    Ok((v, (s.unwrap(), r.unwrap())))
+  }
+}
+
+trait RcFirstPass {
+  fn send_pass_data(&mut self, rc_state: &mut RCState);
+  fn send_pass_summary(&mut self, rc_state: &mut RCState);
+}
+
+trait RcSecondPass {
+  fn feed_pass_data<T: Pixel>(
+    &mut self, inner: &mut ContextInner<T>,
+  ) -> Result<(), ()>;
+}
+
+impl RcFirstPass for Sender<RcData> {
+  fn send_pass_data(&mut self, rc_state: &mut RCState) {
+    if let Some(data) = rc_state.emit_frame_data() {
+      let data = data.to_vec().into_boxed_slice();
+      self.send(RcData::Frame(data)).unwrap();
+    } else {
+      unreachable!(
+        "The encoder received more frames than its internal
+              limit allows"
+      );
+    }
+  }
+  fn send_pass_summary(&mut self, rc_state: &mut RCState) {
+    let data = rc_state.emit_summary();
+    let data = data.to_vec().into_boxed_slice();
+    self.send(RcData::Summary(data)).unwrap();
+  }
+}
+
+impl RcFirstPass for Option<Sender<RcData>> {
+  fn send_pass_data(&mut self, rc_state: &mut RCState) {
+    match self.as_mut() {
+      Some(s) => s.send_pass_data(rc_state),
+      None => {}
+    }
+  }
+  fn send_pass_summary(&mut self, rc_state: &mut RCState) {
+    match self.as_mut() {
+      Some(s) => s.send_pass_summary(rc_state),
+      None => {}
+    }
+  }
+}
+
+impl RcSecondPass for Receiver<RcData> {
+  fn feed_pass_data<T: Pixel>(
+    &mut self, inner: &mut ContextInner<T>,
+  ) -> Result<(), ()> {
+    while inner.rc_state.twopass_in_frames_needed() > 0
+      && !inner.done_processing()
+    {
+      if let Ok(RcData::Frame(data)) = self.recv() {
+        inner
+          .rc_state
+          .parse_frame_data_packet(data.as_ref())
+          .unwrap_or_else(|_| todo!("Error reporting"));
+      } else {
+        todo!("Error reporting");
+      }
+    }
+
+    Ok(())
+  }
+}
+
+impl RcSecondPass for Option<Receiver<RcData>> {
+  fn feed_pass_data<T: Pixel>(
+    &mut self, inner: &mut ContextInner<T>,
+  ) -> Result<(), ()> {
+    match self.as_mut() {
+      Some(s) => s.feed_pass_data(inner),
+      None => Ok(()),
+    }
+  }
+}
+
+impl Config {
+  fn new_channel_internal<T: Pixel>(
+    &self,
+  ) -> Result<
+    (VideoDataChannel<T>, (Option<RcDataSender>, Option<RcDataReceiver>)),
+    InvalidConfig,
+  > {
+    // The inner context is already configured to use the summary at this point.
+    let (mut inner, pool) = self.setup()?;
+
+    // TODO: make it user-settable
+    let input_len = self.enc.rdo_lookahead_frames as usize * 2;
+
+    let (send_frame, receive_frame) = bounded(input_len);
+    let (send_packet, receive_packet) = unbounded();
+
+    let rc = &self.rate_control;
+
+    let (mut send_rc_pass1, rc_data_receiver) = if rc.emit_pass_data {
+      let (send_rc_pass1, receive_rc_pass1) = unbounded();
+      (Some(send_rc_pass1), Some(RcDataReceiver(receive_rc_pass1)))
+    } else {
+      (None, None)
+    };
+
+    let (rc_data_sender, mut receive_rc_pass2, frame_limit) = if rc
+      .summary
+      .is_some()
+    {
+      let (frame_limit, pass_limit) =
+        rc.summary.as_ref().map(|s| (s.ntus as u64, s.total as u64)).unwrap();
+
+      inner.limit = Some(frame_limit);
+
+      let (send_rc_pass2, receive_rc_pass2) = unbounded();
+
+      (
+        Some(RcDataSender::new(pass_limit, send_rc_pass2)),
+        Some(receive_rc_pass2),
+        frame_limit,
+      )
+    } else {
+      (None, None, std::i32::MAX as u64)
+    };
+
+    let config = Arc::new(self.enc);
+
+    let channel = (
+      FrameSender::new(frame_limit, send_frame, config.clone()),
+      PacketReceiver { receiver: receive_packet, config },
+    );
+
+    let pass_channel = (rc_data_sender, rc_data_receiver);
+
+    pool.spawn(move || {
+      for f in receive_frame.iter() {
+        // info!("frame in {}", inner.frame_count);
+        while !inner.needs_more_fi_lookahead() {
+          receive_rc_pass2.feed_pass_data(&mut inner).unwrap();
+          // needs_more_fi_lookahead() should guard for missing output_frameno
+          // already.
+          //
+          // this call should return either Ok or Err(Encoded)
+          let has_pass_data = match inner.receive_packet() {
+            Ok(p) => {
+              send_packet.send(p).unwrap();
+              true
+            }
+            Err(EncoderStatus::Encoded) => true,
+            Err(EncoderStatus::NotReady) => todo!("Error reporting"),
+            _ => unreachable!(),
+          };
+          if has_pass_data {
+            send_rc_pass1.send_pass_data(&mut inner.rc_state);
+          }
+        }
+
+        let (frame, params) = f;
+        let _ = inner.send_frame(frame, params); // TODO make sure it cannot fail.
+      }
+
+      inner.limit = Some(inner.frame_count);
+      let _ = inner.send_frame(None, None);
+
+      loop {
+        receive_rc_pass2.feed_pass_data(&mut inner).unwrap();
+        let r = inner.receive_packet();
+        let has_pass_data = match r {
+          Ok(p) => {
+            // warn!("Sending out {}", p.input_frameno);
+            send_packet.send(p).unwrap();
+            true
+          }
+          Err(EncoderStatus::LimitReached) => break,
+          Err(EncoderStatus::Encoded) => true,
+          Err(EncoderStatus::NotReady) => todo!("Error reporting"),
+          _ => unreachable!(),
+        };
+
+        if has_pass_data {
+          send_rc_pass1.send_pass_data(&mut inner.rc_state);
+        }
+      }
+
+      send_rc_pass1.send_pass_summary(&mut inner.rc_state);
+    });
+
+    Ok((channel, pass_channel))
+  }
+}

--- a/src/api/channel.rs
+++ b/src/api/channel.rs
@@ -90,6 +90,10 @@ impl RcDataReceiver {
   pub fn iter(&self) -> Iter<RcData> {
     self.0.iter()
   }
+
+  pub fn summary_size(&self) -> usize {
+    crate::rate::TWOPASS_HEADER_SZ
+  }
 }
 
 pub type PassDataChannel = (RcDataSender, RcDataReceiver);

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -97,6 +97,10 @@ pub enum InvalidConfig {
   /// The rate control needs a target bitrate in order to produce results
   #[error("The rate control requires a target bitrate")]
   TargetBitrateNeeded,
+
+  /// The configuration
+  #[error("Mismatch in the rate control configuration")]
+  RateControlConfigurationMismatch,
 }
 
 /// Contains the encoder configuration.
@@ -198,6 +202,7 @@ impl Config {
     }
 
     let mut inner = ContextInner::new(&config);
+
     if self.rate_control.emit_pass_data {
       let params = inner.rc_state.get_twopass_out_params(&inner, 0);
       inner.rc_state.init_first_pass(params.pass1_log_base_q);
@@ -228,7 +233,6 @@ impl Config {
   pub fn new_context<T: Pixel>(&self) -> Result<Context<T>, InvalidConfig> {
     let inner = self.new_inner()?;
     let config = inner.config;
-
     let pool = if let Some(ref p) = self.pool {
       p.clone()
     } else {

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -369,7 +369,7 @@ impl<T: Pixel> ContextInner<T> {
 
   /// Indicates whether more frames need to be processed into FrameInvariants
   /// in order for FI lookahead to be full.
-  fn needs_more_fi_lookahead(&self) -> bool {
+  pub fn needs_more_fi_lookahead(&self) -> bool {
     let ready_frames = self.get_rdo_lookahead_frames().count();
     ready_frames < self.config.rdo_lookahead_frames + 1
       && self.needs_more_frames(self.next_lookahead_frame)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,6 +8,8 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 #![deny(missing_docs)]
 
+/// Channel-based encoder
+pub mod channel;
 /// Color model information
 pub mod color;
 /// Encoder Configuration
@@ -24,6 +26,7 @@ mod util;
 #[cfg(test)]
 mod test;
 
+pub use channel::*;
 pub use color::*;
 pub use config::*;
 pub use context::*;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,6 +9,7 @@
 #![deny(missing_docs)]
 
 /// Channel-based encoder
+#[cfg(all(feature = "channel-api", feature = "unstable"))]
 pub mod channel;
 /// Color model information
 pub mod color;
@@ -26,6 +27,7 @@ mod util;
 #[cfg(test)]
 mod test;
 
+#[cfg(all(feature = "channel-api", feature = "unstable"))]
 pub use channel::*;
 pub use color::*;
 pub use config::*;

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -21,9 +21,9 @@ use std::io;
 use std::io::prelude::*;
 
 pub struct EncoderIO {
-  pub input: Box<dyn Read>,
-  pub output: Box<dyn Muxer>,
-  pub rec: Option<Box<dyn Write>>,
+  pub input: Box<dyn Read + Send>,
+  pub output: Box<dyn Muxer + Send>,
+  pub rec: Option<Box<dyn Write + Send>>,
 }
 
 #[derive(PartialEq)]
@@ -436,16 +436,16 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
     Some(f) => Some(Box::new(
       File::create(&f)
         .map_err(|e| e.context("Cannot create reconstruction file"))?,
-    ) as Box<dyn Write>),
+    ) as Box<dyn Write + Send>),
     None => None,
   };
 
   let io = EncoderIO {
     input: match matches.value_of("INPUT").unwrap() {
-      "-" => Box::new(io::stdin()) as Box<dyn Read>,
+      "-" => Box::new(io::stdin()) as Box<dyn Read + Send>,
       f => Box::new(
         File::open(&f).map_err(|e| e.context("Cannot open input file"))?,
-      ) as Box<dyn Read>,
+      ) as Box<dyn Read + Send>,
     },
     output: create_muxer(
       matches.value_of("OUTPUT").unwrap(),

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -26,7 +26,7 @@ pub struct EncoderIO {
   pub rec: Option<Box<dyn Write + Send>>,
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum Verbose {
   Quiet,
   Normal,

--- a/src/bin/decoder/mod.rs
+++ b/src/bin/decoder/mod.rs
@@ -13,10 +13,14 @@ use std::io;
 
 pub mod y4m;
 
+pub trait FrameBuilder<T: Pixel> {
+  fn new_frame(&self) -> Frame<T>;
+}
+
 pub trait Decoder: Send {
   fn get_video_details(&self) -> VideoDetails;
-  fn read_frame<T: Pixel>(
-    &mut self, ctx: &Context<T>, cfg: &VideoDetails,
+  fn read_frame<T: Pixel, F: FrameBuilder<T>>(
+    &mut self, ctx: &F, cfg: &VideoDetails,
   ) -> Result<Frame<T>, DecodeError>;
 }
 

--- a/src/bin/decoder/mod.rs
+++ b/src/bin/decoder/mod.rs
@@ -13,7 +13,7 @@ use std::io;
 
 pub mod y4m;
 
-pub trait Decoder {
+pub trait Decoder: Send {
   fn get_video_details(&self) -> VideoDetails;
   fn read_frame<T: Pixel>(
     &mut self, ctx: &Context<T>, cfg: &VideoDetails,

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -15,7 +15,7 @@ use crate::decoder::{DecodeError, Decoder, VideoDetails};
 use crate::Frame;
 use rav1e::prelude::*;
 
-impl Decoder for y4m::Decoder<Box<dyn Read>> {
+impl Decoder for y4m::Decoder<Box<dyn Read + Send>> {
   fn get_video_details(&self) -> VideoDetails {
     let width = self.get_width();
     let height = self.get_height();

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -11,7 +11,7 @@
 use std::io::Read;
 
 use crate::color::ChromaSampling::Cs400;
-use crate::decoder::{DecodeError, Decoder, VideoDetails};
+use crate::decoder::{DecodeError, Decoder, FrameBuilder, VideoDetails};
 use crate::Frame;
 use rav1e::prelude::*;
 
@@ -41,8 +41,8 @@ impl Decoder for y4m::Decoder<Box<dyn Read + Send>> {
     }
   }
 
-  fn read_frame<T: Pixel>(
-    &mut self, ctx: &Context<T>, cfg: &VideoDetails,
+  fn read_frame<T: Pixel, F: FrameBuilder<T>>(
+    &mut self, ctx: &F, cfg: &VideoDetails,
   ) -> Result<Frame<T>, DecodeError> {
     let bytes = self.get_bytes_per_sample();
     self

--- a/src/bin/muxer/ivf.rs
+++ b/src/bin/muxer/ivf.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use crate::error::*;
 
 pub struct IvfMuxer {
-  output: Box<dyn Write>,
+  output: Box<dyn Write + Send>,
 }
 
 impl Muxer for IvfMuxer {
@@ -80,7 +80,7 @@ impl IvfMuxer {
     Ok(())
   }
 
-  pub fn open(path: &str) -> Result<Box<dyn Muxer>, CliError> {
+  pub fn open(path: &str) -> Result<Box<dyn Muxer + Send>, CliError> {
     let ivf = IvfMuxer {
       output: match path {
         "-" => Box::new(std::io::stdout()),

--- a/src/bin/muxer/mod.rs
+++ b/src/bin/muxer/mod.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 
 use crate::error::*;
 
-pub trait Muxer {
+pub trait Muxer: Send {
   fn write_header(
     &mut self, width: usize, height: usize, framerate_num: usize,
     framerate_den: usize,

--- a/src/bin/muxer/mod.rs
+++ b/src/bin/muxer/mod.rs
@@ -34,7 +34,7 @@ pub trait Muxer {
 
 pub fn create_muxer(
   path: &str, overwrite: bool,
-) -> Result<Box<dyn Muxer>, CliError> {
+) -> Result<Box<dyn Muxer + Send>, CliError> {
   if !overwrite {
     IvfMuxer::check_file(path)?;
   }

--- a/src/bin/muxer/y4m.rs
+++ b/src/bin/muxer/y4m.rs
@@ -13,7 +13,7 @@ use std::io::Write;
 use std::slice;
 
 pub fn write_y4m_frame<T: Pixel>(
-  y4m_enc: &mut y4m::Encoder<Box<dyn Write>>, rec: &Frame<T>,
+  y4m_enc: &mut y4m::Encoder<Box<dyn Write + Send>>, rec: &Frame<T>,
   y4m_details: VideoDetails,
 ) {
   let planes =

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -131,7 +131,7 @@ impl<D: Decoder> Source<D> {
 fn process_frame<T: Pixel, D: Decoder>(
   ctx: &mut Context<T>, output_file: &mut dyn Muxer, source: &mut Source<D>,
   pass1file: Option<&mut File>, pass2file: Option<&mut File>,
-  mut y4m_enc: Option<&mut y4m::Encoder<Box<dyn Write>>>,
+  mut y4m_enc: Option<&mut y4m::Encoder<Box<dyn Write + Send>>>,
   metrics_cli: MetricsEnabled,
 ) -> Result<Option<Vec<FrameSummary>>, CliError> {
   let y4m_details = source.input.get_video_details();
@@ -242,7 +242,7 @@ fn do_encode<T: Pixel, D: Decoder>(
   cfg: Config, verbose: Verbose, mut progress: ProgressInfo,
   output: &mut dyn Muxer, mut source: Source<D>, mut pass1file: Option<File>,
   mut pass2file: Option<File>,
-  mut y4m_enc: Option<y4m::Encoder<Box<dyn Write>>>,
+  mut y4m_enc: Option<y4m::Encoder<Box<dyn Write + Send>>>,
   metrics_enabled: MetricsEnabled,
 ) -> Result<(), CliError> {
   let mut ctx: Context<T> =
@@ -526,7 +526,7 @@ fn run() -> Result<(), error::CliError> {
   let source = Source::new(cli.limit, y4m_dec);
 
   if video_info.bit_depth == 8 {
-    do_encode::<u8, y4m::Decoder<Box<dyn Read>>>(
+    do_encode::<u8, y4m::Decoder<Box<dyn Read + Send>>>(
       cfg,
       cli.verbose,
       progress,
@@ -538,7 +538,7 @@ fn run() -> Result<(), error::CliError> {
       cli.metrics_enabled,
     )?
   } else {
-    do_encode::<u16, y4m::Decoder<Box<dyn Read>>>(
+    do_encode::<u16, y4m::Decoder<Box<dyn Read + Send>>>(
       cfg,
       cli.verbose,
       progress,

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -445,6 +445,7 @@ pub struct RCSummary {
   nframes: [i32; FRAME_NSUBTYPES + 1],
   exp: [u8; FRAME_NSUBTYPES],
   scale_sum: [i64; FRAME_NSUBTYPES],
+  total: i32,
 }
 
 // Backing storage to deserialize Summary and Per-Frame pass data
@@ -552,6 +553,8 @@ impl RCDeserialize {
     if s.ntus > total {
       return Err("More TUs than frames".to_string());
     }
+
+    s.total = total;
 
     for exp in s.exp.iter_mut() {
       *exp = self.unbuffer_val(1) as u8;

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -441,11 +441,11 @@ impl RCFrameMetrics {
 /// encoding pass.
 #[derive(Debug, Default, Clone)]
 pub struct RCSummary {
-  ntus: i32,
+  pub(crate) ntus: i32,
   nframes: [i32; FRAME_NSUBTYPES + 1],
   exp: [u8; FRAME_NSUBTYPES],
   scale_sum: [i64; FRAME_NSUBTYPES],
-  total: i32,
+  pub(crate) total: i32,
 }
 
 // Backing storage to deserialize Summary and Per-Frame pass data


### PR DESCRIPTION
This set provides a channel-based API that should make much simpler the normal usage.

TODO:
- [x] Basic encoding API
  - [x] Works
  - [x] Produces the same output for the same input
- [x] Multipass encoding API
   - [x] Single pass
   - [x] Second pass
     - [x] Produces the same output for the same input
   - [x] Multipass

Open questions:
- Fit a `last-error` inside the ReceiverPacket abstraction and a mean to retrieve it
- For multipass the api can be a single function and use the Config rc information to decide if it has to be multipass/firstpass/secondpass/normal

Solves: #689

(apparently github got some consistency issue with #2118 so I ended up opening this)