### PR TITLE
Shrink CDFs by merging counter to final symbol position

### DIFF
--- a/src/asm/x86/ec.rs
+++ b/src/asm/x86/ec.rs
@@ -13,7 +13,7 @@ use std::arch::x86_64::*;
 
 #[inline(always)]
 pub fn update_cdf(cdf: &mut [u16], val: u32) {
-  if cdf.len() == 5 {
+  if cdf.len() == 4 {
     return unsafe {
       update_cdf_4_sse2(cdf, val);
     };
@@ -95,8 +95,8 @@ mod test {
 
   #[test]
   fn update_cdf_4_sse2() {
-    let mut cdf = [7296, 3819, 1616, 0, 0];
-    let mut cdf2 = [7296, 3819, 1616, 0, 0];
+    let mut cdf = [7296, 3819, 1616, 0];
+    let mut cdf2 = [7296, 3819, 1616, 0];
     for i in 0..4 {
       rust::update_cdf(&mut cdf, i);
       unsafe {
@@ -105,7 +105,7 @@ mod test {
       assert_eq!(cdf, cdf2);
     }
 
-    let mut cdf = [7297, 3820, 1617, 0, 0];
+    let mut cdf = [7297, 3820, 1617, 0];
     let mut cdf2 = cdf.clone();
     for i in 0..4 {
       rust::update_cdf(&mut cdf, i);

--- a/src/asm/x86/ec.rs
+++ b/src/asm/x86/ec.rs
@@ -26,8 +26,8 @@ pub fn update_cdf(cdf: &mut [u16], val: u32) {
 #[inline]
 unsafe fn update_cdf_4_sse2(cdf: &mut [u16], val: u32) {
   let nsymbs = 4;
-  let rate = 5 + (cdf[nsymbs] >> 4) as usize;
-  cdf[nsymbs] += (cdf[nsymbs] < 32) as u16;
+  let rate = 5 + (cdf[nsymbs - 1] >> 4) as usize;
+  let count = cdf[nsymbs - 1] + (cdf[nsymbs - 1] < 32) as u16;
 
   // A bit of explanation of what is happening down here. First of all, let's look at the simple
   // implementation:
@@ -86,6 +86,7 @@ unsafe fn update_cdf_4_sse2(cdf: &mut [u16], val: u32) {
   let result = _mm_sub_epi16(cdf_simd, fixed_if_lt_val);
 
   _mm_storel_epi64(cdf.as_mut_ptr() as *mut __m128i, result);
+  cdf[nsymbs - 1] = count;
 }
 
 #[cfg(test)]

--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -485,19 +485,19 @@ impl<'a> BlockContext<'a> {
 
 #[derive(Clone, Copy)]
 pub struct NMVComponent {
-  pub classes_cdf: [u16; MV_CLASSES + 1],
-  pub class0_fp_cdf: [[u16; MV_FP_SIZE + 1]; CLASS0_SIZE],
-  pub fp_cdf: [u16; MV_FP_SIZE + 1],
-  pub sign_cdf: [u16; 2 + 1],
-  pub class0_hp_cdf: [u16; 2 + 1],
-  pub hp_cdf: [u16; 2 + 1],
-  pub class0_cdf: [u16; CLASS0_SIZE + 1],
-  pub bits_cdf: [[u16; 2 + 1]; MV_OFFSET_BITS],
+  pub classes_cdf: [u16; MV_CLASSES],
+  pub class0_fp_cdf: [[u16; MV_FP_SIZE]; CLASS0_SIZE],
+  pub fp_cdf: [u16; MV_FP_SIZE],
+  pub sign_cdf: [u16; 2],
+  pub class0_hp_cdf: [u16; 2],
+  pub hp_cdf: [u16; 2],
+  pub class0_cdf: [u16; CLASS0_SIZE],
+  pub bits_cdf: [[u16; 2]; MV_OFFSET_BITS],
 }
 
 #[derive(Clone, Copy)]
 pub struct NMVContext {
-  pub joints_cdf: [u16; MV_JOINTS + 1],
+  pub joints_cdf: [u16; MV_JOINTS],
   pub comps: [NMVComponent; 2],
 }
 
@@ -625,7 +625,7 @@ impl IndexMut<PlaneBlockOffset> for FrameBlocks {
 impl<'a> ContextWriter<'a> {
   pub fn get_cdf_intra_mode_kf(
     &self, bo: TileBlockOffset,
-  ) -> &[u16; INTRA_MODES + 1] {
+  ) -> &[u16; INTRA_MODES] {
     static intra_mode_context: [usize; INTRA_MODES] =
       [0, 1, 2, 3, 4, 4, 4, 4, 3, 0, 1, 2, 0];
     let above_mode = if bo.0.y > 0 {
@@ -664,9 +664,7 @@ impl<'a> ContextWriter<'a> {
     symbol_with_update!(self, w, mode as u32, cdf);
   }
 
-  pub fn get_cdf_intra_mode(
-    &self, bsize: BlockSize,
-  ) -> &[u16; INTRA_MODES + 1] {
+  pub fn get_cdf_intra_mode(&self, bsize: BlockSize) -> &[u16; INTRA_MODES] {
     &self.fc.y_mode_cdf[size_group_lookup[bsize as usize] as usize]
   }
 
@@ -689,7 +687,7 @@ impl<'a> ContextWriter<'a> {
     if bs.cfl_allowed() {
       symbol_with_update!(self, w, uv_mode as u32, cdf);
     } else {
-      symbol_with_update!(self, w, uv_mode as u32, &mut cdf[..UV_INTRA_MODES]);
+      symbol_with_update!(self, w, uv_mode as u32, &mut cdf[..INTRA_MODES]);
     }
   }
 

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -9,70 +9,67 @@
 
 use super::*;
 
-const CDF_LEN_MAX: usize = 16 + 1;
+const CDF_LEN_MAX: usize = 16;
 
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct CDFContext {
-  pub partition_cdf: [[u16; EXT_PARTITION_TYPES + 1]; PARTITION_CONTEXTS],
-  pub kf_y_cdf: [[[u16; INTRA_MODES + 1]; KF_MODE_CONTEXTS]; KF_MODE_CONTEXTS],
-  pub y_mode_cdf: [[u16; INTRA_MODES + 1]; BLOCK_SIZE_GROUPS],
-  pub uv_mode_cdf: [[[u16; UV_INTRA_MODES + 1]; INTRA_MODES]; 2],
-  pub cfl_sign_cdf: [u16; CFL_JOINT_SIGNS + 1],
-  pub cfl_alpha_cdf: [[u16; CFL_ALPHABET_SIZE + 1]; CFL_ALPHA_CONTEXTS],
-  pub newmv_cdf: [[u16; 2 + 1]; NEWMV_MODE_CONTEXTS],
-  pub zeromv_cdf: [[u16; 2 + 1]; GLOBALMV_MODE_CONTEXTS],
-  pub refmv_cdf: [[u16; 2 + 1]; REFMV_MODE_CONTEXTS],
-  pub intra_tx_cdf: [[[[u16; TX_TYPES + 1]; INTRA_MODES];
-    TX_SIZE_SQR_CONTEXTS]; TX_SETS_INTRA],
-  pub inter_tx_cdf:
-    [[[u16; TX_TYPES + 1]; TX_SIZE_SQR_CONTEXTS]; TX_SETS_INTER],
-  pub tx_size_cdf:
-    [[[u16; MAX_TX_DEPTH + 1 + 1]; TX_SIZE_CONTEXTS]; MAX_TX_CATS],
-  pub txfm_partition_cdf: [[u16; 2 + 1]; TXFM_PARTITION_CONTEXTS],
-  pub skip_cdfs: [[u16; 3]; SKIP_CONTEXTS],
-  pub intra_inter_cdfs: [[u16; 3]; INTRA_INTER_CONTEXTS],
-  pub angle_delta_cdf: [[u16; 2 * MAX_ANGLE_DELTA + 1 + 1]; DIRECTIONAL_MODES],
-  pub filter_intra_cdfs: [[u16; 3]; BlockSize::BLOCK_SIZES_ALL],
+  pub partition_cdf: [[u16; EXT_PARTITION_TYPES]; PARTITION_CONTEXTS],
+  pub kf_y_cdf: [[[u16; INTRA_MODES]; KF_MODE_CONTEXTS]; KF_MODE_CONTEXTS],
+  pub y_mode_cdf: [[u16; INTRA_MODES]; BLOCK_SIZE_GROUPS],
+  pub uv_mode_cdf: [[[u16; UV_INTRA_MODES]; INTRA_MODES]; 2],
+  pub cfl_sign_cdf: [u16; CFL_JOINT_SIGNS],
+  pub cfl_alpha_cdf: [[u16; CFL_ALPHABET_SIZE]; CFL_ALPHA_CONTEXTS],
+  pub newmv_cdf: [[u16; 2]; NEWMV_MODE_CONTEXTS],
+  pub zeromv_cdf: [[u16; 2]; GLOBALMV_MODE_CONTEXTS],
+  pub refmv_cdf: [[u16; 2]; REFMV_MODE_CONTEXTS],
+  pub intra_tx_cdf:
+    [[[[u16; TX_TYPES]; INTRA_MODES]; TX_SIZE_SQR_CONTEXTS]; TX_SETS_INTRA],
+  pub inter_tx_cdf: [[[u16; TX_TYPES]; TX_SIZE_SQR_CONTEXTS]; TX_SETS_INTER],
+  pub tx_size_cdf: [[[u16; MAX_TX_DEPTH + 1]; TX_SIZE_CONTEXTS]; MAX_TX_CATS],
+  pub txfm_partition_cdf: [[u16; 2]; TXFM_PARTITION_CONTEXTS],
+  pub skip_cdfs: [[u16; 2]; SKIP_CONTEXTS],
+  pub intra_inter_cdfs: [[u16; 2]; INTRA_INTER_CONTEXTS],
+  pub angle_delta_cdf: [[u16; 2 * MAX_ANGLE_DELTA + 1]; DIRECTIONAL_MODES],
+  pub filter_intra_cdfs: [[u16; 2]; BlockSize::BLOCK_SIZES_ALL],
   pub palette_y_mode_cdfs:
-    [[[u16; 3]; PALETTE_Y_MODE_CONTEXTS]; PALETTE_BSIZE_CTXS],
-  pub palette_uv_mode_cdfs: [[u16; 3]; PALETTE_UV_MODE_CONTEXTS],
-  pub comp_mode_cdf: [[u16; 3]; COMP_INTER_CONTEXTS],
-  pub comp_ref_type_cdf: [[u16; 3]; COMP_REF_TYPE_CONTEXTS],
-  pub comp_ref_cdf: [[[u16; 3]; FWD_REFS - 1]; REF_CONTEXTS],
-  pub comp_bwd_ref_cdf: [[[u16; 3]; BWD_REFS - 1]; REF_CONTEXTS],
-  pub single_ref_cdfs: [[[u16; 2 + 1]; SINGLE_REFS - 1]; REF_CONTEXTS],
-  pub drl_cdfs: [[u16; 2 + 1]; DRL_MODE_CONTEXTS],
-  pub compound_mode_cdf:
-    [[u16; INTER_COMPOUND_MODES + 1]; INTER_MODE_CONTEXTS],
+    [[[u16; 2]; PALETTE_Y_MODE_CONTEXTS]; PALETTE_BSIZE_CTXS],
+  pub palette_uv_mode_cdfs: [[u16; 2]; PALETTE_UV_MODE_CONTEXTS],
+  pub comp_mode_cdf: [[u16; 2]; COMP_INTER_CONTEXTS],
+  pub comp_ref_type_cdf: [[u16; 2]; COMP_REF_TYPE_CONTEXTS],
+  pub comp_ref_cdf: [[[u16; 2]; FWD_REFS - 1]; REF_CONTEXTS],
+  pub comp_bwd_ref_cdf: [[[u16; 2]; BWD_REFS - 1]; REF_CONTEXTS],
+  pub single_ref_cdfs: [[[u16; 2]; SINGLE_REFS - 1]; REF_CONTEXTS],
+  pub drl_cdfs: [[u16; 2]; DRL_MODE_CONTEXTS],
+  pub compound_mode_cdf: [[u16; INTER_COMPOUND_MODES]; INTER_MODE_CONTEXTS],
   pub nmv_context: NMVContext,
-  pub deblock_delta_multi_cdf: [[u16; DELTA_LF_PROBS + 1 + 1]; FRAME_LF_COUNT],
-  pub deblock_delta_cdf: [u16; DELTA_LF_PROBS + 1 + 1],
-  pub spatial_segmentation_cdfs: [[u16; 8 + 1]; 3],
-  pub lrf_switchable_cdf: [u16; 3 + 1],
-  pub lrf_sgrproj_cdf: [u16; 2 + 1],
-  pub lrf_wiener_cdf: [u16; 2 + 1],
+  pub deblock_delta_multi_cdf: [[u16; DELTA_LF_PROBS + 1]; FRAME_LF_COUNT],
+  pub deblock_delta_cdf: [u16; DELTA_LF_PROBS + 1],
+  pub spatial_segmentation_cdfs: [[u16; 8]; 3],
+  pub lrf_switchable_cdf: [u16; 3],
+  pub lrf_sgrproj_cdf: [u16; 2],
+  pub lrf_wiener_cdf: [u16; 2],
 
   // lv_map
-  pub txb_skip_cdf: [[[u16; 3]; TXB_SKIP_CONTEXTS]; TxSize::TX_SIZES],
-  pub dc_sign_cdf: [[[u16; 3]; DC_SIGN_CONTEXTS]; PLANE_TYPES],
+  pub txb_skip_cdf: [[[u16; 2]; TXB_SKIP_CONTEXTS]; TxSize::TX_SIZES],
+  pub dc_sign_cdf: [[[u16; 2]; DC_SIGN_CONTEXTS]; PLANE_TYPES],
   pub eob_extra_cdf:
-    [[[[u16; 3]; EOB_COEF_CONTEXTS]; PLANE_TYPES]; TxSize::TX_SIZES],
+    [[[[u16; 2]; EOB_COEF_CONTEXTS]; PLANE_TYPES]; TxSize::TX_SIZES],
 
-  pub eob_flag_cdf16: [[[u16; 5 + 1]; 2]; PLANE_TYPES],
-  pub eob_flag_cdf32: [[[u16; 6 + 1]; 2]; PLANE_TYPES],
-  pub eob_flag_cdf64: [[[u16; 7 + 1]; 2]; PLANE_TYPES],
-  pub eob_flag_cdf128: [[[u16; 8 + 1]; 2]; PLANE_TYPES],
-  pub eob_flag_cdf256: [[[u16; 9 + 1]; 2]; PLANE_TYPES],
-  pub eob_flag_cdf512: [[[u16; 10 + 1]; 2]; PLANE_TYPES],
-  pub eob_flag_cdf1024: [[[u16; 11 + 1]; 2]; PLANE_TYPES],
+  pub eob_flag_cdf16: [[[u16; 5]; 2]; PLANE_TYPES],
+  pub eob_flag_cdf32: [[[u16; 6]; 2]; PLANE_TYPES],
+  pub eob_flag_cdf64: [[[u16; 7]; 2]; PLANE_TYPES],
+  pub eob_flag_cdf128: [[[u16; 8]; 2]; PLANE_TYPES],
+  pub eob_flag_cdf256: [[[u16; 9]; 2]; PLANE_TYPES],
+  pub eob_flag_cdf512: [[[u16; 10]; 2]; PLANE_TYPES],
+  pub eob_flag_cdf1024: [[[u16; 11]; 2]; PLANE_TYPES],
 
   pub coeff_base_eob_cdf:
-    [[[[u16; 3 + 1]; SIG_COEF_CONTEXTS_EOB]; PLANE_TYPES]; TxSize::TX_SIZES],
+    [[[[u16; 3]; SIG_COEF_CONTEXTS_EOB]; PLANE_TYPES]; TxSize::TX_SIZES],
   pub coeff_base_cdf:
-    [[[[u16; 4 + 1]; SIG_COEF_CONTEXTS]; PLANE_TYPES]; TxSize::TX_SIZES],
-  pub coeff_br_cdf: [[[[u16; BR_CDF_SIZE + 1]; LEVEL_CONTEXTS]; PLANE_TYPES];
-    TxSize::TX_SIZES],
+    [[[[u16; 4]; SIG_COEF_CONTEXTS]; PLANE_TYPES]; TxSize::TX_SIZES],
+  pub coeff_br_cdf:
+    [[[[u16; BR_CDF_SIZE]; LEVEL_CONTEXTS]; PLANE_TYPES]; TxSize::TX_SIZES],
 
   padding: [u16; CDF_LEN_MAX],
 }
@@ -143,9 +140,10 @@ impl CDFContext {
 
   pub fn reset_counts(&mut self) {
     macro_rules! reset_1d {
-      ($field:expr) => {{
-        $field[$field.len() - 2] = 0;
-      }};
+      ($field:expr) => {
+        let r = $field.last_mut().unwrap();
+        *r = 0;
+      };
     }
     macro_rules! reset_2d {
       ($field:expr) => {
@@ -603,7 +601,7 @@ impl<'a> ContextWriter<'a> {
 
   pub fn cdf_element_prob(cdf: &[u16], element: usize) -> u16 {
     (if element > 0 { cdf[element - 1] } else { 32768 })
-      - (if element + 2 < cdf.len() { cdf[element] } else { 0 })
+      - (if element + 1 < cdf.len() { cdf[element] } else { 0 })
   }
 
   pub fn checkpoint(&self) -> ContextWriterCheckpoint {

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -143,10 +143,9 @@ impl CDFContext {
 
   pub fn reset_counts(&mut self) {
     macro_rules! reset_1d {
-      ($field:expr) => {
-        let r = $field.last_mut().unwrap();
-        *r = 0;
-      };
+      ($field:expr) => {{
+        $field[$field.len() - 2] = 0;
+      }};
     }
     macro_rules! reset_2d {
       ($field:expr) => {
@@ -171,21 +170,21 @@ impl CDFContext {
     }
 
     for i in 0..4 {
-      self.partition_cdf[i][4] = 0;
+      self.partition_cdf[i][3] = 0;
     }
     for i in 4..16 {
-      self.partition_cdf[i][10] = 0;
+      self.partition_cdf[i][9] = 0;
     }
     for i in 16..20 {
-      self.partition_cdf[i][8] = 0;
+      self.partition_cdf[i][7] = 0;
     }
 
     reset_3d!(self.kf_y_cdf);
     reset_2d!(self.y_mode_cdf);
 
     for i in 0..INTRA_MODES {
-      self.uv_mode_cdf[0][i][UV_INTRA_MODES - 1] = 0;
-      self.uv_mode_cdf[1][i][UV_INTRA_MODES] = 0;
+      self.uv_mode_cdf[0][i][UV_INTRA_MODES - 2] = 0;
+      self.uv_mode_cdf[1][i][UV_INTRA_MODES - 1] = 0;
     }
     reset_1d!(self.cfl_sign_cdf);
     reset_2d!(self.cfl_alpha_cdf);
@@ -195,23 +194,23 @@ impl CDFContext {
 
     for i in 0..TX_SIZE_SQR_CONTEXTS {
       for j in 0..INTRA_MODES {
-        self.intra_tx_cdf[1][i][j][7] = 0;
-        self.intra_tx_cdf[2][i][j][5] = 0;
+        self.intra_tx_cdf[1][i][j][6] = 0;
+        self.intra_tx_cdf[2][i][j][4] = 0;
       }
-      self.inter_tx_cdf[1][i][16] = 0;
-      self.inter_tx_cdf[2][i][12] = 0;
-      self.inter_tx_cdf[3][i][2] = 0;
+      self.inter_tx_cdf[1][i][15] = 0;
+      self.inter_tx_cdf[2][i][11] = 0;
+      self.inter_tx_cdf[3][i][1] = 0;
     }
 
     for i in 0..TX_SIZE_CONTEXTS {
-      self.tx_size_cdf[0][i][MAX_TX_DEPTH] = 0;
+      self.tx_size_cdf[0][i][MAX_TX_DEPTH - 1] = 0;
     }
     reset_2d!(self.tx_size_cdf[1]);
     reset_2d!(self.tx_size_cdf[2]);
     reset_2d!(self.tx_size_cdf[3]);
 
     for i in 0..TXFM_PARTITION_CONTEXTS {
-      self.txfm_partition_cdf[i][2] = 0;
+      self.txfm_partition_cdf[i][1] = 0;
     }
 
     reset_2d!(self.skip_cdfs);
@@ -603,7 +602,8 @@ impl<'a> ContextWriter<'a> {
   }
 
   pub fn cdf_element_prob(cdf: &[u16], element: usize) -> u16 {
-    (if element > 0 { cdf[element - 1] } else { 32768 }) - cdf[element]
+    (if element > 0 { cdf[element - 1] } else { 32768 })
+      - (if element + 2 < cdf.len() { cdf[element] } else { 0 })
   }
 
   pub fn checkpoint(&self) -> ContextWriterCheckpoint {

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -554,12 +554,13 @@ impl CDFContextLog {
     let base = fc as *mut _ as *mut u8;
     let mut len = self.data.len();
     unsafe {
+      let mut src = self.data.get_unchecked_mut(len).as_ptr();
       while len > checkpoint {
         len -= 1;
-        let src = self.data.get_unchecked_mut(len);
-        let offset = src[CDF_LEN_MAX] as usize;
+        src = src.sub(CDF_LEN_MAX + 1);
+        let offset = *src.add(CDF_LEN_MAX) as usize;
         let dst = base.add(offset) as *mut u16;
-        dst.copy_from_nonoverlapping(src.as_ptr(), CDF_LEN_MAX);
+        dst.copy_from_nonoverlapping(src, CDF_LEN_MAX);
       }
       self.data.set_len(len);
     }

--- a/src/context/frame_header.rs
+++ b/src/context/frame_header.rs
@@ -15,18 +15,15 @@ impl CDFContext {
     &self, w: &dyn Writer, rs: &TileRestorationState,
     filter: RestorationFilter, pli: usize,
   ) -> u32 {
-    let nsym = &self.lrf_switchable_cdf.len() - 1;
     match filter {
-      RestorationFilter::None => {
-        w.symbol_bits(0, &self.lrf_switchable_cdf[..nsym])
-      }
+      RestorationFilter::None => w.symbol_bits(0, &self.lrf_switchable_cdf),
       RestorationFilter::Wiener { .. } => {
         unreachable!() // for now, not permanently
       }
       RestorationFilter::Sgrproj { set, xqd } => {
         // Does *not* use 'RESTORE_SGRPROJ' but rather just '2'
         let rp = &rs.planes[pli];
-        let mut bits = w.symbol_bits(2, &self.lrf_switchable_cdf[..nsym])
+        let mut bits = w.symbol_bits(2, &self.lrf_switchable_cdf)
           + ((SGRPROJ_PARAMS_BITS as u32) << OD_BITRES);
         for i in 0..2 {
           let s = SGRPROJ_PARAMS_S[set as usize][i];

--- a/src/context/partition_unit.rs
+++ b/src/context/partition_unit.rs
@@ -307,7 +307,7 @@ impl<'a> ContextWriter<'a> {
     let ctx = self.bc.partition_plane_context(bo, bsize);
     assert!(ctx < PARTITION_CONTEXTS);
     let partition_cdf = if bsize <= BlockSize::BLOCK_8X8 {
-      &mut self.fc.partition_cdf[ctx][..=PARTITION_TYPES]
+      &mut self.fc.partition_cdf[ctx][..PARTITION_TYPES]
     } else {
       &mut self.fc.partition_cdf[ctx]
     };

--- a/src/context/transform_unit.rs
+++ b/src/context/transform_unit.rs
@@ -543,7 +543,7 @@ impl<'a> ContextWriter<'a> {
           w,
           av1_tx_ind[tx_set as usize][tx_type as usize] as u32,
           &mut self.fc.inter_tx_cdf[tx_set_index as usize]
-            [square_tx_size as usize][..=num_tx_set[tx_set as usize]]
+            [square_tx_size as usize][..num_tx_set[tx_set as usize]]
         );
       } else {
         let intra_dir = y_mode;
@@ -557,7 +557,7 @@ impl<'a> ContextWriter<'a> {
           av1_tx_ind[tx_set as usize][tx_type as usize] as u32,
           &mut self.fc.intra_tx_cdf[tx_set_index as usize]
             [square_tx_size as usize][intra_dir as usize]
-            [..=num_tx_set[tx_set as usize]]
+            [..num_tx_set[tx_set as usize]]
         );
       }
     }
@@ -651,7 +651,7 @@ impl<'a> ContextWriter<'a> {
       self,
       w,
       depth as u32,
-      &mut self.fc.tx_size_cdf[tx_size_cat][tx_size_ctx][..=max_depths + 1]
+      &mut self.fc.tx_size_cdf[tx_size_cat][tx_size_ctx][..=max_depths]
     );
   }
 

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -544,7 +544,6 @@ where
     &mut self, s: u32, cdf: &mut [u16],
     log: &mut crate::context::CDFContextLog,
   ) {
-    let nsymbs = cdf.len() - 1;
     #[cfg(feature = "desync_finder")]
     {
       if self.debug {
@@ -552,7 +551,7 @@ where
       }
     }
     log.push(cdf);
-    self.symbol(s, &cdf[..nsymbs]);
+    self.symbol(s, cdf);
 
     update_cdf(cdf, s);
   }
@@ -890,7 +889,7 @@ impl<W: io::Write> BCodeWriter for BitWriter<W, BigEndian> {
 pub(crate) mod rust {
   // Function to update the CDF for Writer calls that do so.
   pub fn update_cdf(cdf: &mut [u16], val: u32) {
-    let nsymbs = cdf.len() - 1;
+    let nsymbs = cdf.len();
     let rate = 3 + (nsymbs >> 1).min(2) + (cdf[nsymbs - 1] >> 4) as usize;
     cdf[nsymbs - 1] += 1 - (cdf[nsymbs - 1] >> 5);
 

--- a/src/entropymode.rs
+++ b/src/entropymode.rs
@@ -37,8 +37,8 @@ pub const TXFM_PARTITION_CONTEXTS: usize = 21; // (TxSize::TX_SIZES - TxSize::TX
 
 // LUTS ---------------------
 
-pub static default_kf_y_mode_cdf: [[[u16; cdf_size!(INTRA_MODES)];
-  KF_MODE_CONTEXTS]; KF_MODE_CONTEXTS] = [
+pub static default_kf_y_mode_cdf: [[[u16; INTRA_MODES]; KF_MODE_CONTEXTS];
+  KF_MODE_CONTEXTS] = [
   [
     cdf!(
       15588, 17027, 19338, 20218, 20682, 21110, 21825, 23244, 24189, 28165,
@@ -151,8 +151,7 @@ pub static default_kf_y_mode_cdf: [[[u16; cdf_size!(INTRA_MODES)];
   ],
 ];
 
-pub static default_angle_delta_cdf: [[u16;
-  cdf_size!(2 * MAX_ANGLE_DELTA + 1)];
+pub static default_angle_delta_cdf: [[u16; 2 * MAX_ANGLE_DELTA + 1];
   DIRECTIONAL_MODES] = [
   cdf!(2180, 5032, 7567, 22776, 26989, 30217),
   cdf!(2301, 5608, 8801, 23487, 26974, 30330),
@@ -164,8 +163,7 @@ pub static default_angle_delta_cdf: [[u16;
   cdf!(3605, 10428, 12459, 17676, 21244, 30655),
 ];
 
-pub static default_if_y_mode_cdf: [[u16; cdf_size!(INTRA_MODES)];
-  BLOCK_SIZE_GROUPS] = [
+pub static default_if_y_mode_cdf: [[u16; INTRA_MODES]; BLOCK_SIZE_GROUPS] = [
   cdf!(
     22801, 23489, 24293, 24756, 25601, 26123, 26606, 27418, 27945, 29228,
     29685, 30349
@@ -184,8 +182,7 @@ pub static default_if_y_mode_cdf: [[u16; cdf_size!(INTRA_MODES)];
   ),
 ];
 
-pub static default_uv_mode_cdf: [[[u16; cdf_size!(UV_INTRA_MODES)];
-  INTRA_MODES]; 2] = [
+pub static default_uv_mode_cdf: [[[u16; UV_INTRA_MODES]; INTRA_MODES]; 2] = [
   [
     cdf!(
       22631, 24152, 25378, 25661, 25986, 26520, 27055, 27923, 28244, 30059,
@@ -296,7 +293,7 @@ pub static default_uv_mode_cdf: [[[u16; cdf_size!(UV_INTRA_MODES)];
   ],
 ];
 
-pub const default_partition_cdf: [[u16; cdf_size!(EXT_PARTITION_TYPES)];
+pub const default_partition_cdf: [[u16; EXT_PARTITION_TYPES];
   PARTITION_CONTEXTS] = [
   cdf!(19132, 25510, 30392, CDFMAX, CDFMAX, CDFMAX, CDFMAX, CDFMAX, CDFMAX),
   cdf!(13928, 19855, 28540, CDFMAX, CDFMAX, CDFMAX, CDFMAX, CDFMAX, CDFMAX),
@@ -320,10 +317,9 @@ pub const default_partition_cdf: [[u16; cdf_size!(EXT_PARTITION_TYPES)];
   cdf!(711, 966, 1172, 32448, 32538, 32617, 32664, CDFMAX, CDFMAX),
 ];
 
-pub static default_intra_ext_tx_cdf: [[[[u16; cdf_size!(TX_TYPES)];
-  INTRA_MODES]; TX_SIZE_SQR_CONTEXTS];
-  TX_SETS_INTRA] = [
-  [[[0; cdf_size!(TX_TYPES)]; INTRA_MODES]; TX_SIZE_SQR_CONTEXTS],
+pub static default_intra_ext_tx_cdf: [[[[u16; TX_TYPES]; INTRA_MODES];
+  TX_SIZE_SQR_CONTEXTS]; TX_SETS_INTRA] = [
+  [[[0; TX_TYPES]; INTRA_MODES]; TX_SIZE_SQR_CONTEXTS],
   [
     [
       cdf!(
@@ -762,9 +758,9 @@ pub static default_intra_ext_tx_cdf: [[[[u16; cdf_size!(TX_TYPES)];
   ],
 ];
 
-pub static default_inter_ext_tx_cdf: [[[u16; cdf_size!(TX_TYPES)];
+pub static default_inter_ext_tx_cdf: [[[u16; TX_TYPES];
   TX_SIZE_SQR_CONTEXTS]; TX_SETS_INTER] = [
-  [[0; cdf_size!(TX_TYPES)]; TX_SIZE_SQR_CONTEXTS],
+  [[0; TX_TYPES]; TX_SIZE_SQR_CONTEXTS],
   [
     cdf!(
       4458, 5560, 7695, 9709, 13330, 14789, 17537, 20266, 21504, 22848, 23934,
@@ -821,10 +817,10 @@ pub static default_inter_ext_tx_cdf: [[[u16; cdf_size!(TX_TYPES)];
   ],
 ];
 
-pub static default_cfl_sign_cdf: [u16; cdf_size!(CFL_JOINT_SIGNS)] =
+pub static default_cfl_sign_cdf: [u16; CFL_JOINT_SIGNS] =
   cdf!(1418, 2123, 13340, 18405, 26972, 28343, 32294);
 
-pub static default_cfl_alpha_cdf: [[u16; cdf_size!(CFL_ALPHABET_SIZE)];
+pub static default_cfl_alpha_cdf: [[u16; CFL_ALPHABET_SIZE];
   CFL_ALPHA_CONTEXTS] = [
   cdf!(
     7637, 20719, 31401, 32481, 32657, 32688, 32692, 32696, 32700, 32704,
@@ -857,8 +853,7 @@ const SWITCHABLE_FILTERS: usize = 3;
 const SWITCHABLE_FILTER_CONTEXTS: usize = (SWITCHABLE_FILTERS + 1) * 4;
 
 #[allow(unused)]
-pub static default_switchable_interp_cdf: [[u16;
-  cdf_size!(SWITCHABLE_FILTERS)];
+pub static default_switchable_interp_cdf: [[u16; SWITCHABLE_FILTERS];
   SWITCHABLE_FILTER_CONTEXTS] = [
   cdf!(31935, 32720),
   cdf!(5568, 32719),
@@ -878,20 +873,20 @@ pub static default_switchable_interp_cdf: [[u16;
   cdf!(14969, 21398),
 ];
 
-pub static default_newmv_cdf: [[u16; cdf_size!(2)]; NEWMV_MODE_CONTEXTS] = [
+pub static default_newmv_cdf: [[u16; 2]; NEWMV_MODE_CONTEXTS] = [
   cdf!(24035),
   cdf!(16630),
   cdf!(15339),
   cdf!(8386),
   cdf!(12222),
   cdf!(4676),
-  [0; cdf_size!(2)],
+  [0; 2],
 ];
 
-pub static default_zeromv_cdf: [[u16; cdf_size!(2)]; GLOBALMV_MODE_CONTEXTS] =
+pub static default_zeromv_cdf: [[u16; 2]; GLOBALMV_MODE_CONTEXTS] =
   [cdf!(2175), cdf!(1054)];
 
-pub static default_refmv_cdf: [[u16; cdf_size!(2)]; REFMV_MODE_CONTEXTS] = [
+pub static default_refmv_cdf: [[u16; 2]; REFMV_MODE_CONTEXTS] = [
   cdf!(23974),
   cdf!(24188),
   cdf!(17848),
@@ -900,11 +895,10 @@ pub static default_refmv_cdf: [[u16; cdf_size!(2)]; REFMV_MODE_CONTEXTS] = [
   cdf!(19923),
 ];
 
-pub static default_drl_cdf: [[u16; cdf_size!(2)]; DRL_MODE_CONTEXTS] =
+pub static default_drl_cdf: [[u16; 2]; DRL_MODE_CONTEXTS] =
   [cdf!(13104), cdf!(24560), cdf!(18945)];
 
-pub static default_compound_mode_cdf: [[u16;
-  cdf_size!(INTER_COMPOUND_MODES)];
+pub static default_compound_mode_cdf: [[u16; INTER_COMPOUND_MODES];
   INTER_MODE_CONTEXTS] = [
   cdf!(7760, 13823, 15808, 17641, 19156, 20666, 26891),
   cdf!(10730, 19452, 21145, 22749, 24039, 25131, 28724),
@@ -917,12 +911,12 @@ pub static default_compound_mode_cdf: [[u16;
 ];
 
 #[allow(unused)]
-pub static default_interintra_cdf: [[u16; cdf_size!(2)]; BLOCK_SIZE_GROUPS] =
+pub static default_interintra_cdf: [[u16; 2]; BLOCK_SIZE_GROUPS] =
   [cdf!(16384), cdf!(26887), cdf!(27597), cdf!(30237)];
 
 #[allow(unused)]
 pub static default_interintra_mode_cdf: [[u16;
-  cdf_size!(InterIntraMode::INTERINTRA_MODES as usize)];
+  InterIntraMode::INTERINTRA_MODES as usize];
   BLOCK_SIZE_GROUPS as usize] = [
   cdf!(8192, 16384, 24576),
   cdf!(1875, 11082, 27332),
@@ -931,7 +925,7 @@ pub static default_interintra_mode_cdf: [[u16;
 ];
 
 #[allow(unused)]
-pub static default_wedge_interintra_cdf: [[u16; cdf_size!(2)];
+pub static default_wedge_interintra_cdf: [[u16; 2];
   BlockSize::BLOCK_SIZES_ALL] = [
   cdf!(16384),
   cdf!(16384),
@@ -959,7 +953,7 @@ pub static default_wedge_interintra_cdf: [[u16; cdf_size!(2)];
 
 #[allow(unused)]
 pub static default_compound_type_cdf: [[u16;
-  cdf_size!(CompoundType::COMPOUND_TYPES as usize - 1)];
+  CompoundType::COMPOUND_TYPES as usize - 1];
   BlockSize::BLOCK_SIZES_ALL as usize] = [
   cdf!(16384),
   cdf!(16384),
@@ -986,8 +980,7 @@ pub static default_compound_type_cdf: [[u16;
 ];
 
 #[allow(unused)]
-pub static default_wedge_idx_cdf: [[u16; cdf_size!(16)];
-  BlockSize::BLOCK_SIZES_ALL] = [
+pub static default_wedge_idx_cdf: [[u16; 16]; BlockSize::BLOCK_SIZES_ALL] = [
   cdf!(
     2048, 4096, 6144, 8192, 10240, 12288, 14336, 16384, 18432, 20480, 22528,
     24576, 26624, 28672, 30720
@@ -1080,7 +1073,7 @@ pub static default_wedge_idx_cdf: [[u16; cdf_size!(16)];
 
 #[allow(unused)]
 pub static default_motion_mode_cdf: [[u16;
-  cdf_size!(MotionMode::MOTION_MODES as usize)];
+  MotionMode::MOTION_MODES as usize];
   BlockSize::BLOCK_SIZES_ALL as usize] = [
   cdf!(10923, 21845),
   cdf!(10923, 21845),
@@ -1107,8 +1100,7 @@ pub static default_motion_mode_cdf: [[u16;
 ];
 
 #[allow(unused)]
-pub static default_obmc_cdf: [[u16; cdf_size!(2)];
-  BlockSize::BLOCK_SIZES_ALL] = [
+pub static default_obmc_cdf: [[u16; 2]; BlockSize::BLOCK_SIZES_ALL] = [
   cdf!(16384),
   cdf!(16384),
   cdf!(16384),
@@ -1133,26 +1125,24 @@ pub static default_obmc_cdf: [[u16; cdf_size!(2)];
   cdf!(26879),
 ];
 
-pub static default_intra_inter_cdf: [[u16; cdf_size!(2)];
-  INTRA_INTER_CONTEXTS] = [cdf!(806), cdf!(16662), cdf!(20186), cdf!(26538)];
+pub static default_intra_inter_cdf: [[u16; 2]; INTRA_INTER_CONTEXTS] =
+  [cdf!(806), cdf!(16662), cdf!(20186), cdf!(26538)];
 
-pub static default_comp_mode_cdf: [[u16; cdf_size!(2)]; COMP_INTER_CONTEXTS] =
+pub static default_comp_mode_cdf: [[u16; 2]; COMP_INTER_CONTEXTS] =
   [cdf!(26828), cdf!(24035), cdf!(12031), cdf!(10640), cdf!(2901)];
 
-pub static default_comp_ref_type_cdf: [[u16; cdf_size!(2)];
-  COMP_REF_TYPE_CONTEXTS] =
+pub static default_comp_ref_type_cdf: [[u16; 2]; COMP_REF_TYPE_CONTEXTS] =
   [cdf!(1198), cdf!(2070), cdf!(9166), cdf!(7499), cdf!(22475)];
 
 #[allow(unused)]
-pub static default_uni_comp_ref_cdf: [[[u16; cdf_size!(2)];
-  UNIDIR_COMP_REFS - 1];
+pub static default_uni_comp_ref_cdf: [[[u16; 2]; UNIDIR_COMP_REFS - 1];
   UNI_COMP_REF_CONTEXTS] = [
   [cdf!(5284), cdf!(3865), cdf!(3128)],
   [cdf!(23152), cdf!(14173), cdf!(15270)],
   [cdf!(31774), cdf!(25120), cdf!(26710)],
 ];
 
-pub static default_single_ref_cdf: [[[u16; cdf_size!(2)]; SINGLE_REFS - 1];
+pub static default_single_ref_cdf: [[[u16; 2]; SINGLE_REFS - 1];
   REF_CONTEXTS] = [
   [cdf!(4897), cdf!(1555), cdf!(4236), cdf!(8650), cdf!(904), cdf!(1444)],
   [
@@ -1173,15 +1163,13 @@ pub static default_single_ref_cdf: [[[u16; cdf_size!(2)]; SINGLE_REFS - 1];
   ],
 ];
 
-pub static default_comp_ref_cdf: [[[u16; cdf_size!(2)]; FWD_REFS - 1];
-  REF_CONTEXTS] = [
+pub static default_comp_ref_cdf: [[[u16; 2]; FWD_REFS - 1]; REF_CONTEXTS] = [
   [cdf!(4946), cdf!(9468), cdf!(1503)],
   [cdf!(19891), cdf!(22441), cdf!(15160)],
   [cdf!(30731), cdf!(31059), cdf!(27544)],
 ];
 
-pub static default_comp_bwdref_cdf: [[[u16; cdf_size!(2)]; BWD_REFS - 1];
-  REF_CONTEXTS] = [
+pub static default_comp_bwdref_cdf: [[[u16; 2]; BWD_REFS - 1]; REF_CONTEXTS] = [
   [cdf!(2235), cdf!(1423)],
   [cdf!(17182), cdf!(15175)],
   [cdf!(30606), cdf!(30489)],
@@ -1189,7 +1177,7 @@ pub static default_comp_bwdref_cdf: [[[u16; cdf_size!(2)]; BWD_REFS - 1];
 
 #[allow(unused)]
 pub static default_palette_y_size_cdf: [[u16;
-  cdf_size!(PaletteSize::PALETTE_SIZES as usize)];
+  PaletteSize::PALETTE_SIZES as usize];
   PALETTE_BSIZE_CTXS] = [
   cdf!(7952, 13000, 18149, 21478, 25527, 29241),
   cdf!(7139, 11421, 16195, 19544, 23666, 28073),
@@ -1202,7 +1190,7 @@ pub static default_palette_y_size_cdf: [[u16;
 
 #[allow(unused)]
 pub static default_palette_uv_size_cdf: [[u16;
-  cdf_size!(PaletteSize::PALETTE_SIZES as usize)];
+  PaletteSize::PALETTE_SIZES as usize];
   PALETTE_BSIZE_CTXS] = [
   cdf!(8713, 19979, 27128, 29609, 31331, 32272),
   cdf!(5839, 15573, 23581, 26947, 29848, 31700),
@@ -1213,8 +1201,7 @@ pub static default_palette_uv_size_cdf: [[u16;
   cdf!(1269, 5435, 10433, 18963, 21700, 25865),
 ];
 
-pub static default_palette_y_mode_cdfs: [[[u16; cdf_size!(2)];
-  PALETTE_Y_MODE_CONTEXTS];
+pub static default_palette_y_mode_cdfs: [[[u16; 2]; PALETTE_Y_MODE_CONTEXTS];
   PALETTE_BSIZE_CTXS] = [
   [cdf!(31676), cdf!(3419), cdf!(1261)],
   [cdf!(31912), cdf!(2859), cdf!(980)],
@@ -1225,12 +1212,12 @@ pub static default_palette_y_mode_cdfs: [[[u16; cdf_size!(2)];
   [cdf!(32450), cdf!(7946), cdf!(129)],
 ];
 
-pub static default_palette_uv_mode_cdfs: [[u16; cdf_size!(2)];
-  PALETTE_UV_MODE_CONTEXTS] = [cdf!(32461), cdf!(21488)];
+pub static default_palette_uv_mode_cdfs: [[u16; 2]; PALETTE_UV_MODE_CONTEXTS] =
+  [cdf!(32461), cdf!(21488)];
 
 #[allow(unused)]
 pub static default_palette_y_color_index_cdf: [[[u16;
-  cdf_size!(PaletteColor::PALETTE_COLORS as usize)];
+  PaletteColor::PALETTE_COLORS as usize];
   PALETTE_COLOR_INDEX_CONTEXTS];
   PaletteSize::PALETTE_SIZES as usize] = [
   [
@@ -1286,7 +1273,7 @@ pub static default_palette_y_color_index_cdf: [[[u16;
 
 #[allow(unused)]
 pub static default_palette_uv_color_index_cdf: [[[u16;
-  cdf_size!(PaletteColor::PALETTE_COLORS as usize)];
+  PaletteColor::PALETTE_COLORS as usize];
   PALETTE_COLOR_INDEX_CONTEXTS];
   PaletteSize::PALETTE_SIZES as usize] = [
   [
@@ -1340,8 +1327,7 @@ pub static default_palette_uv_color_index_cdf: [[[u16;
   ],
 ];
 
-pub static default_txfm_partition_cdf: [[u16; cdf_size!(2)];
-  TXFM_PARTITION_CONTEXTS] = [
+pub static default_txfm_partition_cdf: [[u16; 2]; TXFM_PARTITION_CONTEXTS] = [
   cdf!(28581),
   cdf!(23846),
   cdf!(20847),
@@ -1365,21 +1351,19 @@ pub static default_txfm_partition_cdf: [[u16; cdf_size!(2)];
   cdf!(16088),
 ];
 
-pub static default_skip_cdfs: [[u16; cdf_size!(2)]; SKIP_CONTEXTS] =
+pub static default_skip_cdfs: [[u16; 2]; SKIP_CONTEXTS] =
   [cdf!(31671), cdf!(16515), cdf!(4576)];
 
 #[allow(unused)]
-pub static default_skip_mode_cdfs: [[u16; cdf_size!(2)]; SKIP_MODE_CONTEXTS] =
+pub static default_skip_mode_cdfs: [[u16; 2]; SKIP_MODE_CONTEXTS] =
   [cdf!(32621), cdf!(20708), cdf!(8127)];
 
 #[allow(unused)]
-pub static default_compound_idx_cdfs: [[u16; cdf_size!(2)];
-  COMP_INDEX_CONTEXTS] =
+pub static default_compound_idx_cdfs: [[u16; 2]; COMP_INDEX_CONTEXTS] =
   [cdf!(18244), cdf!(12865), cdf!(7053), cdf!(13259), cdf!(9334), cdf!(4644)];
 
 #[allow(unused)]
-pub static default_comp_group_idx_cdfs: [[u16; cdf_size!(2)];
-  COMP_GROUP_IDX_CONTEXTS] = [
+pub static default_comp_group_idx_cdfs: [[u16; 2]; COMP_GROUP_IDX_CONTEXTS] = [
   cdf!(26607),
   cdf!(22891),
   cdf!(18840),
@@ -1389,15 +1373,14 @@ pub static default_comp_group_idx_cdfs: [[u16; cdf_size!(2)];
 ];
 
 #[allow(unused)]
-pub static default_intrabc_cdf: [u16; cdf_size!(2)] = cdf!(30531);
+pub static default_intrabc_cdf: [u16; 2] = cdf!(30531);
 
 #[allow(unused)]
 pub static default_filter_intra_mode_cdf: [u16;
-  cdf_size!(FilterIntraMode::FILTER_INTRA_MODES as usize)] =
+  FilterIntraMode::FILTER_INTRA_MODES as usize] =
   cdf!(8949, 12776, 17211, 29558);
 
-pub static default_filter_intra_cdfs: [[u16; cdf_size!(2)];
-  BlockSize::BLOCK_SIZES_ALL] = [
+pub static default_filter_intra_cdfs: [[u16; 2]; BlockSize::BLOCK_SIZES_ALL] = [
   cdf!(4621),
   cdf!(6743),
   cdf!(5893),
@@ -1422,18 +1405,18 @@ pub static default_filter_intra_cdfs: [[u16; cdf_size!(2)];
   cdf!(16384),
 ];
 
-pub static default_switchable_restore_cdf: [u16;
-  cdf_size!(RESTORE_SWITCHABLE_TYPES)] = cdf!(9413, 22581);
+pub static default_switchable_restore_cdf: [u16; RESTORE_SWITCHABLE_TYPES] =
+  cdf!(9413, 22581);
 
-pub static default_wiener_restore_cdf: [u16; cdf_size!(2)] = cdf!(11570);
+pub static default_wiener_restore_cdf: [u16; 2] = cdf!(11570);
 
-pub static default_sgrproj_restore_cdf: [u16; cdf_size!(2)] = cdf!(16855);
+pub static default_sgrproj_restore_cdf: [u16; 2] = cdf!(16855);
 
 #[allow(unused)]
-pub static default_delta_q_cdf: [u16; cdf_size!(DELTA_Q_PROBS + 1)] =
+pub static default_delta_q_cdf: [u16; DELTA_Q_PROBS + 1] =
   cdf!(28160, 32120, 32677);
 
-pub static default_delta_lf_multi_cdf: [[u16; cdf_size!(DELTA_LF_PROBS + 1)];
+pub static default_delta_lf_multi_cdf: [[u16; DELTA_LF_PROBS + 1];
   FRAME_LF_COUNT] = [
   cdf!(28160, 32120, 32677),
   cdf!(28160, 32120, 32677),
@@ -1441,29 +1424,27 @@ pub static default_delta_lf_multi_cdf: [[u16; cdf_size!(DELTA_LF_PROBS + 1)];
   cdf!(28160, 32120, 32677),
 ];
 
-pub static default_delta_lf_cdf: [u16; cdf_size!(DELTA_LF_PROBS + 1)] =
+pub static default_delta_lf_cdf: [u16; DELTA_LF_PROBS + 1] =
   cdf!(28160, 32120, 32677);
 
 // FIXME(someone) need real defaults here
 #[allow(unused)]
-pub static default_seg_tree_cdf: [u16; cdf_size!(MAX_SEGMENTS)] =
+pub static default_seg_tree_cdf: [u16; MAX_SEGMENTS] =
   cdf!(4096, 8192, 12288, 16384, 20480, 24576, 28672);
 
 #[allow(unused)]
-pub static default_segment_pred_cdf: [[u16; cdf_size!(2)];
-  SEG_TEMPORAL_PRED_CTXS] =
+pub static default_segment_pred_cdf: [[u16; 2]; SEG_TEMPORAL_PRED_CTXS] =
   [cdf!(128 * 128), cdf!(128 * 128), cdf!(128 * 128)];
 
-pub static default_spatial_pred_seg_tree_cdf: [[u16;
-  cdf_size!(MAX_SEGMENTS)];
+pub static default_spatial_pred_seg_tree_cdf: [[u16; MAX_SEGMENTS];
   SPATIAL_PREDICTION_PROBS] = [
   cdf!(5622, 7893, 16093, 18233, 27809, 28373, 32533),
   cdf!(14274, 18230, 22557, 24935, 29980, 30851, 32344),
   cdf!(27527, 28487, 28723, 28890, 32397, 32647, 32679),
 ];
 
-pub static default_tx_size_cdf: [[[u16; cdf_size!(MAX_TX_DEPTH + 1)];
-  TX_SIZE_CONTEXTS]; MAX_TX_CATS] = [
+pub static default_tx_size_cdf: [[[u16; MAX_TX_DEPTH + 1]; TX_SIZE_CONTEXTS];
+  MAX_TX_CATS] = [
   [cdf!(19968, CDFMAX), cdf!(19968, CDFMAX), cdf!(24320, CDFMAX)],
   [cdf!(12272, 30172), cdf!(12272, 30172), cdf!(18677, 30848)],
   [cdf!(12986, 15180), cdf!(12986, 15180), cdf!(24302, 25602)],

--- a/src/token_cdfs.rs
+++ b/src/token_cdfs.rs
@@ -14,9 +14,8 @@ use crate::transform::*;
 
 const TOKEN_CDF_Q_CTXS: usize = 4;
 
-pub static av1_default_dc_sign_cdfs: [[[[u16; cdf_size!(2)];
-  DC_SIGN_CONTEXTS]; PLANE_TYPES];
-  TOKEN_CDF_Q_CTXS] = [
+pub static av1_default_dc_sign_cdfs: [[[[u16; 2]; DC_SIGN_CONTEXTS];
+  PLANE_TYPES]; TOKEN_CDF_Q_CTXS] = [
   [
     [cdf!(128 * 125), cdf!(128 * 102), cdf!(128 * 147)],
     [cdf!(128 * 119), cdf!(128 * 101), cdf!(128 * 135)],
@@ -35,8 +34,7 @@ pub static av1_default_dc_sign_cdfs: [[[[u16; cdf_size!(2)];
   ],
 ];
 
-pub static av1_default_txb_skip_cdfs: [[[[u16; cdf_size!(2)];
-  TXB_SKIP_CONTEXTS];
+pub static av1_default_txb_skip_cdfs: [[[[u16; 2]; TXB_SKIP_CONTEXTS];
   TxSize::TX_SIZES]; TOKEN_CDF_Q_CTXS] = [
   [
     [
@@ -348,9 +346,9 @@ pub static av1_default_txb_skip_cdfs: [[[[u16; cdf_size!(2)];
   ],
 ];
 
-pub static av1_default_eob_extra_cdfs: [[[[[u16; cdf_size!(2)];
-  EOB_COEF_CONTEXTS]; PLANE_TYPES];
-  TxSize::TX_SIZES]; TOKEN_CDF_Q_CTXS] = [
+pub static av1_default_eob_extra_cdfs: [[[[[u16; 2]; EOB_COEF_CONTEXTS];
+  PLANE_TYPES]; TxSize::TX_SIZES];
+  TOKEN_CDF_Q_CTXS] = [
   [
     [
       [
@@ -841,8 +839,8 @@ pub static av1_default_eob_extra_cdfs: [[[[[u16; cdf_size!(2)];
   ],
 ];
 
-pub static av1_default_eob_multi16_cdfs: [[[[u16; cdf_size!(5)]; 2];
-  PLANE_TYPES]; TOKEN_CDF_Q_CTXS] = [
+pub static av1_default_eob_multi16_cdfs: [[[[u16; 5]; 2]; PLANE_TYPES];
+  TOKEN_CDF_Q_CTXS] = [
   [
     [cdf!(840, 1039, 1980, 4895), cdf!(370, 671, 1883, 4471)],
     [cdf!(3247, 4950, 9688, 14563), cdf!(1904, 3354, 7763, 14647)],
@@ -861,8 +859,8 @@ pub static av1_default_eob_multi16_cdfs: [[[[u16; cdf_size!(5)]; 2];
   ],
 ];
 
-pub static av1_default_eob_multi32_cdfs: [[[[u16; cdf_size!(6)]; 2];
-  PLANE_TYPES]; TOKEN_CDF_Q_CTXS] = [
+pub static av1_default_eob_multi32_cdfs: [[[[u16; 6]; 2]; PLANE_TYPES];
+  TOKEN_CDF_Q_CTXS] = [
   [
     [cdf!(400, 520, 977, 2102, 6542), cdf!(210, 405, 1315, 3326, 7537)],
     [
@@ -896,8 +894,8 @@ pub static av1_default_eob_multi32_cdfs: [[[[u16; cdf_size!(6)]; 2];
   ],
 ];
 
-pub static av1_default_eob_multi64_cdfs: [[[[u16; cdf_size!(7)]; 2];
-  PLANE_TYPES]; TOKEN_CDF_Q_CTXS] = [
+pub static av1_default_eob_multi64_cdfs: [[[[u16; 7]; 2]; PLANE_TYPES];
+  TOKEN_CDF_Q_CTXS] = [
   [
     [
       cdf!(329, 498, 1101, 1784, 3265, 7758),
@@ -940,8 +938,8 @@ pub static av1_default_eob_multi64_cdfs: [[[[u16; cdf_size!(7)]; 2];
   ],
 ];
 
-pub static av1_default_eob_multi128_cdfs: [[[[u16; cdf_size!(8)]; 2];
-  PLANE_TYPES]; TOKEN_CDF_Q_CTXS] = [
+pub static av1_default_eob_multi128_cdfs: [[[[u16; 8]; 2]; PLANE_TYPES];
+  TOKEN_CDF_Q_CTXS] = [
   [
     [
       cdf!(219, 482, 1140, 2091, 3680, 6028, 12586),
@@ -984,8 +982,8 @@ pub static av1_default_eob_multi128_cdfs: [[[[u16; cdf_size!(8)]; 2];
   ],
 ];
 
-pub static av1_default_eob_multi256_cdfs: [[[[u16; cdf_size!(9)]; 2];
-  PLANE_TYPES]; TOKEN_CDF_Q_CTXS] = [
+pub static av1_default_eob_multi256_cdfs: [[[[u16; 9]; 2]; PLANE_TYPES];
+  TOKEN_CDF_Q_CTXS] = [
   [
     [
       cdf!(310, 584, 1887, 3589, 6168, 8611, 11352, 15652),
@@ -1028,8 +1026,8 @@ pub static av1_default_eob_multi256_cdfs: [[[[u16; cdf_size!(9)]; 2];
   ],
 ];
 
-pub static av1_default_eob_multi512_cdfs: [[[[u16; cdf_size!(10)]; 2];
-  PLANE_TYPES]; TOKEN_CDF_Q_CTXS] = [
+pub static av1_default_eob_multi512_cdfs: [[[[u16; 10]; 2]; PLANE_TYPES];
+  TOKEN_CDF_Q_CTXS] = [
   [
     [
       cdf!(641, 983, 3707, 5430, 10234, 14958, 18788, 23412, 26061),
@@ -1072,8 +1070,8 @@ pub static av1_default_eob_multi512_cdfs: [[[[u16; cdf_size!(10)]; 2];
   ],
 ];
 
-pub static av1_default_eob_multi1024_cdfs: [[[[u16; cdf_size!(11)]; 2];
-  PLANE_TYPES]; TOKEN_CDF_Q_CTXS] = [
+pub static av1_default_eob_multi1024_cdfs: [[[[u16; 11]; 2]; PLANE_TYPES];
+  TOKEN_CDF_Q_CTXS] = [
   [
     [
       cdf!(393, 421, 751, 1623, 3160, 6352, 13345, 18047, 22571, 25830),
@@ -1120,7 +1118,7 @@ pub static av1_default_eob_multi1024_cdfs: [[[[u16; cdf_size!(11)]; 2];
   ],
 ];
 
-pub static av1_default_coeff_lps_multi_cdfs: [[[[[u16; cdf_size!(BR_CDF_SIZE)];
+pub static av1_default_coeff_lps_multi_cdfs: [[[[[u16; BR_CDF_SIZE];
   LEVEL_CONTEXTS];
   PLANE_TYPES];
   TxSize::TX_SIZES];
@@ -2095,8 +2093,7 @@ pub static av1_default_coeff_lps_multi_cdfs: [[[[[u16; cdf_size!(BR_CDF_SIZE)];
   ],
 ];
 
-pub static av1_default_coeff_base_multi_cdfs: [[[[[u16;
-  cdf_size!(NUM_BASE_LEVELS + 2)];
+pub static av1_default_coeff_base_multi_cdfs: [[[[[u16; NUM_BASE_LEVELS + 2];
   SIG_COEF_CONTEXTS];
   PLANE_TYPES];
   TxSize::TX_SIZES];
@@ -3912,7 +3909,7 @@ pub static av1_default_coeff_base_multi_cdfs: [[[[[u16;
 ];
 
 pub static av1_default_coeff_base_eob_multi_cdfs: [[[[[u16;
-  cdf_size!(NUM_BASE_LEVELS + 1)];
+  NUM_BASE_LEVELS + 1];
   SIG_COEF_CONTEXTS_EOB];
   PLANE_TYPES];
   TxSize::TX_SIZES];

--- a/src/util/cdf.rs
+++ b/src/util/cdf.rs
@@ -12,9 +12,3 @@
 macro_rules! cdf {
     ($($x:expr),+) =>  {[$(32768 - $x),+, 0]}
 }
-
-macro_rules! cdf_size {
-  ($x:expr) => {
-    $x
-  };
-}

--- a/src/util/cdf.rs
+++ b/src/util/cdf.rs
@@ -10,11 +10,11 @@
 // TODO: Nice to have (although I wasn't able to find a way to do it yet in rust): zero-fill arrays that are
 // shorter than required.  Need const fn (Rust Issue #24111) or const generics (Rust RFC #2000)
 macro_rules! cdf {
-    ($($x:expr),+) =>  {[$(32768 - $x),+, 0, 0]}
+    ($($x:expr),+) =>  {[$(32768 - $x),+, 0]}
 }
 
 macro_rules! cdf_size {
   ($x:expr) => {
-    $x + 1
+    $x
   };
 }


### PR DESCRIPTION
A similar approach is used in dav1d and this enables some improvements to the CDF log.