### PR TITLE
Reduce space to store Block struct

### DIFF
--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -167,11 +167,11 @@ pub struct Block {
   pub ref_frames: [RefType; 2],
   pub mv: [MotionVector; 2],
   // note: indexes are reflist index, NOT the same as libaom
-  pub neighbors_ref_counts: [usize; INTER_REFS_PER_FRAME],
+  pub neighbors_ref_counts: [u8; INTER_REFS_PER_FRAME],
   pub cdef_index: u8,
   pub bsize: BlockSize,
-  pub n4_w: usize, /* block width in the unit of mode_info */
-  pub n4_h: usize, /* block height in the unit of mode_info */
+  pub n4_w: u8, /* block width in the unit of mode_info */
+  pub n4_h: u8, /* block height in the unit of mode_info */
   pub txsize: TxSize,
   // The block-level deblock_deltas are left-shifted by
   // fi.deblock.block_delta_shift and added to the frame-configured
@@ -200,8 +200,8 @@ impl Default for Block {
       neighbors_ref_counts: [0; INTER_REFS_PER_FRAME],
       cdef_index: 0,
       bsize: BLOCK_64X64,
-      n4_w: BLOCK_64X64.width_mi(),
-      n4_h: BLOCK_64X64.height_mi(),
+      n4_w: BLOCK_64X64.width_mi() as u8,
+      n4_h: BLOCK_64X64.height_mi() as u8,
       txsize: TX_64X64,
       deblock_deltas: [0, 0, 0, 0],
       segmentation_idx: 0,
@@ -956,7 +956,7 @@ impl<'a> ContextWriter<'a> {
       let cand =
         &bc.blocks[bo.with_offset(col_offset + i as isize, row_offset)];
 
-      let n4_w = cand.n4_w;
+      let n4_w = cand.n4_w as usize;
       let mut len = cmp::min(target_n4_w, n4_w);
       if use_step_16 {
         len = cmp::max(n4_w_16, len);
@@ -1022,7 +1022,7 @@ impl<'a> ContextWriter<'a> {
     while i < end_mi {
       let cand =
         &bc.blocks[bo.with_offset(col_offset, row_offset + i as isize)];
-      let n4_h = cand.n4_h;
+      let n4_h = cand.n4_h as usize;
       let mut len = cmp::min(target_n4_h, n4_h);
       if use_step_16 {
         len = cmp::max(n4_h_16, len);
@@ -1286,7 +1286,7 @@ impl<'a> ContextWriter<'a> {
             &mut ref_diff_mvs,
           );
 
-          idx += if pass == 0 { blk.n4_w } else { blk.n4_h };
+          idx += if pass == 0 { blk.n4_w } else { blk.n4_h } as usize;
         }
       }
 
@@ -1427,7 +1427,7 @@ impl<'a> ContextWriter<'a> {
   }
 
   #[inline]
-  pub fn ref_count_ctx(counts0: usize, counts1: usize) -> usize {
+  pub fn ref_count_ctx(counts0: u8, counts1: u8) -> usize {
     if counts0 < counts1 {
       0
     } else if counts0 == counts1 {

--- a/src/context/transform_unit.rs
+++ b/src/context/transform_unit.rs
@@ -567,8 +567,8 @@ impl<'a> ContextWriter<'a> {
     &self, bo: TileBlockOffset, bsize: BlockSize,
   ) -> usize {
     let max_tx_size = max_txsize_rect_lookup[bsize as usize];
-    let max_tx_wide = max_tx_size.width();
-    let max_tx_high = max_tx_size.height();
+    let max_tx_wide = max_tx_size.width() as u8;
+    let max_tx_high = max_tx_size.height() as u8;
     let has_above = bo.0.y > 0;
     let has_left = bo.0.x > 0;
     let mut above = self.bc.above_tx_context[bo.0.x] >= max_tx_wide as u8;

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -1132,7 +1132,7 @@ fn filter_v_edge<T: Pixel>(
   let tx_edge = bo.0.x >> xdec & (txsize.width_mi() - 1) == 0;
   if tx_edge {
     let prev_block = deblock_left(blocks, bo, &p.as_const());
-    let block_edge = bo.0.x & (block.n4_w - 1) == 0;
+    let block_edge = bo.0.x & (block.n4_w as usize - 1) == 0;
     let filter_size =
       deblock_size(block, prev_block, &p.as_const(), pli, true, block_edge);
     if filter_size > 0 {
@@ -1179,7 +1179,7 @@ fn sse_v_edge<T: Pixel>(
   let tx_edge = bo.0.x >> xdec & (txsize.width_mi() - 1) == 0;
   if tx_edge {
     let prev_block = deblock_left(blocks, bo, rec_plane);
-    let block_edge = bo.0.x & (block.n4_w - 1) == 0;
+    let block_edge = bo.0.x & (block.n4_w as usize - 1) == 0;
     let filter_size =
       deblock_size(block, prev_block, rec_plane, pli, true, block_edge);
     if filter_size > 0 {
@@ -1228,7 +1228,7 @@ fn filter_h_edge<T: Pixel>(
   let tx_edge = bo.0.y >> ydec & (txsize.height_mi() - 1) == 0;
   if tx_edge {
     let prev_block = deblock_up(blocks, bo, &p.as_const());
-    let block_edge = bo.0.y & (block.n4_h - 1) == 0;
+    let block_edge = bo.0.y & (block.n4_h as usize - 1) == 0;
     let filter_size =
       deblock_size(block, prev_block, &p.as_const(), pli, false, block_edge);
     if filter_size > 0 {
@@ -1275,7 +1275,7 @@ fn sse_h_edge<T: Pixel>(
   let tx_edge = bo.0.y >> ydec & (txsize.height_mi() - 1) == 0;
   if tx_edge {
     let prev_block = deblock_up(blocks, bo, rec_plane);
-    let block_edge = bo.0.y & (block.n4_h - 1) == 0;
+    let block_edge = bo.0.y & (block.n4_h as usize - 1) == 0;
     let filter_size =
       deblock_size(block, prev_block, rec_plane, pli, true, block_edge);
     if filter_size > 0 {

--- a/src/scan_order.rs
+++ b/src/scan_order.rs
@@ -15,7 +15,6 @@ const MAX_NEIGHBORS: usize = 2;
 
 use crate::transform::*;
 
-#[repr(C)]
 pub struct SCAN_ORDER {
   pub scan: &'static [u16],
 }

--- a/src/tiling/tile_blocks.rs
+++ b/src/tiling/tile_blocks.rs
@@ -224,12 +224,12 @@ impl TileBlocksMut<'_> {
 
   #[inline(always)]
   pub fn set_block_size(&mut self, bo: TileBlockOffset, bsize: BlockSize) {
-    let n4_w = bsize.width_mi();
-    let n4_h = bsize.height_mi();
+    let n4_w = bsize.width_mi() as u8;
+    let n4_h = bsize.height_mi() as u8;
     self.for_each(bo, bsize, |block| {
       block.bsize = bsize;
       block.n4_w = n4_w;
-      block.n4_h = n4_h
+      block.n4_h = n4_h;
     });
   }
 

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -52,7 +52,6 @@ pub mod consts {
 pub const TX_TYPES: usize = 16;
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
-#[repr(C)]
 pub enum TxType {
   DCT_DCT = 0,   // DCT  in both horizontal and vertical
   ADST_DCT = 1,  // ADST in vertical, DCT in horizontal
@@ -74,7 +73,6 @@ pub enum TxType {
 
 /// Transform Size
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
-#[repr(C)]
 pub enum TxSize {
   TX_4X4,
   TX_8X8,


### PR DESCRIPTION
Reduces size from 96 bytes to 36 bytes. A single block is used for every
4x4 of the current frame.