### PR TITLE
header: implement frame_size_with_refs()

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -631,6 +631,10 @@ impl<T: Pixel> ContextInner<T> {
       // We do want to propagate the lookahead_rec_buffer though.
       let rfs = Arc::new(ReferenceFrame {
         order_hint: fi.order_hint,
+        width: fi.width as u32,
+        height: fi.height as u32,
+        render_width: fi.render_width,
+        render_height: fi.render_height,
         // Use the original frame contents.
         frame: fs.input.clone(),
         input_hres: fs.input_hres.clone(),
@@ -710,6 +714,10 @@ impl<T: Pixel> ContextInner<T> {
     // FrameInvariants to pick it up.
     let rfs = Arc::new(ReferenceFrame {
       order_hint: fi.order_hint,
+      width: fi.width as u32,
+      height: fi.height as u32,
+      render_width: fi.render_width,
+      render_height: fi.render_height,
       // Use the original frame contents.
       frame: fs.input.clone(),
       input_hres: fs.input_hres.clone(),

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -77,6 +77,10 @@ pub const IMPORTANCE_BLOCK_SIZE: usize =
 #[derive(Debug, Clone)]
 pub struct ReferenceFrame<T: Pixel> {
   pub order_hint: u32,
+  pub width: u32,
+  pub height: u32,
+  pub render_width: u32,
+  pub render_height: u32,
   pub frame: Arc<Frame<T>>,
   pub input_hres: Arc<Plane<T>>,
   pub input_qres: Arc<Plane<T>>,
@@ -3810,6 +3814,10 @@ pub fn update_rec_buffer<T: Pixel>(
 ) {
   let rfs = Arc::new(ReferenceFrame {
     order_hint: fi.order_hint,
+    width: fi.width as u32,
+    height: fi.height as u32,
+    render_width: fi.render_width,
+    render_height: fi.render_height,
     frame: fs.rec.clone(),
     input_hres: fs.input_hres.clone(),
     input_qres: fs.input_qres.clone(),

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -826,6 +826,14 @@ impl<T: Pixel> FrameInvariants<T> {
     fi.error_resilient =
       if fi.frame_type == FrameType::SWITCH { true } else { error_resilient };
 
+    // force frame_size_with_refs() code path if render size != frame size
+    if fi.frame_type == FrameType::INTER
+      && !fi.error_resilient
+      && fi.render_and_frame_size_different
+    {
+      fi.frame_size_override_flag = true;
+    }
+
     if fi.frame_type == FrameType::SWITCH {
       fi.frame_size_override_flag = true;
     } else if fi.sequence.reduced_still_picture_hdr {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -484,6 +484,8 @@ pub struct FrameInvariants<T: Pixel> {
   pub height: usize,
   pub render_width: u32,
   pub render_height: u32,
+  pub frame_size_override_flag: bool,
+  pub render_and_frame_size_different: bool,
   pub sb_width: usize,
   pub sb_height: usize,
   pub w_in_b: usize,
@@ -596,6 +598,8 @@ impl<T: Pixel> FrameInvariants<T> {
     );
 
     let (width, height) = (config.width, config.height);
+    let frame_size_override_flag = width as u32 != sequence.max_frame_width
+      || height as u32 != sequence.max_frame_height;
 
     let sar = config.sample_aspect_ratio.as_f64();
     let (render_width, render_height) = if sar > 1.0 {
@@ -603,6 +607,8 @@ impl<T: Pixel> FrameInvariants<T> {
     } else {
       (width as u32, (height as f64 / sar).round() as u32)
     };
+    let render_and_frame_size_different =
+      render_width != width as u32 || render_height != height as u32;
 
     let use_reduced_tx_set = config.speed_settings.reduced_tx_set;
     let use_tx_domain_distortion =
@@ -664,6 +670,8 @@ impl<T: Pixel> FrameInvariants<T> {
       height,
       render_width,
       render_height,
+      frame_size_override_flag,
+      render_and_frame_size_different,
       sb_width: width.align_power_of_two_and_shift(6),
       sb_height: height.align_power_of_two_and_shift(6),
       w_in_b,
@@ -817,6 +825,12 @@ impl<T: Pixel> FrameInvariants<T> {
     };
     fi.error_resilient =
       if fi.frame_type == FrameType::SWITCH { true } else { error_resilient };
+
+    if fi.frame_type == FrameType::SWITCH {
+      fi.frame_size_override_flag = true;
+    } else if fi.sequence.reduced_still_picture_hdr {
+      fi.frame_size_override_flag = false;
+    }
 
     // this is the slot that the current frame is going to be saved into
     let slot_idx = inter_cfg.get_slot_idx(fi.pyramid_level, fi.order_hint);


### PR DESCRIPTION
The spec has a code path in the uncompressed header named frame_size_with_refs(), defined in section 5.9.7, which an inter frame may use to infer its dimensions from one of the seven frames it uses as reference instead of inferring them from the sequence header or ultimately hardcoding them. This path is triggered on non error resilient encodings by signaling frame_size_override_flag == 1, a bit that means that either frame dimensions are coded in the frame, or that an attempt to infer both frame and render dimensions from a reference frame should be done.

For encodings using a SAR other than 1:1, rav1e is currently hardcoding the render sizes on every frame, which is an overhead of about 4 bytes. With this change, for inter frames the encoder will look at each of the seven reference frames and if it finds one where both frame and render sizes are the same as this frame, instead of writing the sizes it will write the bits needed to tell the decoder to infer them from it.

Here's a comparison of the uncompressed header written for inter frames before and after this PR when encoding a 720x480 sample with SAR 2:1.

Before
```
[trace_headers @ 00000203eb3bfda0] Frame Header
[trace_headers @ 00000203eb3bfda0] 16          show_existing_frame                                         0 = 0
[trace_headers @ 00000203eb3bfda0] 17          frame_type                                                 01 = 1
[trace_headers @ 00000203eb3bfda0] 19          show_frame                                                  1 = 1
[trace_headers @ 00000203eb3bfda0] 20          error_resilient_mode                                        0 = 0
[trace_headers @ 00000203eb3bfda0] 21          disable_cdf_update                                          0 = 0
[trace_headers @ 00000203eb3bfda0] 22          frame_size_override_flag                                    0 = 0
[trace_headers @ 00000203eb3bfda0] 23          order_hint                                             000011 = 3
[trace_headers @ 00000203eb3bfda0] 29          primary_ref_frame                                         010 = 2
[trace_headers @ 00000203eb3bfda0] 32          refresh_frame_flags                                  00100000 = 32
[trace_headers @ 00000203eb3bfda0] 40          frame_refs_short_signaling                                  0 = 0
[trace_headers @ 00000203eb3bfda0] 41          ref_frame_idx[0]                                          100 = 4
[trace_headers @ 00000203eb3bfda0] 44          ref_frame_idx[1]                                          100 = 4
[trace_headers @ 00000203eb3bfda0] 47          ref_frame_idx[2]                                          101 = 5
[trace_headers @ 00000203eb3bfda0] 50          ref_frame_idx[3]                                          100 = 4
[trace_headers @ 00000203eb3bfda0] 53          ref_frame_idx[4]                                          100 = 4
[trace_headers @ 00000203eb3bfda0] 56          ref_frame_idx[5]                                          100 = 4
[trace_headers @ 00000203eb3bfda0] 59          ref_frame_idx[6]                                          001 = 1
[trace_headers @ 00000203eb3bfda0] 62          render_and_frame_size_different                             1 = 1
[trace_headers @ 00000203eb3bfda0] 63          render_width_minus_1                         0000010110011111 = 1439
[trace_headers @ 00000203eb3bfda0] 79          render_height_minus_1                        0000000111011111 = 479
```

After
```
[trace_headers @ 000001e8e5d5fda0] Frame Header
[trace_headers @ 000001e8e5d5fda0] 16          show_existing_frame                                         0 = 0
[trace_headers @ 000001e8e5d5fda0] 17          frame_type                                                 01 = 1
[trace_headers @ 000001e8e5d5fda0] 19          show_frame                                                  1 = 1
[trace_headers @ 000001e8e5d5fda0] 20          error_resilient_mode                                        0 = 0
[trace_headers @ 000001e8e5d5fda0] 21          disable_cdf_update                                          0 = 0
[trace_headers @ 000001e8e5d5fda0] 22          frame_size_override_flag                                    1 = 1
[trace_headers @ 000001e8e5d5fda0] 23          order_hint                                             000011 = 3
[trace_headers @ 000001e8e5d5fda0] 29          primary_ref_frame                                         010 = 2
[trace_headers @ 000001e8e5d5fda0] 32          refresh_frame_flags                                  00100000 = 32
[trace_headers @ 000001e8e5d5fda0] 40          frame_refs_short_signaling                                  0 = 0
[trace_headers @ 000001e8e5d5fda0] 41          ref_frame_idx[0]                                          100 = 4
[trace_headers @ 000001e8e5d5fda0] 44          ref_frame_idx[1]                                          100 = 4
[trace_headers @ 000001e8e5d5fda0] 47          ref_frame_idx[2]                                          101 = 5
[trace_headers @ 000001e8e5d5fda0] 50          ref_frame_idx[3]                                          100 = 4
[trace_headers @ 000001e8e5d5fda0] 53          ref_frame_idx[4]                                          100 = 4
[trace_headers @ 000001e8e5d5fda0] 56          ref_frame_idx[5]                                          100 = 4
[trace_headers @ 000001e8e5d5fda0] 59          ref_frame_idx[6]                                          001 = 1
[trace_headers @ 000001e8e5d5fda0] 62          found_ref[0]                                                1 = 1
```

Currently, rav1e has fixed frame and render sizes for the entire video sequence, so it will always signal to use the very first reference frame, but with this change the frame header writing code is ready to handle both frame and render sizes changing in a per-frame basis, if it ever gets implemented.