### PR TITLE
aarch64: transforms: Enable identity transforms for 16bpc

### DIFF
--- a/src/asm/aarch64/transform/inverse.rs
+++ b/src/asm/aarch64/transform/inverse.rs
@@ -286,14 +286,7 @@ impl_itx_hbd_fns!(
   [(TxType::DCT_DCT, dct, dct)],
   [(64, 64), (64, 32), (32, 64), (16, 64), (64, 16)],
   // 32x
-  // TODO: We are excluding identity transform as tests are failing with
-  // memory misalignment for 4 cases:
-  // inv_txfm2d_add_identity_identity_16x32_neon,
-  // inv_txfm2d_add_identity_identity_32x16_neon,
-  // inv_txfm2d_add_identity_identity_32x32_neon,
-  // inv_txfm2d_add_identity_identity_8x32_neon
-  //[(TxType::IDTX, identity, identity)],
-  [],
+  [(TxType::IDTX, identity, identity)],
   [(32, 32), (32, 16), (16, 32), (32, 8), (8, 32)],
   // 16x16
   [


### PR DESCRIPTION
The 16bpc is not having alignment issues, tested to see if there are any regression, no change in objective-metrics, also almost no change in FPS and encoding time, tested with chimera and costa-rica both of them are 10-bit clips.

Objective Metrics 
<Details>

```mindfreeze@honey-g ~/rav1e (master)> env RUSTFLAGS="-C target-cpu=native" cargo build --release; env RUSTFLAGS="-C target-cpu=native" time cargo run --release ~/COSTA-RICA-1080p-10b-400.y4m -l 100 -o /dev/null --tiles 15 --metrics
    Finished release [optimized + debuginfo] target(s) in 0.12s
    Finished release [optimized + debuginfo] target(s) in 0.12s
     Running `target/release/rav1e /home/mindfreeze/COSTA-RICA-1080p-10b-400.y4m -l 100 -o /dev/null --tiles 15 --metrics`
>  Using y4m decoder: 1920x1080p @ 60000/1001 fps, 4:2:0, 10-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=8x8 max_block_size=64x64 multiref=true fast_deblock=false reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Complex-KFs include_near_mvs=false no_scene_detection=false cdef=true use_satd_subpel=true non_square_partition=false enable_timing_info=false fine_directional_intra=true
>  CPU Feature Level: NEON
>  Using 16 tiles (4x4)
>  encoded 100/100 frames, 0.112 fps, 973.29 Kb/s, est. size: 0.19 MB, est. time: 0s,  elap. time: 14m 54s
>  ----------
>  Key frame:             1 | avg QP:  80.00 | avg size:   50869 B
>  Inter frame:          99 | avg QP: 133.00 | avg size:    1536 B
>  Intra only frame:      0 | avg QP:   0.00 | avg size:       0 B
>  Switching frame:       0 | avg QP:   0.00 | avg size:       0 B
>  ----------
>  Mean PSNR: Avg: 14.3842  Y: 14.6027  Cb: 13.7867  Cr: 14.1772
>  ----------
>  PSNR HVS: 8.7055
>  SSIM: 2.4397  MS SSIM: 4.5295
>  CIEDE2000: 23.5255
>  ----------
2719.06user 13.73system 14:55.17elapsed 305%CPU (0avgtext+0avgdata 2766104maxresident)k
0inputs+0outputs (0major+1048421minor)pagefaults 0swaps
mindfreeze@honey-g ~/rav1e (master)> dav1d COSTA-RICA-1080p-10b.ivf -o COSTA-RICA-1080p-10b-400.y4m^C
mindfreeze@honey-g ~/rav1e (master)> git checkout itx-16bpc-ident
Switched to branch 'itx-16bpc-ident'
Your branch is up to date with 'mindfreeze/itx-16bpc-ident'.
mindfreeze@honey-g ~/rav1e (itx-16bpc-ident)> env RUSTFLAGS="-C target-cpu=native" cargo build --release; env RUSTFLAGS="-C target-cpu=native" time cargo run --release ~/COSTA-RICA-1080p-10b-400.y4m -l 100 -o /dev/null --tiles 15 --metrics
   Compiling rav1e v0.3.0 (/home/mindfreeze/rav1e)
    Finished release [optimized + debuginfo] target(s) in 22.20s
    Finished release [optimized + debuginfo] target(s) in 0.12s
     Running `target/release/rav1e /home/mindfreeze/COSTA-RICA-1080p-10b-400.y4m -l 100 -o /dev/null --tiles 15 --metrics`
>  Using y4m decoder: 1920x1080p @ 60000/1001 fps, 4:2:0, 10-bit
>  Encoding settings: keyint_min=12 keyint_max=240 quantizer=100 bitrate=0 min_quantizer=0 low_latency=false tune=Psychovisual rdo_lookahead_frames=40 min_block_size=8x8 max_block_size=64x64 multiref=true fast_deblock=false reduced_tx_set=true tx_domain_distortion=false tx_domain_rate=false encode_bottomup=false rdo_tx_decision=false prediction_modes=Complex-KFs include_near_mvs=false no_scene_detection=false cdef=true use_satd_subpel=true non_square_partition=false enable_timing_info=false fine_directional_intra=true
>  CPU Feature Level: NEON
>  Using 16 tiles (4x4)
>  encoded 100/100 frames, 0.111 fps, 973.29 Kb/s, est. size: 0.19 MB, est. time: 0s,  elap. time: 14m 56s
>  ----------
>  Key frame:             1 | avg QP:  80.00 | avg size:   50869 B
>  Inter frame:          99 | avg QP: 133.00 | avg size:    1536 B
>  Intra only frame:      0 | avg QP:   0.00 | avg size:       0 B
>  Switching frame:       0 | avg QP:   0.00 | avg size:       0 B
>  ----------
>  Mean PSNR: Avg: 14.3842  Y: 14.6027  Cb: 13.7867  Cr: 14.1772
>  ----------
>  PSNR HVS: 8.7055
>  SSIM: 2.4397  MS SSIM: 4.5295
>  CIEDE2000: 23.5255
>  ----------
2712.30user 12.02system 14:57.25elapsed 303%CPU (0avgtext+0avgdata 2515928maxresident)k
0inputs+0outputs (0major+943134minor)pagefaults 0swaps
```
</Details>

Tests are passing locally.

Reference/Follow-up from last review https://github.com/xiph/rav1e/pull/2502#discussion_r473601178