### PR TITLE
Disable Coveralls step in CI

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -48,7 +48,7 @@ jobs:
           - aom-tests
           - dav1d-tests
           - no-asm-tests
-          - grcov-coveralls
+          # - grcov-coveralls
           - bench
           - doc
           - cargo-c
@@ -67,8 +67,8 @@ jobs:
             toolchain: stable
           - conf: no-asm-tests
             toolchain: stable
-          - conf: grcov-coveralls
-            toolchain: stable
+          # - conf: grcov-coveralls
+          #   toolchain: stable
           - conf: bench
             toolchain: stable
           - conf: doc


### PR DESCRIPTION
Our Coveralls job appears to be broken,
as it is currently returning a 405 error upon upload.
This is causing all builds to fail.
This commit disables the Coveralls step temporarily
until the job can be fixed properly.