### PR TITLE
Use explicit table lookup for ac_q and dc_q

### DIFF
--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -32,25 +32,17 @@ pub fn get_log_tx_scale(tx_size: TxSize) -> usize {
 }
 
 pub fn dc_q(qindex: u8, delta_q: i8, bit_depth: usize) -> i16 {
-  let table = match bit_depth {
-    8 => &dc_qlookup_Q3,
-    10 => &dc_qlookup_10_Q3,
-    12 => &dc_qlookup_12_Q3,
-    _ => unimplemented!(),
-  };
-
-  table[(qindex as isize + delta_q as isize).max(0).min(255) as usize]
+  static DC_Q: [&[i16; 256]; 3] =
+    [&dc_qlookup_Q3, &dc_qlookup_10_Q3, &dc_qlookup_12_Q3];
+  let bd = ((bit_depth ^ 8) >> 1).min(2);
+  DC_Q[bd][((qindex as isize + delta_q as isize).max(0) as usize).min(255)]
 }
 
 pub fn ac_q(qindex: u8, delta_q: i8, bit_depth: usize) -> i16 {
-  let table = match bit_depth {
-    8 => &ac_qlookup_Q3,
-    10 => &ac_qlookup_10_Q3,
-    12 => &ac_qlookup_12_Q3,
-    _ => unimplemented!(),
-  };
-
-  table[(qindex as isize + delta_q as isize).max(0).min(255) as usize]
+  static AC_Q: [&[i16; 256]; 3] =
+    [&ac_qlookup_Q3, &ac_qlookup_10_Q3, &ac_qlookup_12_Q3];
+  let bd = ((bit_depth ^ 8) >> 1).min(2);
+  AC_Q[bd][((qindex as isize + delta_q as isize).max(0) as usize).min(255)]
 }
 
 // TODO: Handle lossless properly.

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -32,7 +32,7 @@ pub fn get_log_tx_scale(tx_size: TxSize) -> usize {
 }
 
 pub fn dc_q(qindex: u8, delta_q: i8, bit_depth: usize) -> i16 {
-  let &table = match bit_depth {
+  let table = match bit_depth {
     8 => &dc_qlookup_Q3,
     10 => &dc_qlookup_10_Q3,
     12 => &dc_qlookup_12_Q3,
@@ -43,7 +43,7 @@ pub fn dc_q(qindex: u8, delta_q: i8, bit_depth: usize) -> i16 {
 }
 
 pub fn ac_q(qindex: u8, delta_q: i8, bit_depth: usize) -> i16 {
-  let &table = match bit_depth {
+  let table = match bit_depth {
     8 => &ac_qlookup_Q3,
     10 => &ac_qlookup_10_Q3,
     12 => &ac_qlookup_12_Q3,


### PR DESCRIPTION
* Resolve a surprising compiler decision to invoke memmove.
* Calculate indices in a way that rustc may elide bounds checks.