### PR TITLE
Adding no-scene-detection as a CLI argument

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -214,6 +214,13 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
         .alias("low_latency")
     )
     .arg(
+      Arg::with_name("NO_SCENE_DETECTION")
+        .help("Disables scene detection entirely\n\
+            Has a significant speed-to-quality trade-off in full encodes. Experimental for rav1e-by-gop")
+        .long("no-scene-detection")
+        .alias("no_scene_detection")
+    )
+    .arg(
       Arg::with_name("RDO_LOOKAHEAD_FRAMES")
         .help("Number of frames encoder should lookahead for RDO purposes\n\
         [default value for speed levels: 10,9 - 10; 8,7,6 - 20; 5,4,3 - 30; 2,1,0 - 40]\n")
@@ -704,6 +711,10 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
   }
 
   cfg.low_latency = matches.is_present("LOW_LATENCY");
+  // Disables scene_detection
+  if matches.is_present("NO_SCENE_DETECTION") {
+    cfg.speed_settings.no_scene_detection = true;
+  }
 
   Ok(cfg)
 }


### PR DESCRIPTION
The reasoning for this change is that in short scenes without any significant scenes changes, the need for scene detection is null. Therefore, disabling scene detection has no visual or metric deficit, and gives a nice free speedup.

This is particularly useful in per GOP software where scene detection is done externally(like av1an or rav1e-by-gop soon), so this would result in essentially a free speedup.

Average speed difference for each speed preset tested(tested on own machine as AWCY has a large backlog, so numbers may not be indicative of a large dataset)
Speed 4 --- 5,5% speed increase
Speed 6 --- 16% speed increase
Speed 10 --- 9% speed increase