### PR TITLE
Optimise NEON assembly for get_sad for widths 32, 64 and 128

### DIFF
--- a/src/arm/64/sad.S
+++ b/src/arm/64/sad.S
@@ -42,11 +42,11 @@ function sad4x4_neon, export=1
         sxtw            x3,  w3
         mov             w4,  #4
 L(sad_w4):
-        subs            w4,  w4,  #1
         ldr             d1,  [x0]
-        add             x0,  x0,  x1
         ldr             d2,  [x2]
+        add             x0,  x0,  x1
         add             x2,  x2,  x3
+        subs            w4,  w4,  #1
         uabal           v0.8h,   v1.8b,   v2.8b
         bne             L(sad_w4)
         uaddlp          v0.2s,   v0.4h
@@ -59,18 +59,14 @@ sad_rect 4, 8
 sad_rect 4, 16
 
 .macro horizontal_long_add_16x8
-        dup             d2,  v1.d[0]
-        dup             d1,  v1.d[1]
-        uaddl           v1.4s,   v2.4h,   v1.4h
-        dup             d2,  v0.d[0]
-        dup             d0,  v0.d[1]
-        uaddl           v0.4s,   v2.4h,   v0.4h
-        add             v1.4s,   v1.4s,   v0.4s
-        uaddlp          v1.2d,   v1.4s
-        dup             d0,  v1.d[0]
-        dup             d1,  v1.d[1]
-        add             v1.2s,   v0.2s,   v1.2s
-        umov            w0,  v1.s[0]
+        ushll           v2.4s,   v1.4h,   #0
+        uaddw2          v1.4s,   v2.4s,   v1.8h
+        uaddw           v1.4s,   v1.4s,   v0.4h
+        uaddw2          v0.4s,   v1.4s,   v0.8h
+        uaddlp          v0.2d,   v0.4s
+        ext             v1.16b,  v0.16b,  v0.16b,  #8
+        add             v0.2s,   v1.2s,   v0.2s
+        fmov            w0,  s0
         ret
 .endm
 
@@ -91,40 +87,24 @@ function sad64x64_neon, export=1
         mov             v1.16b,  v0.16b
 L(sad_w64):
         ldr             q16, [x0]
-        subs            w4,  w4,  #1
         ldr             q17, [x2]
         ldr             q6,  [x0, #16]
         ldr             q7,  [x2, #16]
         ldr             q4,  [x0, #32]
         ldr             q5,  [x2, #32]
         ldr             q2,  [x0, #48]
-        add             x0,  x0,  x1
         ldr             q3,  [x2, #48]
+        add             x0,  x0,  x1
         add             x2,  x2,  x3
-        dup             d18, v16.d[0]
-        dup             d19, v17.d[0]
-        dup             d16, v16.d[1]
-        dup             d17, v17.d[1]
+        subs            w4,  w4,  #1
         uabal           v0.8h,   v16.8b,  v17.8b
-        dup             d16, v6.d[0]
-        dup             d17, v7.d[0]
-        dup             d6,  v6.d[1]
-        dup             d7,  v7.d[1]
+        uabal2          v1.8h,   v16.16b, v17.16b
         uabal           v0.8h,   v6.8b,   v7.8b
-        dup             d6,  v4.d[0]
-        dup             d7,  v5.d[0]
-        dup             d4,  v4.d[1]
-        dup             d5,  v5.d[1]
-        uabal           v1.8h,   v18.8b,  v19.8b
+        uabal2          v1.8h,   v6.16b,  v7.16b
         uabal           v0.8h,   v4.8b,   v5.8b
-        uabal           v1.8h,   v16.8b,  v17.8b
-        dup             d4,  v2.d[0]
-        dup             d5,  v3.d[0]
-        uabal           v1.8h,   v6.8b,   v7.8b
-        dup             d2,  v2.d[1]
-        dup             d3,  v3.d[1]
-        uabal           v1.8h,   v4.8b,   v5.8b
+        uabal2          v1.8h,   v4.16b,  v5.16b
         uabal           v0.8h,   v2.8b,   v3.8b
+        uabal2          v1.8h,   v2.16b,  v3.16b
         bne             L(sad_w64)
         horizontal_long_add_16x8
 endfunc
@@ -141,80 +121,35 @@ function sad128x128_neon, export=1
         mov             w4,  #128
         mov             v2.16b,  v3.16b
 L(sad_w128):
-        ldr             q0,  [x0]
-        subs            w4,  w4,  #1
-        ldr             q28, [x2]
-        ldr             q25, [x0, #16]
-        ldr             q26, [x2, #16]
-        ldr             q23, [x0, #32]
-        ldr             q24, [x2, #32]
-        dup             d27, v0.d[0]
-        ldr             q21, [x0, #48]
-        ldr             q22, [x2, #48]
-        dup             d29, v28.d[0]
-        mov             v1.16b,  v18.16b
-        dup             d28, v28.d[1]
-        uabal           v1.8h,   v27.8b,  v29.8b
-        dup             d27, v0.d[1]
-        ldr             q19, [x0, #64]
-        ldr             q20, [x2, #64]
-        mov             v0.16b,  v18.16b
-        uabal           v0.8h,   v27.8b,  v28.8b
-        dup             d27, v25.d[0]
-        dup             d28, v26.d[0]
-        dup             d25, v25.d[1]
-        dup             d26, v26.d[1]
-        ldr             q16, [x0, #80]
-        uabal           v0.8h,   v25.8b,  v26.8b
-        ldr             q17, [x2, #80]
-        uabal           v1.8h,   v27.8b,  v28.8b
-        dup             d25, v23.d[0]
-        dup             d26, v24.d[0]
-        dup             d23, v23.d[1]
-        dup             d24, v24.d[1]
-        ldr             q6,  [x0, #96]
-        uabal           v0.8h,   v23.8b,  v24.8b
-        ldr             q7,  [x2, #96]
-        uabal           v1.8h,   v25.8b,  v26.8b
-        dup             d23, v21.d[0]
-        dup             d24, v22.d[0]
-        dup             d21, v21.d[1]
-        dup             d22, v22.d[1]
-        ldr             q4,  [x0, #112]
-        uabal           v0.8h,   v21.8b,  v22.8b
-        ldr             q5,  [x2, #112]
-        uabal           v1.8h,   v23.8b,  v24.8b
-        dup             d21, v19.d[0]
+        ldp             q0,  q25, [x0]
+        ldp             q28, q26, [x2]
+        ldp             q23, q21, [x0, #32]
+        ldp             q24, q22, [x2, #32]
+        ldp             q19, q16, [x0, #64]
+        ldp             q20, q17, [x2, #64]
+        ldp             q6,  q4,  [x0, #96]
+        ldp             q7,  q5,  [x2, #96]
         add             x0,  x0,  x1
-        dup             d22, v20.d[0]
         add             x2,  x2,  x3
-        dup             d19, v19.d[1]
-        dup             d20, v20.d[1]
-        uabal           v0.8h,   v19.8b,  v20.8b
-        dup             d19, v16.d[0]
-        dup             d20, v17.d[0]
-        dup             d16, v16.d[1]
-        dup             d17, v17.d[1]
-        uabal           v0.8h,   v16.8b,  v17.8b
-        dup             d16, v6.d[0]
-        dup             d17, v7.d[0]
-        dup             d6,  v6.d[1]
-        dup             d7,  v7.d[1]
-        uabal           v1.8h,   v21.8b,  v22.8b
-        uabal           v0.8h,   v6.8b,   v7.8b
-        uabal           v1.8h,   v19.8b,  v20.8b
-        dup             d6,  v4.d[0]
-        dup             d7,  v5.d[0]
-        uabal           v1.8h,   v16.8b,  v17.8b
-        dup             d4,  v4.d[1]
-        uabal           v1.8h,   v6.8b,   v7.8b
-        dup             d5,  v5.d[1]
-        uabal           v0.8h,   v4.8b,   v5.8b
-        add             v0.8h,   v0.8h,   v1.8h
-        dup             d1,  v0.d[0]
-        dup             d0,  v0.d[1]
-        uaddw           v2.4s,   v2.4s,   v1.4h
-        uaddw           v3.4s,   v3.4s,   v0.4h
+        subs            w4,  w4,  #1
+        uabdl           v18.8h,  v0.8b,   v28.8b
+        uabal2          v18.8h,  v0.16b,  v28.16b
+        uabal           v18.8h,  v25.8b,  v26.8b
+        uabal2          v18.8h,  v25.16b, v26.16b
+        uabal           v18.8h,  v23.8b,  v24.8b
+        uabal2          v18.8h,  v23.16b, v24.16b
+        uabal           v18.8h,  v21.8b,  v22.8b
+        uabal2          v18.8h,  v21.16b, v22.16b
+        uabal           v18.8h,  v19.8b,  v20.8b
+        uabal2          v18.8h,  v19.16b, v20.16b
+        uabal           v18.8h,  v16.8b,  v17.8b
+        uabal2          v18.8h,  v16.16b, v17.16b
+        uabal           v18.8h,  v6.8b,   v7.8b
+        uabal2          v18.8h,  v6.16b,  v7.16b
+        uabal           v18.8h,  v4.8b,   v5.8b
+        uabal2          v18.8h,  v4.16b,  v5.16b
+        uaddw           v3.4s,   v3.4s,   v18.4h
+        uaddw2          v2.4s,   v2.4s,   v18.8h
         bne             L(sad_w128)
         add             v2.4s,   v2.4s,   v3.4s
         uaddlp          v2.2d,   v2.4s
@@ -234,24 +169,16 @@ function sad32x32_neon, export=1
         mov             v1.16b,  v0.16b
 L(sad_w32):
         ldr             q4,  [x0]
-        subs            w4,  w4,  #1
         ldr             q5,  [x2]
         ldr             q2,  [x0, #16]
-        add             x0,  x0,  x1
         ldr             q3,  [x2, #16]
+        add             x0,  x0,  x1
         add             x2,  x2,  x3
-        dup             d6,  v4.d[0]
-        dup             d7,  v5.d[0]
-        dup             d4,  v4.d[1]
-        dup             d5,  v5.d[1]
-        uabal           v1.8h,   v6.8b,   v7.8b
-        uabal           v0.8h,   v4.8b,   v5.8b
-        dup             d4,  v2.d[0]
-        dup             d5,  v3.d[0]
-        dup             d2,  v2.d[1]
-        dup             d3,  v3.d[1]
+        subs            w4,  w4,  #1
         uabal           v1.8h,   v4.8b,   v5.8b
-        uabal           v0.8h,   v2.8b,   v3.8b
+        uabal2          v0.8h,   v4.16b,  v5.16b
+        uabal           v1.8h,   v2.8b,   v3.8b
+        uabal2          v0.8h,   v2.16b,  v3.16b
         bne             L(sad_w32)
         add             v0.8h,   v0.8h,   v1.8h
         horizontal_add_16x8
@@ -291,11 +218,11 @@ function sad8x8_neon, export=1
         sxtw            x3,  w3
         mov             w4,  #8
 L(sad_w8):
-        subs            w4,  w4,  #1
         ldr             d1,  [x0]
-        add             x0,  x0,  x1
         ldr             d2,  [x2]
+        add             x0,  x0,  x1
         add             x2,  x2,  x3
+        subs            w4,  w4,  #1
         uabal           v0.8h,   v1.8b,   v2.8b
         bne             L(sad_w8)
         horizontal_add_16x8


### PR DESCRIPTION
Reduces execution time for these functions by between 35% and 42%.
Binary size of the SAD module is reduced by 23%, to less than 1kB.

Reorder widths 4 and 8 for consistency with other widths.