### PR TITLE
Simplify `adaptive_scenecut` by not collecting into a Vec for `*_over…

### DIFF
--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -272,10 +272,7 @@ impl<T: Pixel> SceneChangeDetector<T> {
       // Check for scenecut after the flashes
       // No frames over threshold forward
       // and some frames over threshold backward
-      if forward_over_tr_count == 0
-        && back_deque.len() > 1
-        && back_over_tr_count > 1
-      {
+      if forward_over_tr_count == 0 && back_over_tr_count > 1 {
         return true;
       }
 


### PR DESCRIPTION
…_tr`

The variables `back_over_tr` and `forward_over_tr` (which have now been renamed to be suffixed with `_count`) were previously initialized by performing an allocation (through the use of `.collect_vec()`) of the filtered values, even though only the *length* of the `Vec` was actually used. We now get the length directly by using `.count()`, which does not perform any allocations, and allows the compiler to make use of SIMD instructions.

Additionally, the previous code essentially did this (simplified for example): `x != 0 && x > 1` (where `x` is a `usize`). This has been simplified to just `x > 1`.