### PR TITLE
CI: Add aarch64-apple-darwin jobs to GitHub Actions

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -333,7 +333,7 @@ jobs:
       SCCACHE_CACHE_SIZE: 300M
       SCCACHE_DIR: /Users/runner/Library/Caches/Mozilla.sccache
 
-    runs-on: macos-latest
+    runs-on: macos-11.0
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -305,10 +305,27 @@ jobs:
 
     strategy:
       matrix:
-        conf:
-         - cargo-build
-         - cargo-test
-         - cargo-c
+        include:
+          - name: Cargo build (x64)
+            conf: cargo-build
+            target: x86_64-apple-darwin
+            toolchain: stable
+          - name: Cargo test (x64)
+            conf: cargo-test
+            target: x86_64-apple-darwin
+            toolchain: stable
+          - name: Cargo C-build (x64)
+            conf: cargo-c
+            target: x86_64-apple-darwin
+            toolchain: stable
+          - name: Cargo build (Arm64)
+            conf: cargo-build
+            target: aarch64-apple-darwin
+            toolchain: beta # Can be switched to stable on Rust 1.49 release
+          - name: Cargo C-build (Arm64)
+            conf: cargo-c
+            target: aarch64-apple-darwin
+            toolchain: beta # Can be switched to stable on Rust 1.49 release
 
     env:
       RUST_BACKTRACE: full
@@ -334,8 +351,10 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: ${{ matrix.toolchain }}
         override: true
+        target: ${{ matrix.target }}
+        default: true
     - name: Generate Cargo.lock and Cargo.version
       run: |
         cargo update
@@ -362,15 +381,15 @@ jobs:
     - name: Build
       if: matrix.conf == 'cargo-build'
       run: |
-        cargo build --release
+        cargo build --release --target=${{ matrix.target }}
     - name: Test
       if: matrix.conf == 'cargo-test'
       run: |
-        cargo test --workspace --verbose
+        cargo test --workspace --verbose --target=${{ matrix.target }}
     - name: Run cargo-c
       if: matrix.conf == 'cargo-c'
       run: |
-        cargo cbuild
+        cargo cbuild --target=${{ matrix.target }}
     - name: Stop sccache server
       run: |
         sccache --stop-server


### PR DESCRIPTION
Adds cargo build and cargo-c build jobs to the macOS build matrix for the aarch64-apple-darwin target (for Apple Silicon / M1).

On the release of Rust 1.49 all toolchains can be switched back to stable (and it can be removed from the build matrix).