### PR TITLE
CI: Upgrade grcov to 0.7.1

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -183,7 +183,7 @@ jobs:
       if: matrix.conf == 'grcov-coveralls'
       env:
         LINK: https://github.com/mozilla/grcov/releases/download
-        GRCOV_VERSION: 0.5.15
+        GRCOV_VERSION: 0.7.1
       run: |
         curl -L "$LINK/v$GRCOV_VERSION/grcov-linux-x86_64.tar.bz2" |
         tar xj -C $HOME/.cargo/bin


### PR DESCRIPTION
Resolves a failure after upgrading to Ubuntu 20.04.