### PR TITLE
Make EncoderConfig non_exhaustive

### DIFF
--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -23,6 +23,7 @@ pub(crate) const MAX_MAX_KEY_FRAME_INTERVAL: u64 = i32::max_value() as u64 / 3;
 
 /// Encoder settings which impact the produced bitstream.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct EncoderConfig {
   // output size
   /// Width of the frames in pixels.


### PR DESCRIPTION
This allows changing it in the future without performing an API breaking
change.