### PR TITLE
crates: vergen: Remove unused import

### DIFF
--- a/crates/vergen/src/lib.rs
+++ b/crates/vergen/src/lib.rs
@@ -95,7 +95,6 @@
 #[macro_use]
 extern crate bitflags;
 #[cfg(test)]
-#[macro_use]
 extern crate lazy_static;
 
 mod constants;


### PR DESCRIPTION
FIxes the warning on master, this came up after we enabled CI for all workspaces, ie. #2525 