### PR TITLE
Replace some deprecated call

### DIFF
--- a/src/api/channel/by_gop.rs
+++ b/src/api/channel/by_gop.rs
@@ -327,7 +327,7 @@ impl Config {
 
     // TODO: make it user-settable
     let input_len = self.enc.rdo_lookahead_frames as usize * 4;
-    let frame_limit = std::i32::MAX as u64;
+    let frame_limit = i32::MAX as u64;
 
     let (send_frame, receive_frame) = bounded(input_len);
     let (send_packet, receive_packet) = unbounded();

--- a/src/api/channel/mod.rs
+++ b/src/api/channel/mod.rs
@@ -258,7 +258,7 @@ impl Config {
         frame_limit,
       )
     } else {
-      (None, None, std::i32::MAX as u64)
+      (None, None, i32::MAX as u64)
     };
 
     let config = Arc::new(self.enc);

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -1367,9 +1367,9 @@ fn output_frameno_no_scene_change_at_short_flash(flash_at: u64) {
   let limit = 5;
   for i in 0..limit {
     if i == flash_at {
-      send_test_frame(&mut ctx, u8::min_value());
+      send_test_frame(&mut ctx, u8::MIN);
     } else {
-      send_test_frame(&mut ctx, u8::max_value());
+      send_test_frame(&mut ctx, u8::MAX);
     }
   }
   ctx.flush();
@@ -1419,14 +1419,14 @@ fn output_frameno_no_scene_change_at_flash_smaller_than_max_len_flash() {
   assert_eq!(ctx.inner.inter_cfg.pyramid_depth, 2);
   assert_eq!(ctx.inner.inter_cfg.group_input_len, 4);
 
-  send_test_frame(&mut ctx, u8::min_value());
-  send_test_frame(&mut ctx, u8::min_value());
-  send_test_frame(&mut ctx, u8::max_value());
-  send_test_frame(&mut ctx, u8::max_value());
-  send_test_frame(&mut ctx, u8::max_value());
-  send_test_frame(&mut ctx, u8::max_value());
-  send_test_frame(&mut ctx, u8::min_value());
-  send_test_frame(&mut ctx, u8::min_value());
+  send_test_frame(&mut ctx, u8::MIN);
+  send_test_frame(&mut ctx, u8::MIN);
+  send_test_frame(&mut ctx, u8::MAX);
+  send_test_frame(&mut ctx, u8::MAX);
+  send_test_frame(&mut ctx, u8::MAX);
+  send_test_frame(&mut ctx, u8::MAX);
+  send_test_frame(&mut ctx, u8::MIN);
+  send_test_frame(&mut ctx, u8::MIN);
   ctx.flush();
 
   let data = get_frame_invariants(ctx)
@@ -1479,18 +1479,18 @@ fn output_frameno_scene_change_before_flash_longer_than_max_flash_len() {
   assert_eq!(ctx.inner.inter_cfg.pyramid_depth, 2);
   assert_eq!(ctx.inner.inter_cfg.group_input_len, 4);
 
-  send_test_frame(&mut ctx, u8::min_value());
-  send_test_frame(&mut ctx, u8::min_value());
-  send_test_frame(&mut ctx, u8::max_value());
-  send_test_frame(&mut ctx, u8::max_value());
-  send_test_frame(&mut ctx, u8::max_value());
-  send_test_frame(&mut ctx, u8::max_value());
-  send_test_frame(&mut ctx, u8::max_value());
-  send_test_frame(&mut ctx, u8::min_value());
-  send_test_frame(&mut ctx, u8::min_value());
-  send_test_frame(&mut ctx, u8::min_value());
-  send_test_frame(&mut ctx, u8::min_value());
-  send_test_frame(&mut ctx, u8::min_value());
+  send_test_frame(&mut ctx, u8::MIN);
+  send_test_frame(&mut ctx, u8::MIN);
+  send_test_frame(&mut ctx, u8::MAX);
+  send_test_frame(&mut ctx, u8::MAX);
+  send_test_frame(&mut ctx, u8::MAX);
+  send_test_frame(&mut ctx, u8::MAX);
+  send_test_frame(&mut ctx, u8::MAX);
+  send_test_frame(&mut ctx, u8::MIN);
+  send_test_frame(&mut ctx, u8::MIN);
+  send_test_frame(&mut ctx, u8::MIN);
+  send_test_frame(&mut ctx, u8::MIN);
+  send_test_frame(&mut ctx, u8::MIN);
   ctx.flush();
 
   let data = get_frame_invariants(ctx)
@@ -1545,8 +1545,8 @@ fn output_frameno_scene_change_after_multiple_flashes() {
   assert_eq!(ctx.inner.inter_cfg.pyramid_depth, 2);
   assert_eq!(ctx.inner.inter_cfg.group_input_len, 4);
 
-  send_test_frame(&mut ctx, u8::min_value());
-  send_test_frame(&mut ctx, u8::min_value());
+  send_test_frame(&mut ctx, u8::MIN);
+  send_test_frame(&mut ctx, u8::MIN);
   send_test_frame(&mut ctx, 40);
   send_test_frame(&mut ctx, 100);
   send_test_frame(&mut ctx, 160);

--- a/src/asm/x86/quantize.rs
+++ b/src/asm/x86/quantize.rs
@@ -192,7 +192,7 @@ mod test {
         let mut rcoeffs = Aligned::new([0i16; 32 * 32]);
 
         // Generate quantized coefficients up to the eob
-        let between = Uniform::from(-std::i16::MAX..=std::i16::MAX);
+        let between = Uniform::from(-i16::MAX..=i16::MAX);
         for (i, qcoeff) in qcoeffs.data.iter_mut().enumerate().take(eob) {
           *qcoeff = between.sample(&mut rng)
             / if i == 0 { dc_quant } else { ac_quant };

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -404,7 +404,7 @@ fn detect_scale_factor(sequence: &Arc<Sequence>) -> usize {
     481..=720 => 4,
     721..=1080 => 8,
     1081..=1600 => 16,
-    1601..=std::usize::MAX => 32,
+    1601..=usize::MAX => 32,
     _ => 1,
   } as usize;
   debug!(

--- a/src/tiling/tiler.rs
+++ b/src/tiling/tiler.rs
@@ -813,7 +813,7 @@ pub mod test {
 
   #[test]
   fn tile_log2_overflow() {
-    assert_eq!(TilingInfo::tile_log2(1, usize::max_value()), None);
+    assert_eq!(TilingInfo::tile_log2(1, usize::MAX), None);
   }
 
   #[test]


### PR DESCRIPTION
Replace deprecated use of std::{number} and min/max_value