### PR TITLE
always set frame_size_override_flag when creating new inter frames

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -819,19 +819,20 @@ impl<T: Pixel> FrameInvariants<T> {
     fi.error_resilient =
       if fi.frame_type == FrameType::SWITCH { true } else { error_resilient };
 
-    // force frame_size_with_refs() code path if render size != frame size
-    if fi.frame_type == FrameType::INTER
+    fi.frame_size_override_flag = if fi.frame_type == FrameType::SWITCH {
+      true
+    } else if fi.sequence.reduced_still_picture_hdr {
+      false
+    } else if fi.frame_type == FrameType::INTER
       && !fi.error_resilient
       && fi.render_and_frame_size_different
     {
-      fi.frame_size_override_flag = true;
-    }
-
-    if fi.frame_type == FrameType::SWITCH {
-      fi.frame_size_override_flag = true;
-    } else if fi.sequence.reduced_still_picture_hdr {
-      fi.frame_size_override_flag = false;
-    }
+      // force frame_size_with_refs() code path if render size != frame size
+      true
+    } else {
+      fi.width as u32 != fi.sequence.max_frame_width
+        || fi.height as u32 != fi.sequence.max_frame_height
+    };
 
     // this is the slot that the current frame is going to be saved into
     let slot_idx = inter_cfg.get_slot_idx(fi.pyramid_level, fi.order_hint);


### PR DESCRIPTION
This prevents the value from the previous frame cloned at the beginning of new_inter_frame() from being used if none of the existing checks succeeds.