### PR TITLE
Fix quantizer index clamping

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -937,10 +937,6 @@ impl<T: Pixel> FrameInvariants<T> {
     self.base_q_idx = qps.ac_qi[0];
     let base_q_idx = self.base_q_idx as i32;
     for pi in 0..3 {
-      debug_assert!(qps.dc_qi[pi] as i32 - base_q_idx >= -128);
-      debug_assert!((qps.dc_qi[pi] as i32 - base_q_idx) < 128);
-      debug_assert!(qps.ac_qi[pi] as i32 - base_q_idx >= -128);
-      debug_assert!((qps.ac_qi[pi] as i32 - base_q_idx) < 128);
       self.dc_delta_q[pi] = (qps.dc_qi[pi] as i32 - base_q_idx) as i8;
       self.ac_delta_q[pi] = (qps.ac_qi[pi] as i32 - base_q_idx) as i8;
     }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1079,6 +1079,7 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
   fn write_delta_q(&mut self, delta_q: i8) -> io::Result<()> {
     self.write_bit(delta_q != 0)?;
     if delta_q != 0 {
+      assert!(delta_q >= -63 && delta_q <= 63);
       self.write_signed(6 + 1, delta_q)?;
     }
     Ok(())


### PR DESCRIPTION
Fixes panics on saturating_add(100) and corruption on saturating_sub(100) to the dc qi.

Should I remove these debug asserts too?
https://github.com/YaLTeR/rav1e/blob/9721626144b00c377530c1dd0c9199040ef36a58/src/encoder.rs#L940-L943