### PR TITLE
Use new, non-broken me predictors

### DIFF
--- a/src/mc.rs
+++ b/src/mc.rs
@@ -23,30 +23,11 @@ use crate::tiling::*;
 use crate::util::*;
 
 use simd_helpers::cold_for_target_arch;
-use std::ops;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct MotionVector {
   pub row: i16,
   pub col: i16,
-}
-
-impl ops::Add<MotionVector> for MotionVector {
-  type Output = MotionVector;
-
-  #[inline]
-  fn add(self, _rhs: MotionVector) -> MotionVector {
-    MotionVector { row: self.row + _rhs.row, col: self.col + _rhs.col }
-  }
-}
-
-impl ops::Div<i16> for MotionVector {
-  type Output = MotionVector;
-
-  #[inline]
-  fn div(self, _rhs: i16) -> MotionVector {
-    MotionVector { row: self.row / _rhs, col: self.col / _rhs }
-  }
 }
 
 impl MotionVector {


### PR DESCRIPTION
The old predictors were sampling without regards to block size. All of
the samples would be taken from 4x4 blocks adjacent or on the upper left
corner of the currently tested block. The top right subset B (EPZS,
current frame) predictor and right and bottom subset C (prev frame) were
sampling entirely incorrect locations. The other predictors were biased
to that upper left corner.

Add an additional top left predictor.

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.3292 | -0.3730 | -0.1695 |  -0.3330 | -0.3641 | -0.3603 |    -0.3046 |