### PR TITLE
Use compile-time generics instead of dyn dispatch for writers

### DIFF
--- a/src/context/frame_header.rs
+++ b/src/context/frame_header.rs
@@ -11,9 +11,9 @@ use super::*;
 
 impl CDFContext {
   // rather than test writing and rolling back the cdf, we just count Q8 bits using the current cdf
-  pub fn count_lrf_switchable(
-    &self, w: &dyn Writer, rs: &TileRestorationState,
-    filter: RestorationFilter, pli: usize,
+  pub fn count_lrf_switchable<W: Writer>(
+    &self, w: &W, rs: &TileRestorationState, filter: RestorationFilter,
+    pli: usize,
   ) -> u32 {
     match filter {
       RestorationFilter::None => w.symbol_bits(0, &self.lrf_switchable_cdf),
@@ -61,9 +61,8 @@ impl<'a> ContextWriter<'a> {
     ContextWriter::ref_count_ctx(fwd_cnt, bwd_cnt)
   }
 
-  pub fn write_ref_frames<T: Pixel>(
-    &mut self, w: &mut dyn Writer, fi: &FrameInvariants<T>,
-    bo: TileBlockOffset,
+  pub fn write_ref_frames<T: Pixel, W: Writer>(
+    &mut self, w: &mut W, fi: &FrameInvariants<T>, bo: TileBlockOffset,
   ) {
     let rf = self.bc.blocks[bo].ref_frames;
     let sz = self.bc.blocks[bo].n4_w.min(self.bc.blocks[bo].n4_h);
@@ -156,15 +155,15 @@ impl<'a> ContextWriter<'a> {
     }
   }
 
-  pub fn count_lrf_switchable(
-    &self, w: &dyn Writer, rs: &TileRestorationState,
-    filter: RestorationFilter, pli: usize,
+  pub fn count_lrf_switchable<W: Writer>(
+    &self, w: &W, rs: &TileRestorationState, filter: RestorationFilter,
+    pli: usize,
   ) -> u32 {
     self.fc.count_lrf_switchable(w, rs, filter, pli)
   }
 
-  pub fn write_lrf<T: Pixel>(
-    &mut self, w: &mut dyn Writer, fi: &FrameInvariants<T>,
+  pub fn write_lrf<T: Pixel, W: Writer>(
+    &mut self, w: &mut W, fi: &FrameInvariants<T>,
     rs: &mut TileRestorationStateMut, sbo: TileSuperBlockOffset, pli: usize,
   ) {
     if !fi.allow_intrabc {
@@ -266,8 +265,8 @@ impl<'a> ContextWriter<'a> {
     }
   }
 
-  pub fn write_cdef(
-    &mut self, w: &mut dyn Writer, strength_index: u8, bits: u8,
+  pub fn write_cdef<W: Writer>(
+    &mut self, w: &mut W, strength_index: u8, bits: u8,
   ) {
     w.literal(bits, strength_index as u32);
   }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -184,9 +184,8 @@ pub fn get_mv_class(z: u32, offset: &mut u32) -> usize {
 }
 
 impl<'a> ContextWriter<'a> {
-  pub fn encode_mv_component(
-    &mut self, w: &mut dyn Writer, comp: i32, axis: usize,
-    precision: MvSubpelPrecision,
+  pub fn encode_mv_component<W: Writer>(
+    &mut self, w: &mut W, comp: i32, axis: usize, precision: MvSubpelPrecision,
   ) {
     assert!(comp != 0);
     assert!(MV_LOW <= comp && comp <= MV_UPP);

--- a/src/context/partition_unit.rs
+++ b/src/context/partition_unit.rs
@@ -232,8 +232,8 @@ impl<'a> ContextWriter<'a> {
   }
 
   #[inline]
-  pub fn write_skip(
-    &mut self, w: &mut dyn Writer, bo: TileBlockOffset, skip: bool,
+  pub fn write_skip<W: Writer>(
+    &mut self, w: &mut W, bo: TileBlockOffset, skip: bool,
   ) {
     let ctx = self.bc.skip_context(bo);
     let cdf = &mut self.fc.skip_cdfs[ctx];
@@ -282,7 +282,7 @@ impl<'a> ContextWriter<'a> {
     (r as u8, cdf_index)
   }
 
-  pub fn write_cfl_alphas(&mut self, w: &mut dyn Writer, cfl: CFLParams) {
+  pub fn write_cfl_alphas<W: Writer>(&mut self, w: &mut W, cfl: CFLParams) {
     symbol_with_update!(self, w, cfl.joint_sign(), &mut self.fc.cfl_sign_cdf);
     for uv in 0..2 {
       if cfl.sign[uv] != CFL_SIGN_ZERO {
@@ -417,9 +417,9 @@ impl<'a> ContextWriter<'a> {
     }
   }
 
-  pub fn write_segmentation(
-    &mut self, w: &mut dyn Writer, bo: TileBlockOffset, bsize: BlockSize,
-    skip: bool, last_active_segid: u8,
+  pub fn write_segmentation<W: Writer>(
+    &mut self, w: &mut W, bo: TileBlockOffset, bsize: BlockSize, skip: bool,
+    last_active_segid: u8,
   ) {
     let (pred, cdf_index) = self.get_segment_pred(bo);
     if skip {

--- a/src/context/transform_unit.rs
+++ b/src/context/transform_unit.rs
@@ -523,8 +523,8 @@ pub struct TXB_CTX {
 }
 
 impl<'a> ContextWriter<'a> {
-  pub fn write_tx_type(
-    &mut self, w: &mut dyn Writer, tx_size: TxSize, tx_type: TxType,
+  pub fn write_tx_type<W: Writer>(
+    &mut self, w: &mut W, tx_size: TxSize, tx_type: TxType,
     y_mode: PredictionMode, is_inter: bool, use_reduced_tx_set: bool,
   ) {
     let square_tx_size = tx_size.sqr();
@@ -604,8 +604,8 @@ impl<'a> ContextWriter<'a> {
     0
   }
 
-  pub fn write_tx_size_intra(
-    &mut self, w: &mut dyn Writer, bo: TileBlockOffset, bsize: BlockSize,
+  pub fn write_tx_size_intra<W: Writer>(
+    &mut self, w: &mut W, bo: TileBlockOffset, bsize: BlockSize,
     tx_size: TxSize,
   ) {
     fn tx_size_to_depth(tx_size: TxSize, bsize: BlockSize) -> usize {
@@ -720,8 +720,8 @@ impl<'a> ContextWriter<'a> {
     category * 3 + above + left
   }
 
-  pub fn write_tx_size_inter(
-    &mut self, w: &mut dyn Writer, bo: TileBlockOffset, bsize: BlockSize,
+  pub fn write_tx_size_inter<W: Writer>(
+    &mut self, w: &mut W, bo: TileBlockOffset, bsize: BlockSize,
     tx_size: TxSize, txfm_split: bool, tbx: usize, tby: usize, depth: usize,
   ) {
     if bo.0.x >= self.bc.blocks.cols() || bo.0.y >= self.bc.blocks.rows() {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1081,11 +1081,11 @@ fn get_qidx<T: Pixel>(
 // For a transform block,
 // predict, transform, quantize, write coefficients to a bitstream,
 // dequantize, inverse-transform.
-pub fn encode_tx_block<T: Pixel>(
+pub fn encode_tx_block<T: Pixel, W: Writer>(
   fi: &FrameInvariants<T>,
   ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter,
-  w: &mut dyn Writer,
+  w: &mut W,
   p: usize,
   // Offset in the luma plane of the partition enclosing this block.
   tile_partition_bo: TileBlockOffset,
@@ -1556,9 +1556,9 @@ pub fn save_block_motion<T: Pixel>(
   }
 }
 
-pub fn encode_block_pre_cdef<T: Pixel>(
-  seq: &Sequence, ts: &TileStateMut<'_, T>, cw: &mut ContextWriter,
-  w: &mut dyn Writer, bsize: BlockSize, tile_bo: TileBlockOffset, skip: bool,
+pub fn encode_block_pre_cdef<T: Pixel, W: Writer>(
+  seq: &Sequence, ts: &TileStateMut<'_, T>, cw: &mut ContextWriter, w: &mut W,
+  bsize: BlockSize, tile_bo: TileBlockOffset, skip: bool,
 ) -> bool {
   cw.bc.blocks.set_skip(tile_bo, bsize, skip);
   if ts.segmentation.enabled
@@ -1592,9 +1592,9 @@ pub fn encode_block_pre_cdef<T: Pixel>(
   cw.bc.cdef_coded
 }
 
-pub fn encode_block_post_cdef<T: Pixel>(
+pub fn encode_block_post_cdef<T: Pixel, W: Writer>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
-  cw: &mut ContextWriter, w: &mut dyn Writer, luma_mode: PredictionMode,
+  cw: &mut ContextWriter, w: &mut W, luma_mode: PredictionMode,
   chroma_mode: PredictionMode, angle_delta: AngleDelta,
   ref_frames: [RefType; 2], mvs: [MotionVector; 2], bsize: BlockSize,
   tile_bo: TileBlockOffset, skip: bool, cfl: CFLParams, tx_size: TxSize,
@@ -1969,9 +1969,9 @@ pub fn luma_ac<T: Pixel>(
   }
 }
 
-pub fn write_tx_blocks<T: Pixel>(
+pub fn write_tx_blocks<T: Pixel, W: Writer>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
-  cw: &mut ContextWriter, w: &mut dyn Writer, luma_mode: PredictionMode,
+  cw: &mut ContextWriter, w: &mut W, luma_mode: PredictionMode,
   chroma_mode: PredictionMode, angle_delta: AngleDelta,
   tile_bo: TileBlockOffset, bsize: BlockSize, tx_size: TxSize,
   tx_type: TxType, skip: bool, cfl: CFLParams, luma_only: bool,
@@ -2129,9 +2129,9 @@ pub fn write_tx_blocks<T: Pixel>(
   (partition_has_coeff, tx_dist)
 }
 
-pub fn write_tx_tree<T: Pixel>(
+pub fn write_tx_tree<T: Pixel, W: Writer>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
-  cw: &mut ContextWriter, w: &mut dyn Writer, luma_mode: PredictionMode,
+  cw: &mut ContextWriter, w: &mut W, luma_mode: PredictionMode,
   angle_delta_y: i8, tile_bo: TileBlockOffset, bsize: BlockSize,
   tx_size: TxSize, tx_type: TxType, skip: bool, luma_only: bool,
   rdo_type: RDOType, need_recon_pixel: bool,
@@ -2286,10 +2286,10 @@ pub fn write_tx_tree<T: Pixel>(
   (partition_has_coeff, tx_dist)
 }
 
-pub fn encode_block_with_modes<T: Pixel>(
+pub fn encode_block_with_modes<T: Pixel, W: Writer>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
-  cw: &mut ContextWriter, w_pre_cdef: &mut dyn Writer,
-  w_post_cdef: &mut dyn Writer, bsize: BlockSize, tile_bo: TileBlockOffset,
+  cw: &mut ContextWriter, w_pre_cdef: &mut W, w_post_cdef: &mut W,
+  bsize: BlockSize, tile_bo: TileBlockOffset,
   mode_decision: &PartitionParameters, rdo_type: RDOType, record_stats: bool,
 ) {
   let (mode_luma, mode_chroma) =


### PR DESCRIPTION
Profiling revealed that some very small Writer functions, such as `bit`, were not being inlined. These functions were sometimes used within loops and therefore the inability to inline resulted in inefficient code. This inability to inline was due to the writers being passed as dynamic objects at runtime. Using generics to monomorphise the functions at compile-time allows the writer functions to be inlined and produces more optimized code.

Testing shows that this produces an overall speed increase of 1-2% at all speed levels.