### PR TITLE
Filter input Y4M SAR

### DIFF
--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -257,16 +257,12 @@ impl Config {
       return Err(InvalidHeight(config.height));
     }
 
-    if config.sample_aspect_ratio.num == 0
-      && config.sample_aspect_ratio.den != 0
-    {
+    if config.sample_aspect_ratio.num == 0 {
       return Err(InvalidAspectRatioNum(
         config.sample_aspect_ratio.num as usize,
       ));
     }
-    if config.sample_aspect_ratio.den == 0
-      && config.sample_aspect_ratio.num != 0
-    {
+    if config.sample_aspect_ratio.den == 0 {
       return Err(InvalidAspectRatioDen(
         config.sample_aspect_ratio.den as usize,
       ));

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -30,10 +30,11 @@ impl Decoder for y4m::Decoder<Box<dyn Read + Send>> {
     VideoDetails {
       width,
       height,
-      sample_aspect_ratio: Rational::new(
-        aspect_ratio.num as u64,
-        aspect_ratio.den as u64,
-      ),
+      sample_aspect_ratio: if aspect_ratio.num == 0 && aspect_ratio.den == 0 {
+        Rational::new(1, 1)
+      } else {
+        Rational::new(aspect_ratio.num as u64, aspect_ratio.den as u64)
+      },
       bit_depth,
       chroma_sampling,
       chroma_sample_position,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -598,9 +598,7 @@ impl<T: Pixel> FrameInvariants<T> {
       || height as u32 != sequence.max_frame_height;
 
     let sar = config.sample_aspect_ratio.as_f64();
-    let (render_width, render_height) = if sar.is_nan() {
-      (width as u32, height as u32)
-    } else if sar > 1.0 {
+    let (render_width, render_height) = if sar > 1.0 {
       ((width as f64 * sar).round() as u32, height as u32)
     } else {
       (width as u32, (height as f64 / sar).round() as u32)


### PR DESCRIPTION
This fixes the minimum SAR to 1:1 so that
Y4M files signaling 0:0 SAR can be processed,
without allowing illegal SAR values at the
API level or handling them from the encoder.

In practice this slightly simplifies the SAR handling in the `encoder` module, as well as validation in the API `config` module, while making the Y4M `decoder` module responsible for filtering the input SAR. A validation error will be returned if the SAR is set to 0:0 at the API level.

As suggested in the comments of #2523.