### PR TITLE
api: internal: Export frame_subtype and update script to store it.

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1043,6 +1043,7 @@ impl<T: Pixel> ContextInner<T> {
         let mut buf = vec![];
         buf.write_u64::<NativeEndian>(fi.h_in_imp_b as u64).unwrap();
         buf.write_u64::<NativeEndian>(fi.w_in_imp_b as u64).unwrap();
+        buf.write_u64::<NativeEndian>(fi.get_frame_subtype() as u64).unwrap();
         for y in 0..fi.h_in_imp_b {
           for x in 0..fi.w_in_imp_b {
             buf

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -593,7 +593,7 @@ impl<T: Pixel> ContextInner<T> {
         plane.cfg.height as u32,
         |x, y| image::Luma([plane.p(x as usize, y as usize).as_()]),
       )
-      .save(format!("{}-qres.png", fi.input_frameno))
+      .save(format!("{:010}-qres.png", fi.input_frameno))
       .unwrap();
       let plane = &fs.input_hres;
       image::GrayImage::from_fn(
@@ -601,7 +601,7 @@ impl<T: Pixel> ContextInner<T> {
         plane.cfg.height as u32,
         |x, y| image::Luma([plane.p(x as usize, y as usize).as_()]),
       )
-      .save(format!("{}-hres.png", fi.input_frameno))
+      .save(format!("{:010}-hres.png", fi.input_frameno))
       .unwrap();
     }
 
@@ -677,7 +677,8 @@ impl<T: Pixel> ContextInner<T> {
           buf.write_i16::<NativeEndian>(mv.col).unwrap();
         }
       }
-      ::std::fs::write(format!("{}-mvs.bin", fi.input_frameno), buf).unwrap();
+      ::std::fs::write(format!("{:010}-mvs.bin", fi.input_frameno), buf)
+        .unwrap();
     }
 
     // Set lookahead_rec_buffer on this FrameInvariants for future
@@ -1053,7 +1054,7 @@ impl<T: Pixel> ContextInner<T> {
               .unwrap();
           }
         }
-        ::std::fs::write(format!("{}-imps.bin", fi.input_frameno), buf)
+        ::std::fs::write(format!("{:010}-imps.bin", fi.input_frameno), buf)
           .unwrap();
       }
     }

--- a/tools/draw-importances.py
+++ b/tools/draw-importances.py
@@ -52,10 +52,12 @@ def blockImportance(input, verbose, path, raw):
         with open(input[1], 'rb') as f:
             contents = f.read()
 
-        rows, cols = struct.unpack('qq', contents[:16])
-        imps = np.frombuffer(contents[16:],
+        rows, cols, frame_type = struct.unpack('qqq', contents[:24])
+        imps = np.frombuffer(contents[24:],
                             dtype=np.float32).reshape((rows, cols))
 
+        if verbose:
+            click.echo("Frame Type: "+ str(frame_type))
         if raw:
             click.secho("imps data after processing:", fg="red")
             click.echo(imps)
@@ -67,6 +69,7 @@ def blockImportance(input, verbose, path, raw):
         imps_list = []
         rows_list = []
         col_list = []
+        frame_type_list = []
         png_list = glob.glob(str(path)+"/*hres.png")
         for png_iter in png_list:
              bin_list.append(png_iter.replace("hres.png","imps.bin"))
@@ -75,18 +78,20 @@ def blockImportance(input, verbose, path, raw):
         for bin in bin_list:
             with open(bin, 'rb') as f:
                 contents_batch = (f.read())
-                rows, cols, = struct.unpack('qq', contents_batch[:16])
-                imps = np.frombuffer(contents_batch[16:],
+                rows, cols, frame_type = struct.unpack('qqq', contents_batch[:24])
+                imps = np.frombuffer(contents_batch[24:],
                                     dtype=np.float32).reshape((rows, cols))
                 imps_list.append(imps)
                 rows_list.append(rows)
                 col_list.append(cols)
+                frame_type_list.append(frame_type)
 
         if raw:
             click.secho("The full imps data after processing:", fg="red")
             click.echo(imps_list)
 
     if verbose and path != None:
+        click.echo("Frame Type List: "+ str(frame_type_list))
         click.secho("\n png list: "+ str(png_list), fg="green")
         click.secho("\n bin list: "+ str(bin_list), fg="red")
         click.secho("\n Total Count: "+ str(total_files))


### PR DESCRIPTION
Right now we are exporting/storing width, height, block_importance,
for exhaustive analysis we need frame_subtype.
The get_frame_subtype from encoder.rs, will give the type of frame:
 - if key_frame, then I(0) frame
 - else, it will P(1) frame + pyramid level depth.

We are currently not using B0, B1 Frames for rav1e, but with help
of pyramid level value we can get the index.

Edit:
CLI Output preview:
<Details>

```bash
vibhoothiiaanand@derpBox /V/b/r/r/t/o/dump (draw-importance) [1]>
/Volumes/buildBox/rav1e/rav1e/tools/draw-importances.py --path .  --verbose

Input given: (None, None)
Path given: .
MODE 2
Frame Type List: [2, 3, 2, 3, 3, 2, 3, 0, 3, 1, 3, 1, 3, 1, 1, 3, 2, 3, 2, 3]

 png list: ['./6-hres.png', './7-hres.png', './14-hres.png', './15-hres.png', './19-hres.png', './18-hres.png', './1-hres.png', './0-hres.png', './13-hres.png', './12-hres.png', './17-hres.png', './16-hres.png', './5-hres.png', './4-hres.png', './8-hres.png', './9-hres.png', './10-hres.png', './11-hres.png', './2-hres.png', './3-hres.png']
```
</Details>


Edit 2:
With the third commit 5c7b96d003c53dd4389689b5c9a30e6a6008b757, the calculation of the frame_subtype in the script is rapid, earlier it was taking some time/script is running till the images are exported, we do not need that on normal runtime.

Edit 3:
Sorry for multiple edits, wanted to make it proper, 
Now it is matured enough for better data collection,
New changes after Version 2.
+ Introduced CSV Option to Export as CSV 

Right now, when we do large processing of data, we are not storing
the mean importance and frame type anywhere, so we require to save
it to a file, by having an export option to csv, this makes things
easier.

To use: append --csv option along with other modes.
This is only applicable to batch mode

+ api: internal: Have zero-padded file name

Currently, we are having natural path names, when we do sorting and
further analysis, it becomes a bit problematic as the natural sort is not
robust. By having zero paddings to the file name, both lexicographic
and natural sort are equal.