### PR TITLE
Move away the info logging

### DIFF
--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 
 use crate::api::{ChromaSampling, Context, ContextInner, PixelRange};
 use crate::rayon::{ThreadPool, ThreadPoolBuilder};
-use crate::tiling::TilingInfo;
 use crate::util::Pixel;
 
 mod encoder;
@@ -25,6 +24,8 @@ pub use rate::{RateControlConfig, RateControlSummary};
 
 mod speedsettings;
 pub use speedsettings::*;
+
+pub use crate::tiling::TilingInfo;
 
 /// Enumeration of possible invalid configuration errors.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Error)]
@@ -379,5 +380,16 @@ impl Config {
     }
 
     Ok(())
+  }
+
+  /// Provide the tiling information for the current Config
+  ///
+  /// Useful for reporting and debugging.
+  pub fn tiling_info(&self) -> Result<TilingInfo, InvalidConfig> {
+    self.validate()?;
+
+    let seq = crate::encoder::Sequence::new(&self.enc);
+
+    Ok(seq.tiling)
   }
 }

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -12,7 +12,6 @@ use thiserror::Error;
 use std::sync::Arc;
 
 use crate::api::{ChromaSampling, Context, ContextInner, PixelRange};
-use crate::cpu_features::CpuFeatureLevel;
 use crate::rayon::{ThreadPool, ThreadPoolBuilder};
 use crate::tiling::TilingInfo;
 use crate::util::Pixel;
@@ -199,12 +198,6 @@ impl Config {
     );
 
     self.validate()?;
-
-    // Because we don't have a FrameInvariants yet,
-    // this is the only way to get the CpuFeatureLevel in use.
-    // Since we only call this once, this shouldn't cause
-    // performance issues.
-    info!("CPU Feature Level: {}", CpuFeatureLevel::default());
 
     let mut config = self.enc;
     config.set_key_frame_interval(

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -27,7 +27,6 @@ use crate::stats::EncoderStats;
 use crate::tiling::Area;
 use crate::util::Pixel;
 use arrayvec::ArrayVec;
-use log::Level::Info;
 use rust_hawktracer::*;
 use std::cmp;
 use std::collections::{BTreeMap, BTreeSet};
@@ -273,20 +272,6 @@ impl<T: Pixel> ContextInner<T> {
     let seq = Arc::new(Sequence::new(enc));
     let inter_cfg = InterConfig::new(enc);
     let lookahead_distance = inter_cfg.keyframe_lookahead_distance() as usize;
-
-    if log_enabled!(Info) {
-      let tiling = seq.tiling;
-      if tiling.tile_count() == 1 {
-        info!("Using 1 tile");
-      } else {
-        info!(
-          "Using {} tiles ({}x{})",
-          tiling.tile_count(),
-          tiling.cols,
-          tiling.rows
-        );
-      }
-    }
 
     ContextInner {
       frame_count: 0,

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -41,6 +41,7 @@ mod stats;
 use crate::common::*;
 use crate::error::*;
 use crate::stats::*;
+use rav1e::config::CpuFeatureLevel;
 use rav1e::prelude::*;
 
 use crate::decoder::{Decoder, FrameBuilder, VideoDetails};
@@ -314,6 +315,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     file_path: "trace.bin".into(),
     buffer_size: 4096,
   });
+
+  info!("CPU Feature Level: {}", CpuFeatureLevel::default());
 
   run().map_err(|e| {
     error::print_error(&e);

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -519,6 +519,19 @@ fn run() -> Result<(), error::CliError> {
   );
   info!("Encoding settings: {}", cli.enc);
 
+  let tiling =
+    cfg.tiling_info().map_err(|e| e.context("Invalid configuration"))?;
+  if tiling.tile_count() == 1 {
+    info!("Using 1 tile");
+  } else {
+    info!(
+      "Using {} tiles ({}x{})",
+      tiling.tile_count(),
+      tiling.cols,
+      tiling.rows
+    );
+  }
+
   let progress = ProgressInfo::new(
     Rational { num: video_info.time_base.den, den: video_info.time_base.num },
     if cli.limit == 0 { None } else { Some(cli.limit) },

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -358,6 +358,7 @@ fn init_logger() {
     // parameter:
     // `info!(target="special_target", "This log message is about special_target");`
     .level_for("rav1e", level)
+    .level_for("rav1e_ch", level)
     // output to stdout
     .chain(std::io::stderr())
     .apply()

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -41,6 +41,7 @@ mod stats;
 use crate::common::*;
 use crate::error::*;
 use crate::stats::*;
+use rav1e::config::CpuFeatureLevel;
 use rav1e::prelude::*;
 
 use crate::decoder::{Decoder, FrameBuilder, VideoDetails};
@@ -304,6 +305,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     file_path: "trace.bin".into(),
     buffer_size: 4096,
   });
+
+  info!("CPU Feature Level: {}", CpuFeatureLevel::default());
 
   run().map_err(|e| {
     error::print_error(&e);

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -508,6 +508,19 @@ fn run() -> Result<(), error::CliError> {
   );
   info!("Encoding settings: {}", cli.enc);
 
+  let tiling =
+    cfg.tiling_info().map_err(|e| e.context("Invalid configuration"))?;
+  if tiling.tile_count() == 1 {
+    info!("Using 1 tile");
+  } else {
+    info!(
+      "Using {} tiles ({}x{})",
+      tiling.tile_count(),
+      tiling.cols,
+      tiling.rows
+    );
+  }
+
   let progress = ProgressInfo::new(
     Rational { num: video_info.time_base.den, den: video_info.time_base.num },
     if cli.limit == 0 { None } else { Some(cli.limit) },


### PR DESCRIPTION
Move all the info! lines in the context creation out, it makes a little simpler to rework the internals (see the by_gop poc PRs)