### PR TITLE
Add colored help to the CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ dump_lookahead_data = ["byteorder", "image"]
 arg_enum_proc_macro = "0.3"
 bitstream-io = "1"
 cfg-if = "1.0"
-clap = { version = "2", optional = true, default-features = false }
+clap = { version = "2", optional = true, default-features = false, features = ["color"] }
 libc = "0.2"
 y4m = { version = "0.7", optional = true }
 backtrace = { version = "0.3", optional = true }

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -89,6 +89,7 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
     .about("AV1 video encoder")
     .setting(AppSettings::DeriveDisplayOrder)
     .setting(AppSettings::SubcommandsNegateReqs)
+    .setting(AppSettings::ColoredHelp)
     .arg(Arg::with_name("FULLHELP")
       .help("Prints more detailed help information")
       .long("fullhelp"))


### PR DESCRIPTION
<img width="794" alt="image" src="https://user-images.githubusercontent.com/239012/110320447-973b2580-8010-11eb-96a5-b49e55c3de95.png">

It improves the usability quite a bit.