### PR TITLE
[WIP] CDEF parallelization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@
 #![warn(clippy::needless_continue)]
 #![warn(clippy::path_buf_push_overwrite)]
 #![warn(clippy::range_plus_one)]
+#![feature(type_ascription)]
 
 // Override assert! and assert_eq! in tests
 #[cfg(test)]


### PR DESCRIPTION
I wish to contribute and join rav1e development as a dev in the future, as I'm heavy invested in video encoding/AV1 and currently I'm a rust newbie. I heard that a good starting piece would be CDEF parallelization, and here we begin)

This code tries to use `rayon`'s  parallel iterator for CDEF parallelization, only issue atm is that `output` can't be borrowed as mutable.
```rust
error[E0596]: cannot borrow `*output` as mutable, as `Fn` closures cannot mutate their captured variables
   --> src/cdef.rs:614:117
    |
614 | ...<T>, input: &Frame<T>, tb: &TileBlocks,  output: &mut TileMut<'_, T>));
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
```