### PR TITLE
Fix clippy warnings from Rust nightly

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -433,14 +433,12 @@ impl<T: Pixel> ContextInner<T> {
     let mut data_location = PathBuf::new();
     if env::var_os("RAV1E_DATA_PATH").is_some() {
       data_location.push(&env::var_os("RAV1E_DATA_PATH").unwrap());
-      fs::create_dir_all(data_location.clone()).unwrap();
-      data_location
     } else {
       data_location.push(&env::current_dir().unwrap());
       data_location.push(".lookahead_data");
-      fs::create_dir_all(data_location.clone()).unwrap();
-      data_location
     }
+    fs::create_dir_all(&data_location).unwrap();
+    data_location
   }
 
   fn build_frame_properties(
@@ -1001,7 +999,7 @@ impl<T: Pixel> ContextInner<T> {
       let mut unique_indices = ArrayVec::<_, 3>::new();
 
       for (mv_index, &rec_index) in fi.ref_frames.iter().enumerate() {
-        if unique_indices.iter().find(|&&(_, r)| r == rec_index).is_none() {
+        if !unique_indices.iter().any(|&(_, r)| r == rec_index) {
           unique_indices.push((mv_index, rec_index));
         }
       }

--- a/src/header.rs
+++ b/src/header.rs
@@ -273,8 +273,8 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     self.write_bit(fi.sequence.reduced_still_picture_hdr)?; // reduced_still_picture_header
 
     if fi.sequence.reduced_still_picture_hdr {
-      assert_eq!(fi.sequence.timing_info_present, false);
-      assert_eq!(fi.sequence.decoder_model_info_present_flag, false);
+      assert!(!fi.sequence.timing_info_present);
+      assert!(!fi.sequence.decoder_model_info_present_flag);
       assert_eq!(fi.sequence.operating_points_cnt_minus_1, 0);
       assert_eq!(fi.sequence.operating_point_idc[0], 0);
       self.write(5, 31)?; // level
@@ -564,11 +564,10 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
       // Inter frame info goes here
       if fi.intra_only {
         assert!(fi.refresh_frame_flags != ALL_REF_FRAMES_MASK);
-        self.write(REF_FRAMES as u32, fi.refresh_frame_flags)?;
       } else {
         // TODO: This should be set once inter mode is used
-        self.write(REF_FRAMES as u32, fi.refresh_frame_flags)?;
       }
+      self.write(REF_FRAMES as u32, fi.refresh_frame_flags)?;
     };
 
     if (!fi.intra_only || fi.refresh_frame_flags != ALL_REF_FRAMES_MASK) {
@@ -1067,8 +1066,8 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
 
     if segmentation.enabled {
       if fi.primary_ref_frame == PRIMARY_REF_NONE {
-        assert_eq!(segmentation.update_map, true);
-        assert_eq!(segmentation.update_data, true);
+        assert!(segmentation.update_map);
+        assert!(segmentation.update_data);
       } else {
         self.write_bit(segmentation.update_map)?;
         if segmentation.update_map {


### PR DESCRIPTION
These will be enabled by default in a future stable Rust,
so fixing them now keeps us ahead of the ball.

Relevant lints:
- used `assert_eq!` with a literal bool
- all if blocks contain the same code at the end
- called `is_none()` after searching an `Iterator` with `find`