### PR TITLE
Bump arrayvec to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ av-metrics = { version = "0.6.2", optional = true, default-features = false }
 rayon = "1.0"
 crossbeam = { version = "0.8", optional = true }
 toml = { version = "0.5", optional = true }
-arrayvec = "0.6"
+arrayvec = "0.7"
 thiserror = "1.0"
 byteorder = { version = "1.3.2", optional = true }
 log = "0.4"


### PR DESCRIPTION
tl;dr they released arrayvec 0.6.1 making `new` a const fn, but that led to performance regressions so they reverted it, which was a breaking change.