### PR TITLE
Reject mismatched color configurations

### DIFF
--- a/src/api/color.rs
+++ b/src/api/color.rs
@@ -183,6 +183,14 @@ pub struct ColorDescription {
   pub matrix_coefficients: MatrixCoefficients,
 }
 
+impl ColorDescription {
+  pub(crate) fn is_srgb_triple(self) -> bool {
+    self.color_primaries == ColorPrimaries::BT709
+      && self.transfer_characteristics == TransferCharacteristics::SRGB
+      && self.matrix_coefficients == MatrixCoefficients::Identity
+  }
+}
+
 /// Allowed pixel value range
 ///
 /// C.f. VideoFullRangeFlag variable specified in ISO/IEC 23091-4/ITU-T H.273


### PR DESCRIPTION
Fixes #2586. Full pixel range and 4:4:4 subsampling are implied by:
CP_BT_709, TC_SRGB, MC_IDENTITY
<https://aomediacodec.github.io/av1-spec/#color-config-syntax>