### PR TITLE
Disable HBD asm without 8-bit support for 8-in-16 and enhance fuzzing

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,6 +29,11 @@ path = "fuzz_targets/encode_decode.rs"
 required-features = ["rav1e/decode_test_dav1d"]
 
 [[bin]]
+name = "encode_decode_hbd"
+path = "fuzz_targets/encode_decode_hbd.rs"
+required-features = ["rav1e/decode_test_dav1d"]
+
+[[bin]]
 name = "encode"
 path = "fuzz_targets/encode.rs"
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -5,6 +5,9 @@ version = "0.0.1"
 authors = ["Automatically generated"]
 publish = false
 
+[features]
+check_asm = ["rav1e/check_asm"]
+
 [package.metadata]
 cargo-fuzz = true
 

--- a/fuzz/fuzz_targets/encode_decode_hbd.rs
+++ b/fuzz/fuzz_targets/encode_decode_hbd.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, The rav1e contributors. All rights reserved
+// Copyright (c) 2019-2021, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
@@ -12,7 +12,7 @@
 extern crate rav1e;
 use rav1e::fuzzing::*;
 
-fuzz_target!(|data: DecodeTestParameters<u8>| {
+fuzz_target!(|data: DecodeTestParameters<u16>| {
   let _ = pretty_env_logger::try_init();
 
   fuzz_encode_decode(data)

--- a/src/asm/aarch64/cdef.rs
+++ b/src/asm/aarch64/cdef.rs
@@ -357,7 +357,7 @@ pub(crate) fn cdef_find_dir<T: Pixel>(
         call_rust(var)
       }
     }
-    PixelType::U16 => {
+    PixelType::U16 if coeff_shift > 0 => {
       if let Some(func) = CDEF_DIR_HBD_FNS[cpu.as_index()] {
         unsafe {
           (func)(
@@ -371,6 +371,7 @@ pub(crate) fn cdef_find_dir<T: Pixel>(
         call_rust(var)
       }
     }
+    _ => call_rust(var),
   };
 
   #[cfg(feature = "check_asm")]

--- a/src/asm/aarch64/mc.rs
+++ b/src/asm/aarch64/mc.rs
@@ -119,7 +119,7 @@ pub fn put_8tap<T: Pixel>(
         None => call_rust(dst),
       }
     }
-    PixelType::U16 => {
+    PixelType::U16 if bit_depth > 8 => {
       match PUT_HBD_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
         Some(func) => unsafe {
           (func)(
@@ -137,6 +137,7 @@ pub fn put_8tap<T: Pixel>(
         None => call_rust(dst),
       }
     }
+    _ => call_rust(dst),
   }
   #[cfg(feature = "check_asm")]
   {
@@ -186,7 +187,7 @@ pub fn prep_8tap<T: Pixel>(
         None => call_rust(tmp),
       }
     }
-    PixelType::U16 => {
+    PixelType::U16 if bit_depth > 8 => {
       match PREP_HBD_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
         Some(func) => unsafe {
           (func)(
@@ -203,6 +204,7 @@ pub fn prep_8tap<T: Pixel>(
         None => call_rust(tmp),
       }
     }
+    _ => call_rust(tmp),
   }
   #[cfg(feature = "check_asm")]
   {
@@ -237,7 +239,7 @@ pub fn mc_avg<T: Pixel>(
       },
       None => call_rust(dst),
     },
-    PixelType::U16 => match AVG_HBD_FNS[cpu.as_index()] {
+    PixelType::U16 if bit_depth > 8 => match AVG_HBD_FNS[cpu.as_index()] {
       Some(func) => unsafe {
         (func)(
           dst.data_ptr_mut() as *mut _,
@@ -251,6 +253,7 @@ pub fn mc_avg<T: Pixel>(
       },
       None => call_rust(dst),
     },
+    _ => call_rust(dst),
   }
   #[cfg(feature = "check_asm")]
   {

--- a/src/asm/aarch64/predict.rs
+++ b/src/asm/aarch64/predict.rs
@@ -187,7 +187,7 @@ pub fn dispatch_predict_intra<T: Pixel>(
         }
         _ => call_rust(dst),
       },
-      PixelType::U16 => match mode {
+      PixelType::U16 if bit_depth > 8 => match mode {
         PredictionMode::DC_PRED => {
           (match variant {
             PredictionVariant::NONE => rav1e_ipred_dc_128_16bpc_neon,
@@ -237,6 +237,7 @@ pub fn dispatch_predict_intra<T: Pixel>(
         }
         _ => call_rust(dst),
       },
+      _ => call_rust(dst),
     }
   }
 }

--- a/src/asm/x86/cdef.rs
+++ b/src/asm/x86/cdef.rs
@@ -220,7 +220,7 @@ pub(crate) fn cdef_find_dir<T: Pixel>(
         call_rust(var)
       }
     }
-    PixelType::U16 => {
+    PixelType::U16 if coeff_shift > 0 => {
       if let Some(func) = CDEF_DIR_HBD_FNS[cpu.as_index()] {
         unsafe {
           (func)(
@@ -234,6 +234,7 @@ pub(crate) fn cdef_find_dir<T: Pixel>(
         call_rust(var)
       }
     }
+    _ => call_rust(var),
   };
 
   #[cfg(feature = "check_asm")]

--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -186,7 +186,7 @@ pub fn prep_8tap<T: Pixel>(
         None => call_rust(tmp),
       }
     }
-    PixelType::U16 => {
+    PixelType::U16 if bit_depth > 8 => {
       match PREP_HBD_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
         Some(func) => unsafe {
           (func)(
@@ -203,6 +203,7 @@ pub fn prep_8tap<T: Pixel>(
         None => call_rust(tmp),
       }
     }
+    _ => call_rust(tmp),
   }
   #[cfg(feature = "check_asm")]
   {
@@ -237,7 +238,7 @@ pub fn mc_avg<T: Pixel>(
       },
       None => call_rust(dst),
     },
-    PixelType::U16 => match AVG_HBD_FNS[cpu.as_index()] {
+    PixelType::U16 if bit_depth > 8 => match AVG_HBD_FNS[cpu.as_index()] {
       Some(func) => unsafe {
         (func)(
           dst.data_ptr_mut() as *mut _,
@@ -251,6 +252,7 @@ pub fn mc_avg<T: Pixel>(
       },
       None => call_rust(dst),
     },
+    _ => call_rust(dst),
   }
   #[cfg(feature = "check_asm")]
   {

--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -309,7 +309,7 @@ pub fn dispatch_predict_intra<T: Pixel>(
           }
         }
       }
-      PixelType::U16 if cpu >= CpuFeatureLevel::AVX2 => {
+      PixelType::U16 if cpu >= CpuFeatureLevel::AVX2 && bit_depth > 8 => {
         let dst_ptr = dst.data_ptr_mut() as *mut _;
         let edge_ptr =
           edge_buf.data.as_ptr().offset(2 * MAX_TX_SIZE as isize) as *const _;

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -7,6 +7,7 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use libfuzzer_sys::arbitrary::{Arbitrary, Error, Unstructured};
@@ -295,7 +296,7 @@ pub fn fuzz_encode(arbitrary: ArbitraryEncoder) {
 }
 
 #[derive(Debug)]
-pub struct DecodeTestParameters {
+pub struct DecodeTestParameters<T: Pixel> {
   w: usize,
   h: usize,
   speed: usize,
@@ -312,9 +313,10 @@ pub struct DecodeTestParameters {
   tile_cols_log2: usize,
   tile_rows_log2: usize,
   still_picture: bool,
+  pixel: PhantomData<T>,
 }
 
-impl Arbitrary for DecodeTestParameters {
+impl<T: Pixel> Arbitrary for DecodeTestParameters<T> {
   fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self, Error> {
     let mut p = Self {
       w: u.int_in_range(16..=16 + 255)?,
@@ -338,7 +340,11 @@ impl Arbitrary for DecodeTestParameters {
       tile_cols_log2: u.int_in_range(0..=2)?,
       tile_rows_log2: u.int_in_range(0..=2)?,
       still_picture: bool::arbitrary(u)?,
+      pixel: PhantomData,
     };
+    if matches!(T::type_enum(), PixelType::U16) {
+      p.bit_depth = *u.choose(&[8, 10, 12])?;
+    }
     if !p.low_latency {
       p.switch_frame_interval = 0;
     }
@@ -350,10 +356,10 @@ impl Arbitrary for DecodeTestParameters {
 }
 
 #[cfg(feature = "decode_test_dav1d")]
-pub fn fuzz_encode_decode(p: DecodeTestParameters) {
+pub fn fuzz_encode_decode<T: Pixel>(p: DecodeTestParameters<T>) {
   use crate::test_encode_decode::*;
 
-  let mut dec = get_decoder::<u8>("dav1d", p.w, p.h);
+  let mut dec = get_decoder::<T>("dav1d", p.w, p.h);
   dec.encode_decode(
     p.w,
     p.h,


### PR DESCRIPTION
Pass `check_asm` feature through to rav1e from fuzz crate. Disable HBD asm without 8-bit support for 8-in-16 on x86_64 and aarch64. Add a new fuzz target, `encode_decode_hbd`.
