### PR TITLE
CI: Run cargo-c in offline mode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,9 @@ jobs:
       run: strip target/release/rav1e.exe
 
     - name: Run cargo-c
-      run:  cargo cinstall --release --destdir="C:\"
+      run: |
+        cargo fetch
+        cargo cinstall --release --destdir="C:\" --offline
 
     - name: Rename cargo-c folder
       run: Rename-Item "C:\usr\local" "C:\usr\rav1e-windows-${{ matrix.conf }}-sdk"

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -265,7 +265,8 @@ jobs:
       - name: Run cargo-c
         if: matrix.conf == 'cargo-c'
         run: |
-          cargo cbuild
+          cargo fetch
+          cargo cbuild --offline
       - name: Install cargo-fuzz
         if: matrix.conf == 'fuzz'
         run: |
@@ -396,7 +397,8 @@ jobs:
       - name: Run cargo-c
         if: matrix.conf == 'cargo-c'
         run: |
-          cargo cbuild --target=${{ matrix.target }}
+          cargo fetch
+          cargo cbuild --target=${{ matrix.target }} --offline
       - name: Stop sccache server
         run: |
           sccache --stop-server
@@ -497,7 +499,8 @@ jobs:
       - name: Run cargo-c
         if: matrix.conf == 'cargo-c'
         run: |
-          cargo cbuild
+          cargo fetch
+          cargo cbuild --offline
       - name: Stop sccache server
         run: |
           sccache --stop-server


### PR DESCRIPTION
This works around SSL-related issues that `cargo-c` has from time to time. If `cargo fetch` fails, we have bigger problems.