### PR TITLE
Replace symbol_with_update macros by const generics

### DIFF
--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -557,16 +557,8 @@ macro_rules! symbol_with_update {
       }
     }
   };
-  ($self:ident, $w:ident, $s:expr, $cdf:expr, 2) => {
-    $w.symbol_with_update_2($s, $cdf, &mut $self.fc_log);
-    symbol_with_update!($self, $cdf);
-  };
-  ($self:ident, $w:ident, $s:expr, $cdf:expr, 3) => {
-    $w.symbol_with_update_3($s, $cdf, &mut $self.fc_log);
-    symbol_with_update!($self, $cdf);
-  };
-  ($self:ident, $w:ident, $s:expr, $cdf:expr, 4) => {
-    $w.symbol_with_update_4($s, $cdf, &mut $self.fc_log);
+  ($self:ident, $w:ident, $s:expr, $cdf:expr, $cdf_len:expr) => {
+    $w.symbol_with_update::<$cdf_len>($s, $cdf, &mut $self.fc_log);
     symbol_with_update!($self, $cdf);
   };
 }

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -28,12 +28,6 @@ const EC_PROB_SHIFT: u32 = 6;
 const EC_MIN_PROB: u32 = 4;
 type ec_window = u32;
 
-macro_rules! symbol_with_update_decl {($($n:expr),*) => {$(paste::item!{
-  fn [<symbol_with_update_ $n>](
-    &mut self, s: u32, cdf: &mut [u16; $n], log: &mut CDFContextLog,
-  );
-})*}}
-
 /// Public trait interface to a bitstream Writer: a Counter can be
 /// used to count bits for cost analysis without actually storing
 /// anything (using a new::WriterCounter() as a Writer), to record
@@ -49,10 +43,9 @@ pub trait Writer {
   /// leaves cdf unchanged
   fn symbol_bits(&self, s: u32, cdf: &[u16]) -> u32;
   /// Write a symbol s, using the passed in cdf reference; updates the referenced cdf.
-  fn symbol_with_update(
-    &mut self, s: u32, cdf: &mut [u16], log: &mut CDFContextLog,
+  fn symbol_with_update<const CDF_LEN: usize>(
+    &mut self, s: u32, cdf: &mut [u16; CDF_LEN], log: &mut CDFContextLog,
   );
-  symbol_with_update_decl!(2, 3, 4);
   /// Write a bool using passed in probability
   fn bool(&mut self, val: bool, f: u16);
   /// Write a single bit with flat proability
@@ -489,14 +482,6 @@ impl WriterBase<WriterEncoder> {
   }
 }
 
-macro_rules! symbol_with_update_impl {($($n:expr),*) => {$(paste::item!{
-  fn [<symbol_with_update_ $n>](
-    &mut self, s: u32, cdf: &mut [u16; $n], log: &mut CDFContextLog,
-  ) {
-    self.symbol_with_update(s, cdf, log);
-  }
-})*}}
-
 /// Generic/shared implementation for Writers with StorageBackends (ie, Encoders and Recorders)
 impl<S> Writer for WriterBase<S>
 where
@@ -558,9 +543,8 @@ where
   ///       The values must be monotonically non-decreasing, and the last value
   ///       must be greater 32704. There should be at most 16 values.
   ///       The lower 6 bits of the last value hold the count.
-  #[inline(always)]
-  fn symbol_with_update(
-    &mut self, s: u32, cdf: &mut [u16], log: &mut CDFContextLog,
+  fn symbol_with_update<const CDF_LEN: usize>(
+    &mut self, s: u32, cdf: &mut [u16; CDF_LEN], log: &mut CDFContextLog,
   ) {
     #[cfg(feature = "desync_finder")]
     {
@@ -573,7 +557,6 @@ where
 
     update_cdf(cdf, s);
   }
-  symbol_with_update_impl!(2, 3, 4);
   /// Returns approximate cost for a symbol given a cumulative
   /// distribution function (CDF) table and current write state.
   /// `s`: The index of the symbol to encode.


### PR DESCRIPTION
After using compile-time generics instead of `dyn` dispatch for writers, the `#[always(inline)]` on `symbol_with_update` causes it to be inline for the long tail of larger CDF sizes. This results in larger binary size, for no speed benefit. Converting to const generics and removing inline preserves the specialization for smaller CDF sizes and reduces binary size by 40KiB on `x86_64`. The code is also more clear and concise.