### PR TITLE
Ensure that min and max quantizer are respected

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1102,7 +1102,7 @@ impl<T: Pixel> ContextInner<T> {
     }
   }
 
-  fn encode_packet(
+  pub(crate) fn encode_packet(
     &mut self, cur_output_frameno: u64,
   ) -> Result<Packet<T>, EncoderStatus> {
     if self.frame_data.get(&cur_output_frameno).unwrap().fi.show_existing_frame


### PR DESCRIPTION
When specifying e.g. `--bitrate 10000 --min-quantizer 100`, the min-quantizer setting did not appear to take effect. For example, on a test clip of BBB 720p first 500 frames, the average QPs were 20 and 68 for I and P frames respectively. After this PR, the QPs are flat as would be expected of a `--quantizer 100` encode (since bitrate 10000 would, in this case, always want a lower quantizer).