### PR TITLE
Enable Thin LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ opt-level = 1
 [profile.release]
 debug = true
 incremental = true
+lto = "thin"
 
 [profile.bench]
 incremental = true


### PR DESCRIPTION
Provides minor build time improvements on all platforms.
Provides minor runtime improvements on x86_64.
Provides significant runtime improvements (~13%) on ARM.