### PR TITLE
CI: Update libdav1d to 0.8.2-dmo1

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -144,11 +144,11 @@ jobs:
         matrix.conf == 'grcov-coveralls' || matrix.conf == 'fuzz' || matrix.conf == 'no-asm-tests'
       env:
         LINK: https://www.deb-multimedia.org/pool/main/d/dav1d-dmo
-        DAV1D_VERSION: 0.8.1-dmo1
+        DAV1D_VERSION: 0.8.2-dmo1
         DAV1D_DEV_SHA256: >-
-          dcf911325699d93a90818e16736e2c93b29d8e7538c1545accd3b25c610876c0
+          04d30fc34056467b91a627563c61b9a0046a2e084bb649791cd31887a6c76d8e
         DAV1D_LIB_SHA256: >-
-          06f51b9660d413417827270b298e2ad541bd8ddaae7e027ebcb6bb7b6b1ad006
+          0c3debb3a926e10009503e639dddcfd4082ed6e012340ca49682b738c243dedc
       run: |
         echo "$LINK/libdav1d-dev_${DAV1D_VERSION}_amd64.deb" >> DEBS
         echo "$LINK/libdav1d5_${DAV1D_VERSION}_amd64.deb" >> DEBS

--- a/.travis/install-dav1d.sh
+++ b/.travis/install-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-DAV1D_VERSION="0.8.1-dmo1"
+DAV1D_VERSION="0.8.2-dmo1"
 PKG_URL="https://www.deb-multimedia.org/pool/main/d/dav1d-dmo"
 
 case "$ARCH" in
@@ -17,10 +17,10 @@ curl -O "$PKG_URL/libdav1d-dev_${DAV1D_VERSION}_$ARCH.deb" \
      -O "$PKG_URL/libdav1d5_${DAV1D_VERSION}_$ARCH.deb"
 
 sha256sum --check --ignore-missing <<EOF
-dcf911325699d93a90818e16736e2c93b29d8e7538c1545accd3b25c610876c0  libdav1d-dev_${DAV1D_VERSION}_amd64.deb
-37094752ae6f8a4c1d6a8267b9632144a235a995f02c5f8bfc69cd8ffc0bb831  libdav1d-dev_${DAV1D_VERSION}_arm64.deb
-06f51b9660d413417827270b298e2ad541bd8ddaae7e027ebcb6bb7b6b1ad006  libdav1d5_${DAV1D_VERSION}_amd64.deb
-3f35ba159cb76108ba483aedae7acd6eb797bc7cf7a8b0023eeaede2f4b2fbb0  libdav1d5_${DAV1D_VERSION}_arm64.deb
+04d30fc34056467b91a627563c61b9a0046a2e084bb649791cd31887a6c76d8e  libdav1d-dev_${DAV1D_VERSION}_amd64.deb
+0ec130514ce8748a84f4db3d624bf6f20e28dfb0f8a64659a75a8087642269fc  libdav1d-dev_${DAV1D_VERSION}_arm64.deb
+0c3debb3a926e10009503e639dddcfd4082ed6e012340ca49682b738c243dedc  libdav1d5_${DAV1D_VERSION}_amd64.deb
+3c29f1782d89f85ac1cc158560828d7e604c7070985e92b7c03135825af478cc  libdav1d5_${DAV1D_VERSION}_arm64.deb
 EOF
 
 sudo dpkg -i "libdav1d5_${DAV1D_VERSION}_$ARCH.deb" \


### PR DESCRIPTION
This is early for once, the build is expected to break in 5 days when the current package is dropped from DMO.