### PR TITLE
Interpret 0:0 SAR as 1:1

### DIFF
--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -246,12 +246,16 @@ impl Config {
       return Err(InvalidHeight(config.height));
     }
 
-    if config.sample_aspect_ratio.num == 0 {
+    if config.sample_aspect_ratio.num == 0
+      && config.sample_aspect_ratio.den != 0
+    {
       return Err(InvalidAspectRatioNum(
         config.sample_aspect_ratio.num as usize,
       ));
     }
-    if config.sample_aspect_ratio.den == 0 {
+    if config.sample_aspect_ratio.den == 0
+      && config.sample_aspect_ratio.num != 0
+    {
       return Err(InvalidAspectRatioDen(
         config.sample_aspect_ratio.den as usize,
       ));

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -594,7 +594,9 @@ impl<T: Pixel> FrameInvariants<T> {
     let (width, height) = (config.width, config.height);
 
     let sar = config.sample_aspect_ratio.as_f64();
-    let (render_width, render_height) = if sar > 1.0 {
+    let (render_width, render_height) = if sar.is_nan() {
+      (width as u32, height as u32)
+    } else if sar > 1.0 {
       ((width as f64 * sar).round() as u32, height as u32)
     } else {
       (width as u32, (height as f64 / sar).round() as u32)


### PR DESCRIPTION
Missing change for #2505, which causes panics when trying to encode clips specifying an SAR of 0:0.