### PR TITLE
CI: Run apt-get update before install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,11 +146,13 @@ jobs:
     - name: Install musl tools
       if: matrix.target != 'wasm32-unknown-unknown'
       run: |
+        sudo apt-get update
         sudo apt-get install musl-tools
 
     - name: Install aarch64 tools
       if: matrix.target == 'aarch64-unknown-linux-musl'
       run: |
+        sudo apt-get update
         sudo apt-get install binutils-aarch64-linux-gnu
 
     - name: Install ${{ matrix.target }} target


### PR DESCRIPTION
If the apt index in the base image is outdated, fetching packages may fail with an HTTP 404 error.