### PR TITLE
Fix distortion calculations overlapping boundaries

### DIFF
--- a/src/dist.rs
+++ b/src/dist.rs
@@ -204,7 +204,7 @@ pub(crate) mod rust {
       for block_x in 0..(w + chunk_size - 1) / chunk_size {
         let mut block_sse: u32 = 0;
 
-        for j in 0..chunk_size {
+        for j in 0..chunk_size.min(h - block_y * chunk_size) {
           let s1 = &src1[block_y * chunk_size + j]
             [block_x * chunk_size..((block_x + 1) * chunk_size).min(w)];
           let s2 = &src2[block_y * chunk_size + j]


### PR DESCRIPTION
Fix cropping at the bottom boundary for weighted SSE.

Fall back to weighted SSE only near the boundary for tune=Psychovisual, rather than for the whole block.
Also, apply spatial weights when falling back in this case.

Fixes #2817.

AWCY results [at default speed on subset1](https://beta.arewecompressedyet.com/?job=master-2021-10-01_055153-48149f18&job=issue-2817%402021-10-05T02%3A18%3A03.973Z):

|  PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |    SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |    VMAF | VMAF-NEG |
|    ---: |    ---: |    ---: |      ---: |    ---: |    ---: |       ---: |        ---: |        ---: |     ---: |    ---: |     ---: |
| -0.1797 | -0.6004 | -0.5008 |   -0.2449 | -0.1481 | -0.1592 |    -0.1544 |     -0.4386 |     -0.4213 |  -0.1608 | -0.2098 |  -0.1892 |