### PR TITLE
Allow Rayon if Wasm is built with atomics support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ mod wasm_bindgen {
 
 mod rayon {
   cfg_if::cfg_if! {
-    if #[cfg(target_arch="wasm32")] {
+    if #[cfg(all(target_arch="wasm32", not(target_feature = "atomics")))] {
       pub struct ThreadPoolBuilder ();
       impl ThreadPoolBuilder {
         pub fn new() -> ThreadPoolBuilder {


### PR DESCRIPTION
`target_feature = "atomics"` currently can be only enabled 1) on nightly and 2) via explicit rustc `-C target-feature=+atomics` flag, so this doesn't change anything for normal builds.

However, if user explicitly opted-in to support for Wasm threads using that flag on nightly, then this change allows to use rav1e multithreading on Wasm too.

The only other limitation is that APIs like `with_threads` will fail even with this flag - user must use preconfigured Wasm-compatible global rayon pool (which is possible after #2685 + #2686) and not locally constructed pools.

Although I guess it's possible someone will find a way to support those dynamic pools on Wasm too, so leaving this method as-is.