### PR TITLE
Cleanups based on clippy suggestions

### DIFF
--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -139,13 +139,7 @@ impl Default for RestorationFilter {
 impl RestorationFilter {
   pub fn notequal(self, cmp: RestorationFilter) -> bool {
     match self {
-      RestorationFilter::None {} => {
-        if let RestorationFilter::None {} = cmp {
-          false
-        } else {
-          true
-        }
-      }
+      RestorationFilter::None {} => !matches!(cmp, RestorationFilter::None {}),
       RestorationFilter::Sgrproj { set, xqd } => {
         if let RestorationFilter::Sgrproj { set: set2, xqd: xqd2 } = cmp {
           !(set == set2 && xqd[0] == xqd2[0] && xqd[1] == xqd2[1])

--- a/src/me.rs
+++ b/src/me.rs
@@ -365,8 +365,8 @@ fn get_subset_predictors<T: Pixel>(
       subset_b.iter().map(|&a| a.row).collect();
     let mut cols: ArrayVec<[i16; 3]> =
       subset_b.iter().map(|&a| a.col).collect();
-    rows.as_mut_slice().sort();
-    cols.as_mut_slice().sort();
+    rows.as_mut_slice().sort_unstable();
+    cols.as_mut_slice().sort_unstable();
     Some(MotionVector { row: rows[1], col: cols[1] })
   };
 

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -76,7 +76,7 @@ impl TxType {
   ///
   /// <https://aomediacodec.github.io/av1-spec/#compute-transform-type-function>
   #[inline]
-  pub fn uv_inter(self: Self, uv_tx_size: TxSize) -> Self {
+  pub fn uv_inter(self, uv_tx_size: TxSize) -> Self {
     use TxType::*;
     if uv_tx_size.sqr_up() == TX_32X32 {
       match self {


### PR DESCRIPTION
The first fix here is simply to add a clippy annotation to the
`get_subset_predictors` function to allow stable sorts. I suspect
order matters in these sorts hence this annotation.

second is a simple use of the `matches!` macro

and the third is a removal of a Self type.

Clippy links:
https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro
https://rust-lang.github.io/rust-clippy/master/index.html#needless_arbitrary_self_type
https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive