### PR TITLE
asm: aarch64: Integrate aarch64 assembly: src/arm/64/itx16.S 

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -139,6 +139,7 @@ fn build_asm_files() {
     "src/arm/64/mc.S",
     "src/arm/64/mc16.S",
     "src/arm/64/itx.S",
+    "src/arm/64/itx16.S",
     "src/arm/64/ipred.S",
     "src/arm/64/ipred16.S",
     "src/arm/64/sad.S",

--- a/src/asm/aarch64/transform/inverse.rs
+++ b/src/asm/aarch64/transform/inverse.rs
@@ -36,6 +36,21 @@ pub fn inverse_transform_add<T: Pixel>(
         );
       }
     }
+    PixelType::U16 if bd == 10 => {
+      if let Some(func) = INV_TXFM_HBD_FNS[cpu.as_index()]
+        [get_tx_size_idx(tx_size)][get_tx_type_idx(tx_type)]
+      {
+        return call_inverse_hbd_func(
+          func,
+          input,
+          output,
+          eob,
+          tx_size.width(),
+          tx_size.height(),
+          bd,
+        );
+      }
+    }
     PixelType::U16 => {}
   };
 
@@ -73,6 +88,37 @@ macro_rules! decl_itx_fns {
   };
 }
 
+macro_rules! decl_itx_hbd_fns {
+  // Takes a 2d list of tx types for W and H
+  ([$([$(($ENUM:expr, $TYPE1:ident, $TYPE2:ident)),*]),*], $W:expr, $H:expr,
+   $OPT_LOWER:ident, $OPT_UPPER:ident) => {
+    paste::item! {
+      // For each tx type, declare an function for the current WxH
+      $(
+        $(
+          extern {
+            // Note: type1 and type2 are flipped
+            fn [<rav1e_inv_txfm_add_ $TYPE2 _$TYPE1 _$W x $H _16bpc_$OPT_LOWER>](
+              dst: *mut u16, dst_stride: libc::ptrdiff_t, coeff: *mut i16,
+              eob: i32,
+            );
+          }
+        )*
+      )*
+      // Create a lookup table for the tx types declared above
+      const [<INV_TXFM_HBD_FNS_$W _$H _$OPT_UPPER>]: [Option<InvTxfmHBDFunc>; TX_TYPES] = {
+        let mut out: [Option<InvTxfmHBDFunc>; 16] = [None; 16];
+        $(
+          $(
+            out[get_tx_type_idx($ENUM)] = Some([<rav1e_inv_txfm_add_$TYPE2 _$TYPE1 _$W x $H _16bpc_$OPT_LOWER>]);
+          )*
+        )*
+        out
+      };
+    }
+  };
+}
+
 macro_rules! create_wxh_tables {
   // Create a lookup table for each cpu feature
   ([$([$(($W:expr, $H:expr)),*]),*], $OPT_LOWER:ident, $OPT_UPPER:ident) => {
@@ -94,6 +140,31 @@ macro_rules! create_wxh_tables {
   ($DIMS:tt, [$(($OPT_LOWER:ident, $OPT_UPPER:ident)),+]) => {
     $(
       create_wxh_tables!($DIMS, $OPT_LOWER, $OPT_UPPER);
+    )*
+  };
+}
+
+macro_rules! create_wxh_hbd_tables {
+  // Create a lookup table for each cpu feature
+  ([$([$(($W:expr, $H:expr)),*]),*], $OPT_LOWER:ident, $OPT_UPPER:ident) => {
+    paste::item! {
+      const [<INV_TXFM_HBD_FNS_$OPT_UPPER>]: [[Option<InvTxfmHBDFunc>; TX_TYPES]; 32] = {
+        let mut out: [[Option<InvTxfmHBDFunc>; TX_TYPES]; 32] = [[None; TX_TYPES]; 32];
+        // For each dimension, add an entry to the table
+        $(
+          $(
+            out[get_tx_size_idx(TxSize::[<TX_ $W X $H>])] = [<INV_TXFM_HBD_FNS_$W _$H _$OPT_UPPER>];
+          )*
+        )*
+        out
+      };
+    }
+  };
+
+  // Loop through cpu features
+  ($DIMS:tt, [$(($OPT_LOWER:ident, $OPT_UPPER:ident)),+]) => {
+    $(
+      create_wxh_hbd_tables!($DIMS, $OPT_LOWER, $OPT_UPPER);
     )*
   };
 }
@@ -172,6 +243,85 @@ impl_itx_fns!(
 
 cpu_function_lookup_table!(
   INV_TXFM_FNS: [[[Option<InvTxfmFunc>; TX_TYPES]; 32]],
+  default: [[None; TX_TYPES]; 32],
+  [NEON]
+);
+
+macro_rules! impl_itx_hbd_fns {
+
+  ($TYPES:tt, $W:expr, $H:expr, [$(($OPT_LOWER:ident, $OPT_UPPER:ident)),+]) => {
+    $(
+      decl_itx_hbd_fns!($TYPES, $W, $H, $OPT_LOWER, $OPT_UPPER);
+    )*
+  };
+
+  // Loop over a list of dimensions
+  ($TYPES_VALID:tt, [$(($W:expr, $H:expr)),*], $OPT:tt) => {
+    $(
+      impl_itx_hbd_fns!($TYPES_VALID, $W, $H, $OPT);
+    )*
+  };
+
+  ($TYPES64:tt, $DIMS64:tt, $TYPES32:tt, $DIMS32:tt, $TYPES16:tt, $DIMS16:tt,
+   $TYPES84:tt, $DIMS84:tt, $OPT:tt) => {
+    // Make 2d list of tx types for each set of dimensions. Each set of
+    //   dimensions uses a superset of the previous set of tx types.
+    impl_itx_hbd_fns!([$TYPES64], $DIMS64, $OPT);
+    impl_itx_hbd_fns!([$TYPES64, $TYPES32], $DIMS32, $OPT);
+    impl_itx_hbd_fns!([$TYPES64, $TYPES32, $TYPES16], $DIMS16, $OPT);
+    impl_itx_hbd_fns!(
+      [$TYPES64, $TYPES32, $TYPES16, $TYPES84], $DIMS84, $OPT
+    );
+
+    // Pool all of the dimensions together to create a table for each cpu
+    // feature level.
+    create_wxh_hbd_tables!(
+      [$DIMS64, $DIMS32, $DIMS16, $DIMS84], $OPT
+    );
+  };
+}
+
+impl_itx_hbd_fns!(
+  // 64x
+  [(TxType::DCT_DCT, dct, dct)],
+  [(64, 64), (64, 32), (32, 64), (16, 64), (64, 16)],
+  // 32x
+  // TODO: We are excluding identity transform as tests are failing with
+  // memory misalignment for 4 cases:
+  // inv_txfm2d_add_identity_identity_16x32_neon,
+  // inv_txfm2d_add_identity_identity_32x16_neon,
+  // inv_txfm2d_add_identity_identity_32x32_neon,
+  // inv_txfm2d_add_identity_identity_8x32_neon
+  //[(TxType::IDTX, identity, identity)],
+  [],
+  [(32, 32), (32, 16), (16, 32), (32, 8), (8, 32)],
+  // 16x16
+  [
+    (TxType::DCT_ADST, dct, adst),
+    (TxType::ADST_DCT, adst, dct),
+    (TxType::DCT_FLIPADST, dct, flipadst),
+    (TxType::FLIPADST_DCT, flipadst, dct),
+    (TxType::V_DCT, dct, identity),
+    (TxType::H_DCT, identity, dct),
+    (TxType::ADST_ADST, adst, adst),
+    (TxType::ADST_FLIPADST, adst, flipadst),
+    (TxType::FLIPADST_ADST, flipadst, adst),
+    (TxType::FLIPADST_FLIPADST, flipadst, flipadst)
+  ],
+  [(16, 16)],
+  // 8x, 4x and 16x (minus 16x16)
+  [
+    (TxType::V_ADST, adst, identity),
+    (TxType::H_ADST, identity, adst),
+    (TxType::V_FLIPADST, flipadst, identity),
+    (TxType::H_FLIPADST, identity, flipadst)
+  ],
+  [(16, 8), (8, 16), (16, 4), (4, 16), (8, 8), (8, 4), (4, 8), (4, 4)],
+  [(neon, NEON)]
+);
+
+cpu_function_lookup_table!(
+  INV_TXFM_HBD_FNS: [[[Option<InvTxfmHBDFunc>; TX_TYPES]; 32]],
   default: [[None; TX_TYPES]; 32],
   [NEON]
 );


### PR DESCRIPTION
This commit integrates the following functions

- [x] `rav1e_inv_txfm_add_adst_adst_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_adst_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_adst_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_adst_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_adst_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_adst_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_adst_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_adst_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_adst_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_dct_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_dct_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_dct_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_dct_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_dct_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_dct_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_dct_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_dct_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_dct_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_flipadst_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_flipadst_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_flipadst_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_flipadst_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_flipadst_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_flipadst_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_flipadst_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_flipadst_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_flipadst_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_identity_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_identity_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_identity_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_identity_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_identity_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_identity_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_identity_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_adst_identity_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_adst_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_adst_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_adst_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_adst_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_adst_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_adst_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_adst_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_adst_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_adst_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_16x32_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_16x64_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_32x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_32x32_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_32x64_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_32x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_64x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_64x32_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_64x64_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_8x32_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_dct_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_flipadst_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_flipadst_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_flipadst_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_flipadst_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_flipadst_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_flipadst_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_flipadst_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_flipadst_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_flipadst_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_identity_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_identity_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_identity_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_identity_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_identity_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_identity_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_identity_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_identity_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_dct_identity_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_adst_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_adst_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_adst_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_adst_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_adst_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_adst_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_adst_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_adst_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_adst_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_dct_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_dct_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_dct_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_dct_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_dct_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_dct_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_dct_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_dct_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_dct_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_flipadst_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_flipadst_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_flipadst_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_flipadst_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_flipadst_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_flipadst_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_flipadst_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_flipadst_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_flipadst_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_identity_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_identity_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_identity_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_identity_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_identity_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_identity_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_identity_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_flipadst_identity_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_adst_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_adst_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_adst_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_adst_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_adst_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_adst_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_adst_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_adst_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_dct_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_dct_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_dct_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_dct_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_dct_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_dct_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_dct_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_dct_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_dct_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_flipadst_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_flipadst_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_flipadst_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_flipadst_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_flipadst_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_flipadst_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_flipadst_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_flipadst_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_16x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_16x32_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_16x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_16x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_32x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_32x32_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_32x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_4x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_4x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_4x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_8x16_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_8x32_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_8x4_16bpc_neon`
- [x] `rav1e_inv_txfm_add_identity_identity_8x8_16bpc_neon`
- [x] `rav1e_inv_txfm_add_wht_wht_4x4_16bpc_neon`


~~This is still in WIP, current state: it do compile, encode, some tests are failing viz. 3~~
~~1. test transform::test::roundtrips_u16~~
~~2.  test_encode_decode::high_bit_depth_10_dav1d~~
~~3.  test_encode_decode::high_bit_depth_12_dav1d~~
~~due to mismatch in output.~~
~~Once it is fixed, the PR will be ready for review~~


Advances #2376 