### PR TITLE
Fix fall-through of x86 dispatch_predict_intra for CpuFeatureLevel::RUST

### DIFF
--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -170,7 +170,7 @@ pub fn dispatch_predict_intra<T: Pixel>(
     let angle = angle as libc::c_int;
 
     match T::type_enum() {
-      PixelType::U8 => {
+      PixelType::U8 if cpu >= CpuFeatureLevel::SSSE3 => {
         let dst_ptr = dst.data_ptr_mut() as *mut _;
         let edge_ptr =
           edge_buf.data.as_ptr().offset(2 * MAX_TX_SIZE as isize) as *const _;


### PR DESCRIPTION
Found by a failure of `asm::shared::predict::test::pred_matches_u8` when running:
```
RAV1E_CPU_TARGET=rust cargo test --release --lib
```