### PR TITLE
Enforce a frame limit of 1 in still picture mode

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -267,7 +267,7 @@ impl<T: Pixel> ContextInner<T> {
     let seq = Sequence::new(enc);
     ContextInner {
       frame_count: 0,
-      limit: None,
+      limit: if enc.still_picture { Some(1) } else { None },
       inter_cfg: InterConfig::new(enc),
       output_frameno: 0,
       frames_processed: 0,

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -472,10 +472,15 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
     MetricsEnabled::None
   };
 
+  let limit = matches.value_of("LIMIT").unwrap().parse().unwrap();
+  if enc.still_picture && limit > 1 {
+    panic!("A limit cannot be set above 1 in still picture mode");
+  }
+
   Ok(CliOptions {
     io,
     enc,
-    limit: matches.value_of("LIMIT").unwrap().parse().unwrap(),
+    limit,
     // Use `occurrences_of()` because `is_present()` is always true
     // if a parameter has a default value.
     color_range_specified: matches.occurrences_of("PIXEL_RANGE") > 0,


### PR DESCRIPTION
As pointed out by @ycho, still picture mode streams must be single frames for compliance.

I am not sure if this is enough to block API users from pushing extra frames, so would like a check from someone who is more familiar with that part.

The CLI will panic if a user sends a limit > 1.