### PR TITLE
Add Opaque as shorthand for Box<dyn Any + Send>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rav1e"
-version = "0.4.0"
+version = "0.5.0-alpha"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
 edition = "2018"
 build = "build.rs"

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -10,7 +10,7 @@
 
 use crate::activity::ActivityMask;
 use crate::api::lookahead::*;
-use crate::api::{EncoderConfig, EncoderStatus, FrameType, Packet};
+use crate::api::{EncoderConfig, EncoderStatus, FrameType, Opaque, Packet};
 use crate::color::ChromaSampling::Cs400;
 use crate::cpu_features::CpuFeatureLevel;
 use crate::dist::get_satd;
@@ -256,7 +256,7 @@ pub(crate) struct ContextInner<T: Pixel> {
   /// The next `output_frameno` to be computed by lookahead.
   next_lookahead_output_frameno: u64,
   /// Optional opaque to be sent back to the user
-  opaque_q: BTreeMap<u64, Box<dyn std::any::Any + Send>>,
+  opaque_q: BTreeMap<u64, Opaque>,
 }
 
 impl<T: Pixel> ContextInner<T> {

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -1176,7 +1176,7 @@ fn send_frame_kf<T: Pixel>(ctx: &mut Context<T>, keyframe: bool) {
   let frame_type_override =
     if keyframe { FrameTypeOverride::Key } else { FrameTypeOverride::No };
 
-  let opaque = Some(Box::new(keyframe) as Box<dyn std::any::Any + Send>);
+  let opaque = Some(Opaque::new(keyframe));
 
   let fp = FrameParameters { frame_type_override, opaque };
 

--- a/src/api/util.rs
+++ b/src/api/util.rs
@@ -13,10 +13,14 @@ use crate::serialize::{Deserialize, Serialize};
 use crate::stats::EncoderStats;
 use crate::util::Pixel;
 
+use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
 
 use thiserror::*;
+
+/// Opaque type to be passed from Frame to Packet
+pub type Opaque = Box<dyn Any + Send>;
 
 // TODO: use the num crate?
 /// A rational number.
@@ -181,7 +185,7 @@ pub struct Packet<T: Pixel> {
   pub enc_stats: EncoderStats,
   /// Optional user-provided opaque data
   #[cfg_attr(feature = "serialize", serde(skip))]
-  pub opaque: Option<Box<dyn std::any::Any + Send>>,
+  pub opaque: Option<Opaque>,
 }
 
 impl<T: Pixel> PartialEq for Packet<T> {

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -180,7 +180,7 @@ impl EncContext {
   }
   fn send_frame(
     &mut self, frame: Option<FrameInternal>, frame_type: FrameTypeOverride,
-    opaque: Option<Box<dyn std::any::Any + Send>>,
+    opaque: Option<rav1e::Opaque>,
   ) -> Result<(), rav1e::EncoderStatus> {
     let info =
       rav1e::FrameParameters { frame_type_override: frame_type, opaque };
@@ -1062,10 +1062,7 @@ pub unsafe extern fn rav1e_send_frame(
   let maybe_opaque = if frame.is_null() {
     None
   } else {
-    (*frame)
-      .opaque
-      .take()
-      .map(|o| Box::new(o) as Box<dyn std::any::Any + Send>)
+    (*frame).opaque.take().map(|o| Box::new(o) as rav1e::Opaque)
   };
 
   let ret = (*ctx)

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -67,6 +67,7 @@ struct FrameOpaque {
 }
 
 unsafe impl Send for FrameOpaque {}
+unsafe impl Sync for FrameOpaque {}
 
 impl Default for FrameOpaque {
   fn default() -> Self {
@@ -1062,7 +1063,7 @@ pub unsafe extern fn rav1e_send_frame(
   let maybe_opaque = if frame.is_null() {
     None
   } else {
-    (*frame).opaque.take().map(|o| Box::new(o) as rav1e::Opaque)
+    (*frame).opaque.take().map(|o| rav1e::Opaque::new(o))
   };
 
   let ret = (*ctx)

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -9,6 +9,7 @@
 
 use num_derive::FromPrimitive;
 
+use crate::api::Opaque;
 use crate::context::SB_SIZE;
 use crate::mc::SUBPEL_FILTER_SIZE;
 use crate::util::*;
@@ -39,7 +40,7 @@ pub struct FrameParameters {
   /// Force emitted frame to be of the type selected
   pub frame_type_override: FrameTypeOverride,
   /// Output the provided data in the matching encoded Packet
-  pub opaque: Option<Box<dyn std::any::Any + Send>>,
+  pub opaque: Option<Opaque>,
 }
 
 pub use v_frame::frame::Frame;


### PR DESCRIPTION
It makes the code a little tidy and paves the way to add `Sync` to the traits once https://github.com/rust-lang/rust/pull/80945 lands.