### PR TITLE
Use the x86 8-bit CDEF assembly on edges

### DIFF
--- a/src/asm/x86/cdef.rs
+++ b/src/asm/x86/cdef.rs
@@ -64,7 +64,7 @@ pub(crate) unsafe fn cdef_filter_block<T: Pixel>(
   };
 
   // TODO: handle padding in the fast path
-  if edges != CDEF_HAVE_ALL {
+  if edges != CDEF_HAVE_ALL && matches!(T::type_enum(), PixelType::U16) {
     call_rust(dst);
   } else {
     #[cfg(feature = "check_asm")]


### PR DESCRIPTION
The current workaround to use 16-bit intermediates also means that
we do not need to fall back to the Rust implementation on edges.