### PR TITLE
CI: Add rav1e-ch.exe binary to pre-release deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,6 +89,12 @@ jobs:
         7z a "$ZIP_PREFIX-${{ matrix.conf }}.zip" `
              "C:\usr\rav1e-windows-${{ matrix.conf }}-sdk"
 
+    - name: Build rav1e-ch (unstable)
+      if: matrix.conf == 'msvc'
+      env:
+        RUSTFLAGS: "-C target-feature=+avx2,+fma"
+      run: cargo build --release --features=unstable,channel-api --bin=rav1e-ch
+
     - name: Upload rav1e msvc binary
       if: matrix.conf == 'msvc'
       uses: actions/upload-artifact@v2
@@ -107,6 +113,12 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: rav1e-${{ steps.tagName.outputs.version }}-windows-${{ matrix.conf }}.zip
+
+    - name: Upload rav1e-ch msvc binary (unstable)
+      if: matrix.conf == 'msvc'
+      uses: actions/upload-artifact@v2
+      with:
+        path: target/release/rav1e-ch.exe
 
   linux-binaries:
     strategy:
@@ -310,6 +322,7 @@ jobs:
         files: |
           Cargo.lock
           rav1e.exe
+          rav1e-ch.exe
           rav1e-linux.tar.gz
           rav1e-aarch64-linux.tar.gz
           rav1e-macos.zip
@@ -327,6 +340,7 @@ jobs:
         files: |
           Cargo.lock
           rav1e.exe
+          rav1e-ch.exe
           rav1e-linux.tar.gz
           rav1e-aarch64-linux.tar.gz
           rav1e-macos.zip


### PR DESCRIPTION
For beta-testing purposes, build and deploy a rav1e-ch binary for Windows that targets AVX2.