### PR TITLE
Defer initialization of FrameInvariants FrameMEStats

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -664,7 +664,7 @@ impl<T: Pixel> ContextInner<T> {
     compute_motion_vectors(fi, fs, &self.inter_cfg);
 
     // Save the motion vectors to FrameInvariants.
-    fi.lookahead_me_stats = fs.frame_me_stats.clone();
+    fi.lookahead_me_stats = Some(fs.frame_me_stats.clone());
 
     #[cfg(feature = "dump_lookahead_data")]
     {
@@ -1007,6 +1007,11 @@ impl<T: Pixel> ContextInner<T> {
       let frame_data = &mut self.frame_data;
       let len = unique_indices.len();
 
+      let lookahead_me_stats = fi
+        .lookahead_me_stats
+        .as_ref()
+        .expect("Lookahead ME stats not populated, this is a bug");
+
       // Compute and propagate the importance, split evenly between the
       // referenced frames.
       unique_indices.iter().for_each(|&(mv_index, rec_index)| {
@@ -1019,7 +1024,7 @@ impl<T: Pixel> ContextInner<T> {
           fi.rec_buffer.frames[rec_index as usize].as_ref().unwrap();
         let reference_frame = &reference.frame;
         let reference_output_frameno = reference.output_frameno;
-        let me_stats = &fi.lookahead_me_stats[mv_index];
+        let me_stats = &lookahead_me_stats[mv_index];
 
         // We should never use frame as its own reference.
         assert_ne!(reference_output_frameno, output_frameno);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -573,7 +573,10 @@ pub struct FrameInvariants<T: Pixel> {
   pub invalid: bool,
   /// Motion vectors to the _original_ reference frames (not reconstructed).
   /// Used for lookahead purposes.
-  pub lookahead_me_stats: Arc<[FrameMEStats; REF_FRAMES as usize]>,
+  ///
+  /// These objects are very expensive to create, so their creation
+  /// is deferred until it is needed.
+  pub lookahead_me_stats: Option<Arc<[FrameMEStats; REF_FRAMES as usize]>>,
   /// The lookahead version of `rec_buffer`, used for storing and propagating
   /// the original reference frames (rather than reconstructed ones). The
   /// lookahead uses both `rec_buffer` and `lookahead_rec_buffer`, where
@@ -722,7 +725,7 @@ impl<T: Pixel> FrameInvariants<T> {
       tx_mode_select: false,
       default_filter: FilterMode::REGULAR,
       invalid: false,
-      lookahead_me_stats: FrameMEStats::new_arc_array(w_in_b, h_in_b),
+      lookahead_me_stats: None,
       lookahead_rec_buffer: ReferenceFramesSet::new(),
       w_in_imp_b,
       h_in_imp_b,


### PR DESCRIPTION
The FrameMEStats arrays are very expensive to create.
We do not always need them in FrameInvariants,
so defering can speed up certain areas of the code
such as scenecut detection.

This reduces the creation time for a FrameInvariants
object by 95%. Scenecut detection time for the standard
method is reduced by 15%.