### PR TITLE
Enable fine directional intra for all presets

### DIFF
--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -135,7 +135,7 @@ impl SpeedSettings {
   /// - 3: min block size 8x8, complex pred modes for keyframes, RDO TX decision, include near MVs,
   ///        full SGR search.
   /// - 2: min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
-  ///        full SGR search, coarse directions.
+  ///        full SGR search.
   /// - 1: min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
   ///        bottom-up encoding, full SGR search.
   /// - 0 (slowest): min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
@@ -271,8 +271,8 @@ impl SpeedSettings {
     speed >= 9
   }
 
-  fn fine_directional_intra_preset(speed: usize) -> bool {
-    speed != 2
+  fn fine_directional_intra_preset(_speed: usize) -> bool {
+    true
   }
 }
 


### PR DESCRIPTION
Changes only speed 2. Encoding speed is reduced by 5.5%:

|    PSNR | PSNR Cb | PSNR Cr | PSNR HVS |    SSIM | MS SSIM | CIEDE 2000 |
|    ---: |    ---: |    ---: |     ---: |    ---: |    ---: |       ---: |
| -0.7704 | -1.6432 | -1.4803 |  -0.6959 | -0.7822 | -0.7149 |    -0.8890 |

The faster speed levels adopted fine directional prediction prior to #2301 and #2486.
The penalty for consistency with other speed levels is more reasonable now.