### PR TITLE
Simplify Hawktracer boilerplate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ desync_finder = ["backtrace"]
 bench = []
 check_asm = []
 capi = []
-tracing = ["rust_hawktracer"]
+tracing = ["rust_hawktracer/profiling_enabled"]
 scenechange = []
 serialize = ["serde", "toml", "v_frame/serialize", "arrayvec/serde"]
 wasm = ["wasm-bindgen"]
@@ -87,17 +87,13 @@ fern = { version = "0.6", optional = true }
 itertools = "0.9"
 simd_helpers = "0.1"
 wasm-bindgen = { version = "0.2.63", optional = true }
+rust_hawktracer = "0.7.0"
 
 [dependencies.image]
 version = "0.23"
 optional = true
 default-features = false
 features = ["png"]
-
-[dependencies.rust_hawktracer]
-version = "0.7.0"
-features = ["profiling_enabled"]
-optional = true
 
 [build-dependencies]
 cc = { version = "1.0", optional = true, features = ["parallel"] }

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -8,9 +8,9 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use crate::frame::*;
-use crate::hawktracer::*;
 use crate::tiling::*;
 use crate::util::*;
+use rust_hawktracer::*;
 
 #[derive(Debug, Default, Clone)]
 pub struct ActivityMask {

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -16,7 +16,6 @@ use crate::cpu_features::CpuFeatureLevel;
 use crate::dist::get_satd;
 use crate::encoder::*;
 use crate::frame::*;
-use crate::hawktracer::*;
 use crate::partition::*;
 use crate::rate::{
   RCState, FRAME_NSUBTYPES, FRAME_SUBTYPE_I, FRAME_SUBTYPE_P,
@@ -28,6 +27,7 @@ use crate::tiling::Area;
 use crate::util::Pixel;
 use arrayvec::ArrayVec;
 use log::Level::Info;
+use rust_hawktracer::*;
 use std::cmp;
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -7,7 +7,6 @@ use crate::encoder::{
   FrameInvariants, FrameState, Sequence, IMPORTANCE_BLOCK_SIZE,
 };
 use crate::frame::{AsRegion, PlaneOffset};
-use crate::hawktracer::*;
 use crate::me::estimate_tile_motion;
 use crate::partition::{get_intra_edges, BlockSize};
 use crate::predict::{IntraParam, PredictionMode};
@@ -15,6 +14,7 @@ use crate::rayon::iter::*;
 use crate::tiling::{Area, TileRect};
 use crate::transform::TxSize;
 use crate::{Frame, Pixel};
+use rust_hawktracer::*;
 use std::sync::Arc;
 
 pub(crate) const IMP_BLOCK_MV_UNITS_PER_PIXEL: i64 = 8;

--- a/src/bin/muxer/ivf.rs
+++ b/src/bin/muxer/ivf.rs
@@ -11,8 +11,8 @@
 use super::Muxer;
 use crate::error::*;
 use ivf::*;
-use rav1e::hawktracer::*;
 use rav1e::prelude::*;
+use rust_hawktracer::*;
 use std::fs;
 use std::fs::File;
 use std::io;

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -9,10 +9,10 @@
 
 use av_metrics::video::*;
 use rav1e::data::EncoderStats;
-use rav1e::hawktracer::*;
 use rav1e::prelude::Rational;
 use rav1e::prelude::*;
 use rav1e::{Packet, Pixel};
+use rust_hawktracer::*;
 use std::fmt;
 use std::time::Instant;
 

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -11,9 +11,9 @@ use crate::color::ChromaSampling::Cs400;
 use crate::context::*;
 use crate::encoder::FrameInvariants;
 use crate::frame::*;
-use crate::hawktracer::*;
 use crate::tiling::*;
 use crate::util::{clamp, msb, CastFromPrimitive, Pixel};
+use rust_hawktracer::*;
 
 use crate::cpu_features::CpuFeatureLevel;
 use std::cmp;

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -11,13 +11,13 @@ use crate::api::FrameType;
 use crate::color::ChromaSampling::Cs400;
 use crate::context::*;
 use crate::encoder::FrameInvariants;
-use crate::hawktracer::*;
 use crate::partition::RefType::*;
 use crate::predict::PredictionMode::*;
 use crate::quantize::*;
 use crate::tiling::*;
 use crate::util::{clamp, ILog, Pixel};
 use crate::DeblockState;
+use rust_hawktracer::*;
 use std::cmp;
 
 use crate::rayon::iter::*;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -47,8 +47,8 @@ use std::mem::MaybeUninit;
 use std::sync::Arc;
 use std::{fmt, io, mem};
 
-use crate::hawktracer::*;
 use crate::rayon::iter::*;
+use rust_hawktracer::*;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,17 +75,6 @@ mod serialize {
   }
 }
 
-#[doc(hidden)]
-pub mod hawktracer {
-  cfg_if::cfg_if! {
-    if #[cfg(feature="tracing")] {
-      pub use rust_hawktracer::*;
-    } else {
-      pub use noop_proc_macro::hawktracer;
-    }
-  }
-}
-
 mod wasm_bindgen {
   cfg_if::cfg_if! {
     if #[cfg(feature="wasm")] {

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -21,9 +21,9 @@ use crate::encoder::FrameInvariants;
 use crate::frame::{
   AsRegion, Frame, Plane, PlaneConfig, PlaneOffset, PlaneSlice,
 };
-use crate::hawktracer::*;
 use crate::tiling::{Area, PlaneRegion, PlaneRegionMut, Rect};
 use crate::util::{clamp, CastFromPrimitive, ILog, Pixel};
+use rust_hawktracer::*;
 
 use crate::api::SGRComplexityLevel;
 use std::cmp;

--- a/src/me.rs
+++ b/src/me.rs
@@ -29,7 +29,7 @@ use crate::util::ILog;
 use std::ops::{Index, IndexMut};
 use std::sync::Arc;
 
-use crate::hawktracer::*;
+use rust_hawktracer::*;
 
 #[derive(Debug, Copy, Clone)]
 pub struct MEStats {

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -12,8 +12,8 @@ use crate::api::EncoderConfig;
 use crate::cpu_features::CpuFeatureLevel;
 use crate::encoder::Sequence;
 use crate::frame::*;
-use crate::hawktracer::*;
 use crate::util::{CastFromPrimitive, Pixel};
+use rust_hawktracer::*;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 


### PR DESCRIPTION
Hawktracer already has a feature, "profiling_enabled",
which controls whether it performs profiling or performs a no-op.
With the feature disabled, it performs the equivalent of our
noop_proc_macro. Therefore, we can remove our extra layer of
boilerplate.