### PR TITLE
CI (js_api.yml): Fix wasm-pack build

### DIFF
--- a/.github/workflows/js_api.yml
+++ b/.github/workflows/js_api.yml
@@ -85,7 +85,8 @@ jobs:
             - name: Build
               if: matrix.conf == 'build'
               working-directory: rav1e_js
-              run: wasm-pack build
+              # --dev needed, because of https://github.com/rustwasm/wasm-pack/issues/886
+              run: wasm-pack build --dev
 
             - name: Pack
               if: matrix.conf == 'build'


### PR DESCRIPTION
Add `--dev` to `wasm-pack build`. This is needed, because of https://github.com/rustwasm/wasm-pack/issues/886.

This should be reverted as soon it is fixed in `wasm-pack`.