### PR TITLE
CI: Always use latest cargo-c and grcov versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install cargo-c
       run: |
-        $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.8.0"
+        $LINK = "https://github.com/lu-zero/cargo-c/releases/latest/download"
         $CARGO_C_FILE = "cargo-c-windows-msvc"
         curl -LO "$LINK/$CARGO_C_FILE.zip"
         7z e -y "$CARGO_C_FILE.zip" -o"${env:USERPROFILE}\.cargo\bin"

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -188,10 +188,9 @@ jobs:
       - name: Install grcov
         if: matrix.conf == 'grcov-coveralls'
         env:
-          LINK: https://github.com/mozilla/grcov/releases/download
-          GRCOV_VERSION: 0.7.1
+          LINK: https://github.com/mozilla/grcov/releases/latest/download
         run: |
-          curl -L "$LINK/v$GRCOV_VERSION/grcov-linux-x86_64.tar.bz2" |
+          curl -L "$LINK/grcov-linux-x86_64.tar.bz2" |
           tar xj -C $HOME/.cargo/bin
       - name: Install ${{ matrix.toolchain }}
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -181,10 +181,9 @@ jobs:
       - name: Install cargo-c
         if: matrix.conf == 'cargo-c'
         env:
-          LINK: https://github.com/lu-zero/cargo-c/releases/download
-          CARGO_C_VERSION: 0.8.0
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
         run: |
-          curl -L "$LINK/v$CARGO_C_VERSION/cargo-c-linux.tar.gz" |
+          curl -L "$LINK/cargo-c-linux.tar.gz" |
           tar xz -C $HOME/.cargo/bin
       - name: Install grcov
         if: matrix.conf == 'grcov-coveralls'
@@ -461,7 +460,7 @@ jobs:
       - name: Install cargo-c
         if: matrix.conf == 'cargo-c'
         run: |
-          $LINK = "https://github.com/lu-zero/cargo-c/releases/download/v0.8.0"
+          $LINK = "https://github.com/lu-zero/cargo-c/releases/latest/download"
           $CARGO_C_FILE = "cargo-c-windows-msvc"
           curl -LO "$LINK/$CARGO_C_FILE.zip"
           7z e -y "$CARGO_C_FILE.zip" -o"${env:USERPROFILE}\.cargo\bin"


### PR DESCRIPTION
Prevents having to update it manually all the time