### PR TITLE
Update dead links for AOM Analyzer

### DIFF
--- a/doc/AOM_ANALYZER.md
+++ b/doc/AOM_ANALYZER.md
@@ -1,7 +1,7 @@
 # AOMAnalyzer
 
 <details>
-<summary><b>Table of Content</b></summary>
+<summary><b>Table of Contents</b></summary>
 
 - [Local Analyzer](#local-analyzer)
 - [Online Analyzer](#online-analyzer)
@@ -10,7 +10,7 @@
 ## Local Analyzer
 
 1. Download the [AOM Analyzer](http://aomanalyzer.org) ([source](https://github.com/xiph/aomanalyzer)).
-2. Download [inspect.js](https://people.xiph.org/~mbebenita/analyzer/inspect.js) ([mirror](https://github.com/xiph/aomanalyzer/files/4685593/inspect.wasm.gz)) and [inspect.wasm](https://people.xiph.org/~mbebenita/analyzer/inspect.wasm) ([mirror](https://github.com/xiph/aomanalyzer/files/4685594/inspect.js.gz)) and save them in the same directory.
+2. Download [inspect.js](https://media.xiph.org/analyzer/inspect.js) ([mirror](https://github.com/xiph/aomanalyzer/files/4685593/inspect.wasm.gz)) and [inspect.wasm](https://media.xiph.org/analyzer/inspect.wasm) ([mirror](https://github.com/xiph/aomanalyzer/files/4685594/inspect.js.gz)) and save them in the same directory.
 3. Run the analyzer:
    ```
    AOMAnalyzer path_to_inspect.js output.ivf
@@ -21,5 +21,5 @@
 If your `.ivf` file is hosted somewhere (and CORS is enabled on your web server) you can use:
 
 ```
-https://arewecompressedyet.com/analyzer/?d=https://people.xiph.org/~mbebenita/analyzer/inspect.js&f=path_to_output.ivf
+https://arewecompressedyet.com/analyzer/?d=https://media.xiph.org/analyzer/inspect.js&f=path_to_output.ivf
 ```


### PR DESCRIPTION
aomanalyzer.org needs an update too, but I don't know if we want to replace it with a link to media.xiph.org or try to get it to redirect there.

Also, it currently redirects to https://people.xiph.org/~mbebenita/analyzer/, which is the root directory containing the wasm files, so I don't understand why the instructions say to download "the AOM Analyzer" followed by the files in the directory. Maybe the instructions need to be rewritten as well.