### PR TITLE
Use env var $GITHUB_PATH instead of add-path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         $LINK="https://www.nasm.us/pub/nasm/releasebuilds/$NASM_VERSION/win64"
         curl --ssl-no-revoke -LO "$LINK/nasm-$NASM_VERSION-win64.zip"
         7z e -y "nasm-$NASM_VERSION-win64.zip" -o"C:\nasm"
-        echo "::add-path::C:\nasm"
+        echo "C:\nasm" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Install cargo-c
       run: |
@@ -50,7 +50,7 @@ jobs:
       if: matrix.conf == 'msvc'
       run: |
         $VsPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
-        echo "::add-path::$VsPath;C:\nasm"
+        echo "$VsPath;C:\nasm" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Set MSVC x86_64 linker path
       if: matrix.conf == 'msvc'
@@ -58,7 +58,7 @@ jobs:
         $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
         $LinkPath = vswhere -latest -products * -find "$LinkGlob" |
                     Select-Object -Last 1
-        echo "::add-path::$LinkPath"
+        echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Install stable
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/js_api.yml
+++ b/.github/workflows/js_api.yml
@@ -43,7 +43,7 @@ jobs:
                   mkdir -p $HOME/.local/bin
                   curl -L "$LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
                   mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
-                  echo "::add-path::$HOME/.local/bin"
+                  echo "$HOME/.local/bin"  >> $GITHUB_PATH
 
             - name: Set up Rust
               uses: actions-rs/toolchain@v1

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Set no-asm-tests env vars
       if: matrix.conf == 'no-asm-tests'
       run: |
-        echo "::set-env name=RAV1E_CPU_TARGET::rust"
+        echo "name=RAV1E_CPU_TARGET::rust" >> $GITHUB_ENV
     - name: Install sccache
       env:
         LINK: https://github.com/mozilla/sccache/releases/download
@@ -110,7 +110,7 @@ jobs:
         mkdir -p $HOME/.local/bin
         curl -L "$LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
         mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
-        echo "::add-path::$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
     - name: Add nasm
       env:
         LINK: http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm
@@ -407,7 +407,7 @@ jobs:
         $SCCACHE_FILE = "sccache-0.2.12-x86_64-pc-windows-msvc"
         curl -LO "$LINK/$SCCACHE_FILE.tar.gz"
         tar xzf "$SCCACHE_FILE.tar.gz"
-        echo "::add-path::$Env:GITHUB_WORKSPACE/$SCCACHE_FILE"
+        echo "$Env:GITHUB_WORKSPACE/$SCCACHE_FILE" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install nasm
       run: |
         $NASM_VERSION="2.15.05"
@@ -415,13 +415,13 @@ jobs:
         $NASM_FILE = "nasm-$NASM_VERSION-win64"
         curl --ssl-no-revoke -LO "$LINK/$NASM_FILE.zip"
         7z e -y "$NASM_FILE.zip" -o"C:\nasm"
-        echo "::add-path::C:\nasm"
+        echo "C:\nasm"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Set MSVC x86_64 linker path
       run: |
         $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
         $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
         $LinkPath = vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1
-        echo "::add-path::$LinkPath"
+        echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install ${{ matrix.toolchain }}
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
As of last week, GitHub's add-path command has been deprecated.