### PR TITLE
Fix still picture frame limiting in the API

### DIFF
--- a/src/api/context.rs
+++ b/src/api/context.rs
@@ -111,7 +111,9 @@ impl<T: Pixel> Context<T> {
       }
       self.inner.limit = Some(self.inner.frame_count);
       self.is_flushing = true;
-    } else if self.is_flushing {
+    } else if self.is_flushing
+      || (self.inner.config.still_picture && self.inner.frame_count > 0)
+    {
       return Err(EncoderStatus::EnoughData);
     // The rate control can process at most std::i32::MAX frames
     } else if self.inner.frame_count == std::i32::MAX as u64 - 1 {

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -267,7 +267,7 @@ impl<T: Pixel> ContextInner<T> {
     let seq = Sequence::new(enc);
     ContextInner {
       frame_count: 0,
-      limit: if enc.still_picture { Some(1) } else { None },
+      limit: None,
       inter_cfg: InterConfig::new(enc),
       output_frameno: 0,
       frames_processed: 0,


### PR DESCRIPTION
The limit was overridden at the wrong place. The `simple_encoding` example hangs trying to queue up more than one frame if `still_picture` is set in the encoder configuration.

This returns `Err(EncoderStatus::EnoughData)` when one frame has already been processed in still picture mode, which allows `simple_encoding` to run through completely, while any frame beyond the first one is simply ignored.