### PR TITLE
per speed rdo-lookahead-frames

### DIFF
--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -211,14 +211,12 @@ impl SpeedSettings {
 
   /// Set default rdo-lookahead-frames for different speed settings
   pub fn rdo_lookahead_frames(speed: usize) -> usize {
-    if speed == 10 || speed == 9 {
-      10
-    } else if speed <= 8 || speed >= 6 {
-      20
-    } else if speed <= 5 || speed >= 3 {
-      30
-    } else {
-      40
+    match speed {
+      9..=10 => 10,
+      6..=8 => 20,
+      3..=5 => 30,
+      0..=2 => 40,
+      _ => 40,
     }
   }
 

--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -209,6 +209,19 @@ impl SpeedSettings {
     speed <= 1
   }
 
+  /// Set default rdo-lookahead-frames for different speed settings
+  pub fn rdo_lookahead_frames(speed: usize) -> usize {
+    if speed == 10 || speed == 9 {
+      10
+    } else if speed <= 8 || speed >= 6 {
+      20
+    } else if speed <= 5 || speed >= 3 {
+      30
+    } else {
+      40
+    }
+  }
+
   const fn rdo_tx_decision_preset(speed: usize) -> bool {
     speed <= 5
   }

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -215,7 +215,7 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
     .arg(
       Arg::with_name("RDO_LOOKAHEAD_FRAMES")
         .help("Number of frames encoder should lookahead for RDO purposes\n\
-        [defaults for speeds: 10,9 - 10, 8,7,6 - 20, 5,4,3 - 30, 2,1,0 - 40]\n")
+        [default value for speed levels: 10,9 - 10; 8,7,6 - 20; 5,4,3 - 30; 2,1,0 - 40]\n")
         .long("rdo-lookahead-frames")
         .takes_value(true)
     )

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -214,7 +214,8 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
     )
     .arg(
       Arg::with_name("RDO_LOOKAHEAD_FRAMES")
-        .help("Number of frames encoder should lookahead for RDO purposes [default: 40]\n")
+        .help("Number of frames encoder should lookahead for RDO purposes\n\
+        [defaults for speeds: 10,9 - 10, 8,7,6 - 20, 5,4,3 - 30, 2,1,0 - 40]\n")
         .long("rdo-lookahead-frames")
         .takes_value(true)
     )
@@ -669,8 +670,16 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
   cfg.reservoir_frame_delay = matches
     .value_of("RESERVOIR_FRAME_DELAY")
     .map(|reservior_frame_delay| reservior_frame_delay.parse().unwrap());
-  cfg.rdo_lookahead_frames =
-    matches.value_of("RDO_LOOKAHEAD_FRAMES").unwrap_or("40").parse().unwrap();
+
+  // rdo-lookahead-frames
+  let maybe_rdo = matches.value_of("RDO_LOOKAHEAD_FRAMES");
+  if maybe_rdo.is_some() {
+    cfg.rdo_lookahead_frames =
+      matches.value_of("RDO_LOOKAHEAD_FRAMES").unwrap().parse().unwrap();
+  } else {
+    cfg.rdo_lookahead_frames = SpeedSettings::rdo_lookahead_frames(speed)
+  }
+
   cfg.tune = matches.value_of("TUNE").unwrap().parse().unwrap();
 
   if cfg.tune == Tune::Psychovisual {


### PR DESCRIPTION
## Motivation:
Make speed settings faster with reasonable trade-off on different rdo-lookahead-frames values and suggest new defaults for each speed

## Encoding speed difference
![](https://cdn.discordapp.com/attachments/696849974666985494/811639256077697074/2021_02_17_18_44_30.webp)

## BD-rate difference
![](https://cdn.discordapp.com/attachments/696849974666985494/811638577330913320/2021_02_17_17_23_00.webp)

### Recommended
* `rdo-lookahead-frames` 10 for speeds 10,9.
* `rdo-lookahead-frames` 20 for speeds 8,7,6.
* `rdo-lookahead-frames` 30 for speeds 5,4,3.
* `rdo-lookahead-frames` 40 for speeds 2,1,0.