### PR TITLE
CI: Update to macOS environment, add Arm64 target

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -308,15 +308,18 @@ jobs:
           - name: Cargo build (x64)
             conf: cargo-build
             target: x86_64-apple-darwin
-            toolchain: stable
           - name: Cargo test (x64)
             conf: cargo-test
             target: x86_64-apple-darwin
-            toolchain: stable
           - name: Cargo C-build (x64)
             conf: cargo-c
             target: x86_64-apple-darwin
-            toolchain: stable
+          - name: Cargo build (Arm64)
+            conf: cargo-build
+            target: aarch64-apple-darwin
+          - name: Cargo C-build (Arm64)
+            conf: cargo-c
+            target: aarch64-apple-darwin
 
     env:
       RUST_BACKTRACE: full
@@ -327,8 +330,7 @@ jobs:
     if: >-
       (github.event_name == 'push' && !endsWith(github.event.head_commit.message, 'CI: skip')) ||
       (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.names, 'skip-ci'))
-
-    runs-on: macos-latest
+    runs-on: macos-11.0
 
     steps:
       - uses: actions/checkout@v2
@@ -346,7 +348,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           override: true
           target: ${{ matrix.target }}
           default: true


### PR DESCRIPTION
Updates the GitHub Actions to macOS 11.0 environment and add aarch64-apple-darwin target for cargo and cargo-C builds.