### PR TITLE
Better autovectorization of `delta_in_planes` for faster fast scene detection

### DIFF
--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -426,10 +426,11 @@ impl<T: Pixel> SceneChangeDetector<T> {
     let lines = plane1.rows_iter().zip(plane2.rows_iter());
 
     for (l1, l2) in lines {
+      let l1 = l1.get(..plane1.cfg.width).unwrap_or(l1);
+      let l2 = l2.get(..plane1.cfg.width).unwrap_or(l2);
       let delta_line = l1
         .iter()
         .zip(l2.iter())
-        .take(plane1.cfg.width)
         .map(|(&p1, &p2)| {
           (i16::cast_from(p1) - i16::cast_from(p2)).abs() as u32
         })


### PR DESCRIPTION
By getting a subslice of the plane before the actual calculation of the
delta, the compiler is able to utilize SIMD instructions, but can't for
some reason when doing `.take()`. When compiling with AVX2 enabled, this
results in about a 5x speedup for `delta_in_planes`.

Difference in generated assembly (simplified for example):
https://godbolt.org/z/oTKe7n5dr