### PR TITLE
Maybe a new crates.io release?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rav1e"
-version = "0.5.0-alpha"
+version = "0.5.0-alpha.2"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
There are significant unreleased quality/performance improvements. 

BTW: rav1e has a very long release cycle, IMHO way too slow for the pace of changes in rav1e and around AV1 in general. 

The long release cycle paradoxically makes stable versions of rav1e quite unattractive. The latest not-alpha v0.4 is too far behind in performance/quality to be useful. Currently only the unreleased version of rav1e is competitive with libaom for AVIF compression.

