### PR TITLE
Fix crash on width or height of 1

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -856,8 +856,8 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     // when we add support for it.
     let width = fi.width - 1;
     let height = fi.height - 1;
-    let width_bits = 32 - (width as u32).leading_zeros();
-    let height_bits = 32 - (height as u32).leading_zeros();
+    let width_bits = log_in_base_2(width as u32) as u32 + 1;
+    let height_bits = log_in_base_2(height as u32) as u32 + 1;
     assert!(width_bits <= 16);
     assert!(height_bits <= 16);
     self.write(4, width_bits - 1)?;
@@ -875,8 +875,8 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     if fi.frame_size_override_flag {
       let width = fi.width - 1;
       let height = fi.height - 1;
-      let width_bits = 32 - (width as u32).leading_zeros();
-      let height_bits = 32 - (height as u32).leading_zeros();
+      let width_bits = log_in_base_2(width as u32) as u32 + 1;
+      let height_bits = log_in_base_2(height as u32) as u32 + 1;
       assert!(width_bits <= 16);
       assert!(height_bits <= 16);
       self.write(width_bits, width as u16)?;

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -286,6 +286,10 @@ mod small_dimension {
 
 mod tiny_dimension {
   test_dimensions! {
+    (1, 1),
+    (2, 2),
+    (4, 4),
+    (8, 8),
     (16, 16),
     (32, 32),
     (64, 64),
@@ -297,6 +301,7 @@ fn dimension(w: usize, h: usize, decoder: &str) {
   let quantizer = 100;
   let limit = 1;
   let speed = 10;
+  let still_picture = w < 16 || h < 16;
 
   let mut dec = get_decoder::<u8>(decoder, w as usize, h as usize);
   dec.encode_decode(
@@ -315,7 +320,7 @@ fn dimension(w: usize, h: usize, decoder: &str) {
     0,
     0,
     0,
-    false,
+    still_picture,
   );
 }
 


### PR DESCRIPTION
Zero bits were incorrectly chosen to encode a dimension of 1; enforce a minimum of 1 bit per dimension.
Dimensions smaller than 16 are only admitted for still_picture. Add encode-decode tests for these tiny images.