### PR TITLE
fuzzer: Increase coverage of encode and encode_decode

### DIFF
--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -47,7 +47,7 @@ impl Arbitrary for ArbitraryConfig {
     config.threads = 1;
     config.enc.width = Arbitrary::arbitrary(u)?;
     config.enc.height = Arbitrary::arbitrary(u)?;
-    config.enc.bit_depth = (u8::arbitrary(u)? % 17) as usize;
+    config.enc.bit_depth = u.int_in_range(0..=16)?;
     config.enc.still_picture = Arbitrary::arbitrary(u)?;
     config.enc.time_base =
       Rational::new(Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?);
@@ -114,13 +114,13 @@ impl Arbitrary for ArbitraryEncoder {
   fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self, Error> {
     let mut config = Config::default();
     config.threads = 1;
-    config.enc.width = u8::arbitrary(u)? as usize + 1;
-    config.enc.height = u8::arbitrary(u)? as usize + 1;
+    config.enc.width = u.int_in_range(1..=256)?;
+    config.enc.height = u.int_in_range(1..=256)?;
     config.enc.still_picture = Arbitrary::arbitrary(u)?;
     config.enc.time_base =
       Rational::new(Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?);
-    config.enc.min_key_frame_interval = (u8::arbitrary(u)? % 4) as u64;
-    config.enc.max_key_frame_interval = (u8::arbitrary(u)? % 4) as u64 + 1;
+    config.enc.min_key_frame_interval = u.int_in_range(0..=3)?;
+    config.enc.max_key_frame_interval = u.int_in_range(1..=4)?;
     config.enc.low_latency = Arbitrary::arbitrary(u)?;
     config.enc.quantizer = Arbitrary::arbitrary(u)?;
     config.enc.min_quantizer = Arbitrary::arbitrary(u)?;
@@ -130,7 +130,7 @@ impl Arbitrary for ArbitraryEncoder {
     // config.enc.tiles = Arbitrary::arbitrary(u)?;
     config.enc.rdo_lookahead_frames = Arbitrary::arbitrary(u)?;
     config.enc.speed_settings = SpeedSettings::from_preset(10);
-    let frame_count = u8::arbitrary(u)? % 3 + 1;
+    let frame_count = u.int_in_range(1..=3)?;
     if u.is_empty() {
       return Err(Error::NotEnoughData);
     }
@@ -187,15 +187,15 @@ pub struct DecodeTestParameters {
 impl Arbitrary for DecodeTestParameters {
   fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self, Error> {
     Ok(Self {
-      w: u8::arbitrary(u)? as usize + 16,
-      h: u8::arbitrary(u)? as usize + 16,
+      w: u.int_in_range(16..=16 + 255)?,
+      h: u.int_in_range(16..=16 + 255)?,
       speed: 10,
-      q: u8::arbitrary(u)? as usize,
-      limit: (u8::arbitrary(u)? % 3) as usize + 1,
+      q: u8::arbitrary(u)?.into(),
+      limit: u.int_in_range(1..=3)?,
       bit_depth: 8,
       chroma_sampling: Default::default(),
-      min_keyint: u64::arbitrary(u)? % 4,
-      max_keyint: u64::arbitrary(u)? % 4 + 1,
+      min_keyint: u.int_in_range(0..=3)?,
+      max_keyint: u.int_in_range(1..=4)?,
       switch_frame_interval: 0,
       low_latency: bool::arbitrary(u)?,
       error_resilient: false,

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -183,24 +183,33 @@ pub struct DecodeTestParameters {
 
 impl Arbitrary for DecodeTestParameters {
   fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self, Error> {
-    Ok(Self {
+    let mut p = Self {
       w: u.int_in_range(16..=16 + 255)?,
       h: u.int_in_range(16..=16 + 255)?,
-      speed: 10,
+      speed: u.int_in_range(0..=10)?,
       q: u8::arbitrary(u)?.into(),
       limit: u.int_in_range(1..=3)?,
       bit_depth: 8,
-      chroma_sampling: Default::default(),
+      chroma_sampling: *u.choose(&[
+        ChromaSampling::Cs420,
+        ChromaSampling::Cs422,
+        ChromaSampling::Cs444,
+        ChromaSampling::Cs400,
+      ])?,
       min_keyint: u.int_in_range(0..=3)?,
       max_keyint: u.int_in_range(1..=4)?,
       switch_frame_interval: 0,
       low_latency: bool::arbitrary(u)?,
-      error_resilient: false,
-      bitrate: i32::arbitrary(u)?,
-      tile_cols_log2: 1,
-      tile_rows_log2: 1,
-      still_picture: false,
-    })
+      error_resilient: bool::arbitrary(u)?,
+      bitrate: u16::arbitrary(u)?.into(),
+      tile_cols_log2: u.int_in_range(0..=2)?,
+      tile_rows_log2: u.int_in_range(0..=2)?,
+      still_picture: bool::arbitrary(u)?,
+    };
+    if p.still_picture {
+      p.limit = 1
+    }
+    Ok(p)
   }
 }
 

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -43,27 +43,25 @@ pub struct ArbitraryConfig {
 
 impl Arbitrary for ArbitraryConfig {
   fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self, Error> {
-    let mut config = Config::default();
-    config.threads = 1;
-    config.enc.width = Arbitrary::arbitrary(u)?;
-    config.enc.height = Arbitrary::arbitrary(u)?;
-    config.enc.bit_depth = u.int_in_range(0..=16)?;
-    config.enc.still_picture = Arbitrary::arbitrary(u)?;
-    config.enc.time_base =
+    let mut enc = EncoderConfig::with_speed_preset(Arbitrary::arbitrary(u)?);
+    enc.width = Arbitrary::arbitrary(u)?;
+    enc.height = Arbitrary::arbitrary(u)?;
+    enc.bit_depth = u.int_in_range(0..=16)?;
+    enc.still_picture = Arbitrary::arbitrary(u)?;
+    enc.time_base =
       Rational::new(Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?);
-    config.enc.min_key_frame_interval = Arbitrary::arbitrary(u)?;
-    config.enc.max_key_frame_interval = Arbitrary::arbitrary(u)?;
-    config.enc.reservoir_frame_delay = Arbitrary::arbitrary(u)?;
-    config.enc.low_latency = Arbitrary::arbitrary(u)?;
-    config.enc.quantizer = Arbitrary::arbitrary(u)?;
-    config.enc.min_quantizer = Arbitrary::arbitrary(u)?;
-    config.enc.bitrate = Arbitrary::arbitrary(u)?;
-    config.enc.tile_cols = Arbitrary::arbitrary(u)?;
-    config.enc.tile_rows = Arbitrary::arbitrary(u)?;
-    config.enc.tiles = Arbitrary::arbitrary(u)?;
-    config.enc.rdo_lookahead_frames = Arbitrary::arbitrary(u)?;
-    config.enc.speed_settings =
-      SpeedSettings::from_preset(Arbitrary::arbitrary(u)?);
+    enc.min_key_frame_interval = Arbitrary::arbitrary(u)?;
+    enc.max_key_frame_interval = Arbitrary::arbitrary(u)?;
+    enc.reservoir_frame_delay = Arbitrary::arbitrary(u)?;
+    enc.low_latency = Arbitrary::arbitrary(u)?;
+    enc.quantizer = Arbitrary::arbitrary(u)?;
+    enc.min_quantizer = Arbitrary::arbitrary(u)?;
+    enc.bitrate = Arbitrary::arbitrary(u)?;
+    enc.tile_cols = Arbitrary::arbitrary(u)?;
+    enc.tile_rows = Arbitrary::arbitrary(u)?;
+    enc.tiles = Arbitrary::arbitrary(u)?;
+    enc.rdo_lookahead_frames = Arbitrary::arbitrary(u)?;
+    let config = Config::new().with_encoder_config(enc).with_threads(1);
     Ok(Self { config })
   }
 }
@@ -112,29 +110,28 @@ pub struct ArbitraryEncoder {
 
 impl Arbitrary for ArbitraryEncoder {
   fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self, Error> {
-    let mut config = Config::default();
-    config.threads = 1;
-    config.enc.width = u.int_in_range(1..=256)?;
-    config.enc.height = u.int_in_range(1..=256)?;
-    config.enc.still_picture = Arbitrary::arbitrary(u)?;
-    config.enc.time_base =
+    let mut enc = EncoderConfig::with_speed_preset(10);
+    enc.width = u.int_in_range(1..=256)?;
+    enc.height = u.int_in_range(1..=256)?;
+    enc.still_picture = Arbitrary::arbitrary(u)?;
+    enc.time_base =
       Rational::new(Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?);
-    config.enc.min_key_frame_interval = u.int_in_range(0..=3)?;
-    config.enc.max_key_frame_interval = u.int_in_range(1..=4)?;
-    config.enc.low_latency = Arbitrary::arbitrary(u)?;
-    config.enc.quantizer = Arbitrary::arbitrary(u)?;
-    config.enc.min_quantizer = Arbitrary::arbitrary(u)?;
-    config.enc.bitrate = Arbitrary::arbitrary(u)?;
-    // config.enc.tile_cols = Arbitrary::arbitrary(u)?;
-    // config.enc.tile_rows = Arbitrary::arbitrary(u)?;
-    // config.enc.tiles = Arbitrary::arbitrary(u)?;
-    config.enc.rdo_lookahead_frames = Arbitrary::arbitrary(u)?;
-    config.enc.speed_settings = SpeedSettings::from_preset(10);
+    enc.min_key_frame_interval = u.int_in_range(0..=3)?;
+    enc.max_key_frame_interval = u.int_in_range(1..=4)?;
+    enc.low_latency = Arbitrary::arbitrary(u)?;
+    enc.quantizer = Arbitrary::arbitrary(u)?;
+    enc.min_quantizer = Arbitrary::arbitrary(u)?;
+    enc.bitrate = Arbitrary::arbitrary(u)?;
+    // enc.tile_cols = Arbitrary::arbitrary(u)?;
+    // enc.tile_rows = Arbitrary::arbitrary(u)?;
+    // enc.tiles = Arbitrary::arbitrary(u)?;
+    enc.rdo_lookahead_frames = Arbitrary::arbitrary(u)?;
     let frame_count = u.int_in_range(1..=3)?;
     if u.is_empty() {
       return Err(Error::NotEnoughData);
     }
     let pixels = u.get_bytes(u.len())?.to_vec().into_boxed_slice();
+    let config = Config::new().with_encoder_config(enc).with_threads(1);
     Ok(Self { config, frame_count, pixels })
   }
 }

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -191,7 +191,9 @@ fn setup_encoder<T: Pixel>(
   enc.tile_rows = 1 << tile_rows_log2;
   enc.still_picture = still_picture;
 
-  let cfg = Config::new().with_encoder_config(enc);
+  let threads = if cfg!(fuzzing) { 1 } else { 2 };
+
+  let cfg = Config::new().with_encoder_config(enc).with_threads(threads);
 
   cfg.new_context().unwrap()
 }


### PR DESCRIPTION
Increase the value ranges for fields of DecodeTestParameters. Ensure the still_picture limit is respected.
Use a single thread for encode_decode - This helps to avoid over-allocating threads when running with many cores.