### PR TITLE
Optimize the buffer size in inverse_transform_add

### DIFF
--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1602,7 +1602,7 @@ pub(crate) mod rust {
 
     // For 64 point transforms, rely on the last 32 columns being initialized
     //   to zero for filling out missing input coeffs.
-    let buffer = &mut [0i32; 64 * 64][..width * height];
+    let mut buffer = vec![0i32; width * height].into_boxed_slice();
     let rect_type = get_rect_tx_log_ratio(width, height);
     let tx_types_1d = get_1d_tx_types(tx_type);
 


### PR DESCRIPTION
The zeroing of this buffer was a hotspot within the native implementation of inverse_transform_add. Changed it to only zero a buffer equivalent to the size that will be used. This is significantly more efficient for smaller-than-64x64 transforms and equivalent for 64x64.

This results in an overall 2% encoding time improvement on HBD content at speed 5.

```
> hyperfine -w 1 "~/Downloads/rav1e-master -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/blue_sky_360p_60f.y4m --limit 10" "~/Downloads/rav1e-try1 -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/blue_sky_360p_60f.y4m --limit 10"
Benchmark #1: ~/Downloads/rav1e-master -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/blue_sky_360p_60f.y4m --limit 10
  Time (mean ± σ):     15.188 s ±  0.079 s    [User: 15.169 s, System: 0.072 s]
  Range (min … max):   15.109 s … 15.383 s    10 runs
 
Benchmark #2: ~/Downloads/rav1e-try1 -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/blue_sky_360p_60f.y4m --limit 10
  Time (mean ± σ):     14.953 s ±  0.061 s    [User: 14.939 s, System: 0.065 s]
  Range (min … max):   14.877 s … 15.053 s    10 runs
 
Summary
  '~/Downloads/rav1e-try1 -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/blue_sky_360p_60f.y4m --limit 10' ran
    1.02 ± 0.01 times faster than '~/Downloads/rav1e-master -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/blue_sky_360p_60f.y4m --limit 10'

> hyperfine -w 1 "~/Downloads/rav1e-master -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/KristenAndSara_1280x720_60f.y4m --limit 10" "~/Downloads/rav1e-try1 -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/KristenAndSara_1280x720_60f.y4m --limit 10"
Benchmark #1: ~/Downloads/rav1e-master -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/KristenAndSara_1280x720_60f.y4m --limit 10
  Time (mean ± σ):     48.159 s ±  0.115 s    [User: 48.106 s, System: 0.146 s]
  Range (min … max):   47.951 s … 48.273 s    10 runs
 
Benchmark #2: ~/Downloads/rav1e-try1 -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/KristenAndSara_1280x720_60f.y4m --limit 10
  Time (mean ± σ):     47.200 s ±  0.182 s    [User: 47.157 s, System: 0.147 s]
  Range (min … max):   47.025 s … 47.678 s    10 runs
 
Summary
  '~/Downloads/rav1e-try1 -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/KristenAndSara_1280x720_60f.y4m --limit 10' ran
    1.02 ± 0.00 times faster than '~/Downloads/rav1e-master -s 5 --quantizer 42 -o /dev/null ~/data/objective-1-fast-10bit/KristenAndSara_1280x720_60f.y4m --limit 10'
```