### PR TITLE
Unify spatial and temporal adaptive quantization

### DIFF
--- a/src/activity.rs
+++ b/src/activity.rs
@@ -10,11 +10,12 @@
 use crate::frame::*;
 use crate::tiling::*;
 use crate::util::*;
+use itertools::izip;
 use rust_hawktracer::*;
 
 #[derive(Debug, Default, Clone)]
 pub struct ActivityMask {
-  variances: Vec<f64>,
+  variances: Vec<u32>,
   // Width and height of the original frame that is masked
   width: usize,
   height: usize,
@@ -50,27 +51,44 @@ impl ActivityMask {
         };
 
         let block = luma.subregion(block_rect);
-
-        let mean: f64 = block
-          .rows_iter()
-          .flatten()
-          .map(|&pix| {
-            let pix: i16 = CastFromPrimitive::cast_from(pix);
-            pix as f64
-          })
-          .sum::<f64>()
-          / 64.0_f64;
-        let variance: f64 = block
-          .rows_iter()
-          .flatten()
-          .map(|&pix| {
-            let pix: i16 = CastFromPrimitive::cast_from(pix);
-            (pix as f64 - mean).powi(2)
-          })
-          .sum::<f64>();
+        let variance = variance_8x8(&block);
         variances.push(variance);
       }
     }
     ActivityMask { variances, width, height, granularity }
   }
+}
+
+// Adapted from the source variance calculation in cdef_dist_wxh_8x8.
+#[inline(never)]
+fn variance_8x8<T: Pixel>(src: &PlaneRegion<'_, T>) -> u32 {
+  debug_assert!(src.plane_cfg.xdec == 0);
+  debug_assert!(src.plane_cfg.ydec == 0);
+
+  // Sum into columns to improve auto-vectorization
+  let mut sum_s_cols: [u16; 8] = [0; 8];
+  let mut sum_s2_cols: [u32; 8] = [0; 8];
+
+  // Check upfront that 8 rows are available.
+  let _row = &src[7];
+
+  for j in 0..8 {
+    let row = &src[j][0..8];
+    for (sum_s, sum_s2, s) in izip!(&mut sum_s_cols, &mut sum_s2_cols, row) {
+      // Don't convert directly to u32 to allow better vectorization
+      let s: u16 = u16::cast_from(*s);
+      *sum_s += s;
+
+      // Convert to u32 to avoid overflows when multiplying
+      let s: u32 = s as u32;
+      *sum_s2 += s * s;
+    }
+  }
+
+  // Sum together the sum of columns
+  let sum_s = sum_s_cols.iter().map(|&a| u32::cast_from(a)).sum::<u32>();
+  let sum_s2 = sum_s2_cols.iter().sum::<u32>();
+
+  // Use sums to calculate variance
+  sum_s2 - ((sum_s * sum_s + 32) >> 6)
 }

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -8,6 +8,7 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use crate::frame::*;
+use crate::rdo::{ssim_boost, DistortionScale};
 use crate::tiling::*;
 use crate::util::*;
 use itertools::izip;
@@ -55,6 +56,15 @@ impl ActivityMask {
       }
     }
     ActivityMask { variances: variances.into_boxed_slice(), width, height }
+  }
+
+  #[hawktracer(activity_mask_fill_scales)]
+  pub fn fill_scales(
+    &self, bit_depth: usize, activity_scales: &mut Box<[DistortionScale]>,
+  ) {
+    for (dst, &src) in activity_scales.iter_mut().zip(self.variances.iter()) {
+      *dst = ssim_boost(src as i64, src as i64, bit_depth);
+    }
   }
 }
 

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -73,45 +73,4 @@ impl ActivityMask {
     }
     ActivityMask { variances, width, height, granularity }
   }
-
-  pub fn variance_at(&self, x: usize, y: usize) -> Option<f64> {
-    let (dec_width, dec_height) =
-      (self.width >> self.granularity, self.height >> self.granularity);
-    if x > dec_width || y > dec_height {
-      None
-    } else {
-      Some(*self.variances.get(x + dec_width * y).unwrap())
-    }
-  }
-
-  pub fn mean_activity_of(&self, rect: Rect) -> Option<f64> {
-    let Rect { x, y, width, height } = rect;
-    let (x, y) = (x as usize, y as usize);
-    let granularity = self.granularity;
-    let (dec_x, dec_y) = (x >> granularity, y >> granularity);
-    let (dec_width, dec_height) =
-      (width >> granularity, height >> granularity);
-
-    if x > self.width
-      || y > self.height
-      || (x + width) > self.width
-      || (y + height) > self.height
-      || dec_width == 0
-      || dec_height == 0
-    {
-      // Region lies out of the frame or is smaller than 8x8 on some axis
-      None
-    } else {
-      let activity = self
-        .variances
-        .chunks_exact(self.width >> granularity)
-        .skip(dec_y)
-        .take(dec_height)
-        .map(|row| row.iter().skip(dec_x).take(dec_width).sum::<f64>())
-        .sum::<f64>()
-        / (dec_width as f64 * dec_height as f64);
-
-      Some(activity.cbrt().sqrt())
-    }
-  }
 }

--- a/src/context/superblock_unit.rs
+++ b/src/context/superblock_unit.rs
@@ -27,6 +27,11 @@ pub const BLOCK_TO_PLANE_SHIFT: usize = MI_SIZE_LOG2;
 pub const IMPORTANCE_BLOCK_TO_BLOCK_SHIFT: usize = 1;
 pub const LOCAL_BLOCK_MASK: usize = (1 << SUPERBLOCK_TO_BLOCK_SHIFT) - 1;
 
+pub const MAX_SB_IN_IMP_B: usize = 1
+  << (MAX_SB_SIZE_LOG2
+    - IMPORTANCE_BLOCK_TO_BLOCK_SHIFT
+    - BLOCK_TO_PLANE_SHIFT);
+
 /// Absolute offset in superblocks, where a superblock is defined
 /// to be an N*N square where N = (1 << SUPERBLOCK_TO_PLANE_SHIFT).
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -606,6 +606,8 @@ pub struct FrameInvariants<T: Pixel> {
   pub block_importances: Box<[f32]>,
   /// Pre-computed distortion_scale.
   pub distortion_scales: Box<[DistortionScale]>,
+  /// Pre-computed activity_scale.
+  pub activity_scales: Box<[DistortionScale]>,
 
   /// Target CPU feature level.
   pub cpu_feature_level: crate::cpu_features::CpuFeatureLevel,
@@ -743,6 +745,11 @@ impl<T: Pixel> FrameInvariants<T> {
       // dynamic allocation: once per frame
       block_importances: vec![0.; w_in_imp_b * h_in_imp_b].into_boxed_slice(),
       distortion_scales: vec![
+        DistortionScale::default();
+        w_in_imp_b * h_in_imp_b
+      ]
+      .into_boxed_slice(),
+      activity_scales: vec![
         DistortionScale::default();
         w_in_imp_b * h_in_imp_b
       ]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -756,7 +756,8 @@ impl<T: Pixel> FrameInvariants<T> {
       .into_boxed_slice(),
       cpu_feature_level: Default::default(),
       activity_mask: Default::default(),
-      enable_segmentation: config.speed_settings.enable_segmentation,
+      enable_segmentation: config.speed_settings.segmentation
+        != SegmentationLevel::Disabled,
       enable_inter_txfm_split: config.speed_settings.enable_inter_tx_split,
       sequence,
       config,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -199,7 +199,7 @@ fn cdef_dist_wxh_8x8<T: Pixel>(
 }
 
 #[inline(always)]
-fn ssim_boost(svar: i64, dvar: i64, bit_depth: usize) -> DistortionScale {
+pub fn ssim_boost(svar: i64, dvar: i64, bit_depth: usize) -> DistortionScale {
   let coeff_shift = bit_depth - 8;
 
   //The two constants were tuned for CDEF, but can probably be better tuned for use in general RDO

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -194,20 +194,20 @@ fn cdef_dist_wxh_8x8<T: Pixel>(
   // Use sums to calculate distortion
   let svar = sum_s2 - ((sum_s * sum_s + 32) >> 6);
   let dvar = sum_d2 - ((sum_d * sum_d + 32) >> 6);
-  let sse = (sum_d2 + sum_s2 - 2 * sum_sd) as f64;
-  RawDistortion::new(
-    (sse * ssim_boost(svar, dvar, bit_depth) + 0.5_f64) as u64,
-  )
+  let sse = (sum_d2 + sum_s2 - 2 * sum_sd) as u64;
+  RawDistortion::new(ssim_boost(svar, dvar, bit_depth).mul_u64(sse))
 }
 
 #[inline(always)]
-fn ssim_boost(svar: i64, dvar: i64, bit_depth: usize) -> f64 {
+fn ssim_boost(svar: i64, dvar: i64, bit_depth: usize) -> DistortionScale {
   let coeff_shift = bit_depth - 8;
 
   //The two constants were tuned for CDEF, but can probably be better tuned for use in general RDO
-  (4033_f64 / 16_384_f64)
-    * (svar + dvar + (16_384 << (2 * coeff_shift))) as f64
-    / f64::sqrt(((16_265_089i64 << (4 * coeff_shift)) + svar * dvar) as f64)
+  DistortionScale::new(
+    (4033_f64 / 16_384_f64)
+      * (svar + dvar + (16_384 << (2 * coeff_shift))) as f64
+      / f64::sqrt(((16_265_089i64 << (4 * coeff_shift)) + svar * dvar) as f64),
+  )
 }
 
 #[allow(unused)]

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -9,6 +9,8 @@
 
 use crate::context::*;
 use crate::header::PRIMARY_REF_NONE;
+use crate::partition::BlockSize;
+use crate::tiling::TileStateMut;
 use crate::util::Pixel;
 use crate::FrameInvariants;
 use crate::FrameState;
@@ -68,4 +70,55 @@ pub fn segmentation_optimize<T: Pixel>(
       }
     }
   }
+}
+
+pub fn select_segment<T: Pixel>(
+  fi: &FrameInvariants<T>, ts: &TileStateMut<'_, T>, tile_bo: TileBlockOffset,
+  bsize: BlockSize, skip: bool,
+) -> std::ops::RangeInclusive<u8> {
+  use crate::rdo::spatiotemporal_scale;
+  use arrayvec::ArrayVec;
+
+  // If skip is true or segmentation is turned off, sidx is not coded.
+  if skip || !fi.enable_segmentation {
+    return 0..=0;
+  }
+
+  let frame_bo = ts.to_frame_block_offset(tile_bo);
+  let scale = spatiotemporal_scale(fi, frame_bo, bsize);
+
+  // TODO: Replace this calculation with precomputed scale thresholds.
+  let segment_2_is_lossless = fi.base_q_idx as i16
+    + ts.segmentation.data[2][SegLvl::SEG_LVL_ALT_Q as usize]
+    < 1;
+
+  let seg_ac_q: ArrayVec<[_; 3]> = if fi.enable_segmentation {
+    use crate::quantize::ac_q;
+    (0..=2)
+      .map(|sidx| {
+        ac_q(
+          (fi.base_q_idx as i16
+            + ts.segmentation.data[sidx][SegLvl::SEG_LVL_ALT_Q as usize])
+            .max(0)
+            .min(255) as u8,
+          0,
+          fi.sequence.bit_depth,
+        )
+      })
+      .collect()
+  } else {
+    Default::default()
+  };
+
+  let sidx = if scale.mul_u64(seg_ac_q[1] as u64) < seg_ac_q[0] as u64 {
+    1
+  } else if !segment_2_is_lossless
+    && scale.mul_u64(seg_ac_q[2] as u64) > seg_ac_q[0] as u64
+  {
+    2
+  } else {
+    0
+  };
+
+  sidx..=sidx
 }


### PR DESCRIPTION
This exposes the implicit scaling of `cdef_dist` and combines it with the explicit temporal scaling to produce a unified model for segment selection. Fixes #2141.