### PR TITLE
Use reduced precision in PDF sort

### DIFF
--- a/src/ec.rs
+++ b/src/ec.rs
@@ -888,6 +888,18 @@ impl<W: io::Write> BCodeWriter for BitWriter<W, BigEndian> {
   }
 }
 
+pub(crate) fn cdf_to_pdf<const CDF_LEN: usize>(
+  cdf: &[u16; CDF_LEN],
+) -> [u16; CDF_LEN] {
+  let mut pdf = [0; CDF_LEN];
+  let mut z = 32768u16 >> EC_PROB_SHIFT;
+  for (d, &a) in pdf.iter_mut().zip(cdf.iter()) {
+    *d = z - (a >> EC_PROB_SHIFT);
+    z = a >> EC_PROB_SHIFT;
+  }
+  pdf
+}
+
 pub(crate) mod rust {
   // Function to update the CDF for Writer calls that do so.
   #[inline]


### PR DESCRIPTION
This fixes an underflow bug triggered when the counter is larger than the previous value. Fixes #2780.

[AWCY results at default preset](https://beta.arewecompressedyet.com/?job=master-0c066cbba2637ba0587a8685f7796be5e24a44a5&job=issue-2780%402021-09-28T05%3A17%3A20.528Z):
| PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |   SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |   VMAF | VMAF-NEG |
|   ---: |    ---: |    ---: |      ---: |   ---: |    ---: |       ---: |        ---: |        ---: |     ---: |   ---: |     ---: |
| 0.0029 |  0.1181 |  0.0019 |    0.0017 | 0.0059 |  0.0158 |    -0.0040 |      0.1020 |      0.0126 |  -0.0006 | 0.0959 |   0.0822 |