### PR TITLE
Make the scenechange detector publicly usable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ bench = []
 check_asm = []
 capi = []
 tracing = ["rust_hawktracer"]
+scenechange = []
 serialize = ["serde", "toml", "v_frame/serialize", "arrayvec/serde"]
 wasm = ["wasm-bindgen"]
 

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -290,6 +290,7 @@ impl<T: Pixel> ContextInner<T> {
         CpuFeatureLevel::default(),
         lookahead_distance,
         seq,
+        true,
       ),
       config: *enc,
       seq,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,9 @@ mod me;
 mod rate;
 mod recon_intra;
 mod scan_order;
+#[cfg(feature = "scenechange")]
+pub mod scenechange;
+#[cfg(not(feature = "scenechange"))]
 mod scenechange;
 mod segmentation;
 mod stats;
@@ -215,7 +218,7 @@ pub use crate::util::{CastFromPrimitive, Pixel, PixelType};
 /// Commonly used types and traits.
 pub mod prelude {
   pub use crate::api::*;
-  pub use crate::encoder::Tune;
+  pub use crate::encoder::{Sequence, Tune};
   pub use crate::frame::{
     Frame, FrameParameters, FrameTypeOverride, Plane, PlaneConfig,
   };
@@ -243,6 +246,7 @@ pub mod config {
     Config, EncoderConfig, InvalidConfig, PredictionModesSetting,
     RateControlConfig, RateControlError, RateControlSummary, SpeedSettings,
   };
+  pub use crate::cpu_features::CpuFeatureLevel;
 }
 
 /// Version information


### PR DESCRIPTION
The intent is to stop av-scenechange from having
to duplicate all of the internals of rav1e's
scenechange detection.
This makes all necessary items public and interoperable
with av-scenechange, so that av-scenechange can pull in
rav1e as a dependency and always be up to date
with its scenechange detection.