### PR TITLE
Partially replace full search with UMH

### DIFF
--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -84,6 +84,10 @@ pub struct SpeedSettings {
   /// Use fine directional intra prediction
   pub fine_directional_intra: bool,
 
+  /// Enable full search in some parts of motion estimation. Allowing full
+  /// search is slower.
+  pub me_allow_full_search: bool,
+
   // NOTE: put enums and basic type fields above
   /// Range of partition sizes that can be used. Larger ranges are slower.
   ///
@@ -119,6 +123,7 @@ impl Default for SpeedSettings {
       segmentation: SegmentationLevel::Full,
       enable_inter_tx_split: false,
       fine_directional_intra: false,
+      me_allow_full_search: false,
     }
   }
 }
@@ -166,6 +171,7 @@ impl SpeedSettings {
       segmentation: Self::segmentation_preset(speed),
       enable_inter_tx_split: Self::enable_inter_tx_split_preset(speed),
       fine_directional_intra: Self::fine_directional_intra_preset(speed),
+      me_allow_full_search: Self::me_allow_full_search_preset(speed),
     }
   }
 
@@ -293,6 +299,10 @@ impl SpeedSettings {
 
   fn fine_directional_intra_preset(_speed: usize) -> bool {
     true
+  }
+
+  const fn me_allow_full_search_preset(speed: usize) -> bool {
+    speed <= 5
   }
 }
 

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, The rav1e contributors. All rights reserved
+// Copyright (c) 2019-2021, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
@@ -23,6 +23,7 @@ use crate::tiling::*;
 use crate::util::*;
 
 use simd_helpers::cold_for_target_arch;
+use std::ops;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct MotionVector {
@@ -46,6 +47,42 @@ impl MotionVector {
     use crate::context::{MV_LOW, MV_UPP};
     ((MV_LOW as i16) < self.row && self.row < (MV_UPP as i16))
       && ((MV_LOW as i16) < self.col && self.col < (MV_UPP as i16))
+  }
+}
+
+impl ops::Mul<i16> for MotionVector {
+  type Output = MotionVector;
+
+  #[inline]
+  fn mul(self, rhs: i16) -> MotionVector {
+    MotionVector { row: self.row * rhs, col: self.col * rhs }
+  }
+}
+
+impl ops::Mul<u16> for MotionVector {
+  type Output = MotionVector;
+
+  #[inline]
+  fn mul(self, rhs: u16) -> MotionVector {
+    MotionVector { row: self.row * rhs as i16, col: self.col * rhs as i16 }
+  }
+}
+
+impl ops::Shl<u8> for MotionVector {
+  type Output = MotionVector;
+
+  #[inline]
+  fn shl(self, rhs: u8) -> MotionVector {
+    MotionVector { row: self.row << rhs, col: self.col << rhs }
+  }
+}
+
+impl ops::Add<MotionVector> for MotionVector {
+  type Output = MotionVector;
+
+  #[inline]
+  fn add(self, rhs: MotionVector) -> MotionVector {
+    MotionVector { row: self.row + rhs.row, col: self.col + rhs.col }
   }
 }
 


### PR DESCRIPTION
Implement uneven multi-hexagon (UMH) and insert it before full search.
On faster speed settings (>= 6), full search is disabled entirely and
UMH is the final search where full search was before.

Other changes:
* Rewrite motion searches using the tools added with UMH.
* Implement regular hexagon search which is currently called from UMH.
* Add comments in places that haven't been changed.
* Refactor to make the newly added code more understandable.

objective-1-fast results
```text
Measured Speedup (using awcy, so high variance)
Speed Preset         | -s 5 || -s 6 | -s 7 | -s 8 | -s 9 | -s 10
Runtime Decrease (%) | 0.27 || 2.31 | 3.53 | 3.57 | 2.98 | 6.77\
```

BD-rate. Values < 0 are good.
```text
Speed Preset | -s 5 || -s 6 | -s 7 | -s 8 | -s 9 | -s 10
-------------|------||------|------|------|------|------
MS-SSIM      |-0.00 || 0.27 | 0.24 | 0.31 | 0.10 |-0.75
PSNR-HVS Y   | 0.09 || 0.33 | 0.18 | 0.23 | 0.07 |-0.72
VMAF         | 0.09 || 0.94 | 0.19 | 0.07 | 0.10 |-0.81
```

The improvement for speed 10 seems to be mostly due to an outlier (the
wikipedia test clip).

This is the run for speed 6 against master.

https://beta.arewecompressedyet.com/?job=master-e09f555d279e7d4dbd0063f072d57695dcc4da7e%402021-08-11T13%3A47%3A01.955Z&job=%E2%98%86UMH-Review%E2%98%861%402021-08-17T15%3A47%3A02.166Z