### PR TITLE
Do not compare invisible padding in fast scenecut

### DIFF
--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -384,6 +384,7 @@ impl<T: Pixel> SceneChangeDetector<T> {
       let delta_line = l1
         .iter()
         .zip(l2.iter())
+        .take(plane1.cfg.width)
         .map(|(&p1, &p2)| {
           (i16::cast_from(p1) - i16::cast_from(p2)).abs() as u32
         })


### PR DESCRIPTION
The padding in a plane is not guaranteed to be the same each time the encoder runs.
It coincidentally was always the same, prior to downscaling being introduced to the scenechange detection.
After downscaling, the padding is not always the same, which results in different scenecut decision
from run to run as a result of this bug.
The correct solution is to have delta_in_planes ignore the padding, which is what this change does.

Fixes #2781