### PR TITLE
tools: submit_awcy: Submit runs by commit ID

### DIFF
--- a/tools/submit_awcy.py
+++ b/tools/submit_awcy.py
@@ -55,6 +55,7 @@ parser = argparse.ArgumentParser(
     description="Submit test to arewecompressedyet.com"
 )
 parser.add_argument("-branch", default=None)
+parser.add_argument("-commit", default=None)
 parser.add_argument("-prefix", default=None)
 parser.add_argument("-master", action="store_true", default=False)
 parser.add_argument("-set", default="objective-1-fast")
@@ -78,12 +79,17 @@ if args.branch is None:
 if args.prefix is None:
     args.prefix = args.branch
 
-commit = subprocess.check_output("git rev-parse HEAD", shell=True).strip()
-short = (
-    subprocess.check_output("git rev-parse --short HEAD", shell=True)
-    .strip()
-    .decode("utf-8")
-)
+if args.commit is None:
+    commit = (
+        subprocess.check_output("git rev-parse HEAD", shell=True)
+        .strip()
+        .decode("utf-8")
+    )
+else:
+    commit = args.commit
+short_arg = "git rev-parse --short " + commit
+short = subprocess.check_output(short_arg, shell=True).strip().decode("utf-8")
+
 date = GetTime().strip()
 date_short = (
     date.split()[0] + "_" + date.split()[1].split(".")[0].replace(":", "")


### PR DESCRIPTION
With this commit, users can submit runs to AWCY with
custom commit ID instead of choosing head which is the
current behaviour.
Usage: submit_awcy.py <normal commands> -commit $ID