### PR TITLE
CI: Add Windows Arm64 job

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -393,20 +393,17 @@ jobs:
         sccache --stop-server
 
   build-windows:
-
     strategy:
       matrix:
-        conf:
-         - cargo-build
-         - cargo-test
-         - cargo-c
         include:
          - conf: cargo-build
-           toolchain: stable
+           target: x86_64-pc-windows-msvc
+         - conf: cargo-build
+           target: aarch64-pc-windows-msvc
          - conf: cargo-test
-           toolchain: stable
+           target: x86_64-pc-windows-msvc
          - conf: cargo-c
-           toolchain: stable-x86_64-pc-windows-gnu
+           target: x86_64-pc-windows-gnu
 
     env:
       RUST_BACKTRACE: full
@@ -417,11 +414,11 @@ jobs:
     if: >-
      (github.event_name == 'push' && !endsWith(github.event.head_commit.message, 'CI: skip')) ||
      (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.names, 'skip-ci'))
-
     runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
+    - uses: ilammy/setup-nasm@v1
     - name: Install sccache
       run: |
         $LINK = "https://github.com/mozilla/sccache/releases/download/0.2.12"
@@ -429,17 +426,17 @@ jobs:
         curl -LO "$LINK/$SCCACHE_FILE.tar.gz"
         tar xzf "$SCCACHE_FILE.tar.gz"
         echo "$Env:GITHUB_WORKSPACE/$SCCACHE_FILE" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    - name: Install nasm
-      run: |
-        $NASM_VERSION="2.15.05"
-        $LINK = "https://www.nasm.us/pub/nasm/releasebuilds/$NASM_VERSION/win64"
-        $NASM_FILE = "nasm-$NASM_VERSION-win64"
-        curl --ssl-no-revoke -LO "$LINK/$NASM_FILE.zip"
-        7z e -y "$NASM_FILE.zip" -o"C:\nasm"
-        echo "C:\nasm"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Set MSVC x86_64 linker path
+      if: matrix.target != 'aarch64-pc-windows-msvc'
       run: |
         $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
+        $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+        $LinkPath = vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1
+        echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    - name: Set MSVC Arm64 linker path
+      if: matrix.target == 'aarch64-pc-windows-msvc'
+      run: |
+        $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\Arm64"
         $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
         $LinkPath = vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1
         echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -447,12 +444,14 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: ${{ matrix.toolchain }}
+        toolchain: stable
+        target: ${{ matrix.target }}
         override: true
+        default: true
     - name: Install cargo-c
       if: matrix.conf == 'cargo-c'
       run: |
-        $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.7.1"
+        $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.7.3"
         $CARGO_C_FILE = "cargo-c-windows-msvc"
         curl -LO "$LINK/$CARGO_C_FILE.zip"
         7z e -y "$CARGO_C_FILE.zip" -o"${env:USERPROFILE}\.cargo\bin"
@@ -465,17 +464,17 @@ jobs:
       continue-on-error: true
       with:
         path: ~/.cargo/registry/cache
-        key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
+          ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-cargo-registry-
     - name: Cache sccache output
       uses: actions/cache@v2
       continue-on-error: true
       with:
         path: C:\sccache
-        key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.*') }}
+        key: ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-sccache-${{ hashFiles('**/Cargo.*') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.conf }}-sccache-
+          ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-sccache-
     - name: Start sccache server
       run: |
         sccache --start-server


### PR DESCRIPTION
Adds a Windows job targeting the Arm64 platform.

Moves Nasm installation to ilammy/setup-nasm and upgrades to Cargo-C v0.7.3.

I'm still working on the deploy CI (on [this branch](https://github.com/EwoutH/rav1e/tree/win-arm64-ci)), that will follow in a separate PR.

Part of #2652.