### PR TITLE
CI: Add check_asm to extra features

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -251,7 +251,7 @@ jobs:
     - name: Check extra features
       if: matrix.toolchain == 'stable' && matrix.conf == 'check-extra-feats'
       run: |
-        cargo check --features=capi,dump_lookahead_data,serialize
+        cargo check --features=check_asm,capi,dump_lookahead_data,serialize
     - name: Run cargo-c
       if: matrix.conf == 'cargo-c'
       run: |

--- a/src/asm/x86/dist/sse.rs
+++ b/src/asm/x86/dist/sse.rs
@@ -145,8 +145,8 @@ pub fn get_weighted_sse<T: Pixel>(
   #[cfg(feature = "check_asm")]
   assert_eq!(
     dist, ref_dist,
-    "Weighted SSE {}: Assembly doesn't match reference code.",
-    bsize
+    "Weighted SSE {:?}: Assembly doesn't match reference code.",
+    bsize_opt
   );
 
   dist


### PR DESCRIPTION
This testing feature fails to compile after #2444 was merged. Fix that error and enable the feature in CI.