### PR TITLE
Write Frame OBUs instead of a pair of Frame Header and Tile Group OBUs

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -843,7 +843,6 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     if fi.large_scale_tile {
       unimplemented!();
     }
-    self.write_bit(true)?; // trailing bit
     self.byte_align()?;
 
     Ok(())


### PR DESCRIPTION
For non show_existing_frame frames, and seeing rav1e currently doens't offer
the option to write more than one Tile Group per frame, it's more
efficient to use Frame OBUs instead of a pair of Frame Header and Tile Group
OBUs.

This saves a few bytes per frame by removing the overhead from the superfluous
OBU header.