### PR TITLE
Strip the local symbols from the nasm objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,9 @@ libfuzzer-sys = "0.3"
 rand = "0.8"
 rand_chacha = "0.3"
 
+[target.'cfg(any(decode_test, decode_test_dav1d))'.dependencies]
+system-deps = "~3.1.2"
+
 [[bin]]
 name = "rav1e"
 required-features = ["binaries"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ cc = { version = "1.0", optional = true, features = ["parallel"] }
 # Vendored to remove the dependency on `failure`,
 # which takes a long time to build.
 vergen = { version = "3", path = "crates/vergen" }
-rustc_version = "0.3"
+rustc_version = "0.4"
 regex = { version = "1", optional = true }
 
 [build-dependencies.nasm-rs]
@@ -118,7 +118,7 @@ pretty_assertions = "0.7"
 interpolate_name = "0.2.2"
 rand = "0.8"
 rand_chacha = "0.3"
-semver = "0.11"
+semver = "1.0"
 
 [target.'cfg(fuzzing)'.dependencies]
 arbitrary = "0.4"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ rav1e currently requires Rust 1.51.0 or later to build.
 
 ### Dependency: NASM
 Some `x86_64`-specific optimizations require [NASM](https://nasm.us/) `2.14.02` or newer and are enabled by default.
+`strip` will be used if available to remove the local symbols from the asm objects.
 
 The CI is testing against `nasm 2.15.05`, so bugs for other versions might happen. If you find one please open an issue!
 

--- a/build.rs
+++ b/build.rs
@@ -40,7 +40,11 @@ fn hash_changed(
 
   let mut hasher = DefaultHasher::new();
 
-  let paths = files.iter().map(Path::new).chain(std::iter::once(config));
+  let paths = files
+    .iter()
+    .map(Path::new)
+    .chain(std::iter::once(config))
+    .chain(std::iter::once(Path::new("build.rs")));
 
   for path in paths {
     if let Ok(mut f) = std::fs::File::open(path) {


### PR DESCRIPTION
They tend to confuse the debugger and are overall unnecessary.