### PR TITLE
Initial port to tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ binaries = [
     "y4m",
     "clap",
     "scan_fmt",
-    "fern",
     "console",
     "av-metrics",
+    "tracing-subscriber",
 ]
 default = ["binaries", "asm", "signal_support"]
 asm = ["nasm-rs", "cc", "regex"]
@@ -42,7 +42,6 @@ desync_finder = ["backtrace"]
 bench = []
 check_asm = []
 capi = []
-tracing = ["rust_hawktracer"]
 serialize = ["serde", "toml", "v_frame/serialize", "arrayvec/serde"]
 wasm = ["wasm-bindgen"]
 
@@ -79,21 +78,17 @@ thiserror = "1.0"
 byteorder = { version = "1.3.2", optional = true }
 log = "0.4"
 console = { version = "0.12", optional = true }
-fern = { version = "0.6", optional = true }
 itertools = "0.9"
 simd_helpers = "0.1"
 wasm-bindgen = { version = "0.2.63", optional = true }
+tracing = "0.1"
+tracing-subscriber = { version = "0.2", optional = true }
 
 [dependencies.image]
 version = "0.23"
 optional = true
 default-features = false
 features = ["png"]
-
-[dependencies.rust_hawktracer]
-version = "0.7.0"
-features = ["profiling_enabled"]
-optional = true
 
 [build-dependencies]
 cc = { version = "1.0", optional = true, features = ["parallel"] }


### PR DESCRIPTION
It behaves as fern since no changes to the logging are present, but should let you use the tracing api if you need something more refined.

It clashes with the `tracing` feature that enables hawktracer and that's in itself unfortunate.