### PR TITLE
x86: cdef: Add SIMD implementation of cdef_dir for 16bpc

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -99,6 +99,9 @@ fn build_nasm_files() {
     "src/x86/satd.asm",
     "src/x86/sse.asm",
     "src/x86/cdef.asm",
+    "src/x86/cdef_sse.asm",
+    "src/x86/cdef16_avx2.asm",
+    "src/x86/cdef16_sse.asm",
     "src/x86/tables.asm",
   ];
 

--- a/src/asm/x86/cdef.rs
+++ b/src/asm/x86/cdef.rs
@@ -183,8 +183,12 @@ cpu_function_lookup_table!(
 
 type CdefDirLBDFn =
   unsafe extern fn(tmp: *const u8, tmp_stride: isize, var: *mut u32) -> i32;
-type CdefDirHBDFn =
-  unsafe extern fn(tmp: *const u16, tmp_stride: isize, var: *mut u32) -> i32;
+type CdefDirHBDFn = unsafe extern fn(
+  tmp: *const u16,
+  tmp_stride: isize,
+  var: *mut u32,
+  bitdepth_max: i32,
+) -> i32;
 
 #[inline(always)]
 #[allow(clippy::let_and_return)]
@@ -223,6 +227,7 @@ pub(crate) fn cdef_find_dir<T: Pixel>(
             img.as_ptr() as *const _,
             T::to_asm_stride(img.plane.cfg.stride),
             var as *mut u32,
+            (1 << (coeff_shift + 8)) - 1,
           )
         }
       } else {
@@ -241,21 +246,27 @@ pub(crate) fn cdef_find_dir<T: Pixel>(
 }
 
 extern {
-  fn rav1e_cdef_dir_8_avx2(
+  fn rav1e_cdef_dir_8bpc_avx2(
     tmp: *const u8, tmp_stride: isize, var: *mut u32,
+  ) -> i32;
+}
+
+extern {
+  fn rav1e_cdef_dir_16bpc_avx2(
+    tmp: *const u16, tmp_stride: isize, var: *mut u32, bitdepth_max: i32,
   ) -> i32;
 }
 
 cpu_function_lookup_table!(
   CDEF_DIR_LBD_FNS: [Option<CdefDirLBDFn>],
   default: None,
-  [(AVX2, Some(rav1e_cdef_dir_8_avx2))]
+  [(AVX2, Some(rav1e_cdef_dir_8bpc_avx2))]
 );
 
 cpu_function_lookup_table!(
   CDEF_DIR_HBD_FNS: [Option<CdefDirHBDFn>],
   default: None,
-  []
+  [(AVX2, Some(rav1e_cdef_dir_16bpc_avx2))]
 );
 
 #[cfg(test)]

--- a/src/x86/cdef.asm
+++ b/src/x86/cdef.asm
@@ -264,7 +264,7 @@ CDEF_FILTER 4, 8
 CDEF_FILTER 4, 4
 
 INIT_YMM avx2
-cglobal cdef_dir_8, 3, 4, 15, src, stride, var, stride3
+cglobal cdef_dir_8bpc, 3, 4, 15, src, stride, var, stride3
     lea       stride3q, [strideq*3]
     movq           xm0, [srcq+strideq*0]
     movq           xm1, [srcq+strideq*1]

--- a/src/x86/cdef16_avx2.asm
+++ b/src/x86/cdef16_avx2.asm
@@ -1,0 +1,51 @@
+; Copyright (c) 2017-2021, The rav1e contributors
+; Copyright (c) 2021, Nathan Egge
+; All rights reserved.
+;
+; This source code is subject to the terms of the BSD 2 Clause License and
+; the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+; was not distributed with this source code in the LICENSE file, you can
+; obtain it at www.aomedia.org/license/software. If the Alliance for Open
+; Media Patent License 1.0 was not distributed with this source code in the
+; PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+%include "config.asm"
+%include "ext/x86/x86inc.asm"
+
+%if ARCH_X86_64
+
+SECTION .text
+
+cextern cdef_dir_8bpc_avx2
+
+INIT_YMM avx2
+cglobal cdef_dir_16bpc, 4, 4, 3, 32 + 8*8, src, ss, var, bdmax
+  popcnt bdmaxd, bdmaxd
+  movzx bdmaxq, bdmaxw
+  sub bdmaxq, 8
+  movq xm2, bdmaxq
+  DEFINE_ARGS src, ss, var, ss3
+  lea ss3q, [ssq*3]
+  mova xm0, [srcq + ssq*0]
+  mova xm1, [srcq + ssq*1]
+  vinserti128 m0, [srcq + ssq*2], 1
+  vinserti128 m1, [srcq + ss3q], 1
+  psraw m0, xm2
+  psraw m1, xm2
+  vpackuswb m0, m1
+  mova [rsp + 32 + 0*8], m0
+  lea srcq, [srcq + ssq*4]
+  mova xm0, [srcq + ssq*0]
+  mova xm1, [srcq + ssq*1]
+  vinserti128 m0, [srcq + ssq*2], 1
+  vinserti128 m1, [srcq + ss3q], 1
+  psraw m0, xm2
+  psraw m1, xm2
+  vpackuswb m0, m1
+  mova [rsp + 32 + 4*8], m0
+  lea srcq, [rsp + 32] ; WIN64 shadow space
+  mov ssq, 8
+  call mangle(private_prefix %+ _cdef_dir_8bpc %+ SUFFIX)
+  RET
+
+%endif ; ARCH_X86_64

--- a/src/x86/cdef16_sse.asm
+++ b/src/x86/cdef16_sse.asm
@@ -1,0 +1,79 @@
+; Copyright (c) 2017-2021, The rav1e contributors
+; Copyright (c) 2021, Nathan Egge
+; All rights reserved.
+;
+; This source code is subject to the terms of the BSD 2 Clause License and
+; the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+; was not distributed with this source code in the LICENSE file, you can
+; obtain it at www.aomedia.org/license/software. If the Alliance for Open
+; Media Patent License 1.0 was not distributed with this source code in the
+; PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+%include "config.asm"
+%include "ext/x86/x86inc.asm"
+
+%ifn ARCH_X86_64
+SECTION_RODATA 16
+
+pq_dir_shr:      dq  2,  4
+%endif
+
+SECTION .text
+
+cextern cdef_dir_8bpc_ssse3
+
+INIT_XMM ssse3
+cglobal cdef_dir_16bpc, 2, 4, 4, 32 + 8*8, src, ss, var, bdmax
+  bsr bdmaxd, bdmaxm
+%if ARCH_X86_64
+  movzx bdmaxq, bdmaxw
+  sub bdmaxq, 7
+  movq m4, bdmaxq
+%else
+  push r4
+  sub bdmaxd, 9
+  LEA r4, pq_dir_shr
+  movq m4, [r4 + bdmaxd*4]
+  pop r4
+%endif
+  DEFINE_ARGS src, ss, var, ss3
+  lea ss3q, [ssq*3]
+  mova m0, [srcq + ssq*0]
+  mova m1, [srcq + ssq*1]
+  mova m2, [srcq + ssq*2]
+  mova m3, [srcq + ss3q]
+  psraw m0, m4
+  psraw m1, m4
+  psraw m2, m4
+  psraw m3, m4
+  packuswb m0, m1
+  packuswb m2, m3
+  mova [rsp + 32 + 0*8], m0
+  mova [rsp + 32 + 2*8], m2
+  lea srcq, [srcq + ssq*4]
+  mova m0, [srcq + ssq*0]
+  mova m1, [srcq + ssq*1]
+  mova m2, [srcq + ssq*2]
+  mova m3, [srcq + ss3q]
+  psraw m0, m4
+  psraw m1, m4
+  psraw m2, m4
+  psraw m3, m4
+  packuswb m0, m1
+  packuswb m2, m3
+  mova [rsp + 32 + 4*8], m0
+  mova [rsp + 32 + 6*8], m2
+  lea srcq, [rsp + 32] ; WIN64 shadow space
+  mov ssq, 8
+%if ARCH_X86_64
+  call mangle(private_prefix %+ _cdef_dir_8bpc %+ SUFFIX)
+%else
+  movifnidn vard, varm
+  push eax ; align stack
+  push vard
+  push ssd
+  push srcd
+  call mangle(private_prefix %+ _cdef_dir_8bpc)
+  add esp, 0x10
+%endif
+  RET

--- a/src/x86/cdef_sse.asm
+++ b/src/x86/cdef_sse.asm
@@ -758,7 +758,7 @@ cglobal cdef_filter_%1x%2, 2, 7, 8, - 7 * 16 - (%2+4)*32, \
 
 %macro CDEF_DIR 0
  %if ARCH_X86_64
-cglobal cdef_dir, 3, 5, 16, 32, src, stride, var, stride3
+cglobal cdef_dir_8bpc, 3, 5, 16, 32, src, stride, var, stride3
     lea       stride3q, [strideq*3]
     movq            m1, [srcq+strideq*0]
     movhps          m1, [srcq+strideq*1]
@@ -1030,7 +1030,7 @@ cglobal cdef_dir, 3, 5, 16, 32, src, stride, var, stride3
     shr            r1d, 10
     mov         [varq], r1d
  %else
-cglobal cdef_dir, 2, 4, 8, 96, src, stride, var, stride3
+cglobal cdef_dir_8bpc, 2, 4, 8, 96, src, stride, var, stride3
 %define base r2-shufw_6543210x
     LEA             r2, shufw_6543210x
     pxor            m0, m0


### PR DESCRIPTION
```
Relative speed-ups over C code (compared with gcc-9.3.0):

                                           C       ASM
cdef_dir_16bpc_avx2:                   534.2      72.5     7.36x
cdef_dir_16bpc_ssse3:                  534.2     104.8     5.10x
cdef_dir_16bpc_ssse3 (x86-32):         854.1     116.2     7.35x
```