### PR TITLE
Allow upper-case acronyms

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: -- -D warnings --verbose -A clippy::wrong-self-convention -A clippy::many_single_char_names
+        args: -- -D warnings --verbose -A clippy::wrong-self-convention -A clippy::many_single_char_names -A clippy::upper-case-acronyms
 
   build-unix:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 #![allow(clippy::wrong_self_convention)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::comparison_chain)]
+#![allow(clippy::upper_case_acronyms)]
 #![warn(clippy::expl_impl_clone_on_copy)]
 #![warn(clippy::linkedlist)]
 #![warn(clippy::map_flatten)]

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1031,6 +1031,7 @@ pub(crate) mod rust {
     bit_depth: usize, ief_params: Option<IntraEdgeFilterParameters>,
   ) {
     #[allow(clippy::collapsible_if)]
+    #[allow(clippy::collapsible_else_if)]
     #[allow(clippy::needless_return)]
     fn select_ief_strength(
       width: usize, height: usize, smooth_filter: bool, angle_delta: isize,


### PR DESCRIPTION
This lint incorrectly matches with screaming snake-case.
In the few cases it correctly matches, readbility is not improved.

The clippy transcript is quite long, with 305 matches reported.

Also, narrowly allow collapsible `else if` in `pred_directional`.
This function already admits collapsible `if` for readability reasons.