### PR TITLE
Replace float sqrt+divide with fixed point rsqrt

### DIFF
--- a/src/activity.rs
+++ b/src/activity.rs
@@ -60,7 +60,7 @@ impl ActivityMask {
     &self, bit_depth: usize, activity_scales: &mut Box<[DistortionScale]>,
   ) {
     for (dst, &src) in activity_scales.iter_mut().zip(self.variances.iter()) {
-      *dst = ssim_boost(src as i64, src as i64, bit_depth);
+      *dst = ssim_boost(src, src, bit_depth);
     }
   }
 }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -36,7 +36,9 @@ use crate::predict::{
 use crate::rdo_tables::*;
 use crate::tiling::*;
 use crate::transform::{TxSet, TxSize, TxType, RAV1E_TX_TYPES};
-use crate::util::{init_slice_repeat_mut, Aligned, CastFromPrimitive, Pixel};
+use crate::util::{
+  init_slice_repeat_mut, Aligned, CastFromPrimitive, ILog, Pixel,
+};
 use crate::write_tx_blocks;
 use crate::write_tx_tree;
 use crate::Tune;
@@ -187,31 +189,165 @@ fn cdef_dist_wxh_8x8<T: Pixel>(
   }
 
   // Sum together the sum of columns
-  let sum_s: i64 =
-    sum_s_cols.iter().map(|&a| u32::cast_from(a)).sum::<u32>() as i64;
-  let sum_d: i64 =
-    sum_d_cols.iter().map(|&a| u32::cast_from(a)).sum::<u32>() as i64;
-  let sum_s2: i64 = sum_s2_cols.iter().sum::<u32>() as i64;
-  let sum_d2: i64 = sum_d2_cols.iter().sum::<u32>() as i64;
-  let sum_sd: i64 = sum_sd_cols.iter().sum::<u32>() as i64;
+  let sum_s: u32 = sum_s_cols.iter().map(|&a| u32::cast_from(a)).sum::<u32>();
+  let sum_d: u32 = sum_d_cols.iter().map(|&a| u32::cast_from(a)).sum::<u32>();
+  let sum_s2: u32 = sum_s2_cols.iter().sum::<u32>();
+  let sum_d2: u32 = sum_d2_cols.iter().sum::<u32>();
+  let sum_sd: u32 = sum_sd_cols.iter().sum::<u32>();
 
   // Use sums to calculate distortion
   let svar = sum_s2 - ((sum_s * sum_s + 32) >> 6);
   let dvar = sum_d2 - ((sum_d * sum_d + 32) >> 6);
-  let sse = (sum_d2 + sum_s2 - 2 * sum_sd) as u64;
-  RawDistortion::new(ssim_boost(svar, dvar, bit_depth).mul_u64(sse))
+  let sse = sum_d2 + sum_s2 - 2 * sum_sd;
+
+  RawDistortion(apply_ssim_boost(sse, svar, dvar, bit_depth) as u64)
+}
+
+/// rsqrt result stored in fixed point w/ scaling such that:
+///   rsqrt = output.rsqrt_norm / (1 << output.shift)
+struct RsqrtOutput {
+  norm: u16,
+  shift: u8,
+}
+
+/// Fixed point rsqrt for ssim_boost
+fn ssim_boost_rsqrt(x: u64) -> RsqrtOutput {
+  const INSHIFT: u8 = 16;
+  const OUTSHIFT: u8 = 14;
+
+  let k = ((x.ilog() - 1) >> 1) as i16;
+  /*t is x in the range [0.25, 1) in QINSHIFT, or x*2^(-s).
+  Shift by log2(x) - log2(0.25*(1 << INSHIFT)) to ensure 0.25 lower bound.*/
+  let s: i16 = 2 * k - (INSHIFT as i16 - 2);
+  let t: u16 = if s > 0 { x >> s } else { x << -s } as u16;
+
+  /*We want to express od_rsqrt() in terms of od_rsqrt_norm(), which is
+   defined as (2^OUTSHIFT)/sqrt(t*(2^-INSHIFT)) with t=x*(2^-s).
+  This simplifies to 2^(OUTSHIFT+(INSHIFT/2)+(s/2))/sqrt(x), so the caller
+   needs to shift right by OUTSHIFT + INSHIFT/2 + s/2.*/
+  let rsqrt_shift: u8 = (OUTSHIFT as i16 + ((s + INSHIFT as i16) >> 1)) as u8;
+
+  #[inline(always)]
+  fn mult16_16_q15(a: i32, b: i32) -> i32 {
+    (a * b) >> 15
+  }
+
+  /* Reciprocal sqrt approximation where the input is in the range [0.25,1) in
+  Q16 and the output is in the range (1.0, 2.0] in Q14). */
+
+  /* Range of n is [-16384,32767] ([-0.5,1) in Q15). */
+  let n: i32 = t as i32 - 32768;
+  debug_assert!(n >= -16384);
+
+  /* Get a rough guess for the root.
+  The optimal minimax quadratic approximation (using relative error) is
+   r = 1.437799046117536+n*(-0.823394375837328+n*0.4096419668459485).
+  Coefficients here, and the final result r, are Q14. */
+  let rsqrt: i32 = 23557 + mult16_16_q15(n, -13490 + mult16_16_q15(n, 6711));
+
+  debug_assert!((16384..32768).contains(&rsqrt));
+  RsqrtOutput { norm: rsqrt as u16, shift: rsqrt_shift }
 }
 
 #[inline(always)]
-pub fn ssim_boost(svar: i64, dvar: i64, bit_depth: usize) -> DistortionScale {
+pub fn ssim_boost(svar: u32, dvar: u32, bit_depth: usize) -> DistortionScale {
+  DistortionScale(apply_ssim_boost(
+    DistortionScale::default().0,
+    svar,
+    dvar,
+    bit_depth,
+  ))
+}
+
+/// Apply ssim boost to a given input
+#[inline(always)]
+fn apply_ssim_boost(
+  input: u32, svar: u32, dvar: u32, bit_depth: usize,
+) -> u32 {
   let coeff_shift = bit_depth - 8;
 
-  //The two constants were tuned for CDEF, but can probably be better tuned for use in general RDO
-  DistortionScale::new(
-    (4033_f64 / 16_384_f64)
-      * (svar + dvar + (16_384 << (2 * coeff_shift))) as f64
-      / f64::sqrt(((16_265_089i64 << (4 * coeff_shift)) + svar * dvar) as f64),
-  )
+  // Scale dvar and svar to lbd range to prevent overflows.
+  let svar = (svar >> (2 * coeff_shift)) as u64;
+  let dvar = (dvar >> (2 * coeff_shift)) as u64;
+
+  // The two constants were tuned for CDEF, but can probably be better tuned
+  //   for use in general RDO
+  const C1: u64 = 4033;
+  const C2: u64 = 16384;
+  const RATIO_SHIFT: u8 = 14;
+  const RATIO: u64 = (((C1 << (RATIO_SHIFT + 1)) / C2) + 1) >> 1;
+
+  //          C1        (svar + dvar + C2)
+  // input * ---- * --------------------------
+  //          C2     sqrt(C1^2 + svar * dvar)
+  let rsqrt = ssim_boost_rsqrt((C1 * C1) + svar * dvar);
+  ((input as u64
+    * (((RATIO * (svar + dvar + C2) as u64) * rsqrt.norm as u64)
+      >> RATIO_SHIFT))
+    >> rsqrt.shift) as u32
+}
+
+#[cfg(test)]
+mod ssim_boost_tests {
+  use super::*;
+  use rand::Rng;
+
+  /// Test to make sure extreme values of ssim boost don't overflow.
+  #[test]
+  fn overflow_test() {
+    // Test variance for 8x8 region with a bit depth of 12
+    let max_pix_diff = (1 << 12) - 1;
+    let max_pix_sse = max_pix_diff * max_pix_diff;
+    let max_variance = max_pix_diff * 8 * 8 / 4;
+    apply_ssim_boost(max_pix_sse * 8 * 8, max_variance, max_variance, 12);
+  }
+
+  /// Floating point reference version of ssim_boost
+  fn reference_ssim_boost(svar: u32, dvar: u32, bit_depth: usize) -> f64 {
+    let coeff_shift = bit_depth - 8;
+    let var_scale = 1f64 / (1 << (2 * coeff_shift)) as f64;
+    let svar = svar as f64 * var_scale;
+    let dvar = dvar as f64 * var_scale;
+    // These constants are from ssim boost and need to be updated if the
+    //  constants in ssim boost change.
+    const C1: f64 = 4033f64;
+    const C2: f64 = 16384f64;
+    const RATIO: f64 = C1 / C2;
+
+    RATIO * (svar + dvar + C2) / f64::sqrt(C1 * C1 + svar * dvar)
+  }
+
+  /// Test that ssim_boost has sufficient accuracy.
+  #[test]
+  fn accuracy_test() {
+    let mut rng = rand::thread_rng();
+
+    let mut max_relative_error = 0f64;
+    let bd = 12;
+
+    // Test different log scale ranges for the variance.
+    // Each scale is tested multiple times with randomized variances.
+    for scale in 0..(bd + 3 * 2 - 2) {
+      for _ in 0..40 {
+        let svar = rng.gen_range(0..(1 << scale));
+        let dvar = rng.gen_range(0..(1 << scale));
+
+        let float = reference_ssim_boost(svar, dvar, 12);
+        let fixed =
+          apply_ssim_boost(1 << 23, svar, dvar, 12) as f64 / (1 << 23) as f64;
+
+        // Compare the two versions
+        max_relative_error =
+          max_relative_error.max(f64::abs(1f64 - fixed / float));
+      }
+    }
+
+    assert!(
+      max_relative_error < 0.05,
+      "SSIM boost error too high. Measured max relative error: {}.",
+      max_relative_error
+    );
+  }
 }
 
 #[allow(unused)]


### PR DESCRIPTION
In cdef distortion, replace floating point sqrt and divide with a fixed
point approximation of reciprocal sqrt.

 The rsqrt implementation was pulled from daala, then modified by
  removing the householder iteration.

```
Benchmarks:
cdef_dist_wxh_8x8       time:   [93.549 ns 93.572 ns 93.597 ns]
                        change: [-6.9962% -6.7169% -6.5117%]

Encode time (AWCY): -0.37%

PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |   SSIM | MS-SSIM | PSNR-HVS Y |
0.0541 | -0.1335 | -0.0211 |    0.0290 | 0.0557 |  0.0050 |     0.0150 |

PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |   VMAF | VMAF-NEG
-0.1746 |     -0.0119 |   0.0122 | 0.0040 |  -0.0030
```
https://beta.arewecompressedyet.com/?job=master-runagain-136672c58e21803633df72dc8f62214dd2ad6b35%402021-10-31T02%3A07%3A13.188Z&job=polynomial_only_2%402021-10-31T01%3A50%3A49.561Z