### PR TITLE
Fix stable clippy lints for Rust 1.57

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -475,7 +475,7 @@ pub fn cdef_filter_superblock<T: Pixel>(
           let in_stride = in_plane.cfg.stride;
           let in_slice = &in_plane.slice(in_po);
 
-          let mut out_block = &mut out_plane.subregion_mut(Area::BlockRect {
+          let out_block = &mut out_plane.subregion_mut(Area::BlockRect {
             bo: tile_sbo.block_offset(2 * bx, 2 * by).0,
             width: xsize,
             height: ysize,
@@ -532,7 +532,7 @@ pub fn cdef_filter_superblock<T: Pixel>(
               );
 
               cdef_filter_block(
-                &mut out_block,
+                out_block,
                 in_slice.as_ptr(),
                 in_stride as isize,
                 local_pri_strength,

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -731,7 +731,7 @@ impl<'a> ContextWriter<'a> {
   }
 
   pub fn rollback(&mut self, checkpoint: &ContextWriterCheckpoint) {
-    self.fc_log.rollback(&mut self.fc, &checkpoint.fc);
+    self.fc_log.rollback(self.fc, &checkpoint.fc);
     self.bc.rollback(&checkpoint.bc);
     #[cfg(feature = "desync_finder")]
     {

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -1569,8 +1569,8 @@ pub fn deblock_filter_frame<T: Pixel>(
   crop_w: usize, crop_h: usize, bd: usize, planes: usize,
 ) {
   (&mut tile.planes[..planes]).par_iter_mut().enumerate().for_each(
-    |(pli, mut plane)| {
-      deblock_plane(deblock, &mut plane, pli, blocks, crop_w, crop_h, bd);
+    |(pli, plane)| {
+      deblock_plane(deblock, plane, pli, blocks, crop_w, crop_h, bd);
     },
   );
 }


### PR DESCRIPTION
Currently these are causing CI to fail.