### PR TITLE
Use global threadpool unless configured otherwise

### DIFF
--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -253,11 +253,13 @@ impl Config {
     let inner = self.new_inner()?;
     let config = *inner.config;
     let pool = if let Some(ref p) = self.pool {
-      p.clone()
-    } else {
+      Some(p.clone())
+    } else if self.threads != 0 {
       let pool =
         ThreadPoolBuilder::new().num_threads(self.threads).build().unwrap();
-      Arc::new(pool)
+      Some(Arc::new(pool))
+    } else {
+      None
     };
 
     Ok(Context { is_flushing: false, inner, pool, config })


### PR DESCRIPTION
Follow-up to #2685, using the global threadpool in one more place.

Fixes #2684.