### PR TITLE
Deploy CI: Reformat, simplify Nasm installation, Cargo C 0.7.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install cargo-c
       run: |
-        $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.6.7"
+        $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.7.1"
         $CARGO_C_FILE = "cargo-c-windows-msvc"
         curl -LO "$LINK/$CARGO_C_FILE.zip"
         7z e -y "$CARGO_C_FILE.zip" -o"${env:USERPROFILE}\.cargo\bin"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,4 @@
 name: deploy
-
 on:
   schedule:
     # Run every Tuesday at 21:00 (UTC)
@@ -10,9 +9,7 @@ on:
       - 'p*'
 
 jobs:
-
   windows-binaries:
-
     strategy:
       matrix:
         conf:
@@ -25,7 +22,6 @@ jobs:
            toolchain: stable-x86_64-pc-windows-gnu
 
     if: github.repository_owner == 'xiph'
-
     runs-on: windows-latest
 
     steps:
@@ -61,21 +57,17 @@ jobs:
         override: true
 
     - name: Build rav1e
-      run: |
-        cargo build --release
+      run: cargo build --release
 
     - name: Strip rav1e gnu-binary
       if: matrix.conf == 'gnu'
-      run: |
-        strip target/release/rav1e.exe
+      run: strip target/release/rav1e.exe
 
     - name: Run cargo-c
-      run: |
-        cargo cinstall --release --destdir="C:\"
+      run:  cargo cinstall --release --destdir="C:\"
 
     - name: Rename cargo-c folder
-      run: |
-        Rename-Item "C:\usr\local" "C:\usr\rav1e-windows-${{ matrix.conf }}-sdk"
+      run: Rename-Item "C:\usr\local" "C:\usr\rav1e-windows-${{ matrix.conf }}-sdk"
 
     - name: Get the version
       if: startsWith(github.ref, 'refs/tags/v')
@@ -118,9 +110,7 @@ jobs:
       with:
         path: rav1e-${{ steps.tagName.outputs.version }}-windows-${{ matrix.conf }}.zip
 
-
   linux-binaries:
-
     strategy:
       matrix:
         target:
@@ -137,7 +127,6 @@ jobs:
            strip: aarch64-linux-gnu-strip
 
     if: github.repository_owner == 'xiph'
-
     runs-on: ubuntu-latest
 
     steps:
@@ -185,18 +174,15 @@ jobs:
 
     - name: Build rav1e for aarch64-musl
       if: matrix.target == 'aarch64-unknown-linux-musl'
-      run: |
-        cross build --target ${{ matrix.target }} --release
+      run: cross build --target ${{ matrix.target }} --release
 
     - name: Build rav1e
       if: matrix.target != 'aarch64-unknown-linux-musl'
-      run: |
-        cargo build --target ${{ matrix.target }} --release
+      run: cargo build --target ${{ matrix.target }} --release
 
     - name: Strip musl rav1e
       if: matrix.target != 'wasm32-unknown-unknown'
-      run: |
-        ${{ matrix.strip }} target/${{ matrix.target }}/release/rav1e
+      run: ${{ matrix.strip }} target/${{ matrix.target }}/release/rav1e
 
     - name: Get the version
       if: startsWith(github.ref, 'refs/tags/v')
@@ -234,17 +220,14 @@ jobs:
         path: rav1e-${{ steps.tagName.outputs.version }}-${{ matrix.name }}.tar.gz
 
   macos-binaries:
-
     if: github.repository_owner == 'xiph'
-
     runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Install nasm
-      run: |
-        brew install nasm
+      run: brew install nasm
 
     - name: Install stable
       uses: actions-rs/toolchain@v1
@@ -254,12 +237,10 @@ jobs:
         override: true
 
     - name: Build rav1e
-      run: |
-        cargo build --release
+      run: cargo build --release
 
     - name: Strip rav1e
-      run: |
-        strip target/release/rav1e
+      run: strip target/release/rav1e
 
     - name: Get the version
       if: startsWith(github.ref, 'refs/tags/v')
@@ -296,11 +277,8 @@ jobs:
         path: rav1e-${{ steps.tagName.outputs.version }}-macos.zip
 
   deploy:
-
     needs: [windows-binaries, linux-binaries, macos-binaries]
-
     if: github.repository_owner == 'xiph'
-
     runs-on: ubuntu-latest
 
     steps:
@@ -319,8 +297,7 @@ jobs:
         override: true
 
     - name: Create Cargo.lock
-      run: |
-        cargo update
+      run: cargo update
 
     - name: Get the version
       if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: deploy
 on:
   schedule:
-    # Run every Tuesday at 21:00 (UTC)
-    - cron: '0 21 * * TUE'
+    - cron: '0 21 * * TUE' # Run every Tuesday at 21:00 (UTC)
   push:
     tags:
       - 'v*.*.*'
@@ -39,7 +38,6 @@ jobs:
       if: matrix.conf == 'msvc'
       run: |
         $VsPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
-        echo "$VsPath;C:\nasm" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Set MSVC x86_64 linker path
       if: matrix.conf == 'msvc'
@@ -131,18 +129,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Install nasm
-      if: matrix.target == 'x86_64-unknown-linux-musl'
-      env:
-        LINK: http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm
-        NASM_VERSION: 2.15.05-1
-        NASM_SHA256: >-
-          c860caec653b865d5b83359452d97b11f1b3ba5b18b07cac554cf72550b3bfc9
-      run: |
-        curl -O "$LINK/nasm_${NASM_VERSION}_amd64.deb"
-        echo "$NASM_SHA256 nasm_${NASM_VERSION}_amd64.deb" | sha256sum --check
-        sudo dpkg -i "nasm_${NASM_VERSION}_amd64.deb"
+    - uses: ilammy/setup-nasm@v1
 
     - name: Install musl tools
       if: matrix.target != 'wasm32-unknown-unknown'

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -173,7 +173,7 @@ jobs:
       if: matrix.conf == 'cargo-c'
       env:
         LINK: https://github.com/lu-zero/cargo-c/releases/download
-        CARGO_C_VERSION: 0.6.7
+        CARGO_C_VERSION: 0.7.1
       run: |
         curl -L "$LINK/v$CARGO_C_VERSION/cargo-c-linux.tar.gz" |
         tar xz -C $HOME/.cargo/bin
@@ -449,7 +449,7 @@ jobs:
     - name: Install cargo-c
       if: matrix.conf == 'cargo-c'
       run: |
-        $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.6.7"
+        $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.7.1"
         $CARGO_C_FILE = "cargo-c-windows-msvc"
         curl -LO "$LINK/$CARGO_C_FILE.zip"
         7z e -y "$CARGO_C_FILE.zip" -o"${env:USERPROFILE}\.cargo\bin"


### PR DESCRIPTION
 - Removes empty lines and reformat single-line `run:` commands
 - Simplify Nasm installation by using [ilammy/setup-nasm](https://github.com/ilammy/setup-nasm) also on Ubuntu
 - Update Cargo C to 0.7.1 (also for the regular CI workflow)

I tested the updated deploy config on [this release](https://github.com/EwoutH/rav1e/releases/tag/p20210124-test2).