### PR TITLE
Optimise NEON assembly for get_sad for width 16

### DIFF
--- a/src/arm/64/sad.S
+++ b/src/arm/64/sad.S
@@ -77,10 +77,9 @@ sad_rect 4, 16
 .macro horizontal_add_16x8
         uaddlp          v0.4s,   v0.8h
         uaddlp          v0.2d,   v0.4s
-        dup             d1,  v0.d[0]
-        dup             d0,  v0.d[1]
+        ext             v1.16b,  v0.16b,  v0.16b,  #8
         add             v0.2s,   v1.2s,   v0.2s
-        umov            w0,  v0.s[0]
+        fmov            w0,  s0
         ret
 .endm
 
@@ -270,16 +269,12 @@ function sad16x16_neon, export=1
         mov             v3.16b,  v0.16b
 L(sad_w16):
         ldr             q1,  [x0]
-        subs            w4,  w4,  #1
         ldr             q2,  [x2]
         add             x0,  x0,  x1
-        dup             d4,  v1.d[0]
         add             x2,  x2,  x3
-        dup             d1,  v1.d[1]
-        dup             d5,  v2.d[0]
-        dup             d2,  v2.d[1]
-        uabal           v3.8h,   v4.8b,   v5.8b
+        subs            w4,  w4,  #1
         uabal           v0.8h,   v1.8b,   v2.8b
+        uabal2          v3.8h,   v1.16b,  v2.16b
         bne             L(sad_w16)
         add             v0.8h,   v0.8h,   v3.8h
         horizontal_add_16x8


### PR DESCRIPTION
Reduces execution time for this function by between 18% and 40%.
The most commonly used block size, 16x16, is improved by 29%.

<details>

```
get_sad/(BLOCK_16X8, 8) time:   [10.095 ns 10.104 ns 10.111 ns]                                     
                        change: [-25.513% -25.484% -25.457%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 25 outliers among 100 measurements (25.00%)
  7 (7.00%) low severe
  1 (1.00%) low mild
  5 (5.00%) high mild
  12 (12.00%) high severe
get_sad/(BLOCK_16X16, 8)                                                                             
                        time:   [15.758 ns 15.769 ns 15.780 ns]
                        change: [-30.763% -30.703% -30.644%] (p = 0.00 < 0.05)
                        Performance has improved.
get_sad/(BLOCK_16X32, 8)                                                                             
                        time:   [26.581 ns 26.586 ns 26.592 ns]
                        change: [-35.741% -35.705% -35.668%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  12 (12.00%) high severe
get_sad/(BLOCK_16X4, 8) time:   [6.9992 ns 7.0004 ns 7.0019 ns]                                     
                        change: [-19.098% -18.976% -18.842%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe
get_sad/(BLOCK_16X64, 8)                                                                             
                        time:   [47.702 ns 47.710 ns 47.720 ns]
                        change: [-38.632% -38.550% -38.465%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  5 (5.00%) high mild
  12 (12.00%) high severe
```
</details>