### PR TITLE
Change the minimum frame size from 16x16 to 1x1

### DIFF
--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -233,10 +233,16 @@ impl Config {
 
     let config = &self.enc;
 
-    if config.width < 16 || config.width > u16::max_value() as usize {
+    if (config.still_picture && config.width < 1)
+      || (!config.still_picture && config.width < 16)
+      || config.width > u16::max_value() as usize
+    {
       return Err(InvalidWidth(config.width));
     }
-    if config.height < 16 || config.height > u16::max_value() as usize {
+    if (config.still_picture && config.height < 1)
+      || (!config.still_picture && config.height < 16)
+      || config.height > u16::max_value() as usize
+    {
       return Err(InvalidHeight(config.height));
     }
 


### PR DESCRIPTION
Resolve #2518 

~~Note that this change violates the constraint of AV1 spec:
"FrameWidth is greater than or equal to 16"
"FrameHeight is greater than or equal to 16"
in https://aomediacodec.github.io/av1-spec/#levels~~