### PR TITLE
Fix typos

### DIFF
--- a/doc/RDO.md
+++ b/doc/RDO.md
@@ -11,7 +11,7 @@ Distortion is a metric selected based on user options, such as MSE for PSNR opti
 
 ![](tile_group.svg)
 
-The bitstream is composed of a hiearchy of units, and rav1e's RDO loops are structured in the same way. After computing some lookahead information, rav1e's first task is to split the frame into tiles (sometimes just one). These are processed completely independently, and usually in parallel.
+The bitstream is composed of a hierarchy of units, and rav1e's RDO loops are structured in the same way. After computing some lookahead information, rav1e's first task is to split the frame into tiles (sometimes just one). These are processed completely independently, and usually in parallel.
 
 The next split is into superblocks, which are currently always 64x64 pixels in the luma plane. rav1e processes superblocks serially, one at a time. Although choices made in a superblock affect later superblocks, rav1e will never revisit a superblock once it has determined the best way to code it - it writes it and continues on.
 
@@ -41,7 +41,7 @@ Inter mode
 
 rav1e's intra search starts with populating a list of inter modes to search. Modes such as NEWMV are always added, however modes such as NEARMV are only added if the current motion vector list is sufficiently long enough for them to be coded. Compound modes are added in a similar manner, if enabled.
 
-Next, a rough distortion approximation based on SATD of the residual is computed. This is also computed at the partition level, however unlike intra mode, this is not an approximation. The resulting list is sorted and pruned to the best 9 entires.
+Next, a rough distortion approximation based on SATD of the residual is computed. This is also computed at the partition level, however unlike intra mode, this is not an approximation. The resulting list is sorted and pruned to the best 9 entries.
 
 Next, each of the modes is fully encoded (with bitstream write disabled). The real distortion and bitrate are measured, and the best mode is chosen.
 

--- a/doc/STRUCTURE.md
+++ b/doc/STRUCTURE.md
@@ -31,7 +31,7 @@ The below table gives a brief overview of design of [`src/*`](../src/)
 | [bin/rav1e.rs](../src/bin/rav1e.rs)                   | CLI Interface for encoding from y4m files with rav1e                                                       |
 | [bin/stats.rs](../src/bin/stats.rs)                   | Functions for displaying Frame summary, progress info, metrics of the encoding process                     |
 | [bin/kv.rs](../src/bin/kv.rs)                         | Serialisation configuration of Key-value strings                                                           |
-| [bin/errror.rs](../src/bin/error.rs)                  | Functions and enums to parse various errors and displaying                                                 |
+| [bin/error.rs](../src/bin/error.rs)                   | Functions and enums to parse various errors and displaying                                                 |
 | [bin/muxer/*.rs](../src/bin/muxer/)                   | Contains IVF Muxer functions for header definition, writing frames and flushing                            |
 | [bin/decoder/*.rs](../src/bin/decoder/)               | Decoder related structures and functions                                                                   |
 | [capi.rs](../src/capi.rs)                             | C Compatible API for using rav1e as a library                                                              |

--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -105,7 +105,7 @@ pub struct EncoderConfig {
   /// Number of frames to read ahead for the RDO lookahead computation.
   pub rdo_lookahead_frames: usize,
 
-  /// Settings which affect the enconding speed vs. quality trade-off.
+  /// Settings which affect the encoding speed vs. quality trade-off.
   pub speed_settings: SpeedSettings,
 }
 

--- a/src/asm/x86/quantize.rs
+++ b/src/asm/x86/quantize.rs
@@ -191,7 +191,7 @@ mod test {
         let mut qcoeffs = Aligned::new([0i16; 32 * 32]);
         let mut rcoeffs = Aligned::new([0i16; 32 * 32]);
 
-        // Generate quantized coefficients upto the eob
+        // Generate quantized coefficients up to the eob
         let between = Uniform::from(-std::i16::MAX..=std::i16::MAX);
         for (i, qcoeff) in qcoeffs.data.iter_mut().enumerate().take(eob) {
           *qcoeff = between.sample(&mut rng)

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -355,7 +355,7 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
     )
     .arg(
       Arg::with_name("METRICS")
-        .help("Calulate and display several metrics including PSNR, SSIM, CIEDE2000 etc")
+        .help("Calculate and display several metrics including PSNR, SSIM, CIEDE2000 etc")
         .long("metrics")
     )
     .arg(

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -386,7 +386,7 @@ pub fn cdef_analyze_superblock<T: Pixel>(
 //   provided blocks co-locate with the output region.  The TileBlocks
 //   provide by-[super]qblock CDEF parameters.
 
-//   output: TileMut detination for filtered pixels.  The output's
+//   output: TileMut destination for filtered pixels.  The output's
 //   rect specifies the region of the input to be processed (x and y
 //   are relative to the input Frame's origin).  Note that an
 //   additional area of 2 pixels of padding is used for CDEF.  When
@@ -578,7 +578,7 @@ pub fn cdef_filter_superblock<T: Pixel>(
 //   tb: the TileBlocks associated with the filtered region; the
 //   provided blocks co-locate with the output region.
 
-//   output: TileMut detination for filtered pixels.  The output's
+//   output: TileMut destination for filtered pixels.  The output's
 //   rect specifies the region of the input to be processed (x and y
 //   are relative to the input Frame's origin).  Note that an
 //   additional area of 2 pixels of padding is used for CDEF.  When

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -1355,7 +1355,7 @@ pub fn deblock_plane<T: Pixel>(
     >> ydec
     << ydec; // Clippy can go suck an egg
 
-  // vertical edge filtering leads horizonal by one full MI-sized
+  // vertical edge filtering leads horizontal by one full MI-sized
   // row (and horizontal filtering doesn't happen along the upper
   // edge).  Unroll to avoid corner-cases.
   if rows > 0 {

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -86,7 +86,7 @@ pub trait Writer {
   ) -> u32;
   /// Return current length of range-coded bitstream in integer bits
   fn tell(&mut self) -> u32;
-  /// Return currrent length of range-coded bitstream in fractional
+  /// Return current length of range-coded bitstream in fractional
   /// bits with OD_BITRES decimal precision
   fn tell_frac(&mut self) -> u32;
   /// Save current point in coding/recording to a checkpoint
@@ -669,7 +669,7 @@ where
       }
     }
   }
-  /// Resturns QOD_BITRES bits for symbol v in [0, n-1] with parameter k as finite subexponential
+  /// Returns QOD_BITRES bits for symbol v in [0, n-1] with parameter k as finite subexponential
   /// n: size of interval
   /// k: 'parameter'
   /// v: value to encode

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -68,7 +68,7 @@ impl<T: Pixel> FrameAlloc for Frame<T> {
   }
 }
 
-/// Public Trait for calulating Padding
+/// Public Trait for calculating Padding
 pub(crate) trait FramePad {
   fn pad(&mut self, w: usize, h: usize, planes: usize);
 }

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -83,7 +83,7 @@ const SGRPROJ_ALL_SETS: &[u8] =
 // parameters as non-zero. The other two are distinguishable by which of the
 // two parameters is zero. There are an even number of each of these groups and
 // the non-zero parameters grow as the indices increase. This array uses the
-// 1nd, 3rd, ... smallest params of each group.
+// 1st, 3rd, ... smallest params of each group.
 const SGRPROJ_REDUCED_SETS: &[u8] = &[1, 3, 5, 7, 9, 11, 13, 15];
 
 pub fn get_sgr_sets(complexity: SGRComplexityLevel) -> &'static [u8] {

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -388,7 +388,7 @@ impl IIRBessel2 {
   // This does not alter the x/y state, but changes the reaction time of the
   //  filter.
   // Altering the time constant of a reactive filter without altering internal
-  //  state is something that has to be done carefuly, but our design operates
+  //  state is something that has to be done carefully, but our design operates
   //  at high enough delays and with small enough time constant changes to make
   //  it safe.
   pub fn reinit(&mut self, delay: i32) {
@@ -823,7 +823,7 @@ impl RCState {
     // Insane framerates or frame sizes mean insane bitrates.
     // Let's not get carried away.
     // We also subtract 16 bits from each temporal unit to account for the
-    //  temporal delimeter, whose bits are not included in the frame sizes
+    //  temporal delimiter, whose bits are not included in the frame sizes
     //  reported to update_state().
     // TODO: Support constraints imposed by levels.
     let bits_per_tu = clamp(
@@ -1427,7 +1427,7 @@ impl RCState {
         self.reservoir_fullness -= bits;
         if show_frame {
           self.reservoir_fullness += self.bits_per_tu;
-          // TODO: Properly account for temporal delimeter bits.
+          // TODO: Properly account for temporal delimiter bits.
         }
         // If we're too quick filling the buffer and overflow is capped, that
         //  rate is lost forever.

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -559,10 +559,10 @@ mod test {
       (TX_16X16, IDTX, 0),
       (TX_16X16, V_DCT, 1),
       (TX_16X16, H_DCT, 1),
-      // 32x tranforms only use DCT_DCT and IDTX
+      // 32x transforms only use DCT_DCT and IDTX
       (TX_32X32, DCT_DCT, 2),
       (TX_32X32, IDTX, 0),
-      // 64x tranforms only use DCT_DCT and IDTX
+      // 64x transforms only use DCT_DCT and IDTX
       //(TX_64X64, DCT_DCT, 0),
       (TX_4X8, DCT_DCT, 1),
       (TX_8X4, DCT_DCT, 1),

--- a/src/x86/itx.asm
+++ b/src/x86/itx.asm
@@ -124,7 +124,7 @@ pw_m2751_3035x8: dw -2751*8, 3035*8
 
 SECTION .text
 
-; Code size reduction trickery: Intead of using rip-relative loads with
+; Code size reduction trickery: Instead of using rip-relative loads with
 ; mandatory 4-byte offsets everywhere, we can set up a base pointer with a
 ; single rip-relative lea and then address things relative from that with
 ; 1-byte offsets as long as data is within +-128 bytes of the base pointer.

--- a/tools/draw-importances.py
+++ b/tools/draw-importances.py
@@ -269,7 +269,7 @@ def blockImportance(input, verbose, path, figure, raw, csv):
 
     elif verbose and csv:
         click.secho(
-            "CSV Saved sucessfully: " + folder_path + "/" + csv + ".",
+            "CSV Saved successfully: " + folder_path + "/" + csv + ".",
             fg="blue",
         )
 


### PR DESCRIPTION
Detected with:
`codespell --skip *.ipynb --ignore-words-list paeth,dest,ser,crate,seh,teh,te,struc`