### PR TITLE
CI: Move to Debian Unstable for aom and dav1d

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -123,49 +123,38 @@ jobs:
         run: |
           echo "$LINK/nasm_${NASM_VERSION}_amd64.deb" >> DEBS
           echo "$NASM_SHA256 nasm_${NASM_VERSION}_amd64.deb" >> CHECKSUMS
-      - name: Add libvmaf
-        if: >
-          matrix.conf == '1.51.0-tests' || matrix.conf == 'aom-tests' ||
-          matrix.conf == 'grcov-coveralls'
-        env:
-          LINK: https://www.deb-multimedia.org/pool/main/v/vmaf-dmo
-          LIBVMAF_VERSION: 2.3.0-dmo1
-          LIBVMAF_SHA256: >-
-            2cceb344173fa86dbe665ade28b5a11c54c8426dd2eb3c1d7e242357b016a857
-          LIBVMAF_DEV_SHA256: >-
-            fde58300cffa120ab7693bea3d43e9e3d63305e77bbbd9815ad6047b400524d8
-        run: |
-          echo "$LINK/libvmaf1_${LIBVMAF_VERSION}_amd64.deb" >> DEBS
-          echo "$LINK/libvmaf-dev_${LIBVMAF_VERSION}_amd64.deb" >> DEBS
-          echo "$LIBVMAF_SHA256 libvmaf1_${LIBVMAF_VERSION}_amd64.deb" >> CHECKSUMS
-          echo "$LIBVMAF_DEV_SHA256 libvmaf-dev_${LIBVMAF_VERSION}_amd64.deb" >> CHECKSUMS
       - name: Add aom
         if: >
           matrix.conf == '1.51.0-tests' || matrix.conf == 'aom-tests' ||
           matrix.conf == 'grcov-coveralls'
         env:
-          LINK: https://www.deb-multimedia.org/pool/main/a/aom-dmo
-          AOM_VERSION: 3.2.0-dmo1
+          LINK: http://debian-archive.trafficmanager.net/debian/pool/main/a/aom
+          AOM0_VERSION: 1.0.0.errata1.ds-1
+          AOM3_VERSION: 3.2.0-1
           AOM_DEV_SHA256: >-
-            c63acfea515b81c1c261e79a10094dcca5bf51474f673e51e9d575cdf2476a1e
-          AOM_LIB_SHA256: >-
-            dd0b4d9bed079150db74006f18b745c11f6a9103bb005d636514f4c3b8939cec
+            10d264f5a1f2be78f0dbe02e6d01aa1a30d79a13a020b689b4a00c655e0a9501
+          AOM_LIB0_SHA256: >-
+            cccbc346d17510d7d3b53979234df6deb82b756243aefd566f193e65f424823b
+          AOM_LIB3_SHA256: >-
+            ac1f915d3643c844506bfced7e7fc4856affa23d39505629b5ab5698026e4d73
         run: |
-          echo "$LINK/libaom-dev_${AOM_VERSION}_amd64.deb" >> DEBS
-          echo "$LINK/libaom3_${AOM_VERSION}_amd64.deb" >> DEBS
-          echo "$AOM_DEV_SHA256 libaom-dev_${AOM_VERSION}_amd64.deb" >> CHECKSUMS
-          echo "$AOM_LIB_SHA256 libaom3_${AOM_VERSION}_amd64.deb" >> CHECKSUMS
+          echo "$LINK/libaom-dev_${AOM3_VERSION}_amd64.deb" >> DEBS
+          echo "$LINK/libaom0_${AOM0_VERSION}_amd64.deb" >> DEBS
+          echo "$LINK/libaom3_${AOM3_VERSION}_amd64.deb" >> DEBS
+          echo "$AOM_DEV_SHA256 libaom-dev_${AOM3_VERSION}_amd64.deb" >> CHECKSUMS
+          echo "$AOM_LIB0_SHA256 libaom0_${AOM0_VERSION}_amd64.deb" >> CHECKSUMS
+          echo "$AOM_LIB3_SHA256 libaom3_${AOM3_VERSION}_amd64.deb" >> CHECKSUMS
       - name: Add dav1d
         if: >
           matrix.conf == '1.51.0-tests' || matrix.conf == 'dav1d-tests' ||
           matrix.conf == 'grcov-coveralls' || matrix.conf == 'fuzz' || matrix.conf == 'no-asm-tests'
         env:
-          LINK: https://www.deb-multimedia.org/pool/main/d/dav1d-dmo
-          DAV1D_VERSION: 0.9.2-dmo1
+          LINK: http://debian-archive.trafficmanager.net/debian/pool/main/d/dav1d
+          DAV1D_VERSION: 0.9.2-1+b1
           DAV1D_DEV_SHA256: >-
-            2ed10b35fa2663d2e7ba04d8fe01f0518602008d066cadcb311a5b8105f70f14
+            a44e6981b36aeae428c7039495c7c2f9c11c49c00cebc7eb0d605f4cb9b472ca
           DAV1D_LIB_SHA256: >-
-            1c4336743115b8a512fb984d289cac65c49ad249ba1456940258e53d9c91bd0c
+            f20e98bcdc6c3eab210061abc55067df548c928225923d6c729b0aff8293b9b8
         run: |
           echo "$LINK/libdav1d-dev_${DAV1D_VERSION}_amd64.deb" >> DEBS
           echo "$LINK/libdav1d5_${DAV1D_VERSION}_amd64.deb" >> DEBS


### PR DESCRIPTION
Now that they are available, pulling these dependencies from the Debian archive should result in less CI configuration churn thanks to a longer retention policy.