### PR TITLE
CI: Update to cargo-c v0.8.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install cargo-c
       run: |
-        $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.7.1"
+        $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.8.0"
         $CARGO_C_FILE = "cargo-c-windows-msvc"
         curl -LO "$LINK/$CARGO_C_FILE.zip"
         7z e -y "$CARGO_C_FILE.zip" -o"${env:USERPROFILE}\.cargo\bin"

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -174,7 +174,7 @@ jobs:
         if: matrix.conf == 'cargo-c'
         env:
           LINK: https://github.com/lu-zero/cargo-c/releases/download
-          CARGO_C_VERSION: 0.7.1
+          CARGO_C_VERSION: 0.8.0
         run: |
           curl -L "$LINK/v$CARGO_C_VERSION/cargo-c-linux.tar.gz" |
           tar xz -C $HOME/.cargo/bin
@@ -449,7 +449,7 @@ jobs:
       - name: Install cargo-c
         if: matrix.conf == 'cargo-c'
         run: |
-          $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.7.3"
+          $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.8.0"
           $CARGO_C_FILE = "cargo-c-windows-msvc"
           curl -LO "$LINK/$CARGO_C_FILE.zip"
           7z e -y "$CARGO_C_FILE.zip" -o"${env:USERPROFILE}\.cargo\bin"


### PR DESCRIPTION
Update the CI config to use cargo-c [v0.8.0](https://github.com/lu-zero/cargo-c/releases/tag/v0.8.0).

Currently cargo-c updates automatically for the macOS runs by using Brew, but not on Linux and Windows. Maybe it would be useful to keep those versions in sync.