### PR TITLE
Avoid bounds checks in copy_from_raw_u8 for HBD

### DIFF
--- a/benches/plane.rs
+++ b/benches/plane.rs
@@ -56,4 +56,38 @@ pub fn downsample_10bit(c: &mut Criterion) {
   });
 }
 
-criterion_group!(plane, downsample_8bit, downsample_odd, downsample_10bit);
+fn init_raw_plane_data(width: usize, height: usize) -> Vec<u8> {
+  let mut ra = ChaChaRng::from_seed([0; 32]);
+  (0..(width * height)).map(|_| ra.gen()).collect()
+}
+
+pub fn copy_from_raw_u8_8bit(c: &mut Criterion) {
+  let input = init_raw_plane_data(1920, 1080);
+  let dest = Plane::<u8>::new(1920, 1080, 0, 0, 0, 0);
+  c.bench_function("copy_from_raw_u8", move |b| {
+    b.iter(|| {
+      let mut dest = dest.clone();
+      let _ = dest.copy_from_raw_u8(&input, dest.cfg.stride, 1);
+    })
+  });
+}
+
+pub fn copy_from_raw_u8_10bit(c: &mut Criterion) {
+  let input = init_raw_plane_data(1920, 1080);
+  let dest = Plane::<u16>::new(1920, 1080, 0, 0, 0, 0);
+  c.bench_function("copy_from_raw_u8", move |b| {
+    b.iter(|| {
+      let mut dest = dest.clone();
+      let _ = dest.copy_from_raw_u8(&input, dest.cfg.stride, 2);
+    })
+  });
+}
+
+criterion_group!(
+  plane,
+  downsample_8bit,
+  downsample_odd,
+  downsample_10bit,
+  copy_from_raw_u8_8bit,
+  copy_from_raw_u8_10bit
+);

--- a/v_frame/src/plane.rs
+++ b/v_frame/src/plane.rs
@@ -422,11 +422,9 @@ impl<T: Pixel> Plane<T> {
             source_bytewidth
           );
           for (self_pixel, bytes) in
-            self_row.iter_mut().zip(source_row.chunks(2))
+            self_row.iter_mut().zip(source_row.chunks_exact(2))
           {
-            *self_pixel = T::cast_from(
-              u16::cast_from(bytes[1]) << 8 | u16::cast_from(bytes[0]),
-            );
+            *self_pixel = T::cast_from(bytes[1]) << 8 | T::cast_from(bytes[0]);
           }
         }
 


### PR DESCRIPTION
The compiler cannot assume that `.chunks` will always produce
slices with 2 elements, because the final chunk may only
contain one element. However, we can assume that if the source
bytewidth is 2 bytes, that there must be an even number of bytes
and every chunk will have 2 elements.

Therefore, we can safely remove the bounds checks in the HBD path.
This improves performance of the HBD version of this function by 30%.
Approximately 1% overall encode performance at speed 10.