### PR TITLE
Support arbitrary SAR anamorphic video

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ bitstream-io = "0.8"
 cfg-if = "0.1"
 clap = { version = "2", optional = true, default-features = false }
 libc = "0.2"
-y4m = { version = "0.6", optional = true }
+y4m = { version = "0.7", optional = true }
 backtrace = { version = "0.3", optional = true }
 num-traits = "0.2"
 num-derive = "0.3"

--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -29,6 +29,8 @@ pub struct EncoderConfig {
   pub width: usize,
   /// Height of the frames in pixels.
   pub height: usize,
+  /// Sample aspect ratio (for anamorphic video).
+  pub sample_aspect_ratio: Rational,
   /// Video time base.
   pub time_base: Rational,
 
@@ -129,6 +131,8 @@ impl EncoderConfig {
     EncoderConfig {
       width: 640,
       height: 480,
+      sample_aspect_ratio: Rational { num: 1, den: 1 },
+      time_base: Rational { num: 1, den: 30 },
 
       bit_depth: 8,
       chroma_sampling: ChromaSampling::Cs420,
@@ -144,8 +148,6 @@ impl EncoderConfig {
 
       error_resilient: false,
       switch_frame_interval: 0,
-
-      time_base: Rational { num: 1, den: 30 },
 
       min_key_frame_interval: 12,
       max_key_frame_interval: 240,

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -37,6 +37,12 @@ pub enum InvalidConfig {
   /// The height is invalid.
   #[error("invalid height {0} (expected >= 16, <= 32767)")]
   InvalidHeight(usize),
+  /// Aspect ratio numerator is invalid.
+  #[error("invalid aspect ratio numerator {0} (expected > 0)")]
+  InvalidAspectRatioNum(usize),
+  /// Aspect ratio denominator is invalid.
+  #[error("invalid aspect ratio denominator {0} (expected > 0)")]
+  InvalidAspectRatioDen(usize),
   /// RDO lookahead frame count is invalid.
   #[error(
     "invalid rdo lookahead frames {actual} (expected <= {max} and >= {min})"
@@ -238,6 +244,17 @@ impl Config {
     }
     if config.height < 16 || config.height > u16::max_value() as usize {
       return Err(InvalidHeight(config.height));
+    }
+
+    if config.sample_aspect_ratio.num == 0 {
+      return Err(InvalidAspectRatioNum(
+        config.sample_aspect_ratio.num as usize,
+      ));
+    }
+    if config.sample_aspect_ratio.den == 0 {
+      return Err(InvalidAspectRatioDen(
+        config.sample_aspect_ratio.den as usize,
+      ));
     }
 
     if config.rdo_lookahead_frames > MAX_RDO_LOOKAHEAD_FRAMES

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -1802,6 +1802,7 @@ fn log_q_exp_overflow() {
   let enc = EncoderConfig {
     width: 16,
     height: 16,
+    sample_aspect_ratio: Rational::new(1, 1),
     bit_depth: 8,
     chroma_sampling: ChromaSampling::Cs420,
     chroma_sample_position: ChromaSamplePosition::Unknown,
@@ -1866,6 +1867,7 @@ fn guess_frame_subtypes_assert() {
   let enc = EncoderConfig {
     width: 16,
     height: 16,
+    sample_aspect_ratio: Rational::new(1, 1),
     bit_depth: 8,
     chroma_sampling: ChromaSampling::Cs420,
     chroma_sample_position: ChromaSamplePosition::Unknown,

--- a/src/bin/decoder/mod.rs
+++ b/src/bin/decoder/mod.rs
@@ -34,6 +34,7 @@ pub enum DecodeError {
 pub struct VideoDetails {
   pub width: usize,
   pub height: usize,
+  pub sample_aspect_ratio: Rational,
   pub bit_depth: usize,
   pub chroma_sampling: ChromaSampling,
   pub chroma_sample_position: ChromaSamplePosition,
@@ -45,6 +46,7 @@ impl Default for VideoDetails {
     VideoDetails {
       width: 640,
       height: 480,
+      sample_aspect_ratio: Rational { num: 1, den: 1 },
       bit_depth: 8,
       chroma_sampling: ChromaSampling::Cs420,
       chroma_sample_position: ChromaSamplePosition::Unknown,

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -19,6 +19,7 @@ impl Decoder for y4m::Decoder<Box<dyn Read>> {
   fn get_video_details(&self) -> VideoDetails {
     let width = self.get_width();
     let height = self.get_height();
+    let aspect_ratio = self.get_pixel_aspect();
     let color_space = self.get_colorspace();
     let bit_depth = color_space.get_bit_depth();
     let (chroma_sampling, chroma_sample_position) =
@@ -29,6 +30,10 @@ impl Decoder for y4m::Decoder<Box<dyn Read>> {
     VideoDetails {
       width,
       height,
+      sample_aspect_ratio: Rational::new(
+        aspect_ratio.num as u64,
+        aspect_ratio.den as u64,
+      ),
       bit_depth,
       chroma_sampling,
       chroma_sample_position,

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -411,6 +411,10 @@ fn run() -> Result<(), error::CliError> {
         ),
       )
       .with_colorspace(y4m_dec.get_colorspace())
+      .with_pixel_aspect(y4m::Ratio {
+        num: video_info.sample_aspect_ratio.num as usize,
+        den: video_info.sample_aspect_ratio.den as usize,
+      })
       .write_header(rec)
       .unwrap(),
     ),
@@ -419,6 +423,7 @@ fn run() -> Result<(), error::CliError> {
 
   cli.enc.width = video_info.width;
   cli.enc.height = video_info.height;
+  cli.enc.sample_aspect_ratio = video_info.sample_aspect_ratio;
   cli.enc.bit_depth = video_info.bit_depth;
   cli.enc.chroma_sampling = video_info.chroma_sampling;
   cli.enc.chroma_sample_position = video_info.chroma_sample_position;

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -457,6 +457,16 @@ pub unsafe extern fn rav1e_config_set_emit_data(
   (*cfg).cfg.rate_control.emit_pass_data = emit != 0;
 }
 
+/// Set the display aspect ratio of the stream
+///
+/// Needed for anamorphic video.
+#[no_mangle]
+pub unsafe extern fn rav1e_config_set_sample_aspect_ratio(
+  cfg: *mut Config, sample_aspect_ratio: Rational,
+) {
+  (*cfg).cfg.enc.sample_aspect_ratio = sample_aspect_ratio
+}
+
 /// Set the time base of the stream
 ///
 /// Needed for rate control.

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -130,6 +130,8 @@ pub struct Sequence {
   pub content_light: Option<ContentLight>,
   pub max_frame_width: u32,
   pub max_frame_height: u32,
+  pub render_width: u32,
+  pub render_height: u32,
   pub frame_id_numbers_present_flag: bool,
   pub frame_id_length: u32,
   pub delta_frame_id_length: u32,
@@ -186,6 +188,14 @@ impl Sequence {
     assert!(width_bits <= 16);
     assert!(height_bits <= 16);
 
+    let sar = config.sample_aspect_ratio.as_f64();
+
+    let (render_width, render_height) = if sar > 1.0 {
+      ((config.width as f64 * sar).round() as u32, config.height as u32)
+    } else {
+      (config.width as u32, (config.height as f64 / sar).round() as u32)
+    };
+
     let profile = if config.bit_depth == 12
       || config.chroma_sampling == ChromaSampling::Cs422
     {
@@ -224,6 +234,8 @@ impl Sequence {
       content_light: config.content_light,
       max_frame_width: config.width as u32,
       max_frame_height: config.height as u32,
+      render_width: render_width as u32,
+      render_height: render_height as u32,
       frame_id_numbers_present_flag: false,
       frame_id_length: FRAME_ID_LENGTH,
       delta_frame_id_length: DELTA_FRAME_ID_LENGTH,

--- a/src/header.rs
+++ b/src/header.rs
@@ -606,13 +606,12 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
       if fi.sequence.enable_superres {
         unimplemented!();
       }
-      let render_and_frame_size_different = fi.sequence.render_width
-        != fi.sequence.max_frame_width
-        || fi.sequence.render_height != fi.sequence.max_frame_height;
+      let render_and_frame_size_different = fi.render_width != fi.width as u32
+        || fi.render_height != fi.height as u32;
       self.write_bit(render_and_frame_size_different)?;
       if render_and_frame_size_different {
-        self.write(16, fi.sequence.render_width - 1);
-        self.write(16, fi.sequence.render_height - 1);
+        self.write(16, fi.render_width - 1);
+        self.write(16, fi.render_height - 1);
       }
       if fi.allow_screen_content_tools != 0 {
         // TODO: && UpscaledWidth == FrameWidth.
@@ -649,13 +648,13 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
         if fi.sequence.enable_superres {
           unimplemented!();
         }
-        let render_and_frame_size_different = fi.sequence.render_width
-          != fi.sequence.max_frame_width
-          || fi.sequence.render_height != fi.sequence.max_frame_height;
+        let render_and_frame_size_different = fi.render_width
+          != fi.width as u32
+          || fi.render_height != fi.height as u32;
         self.write_bit(render_and_frame_size_different)?;
         if render_and_frame_size_different {
-          self.write(16, fi.sequence.render_width - 1);
-          self.write(16, fi.sequence.render_height - 1);
+          self.write(16, fi.render_width - 1);
+          self.write(16, fi.render_height - 1);
         }
       }
 


### PR DESCRIPTION
This adds an aspect ratio input parameter
to the Rust and C APIs, computes the render
size by upscaling one dimension, and codes
it in-bitstream, as well as in Y4M output.

The default aspect ratio is parsed from
Y4M input, or set to 1:1 if absent.

Note that neither aomdec nor dav1d will propagate the bitstream render size to the Y4M files they output.
It doesn't seem to be honored by ffmpeg with aomdec either, but it might be with dav1d (haven't tested it myself, but the code seems present). Reconstruction output is affected as well.
I think we can close #2504 with this, as it implements everything that should be needed for decoders/players to correctly output/display the encoded video.