### PR TITLE
Only use 8-bit AVX2 assembly when bdm8 equals 0.

### DIFF
--- a/src/asm/x86/lrf.rs
+++ b/src/asm/x86/lrf.rs
@@ -24,7 +24,8 @@ pub fn sgrproj_box_ab_r1(
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
   cpu: CpuFeatureLevel,
 ) {
-  if cpu >= CpuFeatureLevel::AVX2 {
+  // only use 8-bit AVX2 assembly when bitdepth minus 8 equals 0
+  if cpu >= CpuFeatureLevel::AVX2 && bdm8 == 0 {
     return unsafe {
       sgrproj_box_ab_r1_avx2(
         af,
@@ -61,7 +62,8 @@ pub fn sgrproj_box_ab_r2(
   iimg_stride: usize, y: usize, stripe_w: usize, s: u32, bdm8: usize,
   cpu: CpuFeatureLevel,
 ) {
-  if cpu >= CpuFeatureLevel::AVX2 {
+  // only use 8-bit AVX2 assembly when bitdepth minus 8 equals 0
+  if cpu >= CpuFeatureLevel::AVX2 && bdm8 == 0 {
     return unsafe {
       sgrproj_box_ab_r2_avx2(
         af,


### PR DESCRIPTION
The sgrproj_box_ab_r1_avx2() and sgrproj_box_ab_r2_avx2() functions call
 sgrproj_box_ab_8_avx2() which only implements the 8bpc path.