### PR TITLE
CI: Pin js_api Rust version to 1.46

### DIFF
--- a/.github/workflows/js_api.yml
+++ b/.github/workflows/js_api.yml
@@ -49,7 +49,7 @@ jobs:
               uses: actions-rs/toolchain@v1
               with:
                   profile: minimal
-                  toolchain: stable
+                  toolchain: 1.46.0
                   override: true
                   target: wasm32-unknown-unknown
 


### PR DESCRIPTION
This PR pins up the `Rust` version used by the `js_api` CI to 1.46