### PR TITLE
rav1e_js: Various small changes

### DIFF
--- a/rav1e_js/Cargo.toml
+++ b/rav1e_js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rav1e_js"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Urhengulas <johann.hemmann@code.berlin>"]
 edition = "2018"
 description = "JavaScript bindings for rav1e"

--- a/rav1e_js/src/encoder/frame_encoder.rs
+++ b/rav1e_js/src/encoder/frame_encoder.rs
@@ -38,19 +38,13 @@ impl Encoder for FrameEncoder {
 #[wasm_bindgen]
 impl FrameEncoder {
   #[wasm_bindgen(constructor)]
-  pub fn fromEncoderConfig(
-    conf: EncoderConfig,
-  ) -> Result<FrameEncoder, JsValue> {
+  pub fn new(conf: &EncoderConfig) -> Result<FrameEncoder, JsValue> {
     let cfg = Config::new().with_encoder_config(conf.conf);
 
     match cfg.new_context() {
       Ok(ctx) => Ok(Self { ctx }),
       Err(e) => Err(construct_js_err(e, "Invalid EncoderConfig")),
     }
-  }
-
-  pub fn default() -> Result<FrameEncoder, JsValue> {
-    Self::fromEncoderConfig(EncoderConfig::new())
   }
 
   pub fn debug(&self) -> String {

--- a/rav1e_js/src/encoder/video_encoder.rs
+++ b/rav1e_js/src/encoder/video_encoder.rs
@@ -44,9 +44,7 @@ impl Encoder for VideoEncoder {
 #[wasm_bindgen]
 impl VideoEncoder {
   #[wasm_bindgen(constructor)]
-  pub fn fromEncoderConfig(
-    conf: EncoderConfig,
-  ) -> Result<VideoEncoder, JsValue> {
+  pub fn new(conf: &EncoderConfig) -> Result<VideoEncoder, JsValue> {
     let cfg = Config::new().with_encoder_config(conf.conf);
 
     match cfg.new_context() {
@@ -59,10 +57,6 @@ impl VideoEncoder {
       }),
       Err(e) => Err(construct_js_err(e, "Invalid EncoderConfig")),
     }
-  }
-
-  pub fn default() -> Result<VideoEncoder, JsValue> {
-    Self::fromEncoderConfig(EncoderConfig::new())
   }
 
   /// Capture data of `HtmlVideoElement`, while it's playing.

--- a/rav1e_js/src/lib.rs
+++ b/rav1e_js/src/lib.rs
@@ -17,6 +17,7 @@ pub(crate) mod utils;
 pub(crate) mod web;
 
 pub use encoder::FrameEncoder;
+pub use encoder::VideoEncoder;
 pub use encoder_config::EncoderConfig;
 pub use frame::Frame;
 pub use packet::Packet;

--- a/rav1e_js/tests/utils.rs
+++ b/rav1e_js/tests/utils.rs
@@ -19,56 +19,28 @@ pub fn simple_encoding(repeats: u32) {
 
   let cfg = Config::new().with_encoder_config(enc);
   let mut ctx: Context<u16> = cfg.new_context().unwrap();
-  rav1e_js::log!("Instantiated new encoder (config: {:?})", cfg);
 
   let f = ctx.new_frame();
-  rav1e_js::log!("Generated new frame: {:?}", f);
 
   for i in 0..repeats {
-    rav1e_js::log!("Sending frame {}", i);
     match ctx.send_frame(f.clone()) {
       Ok(_) => {}
       Err(e) => match e {
-        EncoderStatus::EnoughData => {
-          rav1e_js::log!(
-            "Warn: Unable to append frame {} to the internal queue",
-            i
-          );
-        }
+        EncoderStatus::EnoughData => {}
         _ => {
           panic!("Unable to send frame {}", i);
         }
       },
     }
   }
-  rav1e_js::log!("Successfully send {} frames to the encoder", repeats);
-
   ctx.flush();
-  rav1e_js::log!("Flush encoder");
 
   loop {
     match ctx.receive_packet() {
-      Ok(packet) => {
-        // Mux the packet.
-        rav1e_js::log!("Received packet: {}", packet)
-      }
-      Err(EncoderStatus::Encoded) => {
-        // A frame was encoded without emitting a packet. This is normal,
-        // just proceed as usual.
-      }
-      Err(EncoderStatus::LimitReached) => {
-        // All frames have been encoded. Time to break out of the loop.
-        break;
-      }
-      Err(EncoderStatus::NeedMoreData) => {
-        // The encoder has requested additional frames. Push the next frame
-        // in, or flush the encoder if there are no frames left (on None).
-        ctx.flush();
-      }
-      Err(e) => {
-        panic!(e);
-      }
+      Ok(_packet) => {}
+      Err(EncoderStatus::Encoded) => {}
+      Err(EncoderStatus::LimitReached) => break,
+      Err(e) => panic!(e),
     }
   }
-  rav1e_js::log!("Done encoding the same tiny blank frame {} times.", repeats);
 }


### PR DESCRIPTION
## Changes
* `encoder`
    * Pass `EncoderConfig` as ref to constructor
      --> This enables still using the config afterwards
    * Rename [FrameEncoder, VideoEncoder]::fromEncoderConfig(...) to ::new(...)
      --> doesn't change anything from js user perspective
    * Rm `::default()` from `FrameEncoder`, `VideoEncoder`
      --> get default config via `new Encoder(new EncoderConfig())`
* `mod`: `pub use encoder::VideoEncoder`
* `tests`: Clean `utils::simple_encoding`
  --> Make test output less verbose
* bump version to `0.3.0`