### PR TITLE
Remove Sequence::separate_uv_delta_q

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -176,7 +176,6 @@ pub struct Sequence {
   pub tier: [usize; MAX_NUM_OPERATING_POINTS], // seq_tier in the spec. One bit: 0
   // or 1.
   pub film_grain_params_present: bool,
-  pub separate_uv_delta_q: bool,
   pub timing_info_present: bool,
 }
 
@@ -256,7 +255,6 @@ impl Sequence {
       level,
       tier,
       film_grain_params_present: false,
-      separate_uv_delta_q: true,
       timing_info_present: config.enable_timing_info,
     }
   }

--- a/src/header.rs
+++ b/src/header.rs
@@ -442,7 +442,7 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
       }
     }
 
-    self.write_bit(seq.separate_uv_delta_q)?;
+    self.write_bit(true)?; // separate_uv_delta_q
 
     Ok(())
   }
@@ -750,15 +750,9 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     self.write_delta_q(fi.dc_delta_q[0])?;
     if fi.sequence.chroma_sampling != ChromaSampling::Cs400 {
       assert!(fi.ac_delta_q[0] == 0);
-      let diff_uv_delta = fi.sequence.separate_uv_delta_q
-        && (fi.dc_delta_q[1] != fi.dc_delta_q[2]
-          || fi.ac_delta_q[1] != fi.ac_delta_q[2]);
-      if fi.sequence.separate_uv_delta_q {
-        self.write_bit(diff_uv_delta)?;
-      } else {
-        assert!(fi.dc_delta_q[1] == fi.dc_delta_q[2]);
-        assert!(fi.ac_delta_q[1] == fi.ac_delta_q[2]);
-      }
+      let diff_uv_delta = fi.dc_delta_q[1] != fi.dc_delta_q[2]
+        || fi.ac_delta_q[1] != fi.ac_delta_q[2];
+      self.write_bit(diff_uv_delta)?;
       self.write_delta_q(fi.dc_delta_q[1])?;
       self.write_delta_q(fi.ac_delta_q[1])?;
       if diff_uv_delta {


### PR DESCRIPTION
The false case is never implemented, and implementing it is not currently a priority, so it is essentially dead code.