### PR TITLE
Fix assembly issues not found in our CI.

### DIFF
--- a/src/x86/mc16_avx2.asm
+++ b/src/x86/mc16_avx2.asm
@@ -1589,7 +1589,7 @@ filter_fn prep
 
 %macro bilin_fn 1
 %ifidn %1, avg
-cglobal avg_16bpc, 4, 8, 8, dst, ds, p1, p2, w, h, bdmax, ds3, ow
+cglobal avg_16bpc, 4, 9, 8, dst, ds, p1, p2, w, h, bdmax, ds3, ow
 %elifidn %1, w_avg
 cglobal w_avg_16bpc, 4, 9, 8, dst, ds, p1, p2, w, h, wg, bdmax, ow
 %else
@@ -1634,7 +1634,7 @@ cglobal mask_16bpc, 4, 9, 8, dst, ds, p1, p2, w, h, m, bdmax, ow
 
   vpbroadcastw m6, bdmaxm
 
-  lea owq, [2*wq]
+  lea owd, [2*wd]
 
 DEFINE_ARGS dst, ds, p1, p2, w, h, m, jr, ow
 
@@ -1691,7 +1691,7 @@ DEFINE_ARGS dst, ds, p1, p2, w, h, m, ds3, ow
 
 .w16:
 
-  mov wq, owq
+  mov wd, owd ; upper 32-bits of wq zerod by jmp
   sub dsq, wq
 
 .w16l:
@@ -1710,7 +1710,7 @@ DEFINE_ARGS dst, ds, p1, p2, w, h, m, ds3, ow
   jg .w16l
 
   add dstq, dsq
-  mov wq, owq
+  mov wd, owd
   dec hd
   jg .w16l
 

--- a/src/x86/me.asm
+++ b/src/x86/me.asm
@@ -56,8 +56,8 @@ cglobal sad_4x4_hbd, 4, 6, 8, src, src_stride, dst, dst_stride, \
 %if ARCH_X86_64
 
 INIT_XMM ssse3
-cglobal sad_16x16_hbd, 4, 5, 9, src, src_stride, dst, dst_stride, \
-                                cnt
+cglobal sad_16x16_hbd, 4, 5, 10, src, src_stride, dst, dst_stride, \
+                                 cnt
     mov               cntd, 8
     %define            sum  m0
     pxor               sum, sum


### PR DESCRIPTION
These errors would have been found if we had regression tests on MacOS
 and a similar register clobber checker to the one in dav1d.