### PR TITLE
Resolve an unnecessary clone of rec data

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1200,7 +1200,7 @@ impl<T: Pixel> ContextInner<T> {
       let planes =
         if frame_data.fi.sequence.chroma_sampling == Cs400 { 1 } else { 3 };
 
-      Arc::make_mut(&mut frame_data.fs.rec).pad(
+      Arc::get_mut(&mut frame_data.fs.rec).unwrap().pad(
         frame_data.fi.width,
         frame_data.fi.height,
         planes,

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1206,7 +1206,6 @@ impl<T: Pixel> ContextInner<T> {
         planes,
       );
 
-      // TODO avoid the clone by having rec Arc.
       let (rec, source) = if frame_data.fi.show_frame {
         (Some(frame_data.fs.rec.clone()), Some(frame_data.fs.input.clone()))
       } else {

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1138,7 +1138,7 @@ impl<T: Pixel> ContextInner<T> {
         return Err(EncoderStatus::NotReady);
       }
       let mut frame_data =
-        self.frame_data.get(&cur_output_frameno).cloned().unwrap();
+        self.frame_data.remove(&cur_output_frameno).unwrap();
       let fti = frame_data.fi.get_frame_subtype();
       let qps = self.rc_state.select_qi(
         self,

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1116,7 +1116,7 @@ fn rav1e_frame_fill_plane_internal<T: rav1e::Pixel>(
   f: &mut Arc<rav1e::Frame<T>>, plane: c_int, data_slice: &[u8],
   stride: ptrdiff_t, bytewidth: c_int,
 ) {
-  let input = Arc::make_mut(f);
+  let input = Arc::get_mut(f).unwrap();
   input.planes[plane as usize].copy_from_raw_u8(
     data_slice,
     stride as usize,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -3028,7 +3028,7 @@ fn encode_tile_group<T: Pixel>(
   if fi.sequence.enable_restoration {
     // Until the loop filters are better pipelined, we'll need to keep
     // around a copy of both the deblocked and cdeffed frame.
-    let deblocked_frame = fs.rec.clone();
+    let deblocked_frame = (*fs.rec).clone();
 
     /* TODO: Don't apply if lossless */
     if fi.sequence.enable_cdef {
@@ -3038,14 +3038,14 @@ fn encode_tile_group<T: Pixel>(
     }
     /* TODO: Don't apply if lossless */
     fs.restoration.lrf_filter_frame(
-      Arc::make_mut(&mut fs.rec),
+      Arc::get_mut(&mut fs.rec).unwrap(),
       &deblocked_frame,
       fi,
     );
   } else {
     /* TODO: Don't apply if lossless */
     if fi.sequence.enable_cdef {
-      let deblocked_frame = fs.rec.clone();
+      let deblocked_frame = (*fs.rec).clone();
       let ts = &mut fs.as_tile_state_mut();
       let rec = &mut ts.rec;
       cdef_filter_tile(fi, &deblocked_frame, &blocks.as_tile_blocks(), rec);
@@ -3450,7 +3450,7 @@ pub fn encode_show_existing_frame<T: Pixel>(
 
   let map_idx = fi.frame_to_show_map_idx as usize;
   if let Some(ref rec) = fi.rec_buffer.frames[map_idx] {
-    let fs_rec = Arc::make_mut(&mut fs.rec);
+    let fs_rec = Arc::get_mut(&mut fs.rec).unwrap();
     let planes =
       if fi.sequence.chroma_sampling == ChromaSampling::Cs400 { 1 } else { 3 };
     for p in 0..planes {


### PR DESCRIPTION
This change requires a bit of explanation, because the way Arc::make_mut works is slightly complicated.

First, I found that there are a couple of places in the code where we **want** to clone the rec data so we can keep a copy of it prior to changes being made. This was working coincidentally, because we were cloning the Arc containing it (meaning, the inner data was not cloned, we only made a new reference to it), but a later call to Arc::make_mut caused the original data to be cloned and preserved. I changed the locations where we want to clone the data into explicit clones of the inner data, and changed the `make_mut` calls to `get_mut` to verify that this is the case (get_mut ensures that there is only one reference to an Arc and fails if that is not the case).

I was then investigating the way we handle making mutable references to the rec data within TileStateMut. It turns out that there, as well, Arc::make_mut is implicitly cloning the inner data for each tile that is generated. Fortunately, because we never need that data after the tile is done, this doesn't impact the result of the encode, but it does have the effect of cloning data that we shouldn't need to clone. I attempted to change these calls to `Arc::get_mut_unchecked`--we will need to be able to have multiple mutable references, as many as there are tiles, but these shouldn't overlap, making it safe for our use case. (As a side note, `get_mut_unchecked` is an unstable API, so we can't actually use it in rav1e master yet.) This change caused one of the other calls to `get_mut` to panic, meaning we had some other live reference to the rec data somewhere. I traced this back to the `.cloned()` call on internal.rs:1141, and avoided that clone by removing the frame data from the map so we can modify it, then putting it back on the map when we're done (this is a technique we use in at least one other place in the codebase).

The end result of this change specifically is a slight reduction in peak memory usage. This also unblocked the ability to use `get_mut_unchecked`, which if it is ever stabilized, that additional change would reduce peak memory usage by a more significant amount (about 8% with 4 tiles, with more savings for higher tile counts).