### PR TITLE
Write the 'monochrome' bit correctly

### DIFF
--- a/src/api/channel/data.rs
+++ b/src/api/channel/data.rs
@@ -209,10 +209,10 @@ impl<T: Pixel> PacketReceiver<T> {
         bw.write_bit(false)?; // tier
         bw.write_bit(seq.bit_depth > 8)?; // high_bitdepth
         bw.write_bit(seq.bit_depth == 12)?; // twelve_bit
-        bw.write_bit(seq.bit_depth == 1)?; // monochrome
+        bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs400)?; // monochrome
         bw.write_bit(seq.chroma_sampling != ChromaSampling::Cs444)?; // chroma_subsampling_x
         bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs420)?; // chroma_subsampling_y
-        bw.write(2, 0)?; // sample_position
+        bw.write(2, 0)?; // chroma_sample_position
         bw.write(3, 0)?; // reserved
         bw.write_bit(false)?; // initial_presentation_delay_present
 

--- a/src/api/context.rs
+++ b/src/api/context.rs
@@ -327,10 +327,10 @@ impl<T: Pixel> Context<T> {
         bw.write_bit(false)?; // tier
         bw.write_bit(seq.bit_depth > 8)?; // high_bitdepth
         bw.write_bit(seq.bit_depth == 12)?; // twelve_bit
-        bw.write_bit(seq.bit_depth == 1)?; // monochrome
+        bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs400)?; // monochrome
         bw.write_bit(seq.chroma_sampling != ChromaSampling::Cs444)?; // chroma_subsampling_x
         bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs420)?; // chroma_subsampling_y
-        bw.write(2, 0)?; // sample_position
+        bw.write(2, 0)?; // chroma_sample_position
         bw.write(3, 0)?; // reserved
         bw.write_bit(false)?; // initial_presentation_delay_present
 


### PR DESCRIPTION
The original code write the 'monochrome' bit with the value
seq.bit_depth == 1. I suspect this comes from misunderstanding what
monochrome means in AV1. In AV1, monochrome is what is usually known as
grayscale, rather than black and white. Therefore the correct check for
monochrome should be seq.chroma_sampling == ChromaSampling::Cs400.

Also change the comment "sample_position" to "chroma_sample_position"
because chroma_sample_position is the name of that field in the AV1
ISOBMFF specification.