### PR TITLE
rollback the CDFContext by field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ itertools = "0.10"
 simd_helpers = "0.1"
 wasm-bindgen = { version = "0.2.63", optional = true }
 rust_hawktracer = "0.7.0"
+pretty_assertions = "0.6"
 
 [dependencies.image]
 version = "0.23"
@@ -114,7 +115,6 @@ signal-hook = { version = "0.3", optional = true }
 [dev-dependencies]
 assert_cmd = "1.0"
 criterion = "0.3"
-pretty_assertions = "0.6"
 interpolate_name = "0.2.2"
 rand = "0.8"
 rand_chacha = "0.3"

--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -1694,7 +1694,12 @@ impl<'a> ContextWriter<'a> {
       MotionVector { row: mv.row - ref_mv.row, col: mv.col - ref_mv.col };
     let j: MvJointType = av1_get_mv_joint(diff);
 
-    w.symbol_with_update(j as u32, &mut self.fc.nmv_context.joints_cdf);
+    symbol_with_update!(
+      self,
+      w,
+      j as u32,
+      &mut self.fc.nmv_context.joints_cdf
+    );
 
     if mv_joint_vertical(j) {
       encode_mv_component(

--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -483,7 +483,7 @@ impl<'a> BlockContext<'a> {
   }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub struct NMVComponent {
   pub classes_cdf: [u16; MV_CLASSES + 1],
   pub class0_fp_cdf: [[u16; MV_FP_SIZE + 1]; CLASS0_SIZE],
@@ -495,7 +495,7 @@ pub struct NMVComponent {
   pub bits_cdf: [[u16; 2 + 1]; MV_OFFSET_BITS],
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub struct NMVContext {
   pub joints_cdf: [u16; MV_JOINTS + 1],
   pub comps: [NMVComponent; 2],
@@ -697,6 +697,7 @@ impl<'a> ContextWriter<'a> {
   pub fn write_angle_delta(
     &mut self, w: &mut dyn Writer, angle: i8, mode: PredictionMode,
   ) {
+    println!("writing angle delta");
     symbol_with_update!(
       self,
       w,

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -8,7 +8,6 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use super::*;
-use std::fmt;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct CDFContext {

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -518,9 +518,14 @@ impl FieldMap {
     panic!("  CDF address not found {:x}", addr);
   }
 
-  pub(crate) fn update(
-    &mut self, name: &'static str, start: usize, end: usize,
-  ) {
+  pub(crate) fn update(&mut self, addr: usize) {
+    let (name, start, end) = self.lookup(addr);
+    #[cfg(feature = "desync_finder")]
+    {
+      println!(" CDF {}", name);
+      println!();
+    }
+
     self.log.entry(start).and_modify(|v| v.1 += 1).or_insert((
       name,
       1,
@@ -546,13 +551,7 @@ macro_rules! symbol_with_update {
     {
       let cdf: &[_] = $cdf;
       let map = &mut $self.fc_map;
-      let (name, start, end) = map.lookup(cdf.as_ptr() as usize);
-      #[cfg(feature = "desync_finder")]
-      {
-        println!(" CDF {}", name);
-        println!();
-      }
-      map.update(name, start, end);
+      map.update(cdf.as_ptr() as usize);
     }
   };
 }

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -258,7 +258,7 @@ impl CDFContext {
     reset_4d!(self.coeff_br_cdf);
   }
 
-  pub fn build_map(&self) -> Vec<(&'static str, usize, usize)> {
+  pub fn build_map(&self) -> HashMap<&'static str, (usize, usize)> {
     use std::mem::size_of_val;
 
     let partition_cdf_start =
@@ -423,70 +423,78 @@ impl CDFContext {
     let coeff_br_cdf_end =
       coeff_br_cdf_start + size_of_val(&self.coeff_br_cdf);
 
-    vec![
-      ("partition_cdf", partition_cdf_start, partition_cdf_end),
-      ("kf_y_cdf", kf_y_cdf_start, kf_y_cdf_end),
-      ("y_mode_cdf", y_mode_cdf_start, y_mode_cdf_end),
-      ("uv_mode_cdf", uv_mode_cdf_start, uv_mode_cdf_end),
-      ("cfl_sign_cdf", cfl_sign_cdf_start, cfl_sign_cdf_end),
-      ("cfl_alpha_cdf", cfl_alpha_cdf_start, cfl_alpha_cdf_end),
-      ("newmv_cdf", newmv_cdf_start, newmv_cdf_end),
-      ("zeromv_cdf", zeromv_cdf_start, zeromv_cdf_end),
-      ("refmv_cdf", refmv_cdf_start, refmv_cdf_end),
-      ("intra_tx_cdf", intra_tx_cdf_start, intra_tx_cdf_end),
-      ("inter_tx_cdf", inter_tx_cdf_start, inter_tx_cdf_end),
-      ("tx_size_cdf", tx_size_cdf_start, tx_size_cdf_end),
-      ("txfm_partition_cdf", txfm_partition_cdf_start, txfm_partition_cdf_end),
-      ("skip_cdfs", skip_cdfs_start, skip_cdfs_end),
-      ("intra_inter_cdfs", intra_inter_cdfs_start, intra_inter_cdfs_end),
-      ("angle_delta_cdf", angle_delta_cdf_start, angle_delta_cdf_end),
-      ("filter_intra_cdfs", filter_intra_cdfs_start, filter_intra_cdfs_end),
+    [
+      ("partition_cdf", (partition_cdf_start, partition_cdf_end)),
+      ("kf_y_cdf", (kf_y_cdf_start, kf_y_cdf_end)),
+      ("y_mode_cdf", (y_mode_cdf_start, y_mode_cdf_end)),
+      ("uv_mode_cdf", (uv_mode_cdf_start, uv_mode_cdf_end)),
+      ("cfl_sign_cdf", (cfl_sign_cdf_start, cfl_sign_cdf_end)),
+      ("cfl_alpha_cdf", (cfl_alpha_cdf_start, cfl_alpha_cdf_end)),
+      ("newmv_cdf", (newmv_cdf_start, newmv_cdf_end)),
+      ("zeromv_cdf", (zeromv_cdf_start, zeromv_cdf_end)),
+      ("refmv_cdf", (refmv_cdf_start, refmv_cdf_end)),
+      ("intra_tx_cdf", (intra_tx_cdf_start, intra_tx_cdf_end)),
+      ("inter_tx_cdf", (inter_tx_cdf_start, inter_tx_cdf_end)),
+      ("tx_size_cdf", (tx_size_cdf_start, tx_size_cdf_end)),
+      (
+        "txfm_partition_cdf",
+        (txfm_partition_cdf_start, txfm_partition_cdf_end),
+      ),
+      ("skip_cdfs", (skip_cdfs_start, skip_cdfs_end)),
+      ("intra_inter_cdfs", (intra_inter_cdfs_start, intra_inter_cdfs_end)),
+      ("angle_delta_cdf", (angle_delta_cdf_start, angle_delta_cdf_end)),
+      ("filter_intra_cdfs", (filter_intra_cdfs_start, filter_intra_cdfs_end)),
       (
         "palette_y_mode_cdfs",
-        palette_y_mode_cdfs_start,
-        palette_y_mode_cdfs_end,
+        (palette_y_mode_cdfs_start, palette_y_mode_cdfs_end),
       ),
       (
         "palette_uv_mode_cdfs",
-        palette_uv_mode_cdfs_start,
-        palette_uv_mode_cdfs_end,
+        (palette_uv_mode_cdfs_start, palette_uv_mode_cdfs_end),
       ),
-      ("comp_mode_cdf", comp_mode_cdf_start, comp_mode_cdf_end),
-      ("comp_ref_type_cdf", comp_ref_type_cdf_start, comp_ref_type_cdf_end),
-      ("comp_ref_cdf", comp_ref_cdf_start, comp_ref_cdf_end),
-      ("comp_bwd_ref_cdf", comp_bwd_ref_cdf_start, comp_bwd_ref_cdf_end),
-      ("single_ref_cdfs", single_ref_cdfs_start, single_ref_cdfs_end),
-      ("drl_cdfs", drl_cdfs_start, drl_cdfs_end),
-      ("compound_mode_cdf", compound_mode_cdf_start, compound_mode_cdf_end),
-      ("nmv_context", nmv_context_start, nmv_context_end),
+      ("comp_mode_cdf", (comp_mode_cdf_start, comp_mode_cdf_end)),
+      ("comp_ref_type_cdf", (comp_ref_type_cdf_start, comp_ref_type_cdf_end)),
+      ("comp_ref_cdf", (comp_ref_cdf_start, comp_ref_cdf_end)),
+      ("comp_bwd_ref_cdf", (comp_bwd_ref_cdf_start, comp_bwd_ref_cdf_end)),
+      ("single_ref_cdfs", (single_ref_cdfs_start, single_ref_cdfs_end)),
+      ("drl_cdfs", (drl_cdfs_start, drl_cdfs_end)),
+      ("compound_mode_cdf", (compound_mode_cdf_start, compound_mode_cdf_end)),
+      ("nmv_context", (nmv_context_start, nmv_context_end)),
       (
         "deblock_delta_multi_cdf",
-        deblock_delta_multi_cdf_start,
-        deblock_delta_multi_cdf_end,
+        (deblock_delta_multi_cdf_start, deblock_delta_multi_cdf_end),
       ),
-      ("deblock_delta_cdf", deblock_delta_cdf_start, deblock_delta_cdf_end),
+      ("deblock_delta_cdf", (deblock_delta_cdf_start, deblock_delta_cdf_end)),
       (
         "spatial_segmentation_cdfs",
-        spatial_segmentation_cdfs_start,
-        spatial_segmentation_cdfs_end,
+        (spatial_segmentation_cdfs_start, spatial_segmentation_cdfs_end),
       ),
-      ("lrf_switchable_cdf", lrf_switchable_cdf_start, lrf_switchable_cdf_end),
-      ("lrf_sgrproj_cdf", lrf_sgrproj_cdf_start, lrf_sgrproj_cdf_end),
-      ("lrf_wiener_cdf", lrf_wiener_cdf_start, lrf_wiener_cdf_end),
-      ("txb_skip_cdf", txb_skip_cdf_start, txb_skip_cdf_end),
-      ("dc_sign_cdf", dc_sign_cdf_start, dc_sign_cdf_end),
-      ("eob_extra_cdf", eob_extra_cdf_start, eob_extra_cdf_end),
-      ("eob_flag_cdf16", eob_flag_cdf16_start, eob_flag_cdf16_end),
-      ("eob_flag_cdf32", eob_flag_cdf32_start, eob_flag_cdf32_end),
-      ("eob_flag_cdf64", eob_flag_cdf64_start, eob_flag_cdf64_end),
-      ("eob_flag_cdf128", eob_flag_cdf128_start, eob_flag_cdf128_end),
-      ("eob_flag_cdf256", eob_flag_cdf256_start, eob_flag_cdf256_end),
-      ("eob_flag_cdf512", eob_flag_cdf512_start, eob_flag_cdf512_end),
-      ("eob_flag_cdf1024", eob_flag_cdf1024_start, eob_flag_cdf1024_end),
-      ("coeff_base_eob_cdf", coeff_base_eob_cdf_start, coeff_base_eob_cdf_end),
-      ("coeff_base_cdf", coeff_base_cdf_start, coeff_base_cdf_end),
-      ("coeff_br_cdf", coeff_br_cdf_start, coeff_br_cdf_end),
+      (
+        "lrf_switchable_cdf",
+        (lrf_switchable_cdf_start, lrf_switchable_cdf_end),
+      ),
+      ("lrf_sgrproj_cdf", (lrf_sgrproj_cdf_start, lrf_sgrproj_cdf_end)),
+      ("lrf_wiener_cdf", (lrf_wiener_cdf_start, lrf_wiener_cdf_end)),
+      ("txb_skip_cdf", (txb_skip_cdf_start, txb_skip_cdf_end)),
+      ("dc_sign_cdf", (dc_sign_cdf_start, dc_sign_cdf_end)),
+      ("eob_extra_cdf", (eob_extra_cdf_start, eob_extra_cdf_end)),
+      ("eob_flag_cdf16", (eob_flag_cdf16_start, eob_flag_cdf16_end)),
+      ("eob_flag_cdf32", (eob_flag_cdf32_start, eob_flag_cdf32_end)),
+      ("eob_flag_cdf64", (eob_flag_cdf64_start, eob_flag_cdf64_end)),
+      ("eob_flag_cdf128", (eob_flag_cdf128_start, eob_flag_cdf128_end)),
+      ("eob_flag_cdf256", (eob_flag_cdf256_start, eob_flag_cdf256_end)),
+      ("eob_flag_cdf512", (eob_flag_cdf512_start, eob_flag_cdf512_end)),
+      ("eob_flag_cdf1024", (eob_flag_cdf1024_start, eob_flag_cdf1024_end)),
+      (
+        "coeff_base_eob_cdf",
+        (coeff_base_eob_cdf_start, coeff_base_eob_cdf_end),
+      ),
+      ("coeff_base_cdf", (coeff_base_cdf_start, coeff_base_cdf_end)),
+      ("coeff_br_cdf", (coeff_br_cdf_start, coeff_br_cdf_end)),
     ]
+    .iter()
+    .cloned()
+    .collect()
   }
 }
 
@@ -498,7 +506,7 @@ impl fmt::Debug for CDFContext {
 
 #[derive(Debug, Default)]
 pub struct FieldMap {
-  map: Vec<(&'static str, usize, usize)>,
+  map: HashMap<&'static str, (usize, usize)>,
   log: HashMap<usize, (&'static str, usize, usize)>,
 }
 
@@ -509,7 +517,7 @@ impl FieldMap {
 
   /// Print the field the address belong to
   pub(crate) fn lookup(&self, addr: usize) -> (&'static str, usize, usize) {
-    for (name, start, end) in &self.map {
+    for (name, (start, end)) in &self.map {
       if addr >= *start && addr < *end {
         return (name, *start, *end);
       }

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -602,7 +602,17 @@ impl<'a> ContextWriter<'a> {
   }
 
   pub fn rollback(&mut self, checkpoint: &ContextWriterCheckpoint) {
-    *self.fc = checkpoint.fc;
+    for (d_start, (name, _, len)) in self.fc_map.log.iter() {
+      let (s_start, _s_end) = checkpoint.fc_map.map[name];
+      unsafe {
+        std::ptr::copy_nonoverlapping(
+          s_start as *const u8,
+          (*d_start) as *mut u8,
+          *len,
+        );
+      }
+    }
+    // *self.fc = checkpoint.fc;
     self.bc.rollback(&checkpoint.bc);
     if self.debug {
       self.fc_map.summary(self as *const Self as usize);

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -347,6 +347,8 @@ impl CDFContext {
       self.compound_mode_cdf.first().unwrap().as_ptr() as usize;
     let compound_mode_cdf_end =
       compound_mode_cdf_start + size_of_val(&self.compound_mode_cdf);
+    let nmv_context_start = &self.nmv_context as *const NMVContext as usize;
+    let nmv_context_end = nmv_context_start + size_of_val(&self.nmv_context);
     let deblock_delta_multi_cdf_start =
       self.deblock_delta_multi_cdf.first().unwrap().as_ptr() as usize;
     let deblock_delta_multi_cdf_end = deblock_delta_multi_cdf_start
@@ -455,6 +457,7 @@ impl CDFContext {
       ("single_ref_cdfs", single_ref_cdfs_start, single_ref_cdfs_end),
       ("drl_cdfs", drl_cdfs_start, drl_cdfs_end),
       ("compound_mode_cdf", compound_mode_cdf_start, compound_mode_cdf_end),
+      ("nmv_context", nmv_context_start, nmv_context_end),
       (
         "deblock_delta_multi_cdf",
         deblock_delta_multi_cdf_start,

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -10,7 +10,7 @@
 use super::*;
 use std::fmt;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct CDFContext {
   pub partition_cdf: [[u16; EXT_PARTITION_TYPES + 1]; PARTITION_CONTEXTS],
   pub kf_y_cdf: [[[u16; INTRA_MODES + 1]; KF_MODE_CONTEXTS]; KF_MODE_CONTEXTS],
@@ -498,11 +498,13 @@ impl CDFContext {
   }
 }
 
+/*
 impl fmt::Debug for CDFContext {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(f, "CDFContext contains too many numbers to print :-(")
   }
 }
+*/
 
 #[derive(Debug, Default)]
 pub struct FieldMap {
@@ -618,5 +620,6 @@ impl<'a> ContextWriter<'a> {
       self.fc_map.summary(self as *const Self as usize);
       self.fc_map.log.clear();
     }
+    pretty_assertions::assert_eq!(self.fc, &checkpoint.fc);
   }
 }

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -278,6 +278,12 @@ impl CDFContext {
       self.cfl_alpha_cdf.first().unwrap().as_ptr() as usize;
     let cfl_alpha_cdf_end =
       cfl_alpha_cdf_start + size_of_val(&self.cfl_alpha_cdf);
+    let newmv_cdf_start = self.newmv_cdf.first().unwrap().as_ptr() as usize;
+    let newmv_cdf_end = newmv_cdf_start + size_of_val(&self.newmv_cdf);
+    let zeromv_cdf_start = self.zeromv_cdf.first().unwrap().as_ptr() as usize;
+    let zeromv_cdf_end = zeromv_cdf_start + size_of_val(&self.zeromv_cdf);
+    let refmv_cdf_start = self.refmv_cdf.first().unwrap().as_ptr() as usize;
+    let refmv_cdf_end = refmv_cdf_start + size_of_val(&self.refmv_cdf);
     let intra_tx_cdf_start =
       self.intra_tx_cdf.first().unwrap().as_ptr() as usize;
     let intra_tx_cdf_end =
@@ -286,6 +292,13 @@ impl CDFContext {
       self.inter_tx_cdf.first().unwrap().as_ptr() as usize;
     let inter_tx_cdf_end =
       inter_tx_cdf_start + size_of_val(&self.inter_tx_cdf);
+    let tx_size_cdf_start =
+      self.tx_size_cdf.first().unwrap().as_ptr() as usize;
+    let tx_size_cdf_end = tx_size_cdf_start + size_of_val(&self.tx_size_cdf);
+    let txfm_partition_cdf_start =
+      self.txfm_partition_cdf.first().unwrap().as_ptr() as usize;
+    let txfm_partition_cdf_end =
+      txfm_partition_cdf_start + size_of_val(&self.txfm_partition_cdf);
     let skip_cdfs_start = self.skip_cdfs.first().unwrap().as_ptr() as usize;
     let skip_cdfs_end = skip_cdfs_start + size_of_val(&self.skip_cdfs);
     let intra_inter_cdfs_start =
@@ -324,6 +337,16 @@ impl CDFContext {
       self.comp_bwd_ref_cdf.first().unwrap().as_ptr() as usize;
     let comp_bwd_ref_cdf_end =
       comp_bwd_ref_cdf_start + size_of_val(&self.comp_bwd_ref_cdf);
+    let single_ref_cdfs_start =
+      self.single_ref_cdfs.first().unwrap().as_ptr() as usize;
+    let single_ref_cdfs_end =
+      single_ref_cdfs_start + size_of_val(&self.single_ref_cdfs);
+    let drl_cdfs_start = self.drl_cdfs.first().unwrap().as_ptr() as usize;
+    let drl_cdfs_end = drl_cdfs_start + size_of_val(&self.drl_cdfs);
+    let compound_mode_cdf_start =
+      self.compound_mode_cdf.first().unwrap().as_ptr() as usize;
+    let compound_mode_cdf_end =
+      compound_mode_cdf_start + size_of_val(&self.compound_mode_cdf);
     let deblock_delta_multi_cdf_start =
       self.deblock_delta_multi_cdf.first().unwrap().as_ptr() as usize;
     let deblock_delta_multi_cdf_end = deblock_delta_multi_cdf_start
@@ -404,8 +427,13 @@ impl CDFContext {
       ("uv_mode_cdf", uv_mode_cdf_start, uv_mode_cdf_end),
       ("cfl_sign_cdf", cfl_sign_cdf_start, cfl_sign_cdf_end),
       ("cfl_alpha_cdf", cfl_alpha_cdf_start, cfl_alpha_cdf_end),
+      ("newmv_cdf", newmv_cdf_start, newmv_cdf_end),
+      ("zeromv_cdf", zeromv_cdf_start, zeromv_cdf_end),
+      ("refmv_cdf", refmv_cdf_start, refmv_cdf_end),
       ("intra_tx_cdf", intra_tx_cdf_start, intra_tx_cdf_end),
       ("inter_tx_cdf", inter_tx_cdf_start, inter_tx_cdf_end),
+      ("tx_size_cdf", tx_size_cdf_start, tx_size_cdf_end),
+      ("txfm_partition_cdf", txfm_partition_cdf_start, txfm_partition_cdf_end),
       ("skip_cdfs", skip_cdfs_start, skip_cdfs_end),
       ("intra_inter_cdfs", intra_inter_cdfs_start, intra_inter_cdfs_end),
       ("angle_delta_cdf", angle_delta_cdf_start, angle_delta_cdf_end),
@@ -424,6 +452,9 @@ impl CDFContext {
       ("comp_ref_type_cdf", comp_ref_type_cdf_start, comp_ref_type_cdf_end),
       ("comp_ref_cdf", comp_ref_cdf_start, comp_ref_cdf_end),
       ("comp_bwd_ref_cdf", comp_bwd_ref_cdf_start, comp_bwd_ref_cdf_end),
+      ("single_ref_cdfs", single_ref_cdfs_start, single_ref_cdfs_end),
+      ("drl_cdfs", drl_cdfs_start, drl_cdfs_end),
+      ("compound_mode_cdf", compound_mode_cdf_start, compound_mode_cdf_end),
       (
         "deblock_delta_multi_cdf",
         deblock_delta_multi_cdf_start,

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -600,7 +600,7 @@ impl<'a> ContextWriter<'a> {
       gen: self.checkpoints,
     };
 
-    println!("Making a new checkpoint {} {:p}", self.checkpoints, &cc);
+    //    println!("Making a new checkpoint {} {:p}", self.checkpoints, &cc);
     self.checkpoints += 1;
 
     cc.fc_map = FieldMap::new(&cc.fc);
@@ -623,9 +623,9 @@ impl<'a> ContextWriter<'a> {
     self.bc.rollback(&checkpoint.bc);
     if self.debug {
       self.fc_map.summary(self as *const Self as usize);
-      self.fc_map.log.clear();
+      pretty_assertions::assert_eq!(self.fc, &checkpoint.fc);
+      // self.fc_map.log.clear();
     }
-    println!("rolling back checkpoint {:p}", checkpoint);
-    pretty_assertions::assert_eq!(self.fc, &checkpoint.fc);
+    //    println!("rolling back checkpoint {:p}", checkpoint);
   }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -73,43 +73,6 @@ pub use block_unit::*;
 mod frame_header;
 pub use frame_header::*;
 
-#[derive(Debug, Default)]
-pub struct FieldMap {
-  map: Vec<(&'static str, usize, usize)>,
-  log: HashMap<usize, (&'static str, usize, usize)>,
-}
-
-impl FieldMap {
-  /// Print the field the address belong to
-  fn lookup(&self, addr: usize) -> (&'static str, usize, usize) {
-    for (name, start, end) in &self.map {
-      if addr >= *start && addr < *end {
-        return (name, *start, *end);
-      }
-    }
-
-    panic!("  CDF address not found {:x}", addr);
-  }
-
-  fn update(&mut self, name: &'static str, start: usize, end: usize) {
-    self.log.entry(start).and_modify(|v| v.1 += 1).or_insert((
-      name,
-      1,
-      end - start,
-    ));
-  }
-
-  fn summary(&self, ctx: usize) {
-    println!("Summary for {:x}", ctx);
-    let mut sum = 0;
-    for (k, v) in self.log.iter() {
-      println!(" {:x} {:x} {}: {} {}b", ctx, k, v.0, v.1, v.2);
-      sum += v.2;
-    }
-    println!("total: {}", sum);
-  }
-}
-
 #[inline]
 pub fn av1_get_coded_tx_size(tx_size: TxSize) -> TxSize {
   match tx_size {

--- a/src/context/partition_unit.rs
+++ b/src/context/partition_unit.rs
@@ -127,7 +127,7 @@ mod test {
     use super::*;
 
     let cdf = CDFContext::new(8);
-    let cdf_map = FieldMap { map: cdf.build_map() };
+    let cdf_map = FieldMap::new(&cdf);
     let f = &cdf.partition_cdf[2];
     cdf_map.lookup(f.as_ptr() as usize);
   }


### PR DESCRIPTION
In theory we change the cdf only using `symbol_with_update` so we can recycle the FieldMap to copy back the single fields using copy_nonoverlapping.

In practice something does not quite work yet.

### Speed 0
![rdo-rollback-0 svg](https://user-images.githubusercontent.com/239012/106027405-26c4ee80-60cb-11eb-854e-651d5063aa0a.png)
### Speed 1
![rdo-rollback-1 svg](https://user-images.githubusercontent.com/239012/106027427-2b89a280-60cb-11eb-90d2-65af8984013c.png)
### Speed 2
![rdo-rollback-2 svg](https://user-images.githubusercontent.com/239012/106027447-30e6ed00-60cb-11eb-9d7b-8cea1f5c4a6f.png)
### Speed 3
![rdo-rollback-3 svg](https://user-images.githubusercontent.com/239012/106027448-317f8380-60cb-11eb-81ee-8dccc52b75b2.png)
### Speed 4
![rdo-rollback-4 svg](https://user-images.githubusercontent.com/239012/106027449-317f8380-60cb-11eb-9b50-db6d4448a937.png)
### Speed 5
![rdo-rollback-5 svg](https://user-images.githubusercontent.com/239012/106027450-32181a00-60cb-11eb-835a-eaaf3bf2e20a.png)
### Speed 6
![rdo-rollback-6 svg](https://user-images.githubusercontent.com/239012/106027452-32181a00-60cb-11eb-8378-cdd25b5a3bc7.png)
### Speed 7
![rdo-rollback-7 svg](https://user-images.githubusercontent.com/239012/106027455-32b0b080-60cb-11eb-8e29-12a3a9740f59.png)
### Speed 8
![rdo-rollback-8 svg](https://user-images.githubusercontent.com/239012/106027457-32b0b080-60cb-11eb-9d48-42bff4c3d912.png)
### Speed 9
![rdo-rollback-9 svg](https://user-images.githubusercontent.com/239012/106027460-33494700-60cb-11eb-8791-c22c3cab11c7.png)
### Speed 10
![rdo-rollback-10 svg](https://user-images.githubusercontent.com/239012/106027480-37756480-60cb-11eb-8cc9-c010c611f177.png)



