### PR TITLE
Bump decoders versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ num-derive = "0.3"
 paste = "1.0"
 noop_proc_macro = "0.3.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
-dav1d-sys = { version = "0.3.2", optional = true }
-aom-sys = { version = "0.2.1", optional = true }
+dav1d-sys = { version = "0.3.4", optional = true }
+aom-sys = { version = "0.3.0", optional = true }
 scan_fmt = { version = "0.2.3", optional = true, default-features = false }
 ivf = { version = "0.1", path = "ivf/", optional = true }
 v_frame = { version = "0.2.1", path = "v_frame/" }


### PR DESCRIPTION
- aom-3 is now needed
- dav1d-sys bumped to use the same bindgen version