### PR TITLE
Add a log struct for CDFContext rollback

### DIFF
--- a/src/ec.rs
+++ b/src/ec.rs
@@ -42,7 +42,10 @@ pub trait Writer {
   /// leaves cdf unchanged
   fn symbol_bits(&self, s: u32, cdf: &[u16]) -> u32;
   /// Write a symbol s, using the passed in cdf reference; updates the referenced cdf.
-  fn symbol_with_update(&mut self, s: u32, cdf: &mut [u16]);
+  fn symbol_with_update(
+    &mut self, s: u32, cdf: &mut [u16],
+    log: &mut crate::context::CDFContextLog,
+  );
   /// Write a bool using passed in probability
   fn bool(&mut self, val: bool, f: u16);
   /// Write a single bit with flat proability
@@ -535,7 +538,10 @@ where
   ///        `[s > 0 ? cdf[s - 1] : 0, cdf[s])`.
   ///       The values must be monotonically non-decreasing, and the last value
   ///       must be exactly 32768. There should be at most 16 values.
-  fn symbol_with_update(&mut self, s: u32, cdf: &mut [u16]) {
+  fn symbol_with_update(
+    &mut self, s: u32, cdf: &mut [u16],
+    log: &mut crate::context::CDFContextLog,
+  ) {
     let nsymbs = cdf.len() - 1;
     #[cfg(feature = "desync_finder")]
     {
@@ -543,6 +549,7 @@ where
         self.print_backtrace(s);
       }
     }
+    log.push(cdf);
     self.symbol(s, &cdf[..nsymbs]);
 
     update_cdf(cdf, s);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -3207,6 +3207,8 @@ fn encode_tile<'a, T: Pixel>(
     cw.bc.reset_left_contexts(planes);
 
     for sbx in 0..ts.sb_width {
+      cw.fc_log.clear();
+
       let tile_sbo = TileSuperBlockOffset(SuperBlockOffset { x: sbx, y: sby });
       let mut sbs_qe = SBSQueueEntry {
         sbo: tile_sbo,


### PR DESCRIPTION
Detailed performance analysis to be added shortly. The essence is that large `memmove` is replaced by smaller copies:
```
     5.69%     -3.32%  libc-2.32.so        [.] __memmove_avx_unaligned_erms
     3.16%     +1.63%  rav1e               [.] <rav1e::ec::WriterBase<S> as rav1e::ec::Writer>::symbol_with_update
```