### PR TITLE
Bump arrayvec to 0.6

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -12,76 +12,74 @@ on:
 
 jobs:
   rustfmt-clippy:
-
     if: >-
-     (github.event_name == 'push' && !endsWith(github.event.head_commit.message, 'CI: skip')) ||
-     (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.names, 'skip-ci'))
+      (github.event_name == 'push' && !endsWith(github.event.head_commit.message, 'CI: skip')) ||
+      (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.names, 'skip-ci'))
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: ilammy/setup-nasm@v1
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: clippy, rustfmt
-    - name: Run rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: -- --check --verbose
-    - name: Run clippy
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: -- -D warnings --verbose -A clippy::wrong-self-convention -A clippy::many_single_char_names -A clippy::upper-case-acronyms
+      - uses: actions/checkout@v2
+      - uses: ilammy/setup-nasm@v1
+      - name: Install stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy, rustfmt
+      - name: Run rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check --verbose
+      - name: Run clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- -D warnings --verbose -A clippy::wrong-self-convention -A clippy::many_single_char_names -A clippy::upper-case-acronyms
 
   build-unix:
-
     strategy:
       matrix:
         conf:
-         - beta-build
-         - 1.44.1-tests
-         - aom-tests
-         - dav1d-tests
-         - no-asm-tests
-         - grcov-coveralls
-         - bench
-         - doc
-         - cargo-c
-         - check-no-default
-         - check-extra-feats
-         - fuzz
+          - beta-build
+          - 1.51.0-tests
+          - aom-tests
+          - dav1d-tests
+          - no-asm-tests
+          - grcov-coveralls
+          - bench
+          - doc
+          - cargo-c
+          - check-no-default
+          - check-extra-feats
+          - fuzz
         include:
-         - conf: beta-build
-           toolchain: beta
-         - conf: 1.44.1-tests
-           toolchain: 1.44.1
-         - conf: aom-tests
-           toolchain: stable
-         - conf: dav1d-tests
-           toolchain: stable
-         - conf: no-asm-tests
-           toolchain: stable
-         - conf: grcov-coveralls
-           toolchain: stable
-         - conf: bench
-           toolchain: stable
-         - conf: doc
-           toolchain: stable
-         - conf: cargo-c
-           toolchain: stable
-         - conf: check-no-default
-           toolchain: stable
-         - conf: check-extra-feats
-           toolchain: stable
-         - conf: fuzz
-           toolchain: stable
+          - conf: beta-build
+            toolchain: beta
+          - conf: 1.51.0-tests
+            toolchain: 1.51.0
+          - conf: aom-tests
+            toolchain: stable
+          - conf: dav1d-tests
+            toolchain: stable
+          - conf: no-asm-tests
+            toolchain: stable
+          - conf: grcov-coveralls
+            toolchain: stable
+          - conf: bench
+            toolchain: stable
+          - conf: doc
+            toolchain: stable
+          - conf: cargo-c
+            toolchain: stable
+          - conf: check-no-default
+            toolchain: stable
+          - conf: check-extra-feats
+            toolchain: stable
+          - conf: fuzz
+            toolchain: stable
 
     env:
       RUST_BACKTRACE: full
@@ -91,220 +89,219 @@ jobs:
       SCCACHE_IDLE_TIMEOUT: 0
 
     if: >-
-     (github.event_name == 'push' && !endsWith(github.event.head_commit.message, 'CI: skip')) ||
-     (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.names, 'skip-ci'))
+      (github.event_name == 'push' && !endsWith(github.event.head_commit.message, 'CI: skip')) ||
+      (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.names, 'skip-ci'))
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set no-asm-tests env vars
-      if: matrix.conf == 'no-asm-tests'
-      run: |
-        echo "name=RAV1E_CPU_TARGET::rust" >> $GITHUB_ENV
-    - name: Install sccache
-      env:
-        LINK: https://github.com/mozilla/sccache/releases/download
-        SCCACHE_VERSION: 0.2.15
-      run: |
-        SCCACHE_FILE=sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl
-        mkdir -p $HOME/.local/bin
-        curl -L "$LINK/v$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
-        chmod +x $SCCACHE_FILE/sccache
-        mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-    - name: Add nasm
-      env:
-        LINK: http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm
-        NASM_VERSION: 2.15.05-1
-        NASM_SHA256: >-
-          c860caec653b865d5b83359452d97b11f1b3ba5b18b07cac554cf72550b3bfc9
-      run: |
-        echo "$LINK/nasm_${NASM_VERSION}_amd64.deb" >> DEBS
-        echo "$NASM_SHA256 nasm_${NASM_VERSION}_amd64.deb" >> CHECKSUMS
-    - name: Add aom
-      if: >
-        matrix.conf == '1.44.1-tests' || matrix.conf == 'aom-tests' ||
-        matrix.conf == 'grcov-coveralls'
-      env:
-        LINK: https://www.deb-multimedia.org/pool/main/a/aom-dmo
-        AOM_VERSION: 2.0.2-dmo0~bpo10+1
-        AOM_DEV_SHA256: >-
-          d31eee6524ea64c080312eeafc65355e378e043b1d738ff9b9bde3734a85779c
-        AOM_LIB_SHA256: >-
-          db8a04ca0984604f410c6bd8810ee31666a3bfd3964f3109cdb8f1ae33fec664
-      run: |
-        echo "$LINK/libaom-dev_${AOM_VERSION}_amd64.deb" >> DEBS
-        echo "$LINK/libaom2_${AOM_VERSION}_amd64.deb" >> DEBS
-        echo "$AOM_DEV_SHA256 libaom-dev_${AOM_VERSION}_amd64.deb" >> CHECKSUMS
-        echo "$AOM_LIB_SHA256 libaom2_${AOM_VERSION}_amd64.deb" >> CHECKSUMS
-    - name: Add dav1d
-      if: >
-        matrix.conf == '1.44.1-tests' || matrix.conf == 'dav1d-tests' ||
-        matrix.conf == 'grcov-coveralls' || matrix.conf == 'fuzz' || matrix.conf == 'no-asm-tests'
-      env:
-        LINK: https://www.deb-multimedia.org/pool/main/d/dav1d-dmo
-        DAV1D_VERSION: 0.8.2-dmo1
-        DAV1D_DEV_SHA256: >-
-          04d30fc34056467b91a627563c61b9a0046a2e084bb649791cd31887a6c76d8e
-        DAV1D_LIB_SHA256: >-
-          0c3debb3a926e10009503e639dddcfd4082ed6e012340ca49682b738c243dedc
-      run: |
-        echo "$LINK/libdav1d-dev_${DAV1D_VERSION}_amd64.deb" >> DEBS
-        echo "$LINK/libdav1d5_${DAV1D_VERSION}_amd64.deb" >> DEBS
-        echo "$DAV1D_DEV_SHA256 libdav1d-dev_${DAV1D_VERSION}_amd64.deb" >> CHECKSUMS
-        echo "$DAV1D_LIB_SHA256 libdav1d5_${DAV1D_VERSION}_amd64.deb" >> CHECKSUMS
-    - name: Cache packages
-      uses: actions/cache@v2
-      continue-on-error: true
-      id: debs
-      with:
-        path: ~/.cache/debs
-        key: debs-${{ hashFiles('CHECKSUMS') }}
-    - name: Fetch packages
-      if: steps.debs.outputs.cache-hit != 'true'
-      run: |
-        mkdir -p ~/.cache/debs
-        cp DEBS CHECKSUMS ~/.cache/debs
-        cd ~/.cache/debs
-        xargs -a DEBS curl --remote-name-all
-        sha256sum -c CHECKSUMS
-    - name: Install packages
-      run: |
-        sudo dpkg -i ~/.cache/debs/*.deb
-    - name: Install cargo-c
-      if: matrix.conf == 'cargo-c'
-      env:
-        LINK: https://github.com/lu-zero/cargo-c/releases/download
-        CARGO_C_VERSION: 0.7.1
-      run: |
-        curl -L "$LINK/v$CARGO_C_VERSION/cargo-c-linux.tar.gz" |
-        tar xz -C $HOME/.cargo/bin
-    - name: Install grcov
-      if: matrix.conf == 'grcov-coveralls'
-      env:
-        LINK: https://github.com/mozilla/grcov/releases/download
-        GRCOV_VERSION: 0.7.1
-      run: |
-        curl -L "$LINK/v$GRCOV_VERSION/grcov-linux-x86_64.tar.bz2" |
-        tar xj -C $HOME/.cargo/bin
-    - name: Install ${{ matrix.toolchain }}
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.toolchain }}
-        override: true
-    - name: Generate Cargo.lock and Cargo.version
-      run: |
-        cargo update
-        cargo --version > Cargo.version
-    - name: Cache cargo registry
-      uses: actions/cache@v2
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry/cache
-        key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
-    - name: Cache sccache output
-      uses: actions/cache@v2
-      continue-on-error: true
-      with:
-        path: /home/runner/.cache/sccache
-        key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.*') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.conf }}-sccache-
-    - name: Start sccache server
-      run: |
-        sccache --start-server
-    - name: Run 1.44.1 tests
-      if: matrix.toolchain == '1.44.1' && matrix.conf == '1.44.1-tests'
-      run: |
-        cargo test --workspace --verbose \
-                   --features=decode_test,decode_test_dav1d,quick_test,capi
-    - name: Run aom tests
-      if: matrix.toolchain == 'stable' && matrix.conf == 'aom-tests'
-      run: |
-        cargo test --workspace --verbose --release \
-                   --features=decode_test \
-                   --color=always -- --color=always --ignored
-    - name: Run dav1d tests
-      if: matrix.toolchain == 'stable' && (matrix.conf == 'dav1d-tests' || matrix.conf == 'no-asm-tests')
-      run: |
-        cargo test --workspace --verbose --release \
-                   --features=decode_test_dav1d \
-                   --color=always -- --color=always --ignored
-    - name: Run build
-      if: matrix.conf == 'beta-build'
-      run: |
-        cargo build --verbose
-    - name: Run bench
-      if: matrix.toolchain == 'stable' && matrix.conf == 'bench'
-      run: |
-        cargo bench --features=bench --no-run --verbose
-    - name: Run doc
-      if: matrix.toolchain == 'stable' && matrix.conf == 'doc'
-      run: |
-        cargo doc --verbose --no-deps
-    - name: Check no default features
-      if: matrix.toolchain == 'stable' && matrix.conf == 'check-no-default'
-      run: |
-        cargo check --no-default-features
-    - name: Check extra features
-      if: matrix.toolchain == 'stable' && matrix.conf == 'check-extra-feats'
-      run: |
-        cargo check --features=check_asm,capi,dump_lookahead_data,serialize
-    - name: Run cargo-c
-      if: matrix.conf == 'cargo-c'
-      run: |
-        cargo cbuild
-    - name: Install cargo-fuzz
-      if: matrix.conf == 'fuzz'
-      run: |
-        cargo install cargo-fuzz
-    - name: Run cargo-fuzz
-      if: matrix.conf == 'fuzz'
-      run: |
-        cargo fuzz build --sanitizer none
-    - name: Run cargo clean
-      if: matrix.conf == 'grcov-coveralls'
-      uses: actions-rs/cargo@v1
-      with:
-        command: clean
-    - name: Run tests with coverage
-      if: matrix.conf == 'grcov-coveralls'
-      env:
-        CARGO_INCREMENTAL: 0
-        RUSTC_BOOTSTRAP: 1
-        RUSTFLAGS: >
-          -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off
-          -Cpanic=abort -Zpanic_abort_tests
-        RUSTDOCFLAGS: >
-          -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off
-          -Cpanic=abort -Zpanic_abort_tests
-      run: |
-        cargo test --workspace --verbose --target x86_64-unknown-linux-gnu \
-                   --features=decode_test,decode_test_dav1d,quick_test
-    - name: Run unit tests
-      if: matrix.conf == 'no-asm-tests'
-      run: |
-        cargo test --workspace --verbose
-    - name: Run grcov
-      if: matrix.conf == 'grcov-coveralls'
-      id: coverage
-      uses: actions-rs/grcov@v0.1
-    - name: Stop sccache server
-      run: |
-        sccache --stop-server
-    - name: Coveralls upload
-      if: matrix.conf == 'grcov-coveralls'
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ${{ steps.coverage.outputs.report }}
+      - uses: actions/checkout@v2
+      - name: Set no-asm-tests env vars
+        if: matrix.conf == 'no-asm-tests'
+        run: |
+          echo "name=RAV1E_CPU_TARGET::rust" >> $GITHUB_ENV
+      - name: Install sccache
+        env:
+          LINK: https://github.com/mozilla/sccache/releases/download
+          SCCACHE_VERSION: 0.2.15
+        run: |
+          SCCACHE_FILE=sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl
+          mkdir -p $HOME/.local/bin
+          curl -L "$LINK/v$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          chmod +x $SCCACHE_FILE/sccache
+          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Add nasm
+        env:
+          LINK: http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm
+          NASM_VERSION: 2.15.05-1
+          NASM_SHA256: >-
+            c860caec653b865d5b83359452d97b11f1b3ba5b18b07cac554cf72550b3bfc9
+        run: |
+          echo "$LINK/nasm_${NASM_VERSION}_amd64.deb" >> DEBS
+          echo "$NASM_SHA256 nasm_${NASM_VERSION}_amd64.deb" >> CHECKSUMS
+      - name: Add aom
+        if: >
+          matrix.conf == '1.51.0-tests' || matrix.conf == 'aom-tests' ||
+          matrix.conf == 'grcov-coveralls'
+        env:
+          LINK: https://www.deb-multimedia.org/pool/main/a/aom-dmo
+          AOM_VERSION: 2.0.2-dmo0~bpo10+1
+          AOM_DEV_SHA256: >-
+            d31eee6524ea64c080312eeafc65355e378e043b1d738ff9b9bde3734a85779c
+          AOM_LIB_SHA256: >-
+            db8a04ca0984604f410c6bd8810ee31666a3bfd3964f3109cdb8f1ae33fec664
+        run: |
+          echo "$LINK/libaom-dev_${AOM_VERSION}_amd64.deb" >> DEBS
+          echo "$LINK/libaom2_${AOM_VERSION}_amd64.deb" >> DEBS
+          echo "$AOM_DEV_SHA256 libaom-dev_${AOM_VERSION}_amd64.deb" >> CHECKSUMS
+          echo "$AOM_LIB_SHA256 libaom2_${AOM_VERSION}_amd64.deb" >> CHECKSUMS
+      - name: Add dav1d
+        if: >
+          matrix.conf == '1.51.0-tests' || matrix.conf == 'dav1d-tests' ||
+          matrix.conf == 'grcov-coveralls' || matrix.conf == 'fuzz' || matrix.conf == 'no-asm-tests'
+        env:
+          LINK: https://www.deb-multimedia.org/pool/main/d/dav1d-dmo
+          DAV1D_VERSION: 0.8.2-dmo1
+          DAV1D_DEV_SHA256: >-
+            04d30fc34056467b91a627563c61b9a0046a2e084bb649791cd31887a6c76d8e
+          DAV1D_LIB_SHA256: >-
+            0c3debb3a926e10009503e639dddcfd4082ed6e012340ca49682b738c243dedc
+        run: |
+          echo "$LINK/libdav1d-dev_${DAV1D_VERSION}_amd64.deb" >> DEBS
+          echo "$LINK/libdav1d5_${DAV1D_VERSION}_amd64.deb" >> DEBS
+          echo "$DAV1D_DEV_SHA256 libdav1d-dev_${DAV1D_VERSION}_amd64.deb" >> CHECKSUMS
+          echo "$DAV1D_LIB_SHA256 libdav1d5_${DAV1D_VERSION}_amd64.deb" >> CHECKSUMS
+      - name: Cache packages
+        uses: actions/cache@v2
+        continue-on-error: true
+        id: debs
+        with:
+          path: ~/.cache/debs
+          key: debs-${{ hashFiles('CHECKSUMS') }}
+      - name: Fetch packages
+        if: steps.debs.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.cache/debs
+          cp DEBS CHECKSUMS ~/.cache/debs
+          cd ~/.cache/debs
+          xargs -a DEBS curl --remote-name-all
+          sha256sum -c CHECKSUMS
+      - name: Install packages
+        run: |
+          sudo dpkg -i ~/.cache/debs/*.deb
+      - name: Install cargo-c
+        if: matrix.conf == 'cargo-c'
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/download
+          CARGO_C_VERSION: 0.7.1
+        run: |
+          curl -L "$LINK/v$CARGO_C_VERSION/cargo-c-linux.tar.gz" |
+          tar xz -C $HOME/.cargo/bin
+      - name: Install grcov
+        if: matrix.conf == 'grcov-coveralls'
+        env:
+          LINK: https://github.com/mozilla/grcov/releases/download
+          GRCOV_VERSION: 0.7.1
+        run: |
+          curl -L "$LINK/v$GRCOV_VERSION/grcov-linux-x86_64.tar.bz2" |
+          tar xj -C $HOME/.cargo/bin
+      - name: Install ${{ matrix.toolchain }}
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+      - name: Generate Cargo.lock and Cargo.version
+        run: |
+          cargo update
+          cargo --version > Cargo.version
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        continue-on-error: true
+        with:
+          path: ~/.cargo/registry/cache
+          key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
+      - name: Cache sccache output
+        uses: actions/cache@v2
+        continue-on-error: true
+        with:
+          path: /home/runner/.cache/sccache
+          key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.*') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.conf }}-sccache-
+      - name: Start sccache server
+        run: |
+          sccache --start-server
+      - name: Run 1.51.0 tests
+        if: matrix.toolchain == '1.51.0' && matrix.conf == '1.51.0-tests'
+        run: |
+          cargo test --workspace --verbose \
+                     --features=decode_test,decode_test_dav1d,quick_test,capi
+      - name: Run aom tests
+        if: matrix.toolchain == 'stable' && matrix.conf == 'aom-tests'
+        run: |
+          cargo test --workspace --verbose --release \
+                     --features=decode_test \
+                     --color=always -- --color=always --ignored
+      - name: Run dav1d tests
+        if: matrix.toolchain == 'stable' && (matrix.conf == 'dav1d-tests' || matrix.conf == 'no-asm-tests')
+        run: |
+          cargo test --workspace --verbose --release \
+                     --features=decode_test_dav1d \
+                     --color=always -- --color=always --ignored
+      - name: Run build
+        if: matrix.conf == 'beta-build'
+        run: |
+          cargo build --verbose
+      - name: Run bench
+        if: matrix.toolchain == 'stable' && matrix.conf == 'bench'
+        run: |
+          cargo bench --features=bench --no-run --verbose
+      - name: Run doc
+        if: matrix.toolchain == 'stable' && matrix.conf == 'doc'
+        run: |
+          cargo doc --verbose --no-deps
+      - name: Check no default features
+        if: matrix.toolchain == 'stable' && matrix.conf == 'check-no-default'
+        run: |
+          cargo check --no-default-features
+      - name: Check extra features
+        if: matrix.toolchain == 'stable' && matrix.conf == 'check-extra-feats'
+        run: |
+          cargo check --features=check_asm,capi,dump_lookahead_data,serialize
+      - name: Run cargo-c
+        if: matrix.conf == 'cargo-c'
+        run: |
+          cargo cbuild
+      - name: Install cargo-fuzz
+        if: matrix.conf == 'fuzz'
+        run: |
+          cargo install cargo-fuzz
+      - name: Run cargo-fuzz
+        if: matrix.conf == 'fuzz'
+        run: |
+          cargo fuzz build --sanitizer none
+      - name: Run cargo clean
+        if: matrix.conf == 'grcov-coveralls'
+        uses: actions-rs/cargo@v1
+        with:
+          command: clean
+      - name: Run tests with coverage
+        if: matrix.conf == 'grcov-coveralls'
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTC_BOOTSTRAP: 1
+          RUSTFLAGS: >
+            -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off
+            -Cpanic=abort -Zpanic_abort_tests
+          RUSTDOCFLAGS: >
+            -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off
+            -Cpanic=abort -Zpanic_abort_tests
+        run: |
+          cargo test --workspace --verbose --target x86_64-unknown-linux-gnu \
+                     --features=decode_test,decode_test_dav1d,quick_test
+      - name: Run unit tests
+        if: matrix.conf == 'no-asm-tests'
+        run: |
+          cargo test --workspace --verbose
+      - name: Run grcov
+        if: matrix.conf == 'grcov-coveralls'
+        id: coverage
+        uses: actions-rs/grcov@v0.1
+      - name: Stop sccache server
+        run: |
+          sccache --stop-server
+      - name: Coveralls upload
+        if: matrix.conf == 'grcov-coveralls'
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ${{ steps.coverage.outputs.report }}
 
   build-macos:
-
     strategy:
       matrix:
         include:
@@ -328,82 +325,82 @@ jobs:
       SCCACHE_DIR: /Users/runner/Library/Caches/Mozilla.sccache
 
     if: >-
-     (github.event_name == 'push' && !endsWith(github.event.head_commit.message, 'CI: skip')) ||
-     (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.names, 'skip-ci'))
+      (github.event_name == 'push' && !endsWith(github.event.head_commit.message, 'CI: skip')) ||
+      (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.names, 'skip-ci'))
 
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install sccache
-      run: |
-        brew install sccache
-    - name: Install nasm
-      run: |
-        brew install nasm
-    - name: Install cargo-c
-      if: matrix.conf == 'cargo-c'
-      run: |
-        brew install cargo-c
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.toolchain }}
-        override: true
-        target: ${{ matrix.target }}
-        default: true
-    - name: Generate Cargo.lock and Cargo.version
-      run: |
-        cargo update
-        cargo --version > Cargo.version
-    - name: Cache cargo registry
-      uses: actions/cache@v2
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry/cache
-        key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
-    - name: Cache sccache output
-      uses: actions/cache@v2
-      continue-on-error: true
-      with:
-        path: /Users/runner/Library/Caches/Mozilla.sccache
-        key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.*') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.conf }}-sccache-
-    - name: Start sccache server
-      run: |
-        sccache --start-server
-    - name: Build
-      if: matrix.conf == 'cargo-build'
-      run: |
-        cargo build --release --target=${{ matrix.target }}
-    - name: Test
-      if: matrix.conf == 'cargo-test'
-      run: |
-        cargo test --workspace --verbose --target=${{ matrix.target }}
-    - name: Run cargo-c
-      if: matrix.conf == 'cargo-c'
-      run: |
-        cargo cbuild --target=${{ matrix.target }}
-    - name: Stop sccache server
-      run: |
-        sccache --stop-server
+      - uses: actions/checkout@v2
+      - name: Install sccache
+        run: |
+          brew install sccache
+      - name: Install nasm
+        run: |
+          brew install nasm
+      - name: Install cargo-c
+        if: matrix.conf == 'cargo-c'
+        run: |
+          brew install cargo-c
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+          target: ${{ matrix.target }}
+          default: true
+      - name: Generate Cargo.lock and Cargo.version
+        run: |
+          cargo update
+          cargo --version > Cargo.version
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        continue-on-error: true
+        with:
+          path: ~/.cargo/registry/cache
+          key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
+      - name: Cache sccache output
+        uses: actions/cache@v2
+        continue-on-error: true
+        with:
+          path: /Users/runner/Library/Caches/Mozilla.sccache
+          key: ${{ runner.os }}-${{ matrix.conf }}-sccache-${{ hashFiles('**/Cargo.*') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.conf }}-sccache-
+      - name: Start sccache server
+        run: |
+          sccache --start-server
+      - name: Build
+        if: matrix.conf == 'cargo-build'
+        run: |
+          cargo build --release --target=${{ matrix.target }}
+      - name: Test
+        if: matrix.conf == 'cargo-test'
+        run: |
+          cargo test --workspace --verbose --target=${{ matrix.target }}
+      - name: Run cargo-c
+        if: matrix.conf == 'cargo-c'
+        run: |
+          cargo cbuild --target=${{ matrix.target }}
+      - name: Stop sccache server
+        run: |
+          sccache --stop-server
 
   build-windows:
     strategy:
       matrix:
         include:
-         - conf: cargo-build
-           target: x86_64-pc-windows-msvc
-         - conf: cargo-build
-           target: aarch64-pc-windows-msvc
-         - conf: cargo-test
-           target: x86_64-pc-windows-msvc
-         - conf: cargo-c
-           target: x86_64-pc-windows-gnu
+          - conf: cargo-build
+            target: x86_64-pc-windows-msvc
+          - conf: cargo-build
+            target: aarch64-pc-windows-msvc
+          - conf: cargo-test
+            target: x86_64-pc-windows-msvc
+          - conf: cargo-c
+            target: x86_64-pc-windows-gnu
 
     env:
       RUST_BACKTRACE: full
@@ -412,84 +409,83 @@ jobs:
       SCCACHE_DIR: C:\sccache
 
     if: >-
-     (github.event_name == 'push' && !endsWith(github.event.head_commit.message, 'CI: skip')) ||
-     (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.names, 'skip-ci'))
+      (github.event_name == 'push' && !endsWith(github.event.head_commit.message, 'CI: skip')) ||
+      (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.names, 'skip-ci'))
     runs-on: windows-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - uses: ilammy/setup-nasm@v1
-    - name: Install sccache
-      run: |
-        $LINK = "https://github.com/mozilla/sccache/releases/download/0.2.12"
-        $SCCACHE_FILE = "sccache-0.2.12-x86_64-pc-windows-msvc"
-        curl -LO "$LINK/$SCCACHE_FILE.tar.gz"
-        tar xzf "$SCCACHE_FILE.tar.gz"
-        echo "$Env:GITHUB_WORKSPACE/$SCCACHE_FILE" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    - name: Set MSVC x86_64 linker path
-      if: matrix.target != 'aarch64-pc-windows-msvc'
-      run: |
-        $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
-        $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
-        $LinkPath = vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1
-        echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    - name: Set MSVC Arm64 linker path
-      if: matrix.target == 'aarch64-pc-windows-msvc'
-      run: |
-        $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\Arm64"
-        $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
-        $LinkPath = vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1
-        echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    - name: Install ${{ matrix.toolchain }}
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        target: ${{ matrix.target }}
-        override: true
-        default: true
-    - name: Install cargo-c
-      if: matrix.conf == 'cargo-c'
-      run: |
-        $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.7.3"
-        $CARGO_C_FILE = "cargo-c-windows-msvc"
-        curl -LO "$LINK/$CARGO_C_FILE.zip"
-        7z e -y "$CARGO_C_FILE.zip" -o"${env:USERPROFILE}\.cargo\bin"
-    - name: Generate Cargo.lock and Cargo.version
-      run: |
-        cargo update
-        cargo --version > Cargo.version
-    - name: Cache cargo registry
-      uses: actions/cache@v2
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry/cache
-        key: ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-cargo-registry-
-    - name: Cache sccache output
-      uses: actions/cache@v2
-      continue-on-error: true
-      with:
-        path: C:\sccache
-        key: ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-sccache-${{ hashFiles('**/Cargo.*') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-sccache-
-    - name: Start sccache server
-      run: |
-        sccache --start-server
-    - name: Build
-      if: matrix.conf == 'cargo-build'
-      run: |
-        cargo build --release
-    - name: Test
-      if: matrix.conf == 'cargo-test'
-      run: |
-        cargo test --workspace --verbose
-    - name: Run cargo-c
-      if: matrix.conf == 'cargo-c'
-      run: |
-        cargo cbuild
-    - name: Stop sccache server
-      run: |
-        sccache --stop-server
+      - uses: actions/checkout@v2
+      - uses: ilammy/setup-nasm@v1
+      - name: Install sccache
+        run: |
+          $LINK = "https://github.com/mozilla/sccache/releases/download/0.2.12"
+          $SCCACHE_FILE = "sccache-0.2.12-x86_64-pc-windows-msvc"
+          curl -LO "$LINK/$SCCACHE_FILE.tar.gz"
+          tar xzf "$SCCACHE_FILE.tar.gz"
+          echo "$Env:GITHUB_WORKSPACE/$SCCACHE_FILE" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Set MSVC x86_64 linker path
+        if: matrix.target != 'aarch64-pc-windows-msvc'
+        run: |
+          $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
+          $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+          $LinkPath = vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1
+          echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Set MSVC Arm64 linker path
+        if: matrix.target == 'aarch64-pc-windows-msvc'
+        run: |
+          $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\Arm64"
+          $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+          $LinkPath = vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1
+          echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install ${{ matrix.toolchain }}
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+          default: true
+      - name: Install cargo-c
+        if: matrix.conf == 'cargo-c'
+        run: |
+          $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.7.3"
+          $CARGO_C_FILE = "cargo-c-windows-msvc"
+          curl -LO "$LINK/$CARGO_C_FILE.zip"
+          7z e -y "$CARGO_C_FILE.zip" -o"${env:USERPROFILE}\.cargo\bin"
+      - name: Generate Cargo.lock and Cargo.version
+        run: |
+          cargo update
+          cargo --version > Cargo.version
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        continue-on-error: true
+        with:
+          path: ~/.cargo/registry/cache
+          key: ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-cargo-registry-
+      - name: Cache sccache output
+        uses: actions/cache@v2
+        continue-on-error: true
+        with:
+          path: C:\sccache
+          key: ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-sccache-${{ hashFiles('**/Cargo.*') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.conf }}-${{ matrix.target }}-sccache-
+      - name: Start sccache server
+        run: |
+          sccache --start-server
+      - name: Build
+        if: matrix.conf == 'cargo-build'
+        run: |
+          cargo build --release
+      - name: Test
+        if: matrix.conf == 'cargo-test'
+        run: |
+          cargo test --workspace --verbose
+      - name: Run cargo-c
+        if: matrix.conf == 'cargo-c'
+        run: |
+          cargo cbuild
+      - name: Stop sccache server
+        run: |
+          sccache --stop-server

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ av-metrics = { version = "0.6.2", optional = true, default-features = false }
 rayon = "1.0"
 crossbeam = { version = "0.8", optional = true }
 toml = { version = "0.5", optional = true }
-arrayvec = { version = "0.5", features = ["array-sizes-33-128"] }
+arrayvec = "0.6"
 thiserror = "1.0"
 byteorder = { version = "1.3.2", optional = true }
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ For the foreseeable future, a weekly pre-release of rav1e will be [published](ht
 ## Building
 
 ### Toolchain: Rust
-rav1e currently requires Rust 1.44.1 or later to build.
+
+rav1e currently requires Rust 1.51.0 or later to build.
 
 ### Dependency: NASM
 Some `x86_64`-specific optimizations require [NASM](https://nasm.us/) `2.14.02` or newer and are enabled by default.

--- a/build.rs
+++ b/build.rs
@@ -180,7 +180,7 @@ fn build_asm_files() {
 fn rustc_version_check() {
   // This should match the version in the CI
   // Make sure to updated README.md when this changes.
-  const REQUIRED_VERSION: &str = "1.44.1";
+  const REQUIRED_VERSION: &str = "1.51.0";
   if version().unwrap() < Version::parse(REQUIRED_VERSION).unwrap() {
     eprintln!("rav1e requires rustc >= {}.", REQUIRED_VERSION);
     exit(1);

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -998,7 +998,7 @@ impl<T: Pixel> ContextInner<T> {
       let frame = self.frame_q[&fi.input_frameno].as_ref().unwrap();
 
       // There can be at most 3 of these.
-      let mut unique_indices = ArrayVec::<[_; 3]>::new();
+      let mut unique_indices = ArrayVec::<_, 3>::new();
 
       for (mv_index, &rec_index) in fi.ref_frames.iter().enumerate() {
         if unique_indices.iter().find(|&&(_, r)| r == rec_index).is_none() {

--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -807,7 +807,7 @@ impl<'a> ContextWriter<'a> {
   }
 
   fn find_matching_mv(
-    mv: MotionVector, mv_stack: &mut ArrayVec<[CandidateMV; 9]>,
+    mv: MotionVector, mv_stack: &mut ArrayVec<CandidateMV, 9>,
   ) -> bool {
     for mv_cand in mv_stack {
       if mv.row == mv_cand.this_mv.row && mv.col == mv_cand.this_mv.col {
@@ -818,7 +818,7 @@ impl<'a> ContextWriter<'a> {
   }
 
   fn find_matching_mv_and_update_weight(
-    mv: MotionVector, mv_stack: &mut ArrayVec<[CandidateMV; 9]>, weight: u32,
+    mv: MotionVector, mv_stack: &mut ArrayVec<CandidateMV, 9>, weight: u32,
   ) -> bool {
     for mut mv_cand in mv_stack {
       if mv.row == mv_cand.this_mv.row && mv.col == mv_cand.this_mv.col {
@@ -830,7 +830,7 @@ impl<'a> ContextWriter<'a> {
   }
 
   fn find_matching_comp_mv_and_update_weight(
-    mvs: [MotionVector; 2], mv_stack: &mut ArrayVec<[CandidateMV; 9]>,
+    mvs: [MotionVector; 2], mv_stack: &mut ArrayVec<CandidateMV, 9>,
     weight: u32,
   ) -> bool {
     for mv_cand in mv_stack {
@@ -848,7 +848,7 @@ impl<'a> ContextWriter<'a> {
 
   fn add_ref_mv_candidate(
     ref_frames: [RefType; 2], blk: &Block,
-    mv_stack: &mut ArrayVec<[CandidateMV; 9]>, weight: u32,
+    mv_stack: &mut ArrayVec<CandidateMV, 9>, weight: u32,
     newmv_count: &mut usize, is_compound: bool,
   ) -> bool {
     if !blk.is_inter() {
@@ -908,7 +908,7 @@ impl<'a> ContextWriter<'a> {
 
   fn add_extra_mv_candidate<T: Pixel>(
     blk: &Block, ref_frames: [RefType; 2],
-    mv_stack: &mut ArrayVec<[CandidateMV; 9]>, fi: &FrameInvariants<T>,
+    mv_stack: &mut ArrayVec<CandidateMV, 9>, fi: &FrameInvariants<T>,
     is_compound: bool, ref_id_count: &mut [usize; 2],
     ref_id_mvs: &mut [[MotionVector; 2]; 2], ref_diff_count: &mut [usize; 2],
     ref_diff_mvs: &mut [[MotionVector; 2]; 2],
@@ -963,7 +963,7 @@ impl<'a> ContextWriter<'a> {
   fn scan_row_mbmi(
     &self, bo: TileBlockOffset, row_offset: isize, max_row_offs: isize,
     processed_rows: &mut isize, ref_frames: [RefType; 2],
-    mv_stack: &mut ArrayVec<[CandidateMV; 9]>, newmv_count: &mut usize,
+    mv_stack: &mut ArrayVec<CandidateMV, 9>, newmv_count: &mut usize,
     bsize: BlockSize, is_compound: bool,
   ) -> bool {
     let bc = &self.bc;
@@ -1029,7 +1029,7 @@ impl<'a> ContextWriter<'a> {
   fn scan_col_mbmi(
     &self, bo: TileBlockOffset, col_offset: isize, max_col_offs: isize,
     processed_cols: &mut isize, ref_frames: [RefType; 2],
-    mv_stack: &mut ArrayVec<[CandidateMV; 9]>, newmv_count: &mut usize,
+    mv_stack: &mut ArrayVec<CandidateMV, 9>, newmv_count: &mut usize,
     bsize: BlockSize, is_compound: bool,
   ) -> bool {
     let bc = &self.bc;
@@ -1094,7 +1094,7 @@ impl<'a> ContextWriter<'a> {
 
   fn scan_blk_mbmi(
     &self, bo: TileBlockOffset, ref_frames: [RefType; 2],
-    mv_stack: &mut ArrayVec<[CandidateMV; 9]>, newmv_count: &mut usize,
+    mv_stack: &mut ArrayVec<CandidateMV, 9>, newmv_count: &mut usize,
     is_compound: bool,
   ) -> bool {
     if bo.0.x >= self.bc.blocks.cols() || bo.0.y >= self.bc.blocks.rows() {
@@ -1113,7 +1113,7 @@ impl<'a> ContextWriter<'a> {
     )
   }
 
-  fn add_offset(mv_stack: &mut ArrayVec<[CandidateMV; 9]>) {
+  fn add_offset(mv_stack: &mut ArrayVec<CandidateMV, 9>) {
     for mut cand_mv in mv_stack {
       cand_mv.weight += REF_CAT_LEVEL;
     }
@@ -1121,7 +1121,7 @@ impl<'a> ContextWriter<'a> {
 
   fn setup_mvref_list<T: Pixel>(
     &self, bo: TileBlockOffset, ref_frames: [RefType; 2],
-    mv_stack: &mut ArrayVec<[CandidateMV; 9]>, bsize: BlockSize,
+    mv_stack: &mut ArrayVec<CandidateMV, 9>, bsize: BlockSize,
     fi: &FrameInvariants<T>, is_compound: bool,
   ) -> usize {
     let (_rf, _rf_num) = (INTRA_FRAME, 1);
@@ -1417,7 +1417,7 @@ impl<'a> ContextWriter<'a> {
 
   pub fn find_mvrefs<T: Pixel>(
     &self, bo: TileBlockOffset, ref_frames: [RefType; 2],
-    mv_stack: &mut ArrayVec<[CandidateMV; 9]>, bsize: BlockSize,
+    mv_stack: &mut ArrayVec<CandidateMV, 9>, bsize: BlockSize,
     fi: &FrameInvariants<T>, is_compound: bool,
   ) -> usize {
     assert!(ref_frames[0] != NONE_FRAME);
@@ -1789,7 +1789,7 @@ impl<'a> ContextWriter<'a> {
     let height = av1_get_coded_tx_size(tx_size).height();
 
     // Create a slice with coeffs in scan order
-    let mut coeffs_storage: Aligned<ArrayVec<[T; 32 * 32]>> =
+    let mut coeffs_storage: Aligned<ArrayVec<T, { 32 * 32 }>> =
       Aligned::new(ArrayVec::new());
     let coeffs = &mut coeffs_storage.data;
     coeffs.extend(scan.iter().map(|&scan_idx| coeffs_in[scan_idx as usize]));

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2304,7 +2304,7 @@ pub fn encode_block_with_modes<T: Pixel>(
   // rdo_tx_size_type().
   cw.bc.blocks.set_segmentation_idx(tile_bo, bsize, mode_decision.sidx);
 
-  let mut mv_stack = ArrayVec::<[CandidateMV; 9]>::new();
+  let mut mv_stack = ArrayVec::<CandidateMV, 9>::new();
   let is_compound = ref_frames[1] != NONE_FRAME;
   let mode_context =
     cw.find_mvrefs(tile_bo, ref_frames, &mut mv_stack, bsize, fi, is_compound);
@@ -2453,7 +2453,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
   if can_split {
     debug_assert!(is_square);
 
-    let mut partition_types = ArrayVec::<[PartitionType; 3]>::new();
+    let mut partition_types = ArrayVec::<PartitionType, 3>::new();
     if fi.config.speed_settings.non_square_partition
       || is_straddle_x
       || is_straddle_y
@@ -2490,7 +2490,7 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
       let subsize = bsize.subsize(partition);
       let hbsw = subsize.width_mi(); // Half the block size width in blocks
       let hbsh = subsize.height_mi(); // Half the block size height in blocks
-      let mut child_modes = ArrayVec::<[PartitionParameters; 4]>::new();
+      let mut child_modes = ArrayVec::<PartitionParameters, 4>::new();
       rd_cost = 0.0;
 
       if bsize >= BlockSize::BLOCK_8X8 {
@@ -2681,7 +2681,7 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
   } else if can_split {
     debug_assert!(bsize.is_sqr());
     // Blocks of sizes within the supported range are subjected to a partitioning decision
-    let mut partition_types = ArrayVec::<[PartitionType; 3]>::new();
+    let mut partition_types = ArrayVec::<PartitionType, 3>::new();
 
     partition_types.push(PartitionType::PARTITION_SPLIT);
     if !must_split {
@@ -2749,7 +2749,7 @@ fn encode_partition_topdown<T: Pixel, W: Writer>(
         fi, ts, cw, bsize, tile_bo, mode_luma, ref_frames, mvs, skip,
       );
 
-      let mut mv_stack = ArrayVec::<[CandidateMV; 9]>::new();
+      let mut mv_stack = ArrayVec::<CandidateMV, 9>::new();
       let is_compound = ref_frames[1] != NONE_FRAME;
       let mode_context = cw.find_mvrefs(
         tile_bo,

--- a/src/me.rs
+++ b/src/me.rs
@@ -63,7 +63,7 @@ impl FrameMEStats {
   pub fn new_arc_array(cols: usize, rows: usize) -> Arc<[Self; REF_FRAMES]> {
     let stats = (0..REF_FRAMES)
       .map(|_| FrameMEStats::new(cols, rows))
-      .collect::<ArrayVec<[_; REF_FRAMES]>>()
+      .collect::<ArrayVec<_, REF_FRAMES>>()
       .into_inner()
       .unwrap();
     Arc::new(stats)
@@ -274,12 +274,12 @@ fn get_mv_range(
 struct MotionEstimationSubsets {
   min_sad: u32,
   median: Option<MotionVector>,
-  subset_b: ArrayVec<[MotionVector; 5]>,
-  subset_c: ArrayVec<[MotionVector; 5]>,
+  subset_b: ArrayVec<MotionVector, 5>,
+  subset_c: ArrayVec<MotionVector, 5>,
 }
 
 impl MotionEstimationSubsets {
-  fn all_mvs(&self) -> ArrayVec<[MotionVector; 11]> {
+  fn all_mvs(&self) -> ArrayVec<MotionVector, 11> {
     let mut all = ArrayVec::new();
     if let Some(median) = self.median {
       all.push(median);
@@ -302,8 +302,8 @@ fn get_subset_predictors<T: Pixel>(
   let ssdec = conf.ssdec;
 
   let mut min_sad: u32 = u32::MAX;
-  let mut subset_b = ArrayVec::<[MotionVector; 5]>::new();
-  let mut subset_c = ArrayVec::<[MotionVector; 5]>::new();
+  let mut subset_b = ArrayVec::<MotionVector, 5>::new();
+  let mut subset_c = ArrayVec::<MotionVector, 5>::new();
   let w = bsize.width_mi() << ssdec;
   let h = bsize.height_mi() << ssdec;
 
@@ -369,10 +369,8 @@ fn get_subset_predictors<T: Pixel>(
   } else if subset_b.len() != 3 {
     None
   } else {
-    let mut rows: ArrayVec<[i16; 3]> =
-      subset_b.iter().map(|&a| a.row).collect();
-    let mut cols: ArrayVec<[i16; 3]> =
-      subset_b.iter().map(|&a| a.col).collect();
+    let mut rows: ArrayVec<i16, 3> = subset_b.iter().map(|&a| a.row).collect();
+    let mut cols: ArrayVec<i16, 3> = subset_b.iter().map(|&a| a.col).collect();
     rows.as_mut_slice().sort_unstable();
     cols.as_mut_slice().sort_unstable();
     Some(MotionVector { row: rows[1], col: cols[1] })

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -97,7 +97,7 @@ pub fn select_segment<T: Pixel>(
   let scale = spatiotemporal_scale(fi, frame_bo, bsize);
 
   // TODO: Replace this calculation with precomputed scale thresholds.
-  let seg_ac_q: ArrayVec<[_; 3]> = if fi.enable_segmentation {
+  let seg_ac_q: ArrayVec<_, 3> = if fi.enable_segmentation {
     use crate::quantize::ac_q;
     (0..=2)
       .map(|sidx| {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -23,9 +23,9 @@ pub struct EncoderStats {
   /// Stores count of pixels belonging to each transform type in this frame
   pub tx_type_counts: [usize; TX_TYPES],
   /// Stores count of pixels belonging to each luma prediction mode in this frame
-  pub luma_pred_mode_counts: ArrayVec<[usize; PREDICTION_MODES]>,
+  pub luma_pred_mode_counts: ArrayVec<usize, PREDICTION_MODES>,
   /// Stores count of pixels belonging to each chroma prediction mode in this frame
-  pub chroma_pred_mode_counts: ArrayVec<[usize; PREDICTION_MODES]>,
+  pub chroma_pred_mode_counts: ArrayVec<usize, PREDICTION_MODES>,
 }
 
 impl Default for EncoderStats {


### PR DESCRIPTION
This is the const generics release of arrayvec. It seems to give about a 1.5% global encode speed improvement. However, it requires a minimum of Rust 1.51.

Before merging:
- [x] Update AWCY to Rust 1.51