### PR TITLE
Consider tune when setting speed presets

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -46,7 +46,7 @@ fn write_b_bench(b: &mut Bencher, tx_size: TxSize, qindex: usize) {
     width: 1024,
     height: 1024,
     quantizer: qindex,
-    speed_settings: SpeedSettings::from_preset(10),
+    speed_settings: SpeedSettings::from_preset(10, Tune::Psychovisual),
     ..Default::default()
   });
   let sequence = Arc::new(Sequence::new(&Default::default()));
@@ -132,7 +132,7 @@ fn cdef_frame_bench(b: &mut Bencher, width: usize, height: usize) {
     width,
     height,
     quantizer: 100,
-    speed_settings: SpeedSettings::from_preset(10),
+    speed_settings: SpeedSettings::from_preset(10, Tune::Psychovisual),
     ..Default::default()
   });
   let sequence = Arc::new(Sequence::new(&Default::default()));
@@ -164,7 +164,7 @@ fn cfl_rdo_bench(b: &mut Bencher, bsize: BlockSize) {
     width: 1024,
     height: 1024,
     quantizer: 100,
-    speed_settings: SpeedSettings::from_preset(10),
+    speed_settings: SpeedSettings::from_preset(10, Tune::Psychovisual),
     ..Default::default()
   });
   let sequence = Arc::new(Sequence::new(&Default::default()));

--- a/examples/simple_encoding.rs
+++ b/examples/simple_encoding.rs
@@ -9,6 +9,7 @@
 
 // Encode the same tiny blank frame 30 times
 use rav1e::config::SpeedSettings;
+use rav1e::prelude::Tune;
 use rav1e::*;
 
 fn main() {
@@ -17,7 +18,7 @@ fn main() {
   enc.width = 64;
   enc.height = 96;
 
-  enc.speed_settings = SpeedSettings::from_preset(9);
+  enc.speed_settings = SpeedSettings::from_preset(9, Tune::Psychovisual);
 
   let cfg = Config::new().with_encoder_config(enc);
 

--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -116,7 +116,7 @@ pub struct EncoderConfig {
 impl Default for EncoderConfig {
   fn default() -> Self {
     const DEFAULT_SPEED: usize = 6;
-    Self::with_speed_preset(DEFAULT_SPEED)
+    Self::with_speed_preset(DEFAULT_SPEED, Tune::Psychovisual)
   }
 }
 
@@ -127,7 +127,7 @@ impl EncoderConfig {
   /// than 10, it will result in the same settings as 10.
   ///
   /// [`from_preset()`]: struct.SpeedSettings.html#method.from_preset
-  pub fn with_speed_preset(speed: usize) -> Self {
+  pub fn with_speed_preset(speed: usize, tune: Tune) -> Self {
     EncoderConfig {
       width: 640,
       height: 480,
@@ -161,7 +161,7 @@ impl EncoderConfig {
       tile_rows: 0,
       tiles: 0,
       rdo_lookahead_frames: 40,
-      speed_settings: SpeedSettings::from_preset(speed),
+      speed_settings: SpeedSettings::from_preset(speed, tune),
     }
   }
 

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -21,7 +21,7 @@ fn setup_config(
   no_scene_detection: bool, rdo_lookahead_frames: usize,
   min_quantizer: Option<u8>,
 ) -> Config {
-  let mut enc = EncoderConfig::with_speed_preset(speed);
+  let mut enc = EncoderConfig::with_speed_preset(speed, Tune::Psychovisual);
   enc.quantizer = quantizer;
   enc.min_key_frame_interval = min_keyint;
   enc.max_key_frame_interval = max_keyint;

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -54,7 +54,7 @@ pub struct CliOptions {
 fn build_speed_long_help() -> String {
   let levels = (0..=10)
     .map(|speed| {
-      let s = SpeedSettings::from_preset(speed);
+      let s = SpeedSettings::from_preset(speed, Tune::default());
       let o = crate::kv::to_string(&s).unwrap().replace(", ", "\n    ");
       format!("{:2} :\n    {}", speed, o)
     })
@@ -591,7 +591,9 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
     .parse()
     .unwrap_or_default();
 
-  let mut cfg = EncoderConfig::with_speed_preset(speed);
+  let tune = matches.value_of("TUNE").unwrap().parse().unwrap();
+
+  let mut cfg = EncoderConfig::with_speed_preset(speed, tune);
   cfg.set_key_frame_interval(min_interval, max_interval);
   cfg.switch_frame_interval =
     matches.value_of("SWITCH_FRAME_INTERVAL").unwrap().parse().unwrap();
@@ -700,17 +702,8 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
 
   // rdo-lookahead-frames
   let maybe_rdo = matches.value_of("RDO_LOOKAHEAD_FRAMES");
-  if maybe_rdo.is_some() {
-    cfg.rdo_lookahead_frames =
-      matches.value_of("RDO_LOOKAHEAD_FRAMES").unwrap().parse().unwrap();
-  } else {
-    cfg.rdo_lookahead_frames = SpeedSettings::rdo_lookahead_frames(speed)
-  }
-
-  cfg.tune = matches.value_of("TUNE").unwrap().parse().unwrap();
-
-  if cfg.tune == Tune::Psychovisual {
-    cfg.speed_settings.tx_domain_distortion = false;
+  if let Some(rdo_frames) = maybe_rdo {
+    cfg.rdo_lookahead_frames = rdo_frames.parse().unwrap();
   }
 
   cfg.tile_cols = matches.value_of("TILE_COLS").unwrap().parse().unwrap();

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -613,8 +613,10 @@ unsafe fn option_match(
     "width" => enc.width = value.parse().map_err(|_| ())?,
     "height" => enc.height = value.parse().map_err(|_| ())?,
     "speed" => {
-      enc.speed_settings =
-        rav1e::SpeedSettings::from_preset(value.parse().map_err(|_| ())?)
+      enc.speed_settings = rav1e::SpeedSettings::from_preset(
+        value.parse().map_err(|_| ())?,
+        enc.tune,
+      )
     }
 
     "threads" => (*cfg).cfg.threads = value.parse().map_err(|_| ())?,
@@ -623,7 +625,10 @@ unsafe fn option_match(
     "tile_rows" => enc.tile_rows = value.parse().map_err(|_| ())?,
     "tile_cols" => enc.tile_cols = value.parse().map_err(|_| ())?,
 
-    "tune" => enc.tune = value.parse().map_err(|_| ())?,
+    "tune" => {
+      enc.tune = value.parse().map_err(|_| ())?;
+      enc.speed_settings.apply_tune(enc.tune);
+    }
     "quantizer" => enc.quantizer = value.parse().map_err(|_| ())?,
     "min_quantizer" => enc.min_quantizer = value.parse().map_err(|_| ())?,
     "bitrate" => enc.bitrate = value.parse().map_err(|_| ())?,

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -150,7 +150,10 @@ fn arbitrary_content_light(
 
 impl Arbitrary for ArbitraryConfig {
   fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self, Error> {
-    let mut enc = EncoderConfig::with_speed_preset(Arbitrary::arbitrary(u)?);
+    let mut enc = EncoderConfig::with_speed_preset(
+      Arbitrary::arbitrary(u)?,
+      *u.choose(&[Tune::Psnr, Tune::Psychovisual])?,
+    );
     enc.width = Arbitrary::arbitrary(u)?;
     enc.height = Arbitrary::arbitrary(u)?;
     enc.bit_depth = u.int_in_range(0..=16)?;
@@ -216,8 +219,12 @@ pub struct ArbitraryEncoder {
 
 impl Arbitrary for ArbitraryEncoder {
   fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self, Error> {
+    let tune = u.choose(&[Tune::Psnr, Tune::Psychovisual])?;
     let enc = EncoderConfig {
-      speed_settings: SpeedSettings::from_preset(u.int_in_range(0..=10)?),
+      speed_settings: SpeedSettings::from_preset(
+        u.int_in_range(0..=10)?,
+        *tune,
+      ),
       width: u.int_in_range(1..=256)?,
       height: u.int_in_range(1..=256)?,
       still_picture: Arbitrary::arbitrary(u)?,
@@ -255,7 +262,7 @@ impl Arbitrary for ArbitraryEncoder {
       content_light: arbitrary_content_light(u)?,
       enable_timing_info: Arbitrary::arbitrary(u)?,
       switch_frame_interval: u.int_in_range(0..=3)?,
-      tune: *u.choose(&[Tune::Psnr, Tune::Psychovisual])?,
+      tune: *tune,
     };
 
     let frame_count =

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -175,7 +175,7 @@ fn setup_encoder<T: Pixel>(
   still_picture: bool,
 ) -> Context<T> {
   assert!(bit_depth == 8 || std::mem::size_of::<T>() > 1);
-  let mut enc = EncoderConfig::with_speed_preset(speed);
+  let mut enc = EncoderConfig::with_speed_preset(speed, Tune::Psychovisual);
   enc.quantizer = quantizer;
   enc.min_key_frame_interval = min_keyint;
   enc.max_key_frame_interval = max_keyint;


### PR DESCRIPTION
Temporal RDO depends on tx_domain_distortion being disabled.
Currently it's easy for a user of the API to accidentally
leave tx_domain_distortion enabled if they are using the speed presets.
This change should make it easier to keep settings in a consistent
state.