### PR TITLE
Remove the histogram crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ wasm = ["wasm-bindgen"]
 dump_lookahead_data = ["byteorder", "image"]
 
 [dependencies]
-histogram = "0.6.9"
 arg_enum_proc_macro = "0.3"
 bitstream-io = "1"
 cfg-if = "1.0"

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -14,7 +14,6 @@ use crate::rayon::iter::*;
 use crate::tiling::{Area, TileRect};
 use crate::transform::TxSize;
 use crate::{Frame, Pixel};
-use histogram::Histogram;
 use rust_hawktracer::*;
 use std::sync::Arc;
 use v_frame::pixel::CastFromPrimitive;
@@ -145,31 +144,30 @@ pub(crate) fn estimate_inter_costs_histogram_blocks<T: Pixel>(
         height: IMPORTANCE_BLOCK_SIZE,
       });
 
-      let max_value = 1u64 << 12; // At most 12 bit per pixel
-
-      let mut histogram_org =
-        Histogram::configure().max_value(max_value).build().unwrap();
+      let mut count = 0u64;
+      let mut histogram_org_sum = 0f64;
       let iter_org = region_org.rows_iter();
       for row in iter_org {
         for pixel in row {
-          let cur = i16::cast_from(*pixel);
-          histogram_org.increment(cur as u64).unwrap();
+          let cur = u16::cast_from(*pixel);
+          histogram_org_sum += cur as f64;
+          count += 1;
         }
       }
 
-      let mut histogram_ref =
-        Histogram::configure().max_value(max_value).build().unwrap();
+      let mut histogram_ref_sum = 0f64;
       let iter_ref = region_ref.rows_iter();
       for row in iter_ref {
         for pixel in row {
-          let cur = i16::cast_from(*pixel);
-          histogram_ref.increment(cur as u64).unwrap();
+          let cur = u16::cast_from(*pixel);
+          histogram_ref_sum += cur as f64;
         }
       }
 
-      let mean = (histogram_org.mean().unwrap() as i32
-        - histogram_ref.mean().unwrap() as i32)
-        .abs();
+      let mean = ((histogram_org_sum / count as f64)
+        - (histogram_ref_sum / count as f64))
+        .abs()
+        .round();
 
       inter_costs.push(mean as u32);
     });

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -144,30 +144,29 @@ pub(crate) fn estimate_inter_costs_histogram_blocks<T: Pixel>(
         height: IMPORTANCE_BLOCK_SIZE,
       });
 
-      let mut count = 0u64;
-      let mut histogram_org_sum = 0u64;
+      let mut count = 0i64;
+      let mut histogram_org_sum = 0i64;
       let iter_org = region_org.rows_iter();
       for row in iter_org {
         for pixel in row {
           let cur = u16::cast_from(*pixel);
-          histogram_org_sum += cur as u64;
+          histogram_org_sum += cur as i64;
           count += 1;
         }
       }
 
-      let mut histogram_ref_sum = 0u64;
+      let mut histogram_ref_sum = 0i64;
       let iter_ref = region_ref.rows_iter();
       for row in iter_ref {
         for pixel in row {
           let cur = u16::cast_from(*pixel);
-          histogram_ref_sum += cur as u64;
+          histogram_ref_sum += cur as i64;
         }
       }
 
-      let mean = ((histogram_org_sum as f64 / count as f64)
-        - (histogram_ref_sum as f64 / count as f64))
-        .abs()
-        .round();
+      let mean = (((histogram_org_sum + count / 2) / count)
+        - ((histogram_ref_sum + count / 2) / count))
+        .abs();
 
       inter_costs.push(mean as u32);
     });

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -145,27 +145,27 @@ pub(crate) fn estimate_inter_costs_histogram_blocks<T: Pixel>(
       });
 
       let mut count = 0u64;
-      let mut histogram_org_sum = 0f64;
+      let mut histogram_org_sum = 0u64;
       let iter_org = region_org.rows_iter();
       for row in iter_org {
         for pixel in row {
           let cur = u16::cast_from(*pixel);
-          histogram_org_sum += cur as f64;
+          histogram_org_sum += cur as u64;
           count += 1;
         }
       }
 
-      let mut histogram_ref_sum = 0f64;
+      let mut histogram_ref_sum = 0u64;
       let iter_ref = region_ref.rows_iter();
       for row in iter_ref {
         for pixel in row {
           let cur = u16::cast_from(*pixel);
-          histogram_ref_sum += cur as f64;
+          histogram_ref_sum += cur as u64;
         }
       }
 
-      let mean = ((histogram_org_sum / count as f64)
-        - (histogram_ref_sum / count as f64))
+      let mean = ((histogram_org_sum as f64 / count as f64)
+        - (histogram_ref_sum as f64 / count as f64))
         .abs()
         .round();
 


### PR DESCRIPTION
It was extremely slow, especially at higher max values.
We can just calculate the mean directly by summing and division.

This version makes the slow scenechange only 15% slower than medium. (Approximately a 4x speedup compared to before.)
As part of a speed 6 encode, the difference in full encode time is 1-2% between slow and medium scenecut.

There is a slight AWCY difference, likely due to differences in how the means are rounded.
I don't feel that this is significant enough to hold up this PR, although I am open to opinions.

https://beta.arewecompressedyet.com/?job=master-vimeo%402021-09-06T18%3A36%3A16.994Z&job=no-histogram-try3%402021-09-06T19%3A26%3A04.175Z