### PR TITLE
Map chroma transform types for inter

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2230,7 +2230,11 @@ pub fn write_tx_tree<T: Pixel>(
   bw_uv /= uv_tx_size.width_mi();
   bh_uv /= uv_tx_size.height_mi();
 
-  let uv_tx_type = if partition_has_coeff { tx_type } else { TxType::DCT_DCT }; // if inter mode, uv_tx_type == tx_type
+  let uv_tx_type = if partition_has_coeff {
+    tx_type.uv_inter(uv_tx_size)
+  } else {
+    TxType::DCT_DCT
+  };
 
   for p in 1..3 {
     ts.qc.update(

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -71,6 +71,29 @@ pub enum TxType {
   H_FLIPADST = 15,
 }
 
+impl TxType {
+  /// Compute transform type for inter chroma.
+  ///
+  /// <https://aomediacodec.github.io/av1-spec/#compute-transform-type-function>
+  #[inline]
+  pub fn uv_inter(self: Self, uv_tx_size: TxSize) -> Self {
+    use TxType::*;
+    if uv_tx_size.sqr_up() == TX_32X32 {
+      match self {
+        IDTX => IDTX,
+        _ => DCT_DCT,
+      }
+    } else if uv_tx_size.sqr() == TX_16X16 {
+      match self {
+        V_ADST | H_ADST | V_FLIPADST | H_FLIPADST => DCT_DCT,
+        _ => self,
+      }
+    } else {
+      self
+    }
+  }
+}
+
 /// Transform Size
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub enum TxSize {


### PR DESCRIPTION
Note that https://github.com/xiph/rav1e/commit/22bf11b7fc5ec47c2f31716fc916f8c3a5c11817 disabled RDO of transform type for inter blocks. To verify this change I reverted that commit, forced `reduced_tx_set_preset()` to `false` and forced `enable_inter_tx_split_preset()` to `true`. i.e.: https://github.com/barrbrain/rav1e/commit/ab278ccc2ddcc0bf1d2959ec28e1d786952f07cc
The only test failure I was able to induce was an assertion in `test_encode_decode::chroma_sampling_444_dav1d`.

This implementation uses the same simplification as in dav1d to remove the indirection via `TxSet`. Fixes #2122.