### PR TITLE
Run keyframe cost estimations in parallel

### DIFF
--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -23,6 +23,7 @@ pub(crate) const IMP_BLOCK_SIZE_IN_MV_UNITS: i64 =
 pub(crate) const IMP_BLOCK_AREA_IN_MV_UNITS: i64 =
   IMP_BLOCK_SIZE_IN_MV_UNITS * IMP_BLOCK_SIZE_IN_MV_UNITS;
 
+#[hawktracer(estimate_intra_costs)]
 pub(crate) fn estimate_intra_costs<T: Pixel>(
   frame: &Frame<T>, bit_depth: usize, cpu_feature_level: CpuFeatureLevel,
 ) -> Box<[u32]> {
@@ -114,6 +115,7 @@ pub(crate) fn estimate_intra_costs<T: Pixel>(
   intra_costs.into_boxed_slice()
 }
 
+#[hawktracer(estimate_inter_costs)]
 pub(crate) fn estimate_inter_costs<T: Pixel>(
   frame: Arc<Frame<T>>, ref_frame: Arc<Frame<T>>, bit_depth: usize,
   mut config: EncoderConfig, sequence: Arc<Sequence>,

--- a/src/bin/muxer/ivf.rs
+++ b/src/bin/muxer/ivf.rs
@@ -9,15 +9,15 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use super::Muxer;
+use crate::error::*;
 use ivf::*;
+use rav1e::hawktracer::*;
 use rav1e::prelude::*;
 use std::fs;
 use std::fs::File;
 use std::io;
 use std::io::Write;
 use std::path::Path;
-
-use crate::error::*;
 
 pub struct IvfMuxer {
   output: Box<dyn Write + Send>,
@@ -37,6 +37,7 @@ impl Muxer for IvfMuxer {
     );
   }
 
+  #[hawktracer(write_frame)]
   fn write_frame(&mut self, pts: u64, data: &[u8], _frame_type: FrameType) {
     write_ivf_frame(&mut self.output, pts, data);
   }

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -9,6 +9,7 @@
 
 use av_metrics::video::*;
 use rav1e::data::EncoderStats;
+use rav1e::hawktracer::*;
 use rav1e::prelude::Rational;
 use rav1e::prelude::*;
 use rav1e::{Packet, Pixel};
@@ -29,6 +30,7 @@ pub struct FrameSummary {
   pub enc_stats: EncoderStats,
 }
 
+#[hawktracer(build_frame_summary)]
 pub fn build_frame_summary<T: Pixel>(
   packets: Packet<T>, bit_depth: usize, chroma_sampling: ChromaSampling,
   metrics_cli: MetricsEnabled,
@@ -740,6 +742,7 @@ pub enum MetricsEnabled {
   All,
 }
 
+#[hawktracer(calculate_frame_metrics)]
 pub fn calculate_frame_metrics<T: Pixel>(
   frame1: &Frame<T>, frame2: &Frame<T>, bit_depth: usize, cs: ChromaSampling,
   metrics: MetricsEnabled,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,15 @@ mod rayon {
                 self.into_par_iter()
             }
         }
+      }
 
+      pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
+      where
+        A: FnOnce() -> RA + Send,
+        B: FnOnce() -> RB + Send,
+        RA: Send,
+        RB: Send {
+        (oper_a(), oper_b())
       }
     } else {
       pub use rayon::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,8 @@ mod serialize {
   }
 }
 
-mod hawktracer {
+#[doc(hidden)]
+pub mod hawktracer {
   cfg_if::cfg_if! {
     if #[cfg(feature="tracing")] {
       pub use rust_hawktracer::*;

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -246,7 +246,7 @@ impl SceneChangeDetector {
       }
     } else {
       let frame2_ref2 = Arc::clone(&frame2);
-      let (intra_cost, inter_cost) = rayon::join(
+      let (intra_cost, inter_cost) = crate::rayon::join(
         move || {
           let intra_costs = estimate_intra_costs(
             &*frame2,


### PR DESCRIPTION
Intra cost and inter cost estimation account for 99%
of the time spent in keyframe detection (except at speed 10).
These two computations can be run in parallel,
thus providing a 30-40% speedup on keyframe detection
and a 1-3% speedup overall (depends on speed level, etc).