### PR TITLE
CI: Remove a useless condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
          - conf: gnu
            toolchain: stable-x86_64-pc-windows-gnu
 
-    if: github.event_name == 'schedule' && github.repository_owner == 'xiph'
+    if: github.repository_owner == 'xiph'
 
     runs-on: windows-latest
 
@@ -136,7 +136,7 @@ jobs:
            binaries: rav1e
            strip: aarch64-linux-gnu-strip
 
-    if: github.event_name == 'schedule' && github.repository_owner == 'xiph'
+    if: github.repository_owner == 'xiph'
 
     runs-on: ubuntu-latest
 
@@ -235,7 +235,7 @@ jobs:
 
   macos-binaries:
 
-    if: github.event_name == 'schedule' && github.repository_owner == 'xiph'
+    if: github.repository_owner == 'xiph'
 
     runs-on: macos-latest
 
@@ -299,7 +299,7 @@ jobs:
 
     needs: [windows-binaries, linux-binaries, macos-binaries]
 
-    if: github.event_name == 'schedule' && github.repository_owner == 'xiph'
+    if: github.repository_owner == 'xiph'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The deploy action should run only on the `xiph` organization regardless
of the events.