### PR TITLE
Create new speed level 1, drop level 4

### DIFF
--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -271,7 +271,7 @@ impl SpeedSettings {
   }
 
   const fn non_square_partition_preset(speed: usize) -> bool {
-    speed == 0
+    speed <= 1
   }
 
   fn segmentation_preset(speed: usize) -> SegmentationLevel {

--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -133,15 +133,17 @@ impl SpeedSettings {
   /// - 7: min block size 8x8, reduced TX set.
   /// - 6 (default): min block size 8x8, reduced TX set, complex pred modes for keyframes.
   /// - 5: min block size 8x8, complex pred modes for keyframes, RDO TX decision.
-  /// - 4: min block size 8x8, complex pred modes for keyframes, RDO TX decision, full SGR search.
-  /// - 3: min block size 8x8, complex pred modes for keyframes, RDO TX decision, include near MVs,
+  /// - 4: min block size 8x8, complex pred modes for keyframes, RDO TX decision, include near MVs,
   ///        full SGR search.
-  /// - 2: min block size 8x8, complex pred modes for keyframes, RDO TX decision, include near MVs,
+  /// - 3: min block size 8x8, complex pred modes for keyframes, RDO TX decision, include near MVs,
+  ///        bottom-up encoding, full SGR search.
+  /// - 2: min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
   ///        bottom-up encoding, full SGR search.
   /// - 1: min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
-  ///        bottom-up encoding, full SGR search.
-  /// - 0 (slowest): min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
   ///        bottom-up encoding with non-square partitions everywhere, full SGR search.
+  /// - 0 (slowest): min block size 4x4, complex pred modes, RDO TX decision, include near MVs,
+  ///        bottom-up encoding with non-square partitions everywhere, full SGR search,
+  ///        full segmentation search.
   pub fn from_preset(speed: usize) -> Self {
     SpeedSettings {
       partition_range: Self::partition_range_preset(speed),
@@ -170,7 +172,7 @@ impl SpeedSettings {
   /// This preset is set this way because 8x8 with reduced TX set is faster but with equivalent
   /// or better quality compared to 16x16 (to which reduced TX set does not apply).
   fn partition_range_preset(speed: usize) -> PartitionRange {
-    if speed <= 1 {
+    if speed <= 2 {
       PartitionRange::new(BlockSize::BLOCK_4X4, BlockSize::BLOCK_64X64)
     } else if speed <= 8 {
       PartitionRange::new(BlockSize::BLOCK_8X8, BlockSize::BLOCK_64X64)
@@ -208,7 +210,7 @@ impl SpeedSettings {
   }
 
   const fn encode_bottomup_preset(speed: usize) -> bool {
-    speed <= 2
+    speed <= 3
   }
 
   /// Set default rdo-lookahead-frames for different speed settings
@@ -216,8 +218,8 @@ impl SpeedSettings {
     match speed {
       9..=10 => 10,
       6..=8 => 20,
-      2..=5 => 30,
-      0..=1 => 40,
+      3..=5 => 30,
+      0..=2 => 40,
       _ => 40,
     }
   }
@@ -227,7 +229,7 @@ impl SpeedSettings {
   }
 
   fn prediction_modes_preset(speed: usize) -> PredictionModesSetting {
-    if speed <= 1 {
+    if speed <= 2 {
       PredictionModesSetting::ComplexAll
     } else if speed <= 6 {
       PredictionModesSetting::ComplexKeyframes
@@ -237,7 +239,7 @@ impl SpeedSettings {
   }
 
   const fn include_near_mvs_preset(speed: usize) -> bool {
-    speed <= 3
+    speed <= 4
   }
 
   const fn no_scene_detection_preset(_speed: usize) -> bool {


### PR DESCRIPTION
Drop speed level 4 which requires [14.69% greater encoding time than speed 5](https://beta.arewecompressedyet.com/?job=cdf-dist-opt-s5%402021-04-28T07%3A57%3A17.637Z&job=cdf-dist-opt-s4%402021-04-28T07%3A57%3A01.338Z) for very marginal gains:

| PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |   SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |   VMAF | VMAF-NEG |
|   ---: |    ---: |    ---: |      ---: |   ---: |    ---: |       ---: |        ---: |        ---: |     ---: |   ---: |     ---: |
| 0.0187 | -0.1219 | -0.2468 |   -0.0744 | 0.0048 | -0.0100 |     0.0146 |     -0.0276 |     -0.1719 |   0.0107 | 0.0978 |   0.0966 |

Insert a new speed level with [twice the encoding time of the prior speed 1](https://beta.arewecompressedyet.com/?job=cdf-dist-opt-s1%402021-04-26T12%3A19%3A15.775Z&job=cdf-dist-opt-s1-rect%402021-04-27T15%3A00%3A52.429Z) but very significant efficiency gains:

|  PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |    SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |    VMAF | VMAF-NEG |
|    ---: |    ---: |    ---: |      ---: |    ---: |    ---: |       ---: |        ---: |        ---: |     ---: |    ---: |     ---: |
| -3.3335 | -5.9477 | -6.2786 |   -4.4695 | -3.4404 | -3.3753 |    -3.3563 |     -5.9527 |     -6.7053 |  -3.4610 | -3.4325 |  -3.4850 |

Likewise, the prior speed 0 has [more than twice the encoding time of this new level](https://beta.arewecompressedyet.com/?job=cdf-dist-opt-s1-rect%402021-04-27T15%3A00%3A52.429Z&job=cdf-dist-opt-s0%402021-04-26T12%3A18%3A47.602Z) and significant efficiency gains:

|  PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |    SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |    VMAF | VMAF-NEG |
|    ---: |    ---: |    ---: |      ---: |    ---: |    ---: |       ---: |        ---: |        ---: |     ---: |    ---: |     ---: |
| -2.0265 |  0.8643 |  0.3991 |   -1.2325 | -1.4498 | -1.3123 |    -2.0252 |      2.0639 |      1.0175 |  -1.9425 | -2.4707 |  -2.2548 |