### PR TITLE
Fix documentation speed 10

### DIFF
--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -125,7 +125,7 @@ impl SpeedSettings {
   /// Set the speed setting according to a numeric speed preset.
   ///
   /// The speed settings vary depending on speed value from 0 to 10.
-  /// - 10 (fastest): min block size 64x64, reduced TX set, fast deblock, fast scenechange detection.
+  /// - 10 (fastest): fixed block size 32x32, reduced TX set, fast deblock, fast scenechange detection.
   /// - 9: min block size 32x32, reduced TX set, fast deblock.
   /// - 8: min block size 8x8, reduced TX set, fast deblock.
   /// - 7: min block size 8x8, reduced TX set.


### PR DESCRIPTION
Correcting a comment in the speedsettings documentation about speed 10 using minimum block sizes of 64x64, which was changed to a minimum and maximum block size of 32x32 in this commit:
https://github.com/xiph/rav1e/commit/8d3affb