### PR TITLE
Correct lowest pdf search to not use ec counter

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1392,7 +1392,9 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
       cw.get_cdf_intra_mode_kf(tile_bo)
     }
     .iter()
-    .take(INTRA_MODES)
+    .take(INTRA_MODES - 1)
+    // Tac on the final icdf (always 0), since it isn't stored explicitly.
+    .chain(&[0u16])
     .scan(32768, |z, &a| {
       let d = *z - a;
       *z = a;


### PR DESCRIPTION
The last element in the cdf array is a counter. This code was using it
as the last (inverse) cumulative distribution, when it should instead be
using a hardcoded zero.

This fixes an underflow bug triggered when the counter is larger than
the previous value.

Fixes #2780