### PR TITLE
Do not build av-metrics with the decoders dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ aom-sys = { version = "0.2.1", optional = true }
 scan_fmt = { version = "0.2.3", optional = true, default-features = false }
 ivf = { version = "0.1", path = "ivf/", optional = true }
 v_frame = { version = "0.1", path = "v_frame/" }
-av-metrics = { version = "0.5.1", optional = true }
+av-metrics = { version = "0.5.1", optional = true, default-features = false }
 rayon = "1.0"
 crossbeam = { version = "0.7", optional = true }
 toml = { version = "0.5", optional = true }


### PR DESCRIPTION
The cli uses the direct API.