### PR TITLE
Refactor the SpeedSettings struct and impl

### DIFF
--- a/src/api/channel/by_gop.rs
+++ b/src/api/channel/by_gop.rs
@@ -326,7 +326,7 @@ impl Config {
     self.validate()?;
 
     // TODO: make it user-settable
-    let input_len = self.enc.rdo_lookahead_frames as usize * 4;
+    let input_len = self.enc.speed_settings.rdo_lookahead_frames as usize * 4;
     let frame_limit = i32::MAX as u64;
 
     let (send_frame, receive_frame) = bounded(input_len);

--- a/src/api/channel/by_gop.rs
+++ b/src/api/channel/by_gop.rs
@@ -141,7 +141,7 @@ fn workerpool<T: Pixel>(
   let (send_reassemble, recv_reassemble) = unbounded();
 
   // TODO: unpack send_frame in process
-  cfg.enc.speed_settings.no_scene_detection = true;
+  cfg.enc.speed_settings.scene_detection_mode = SceneDetectionSpeed::None;
 
   for _ in 0..workers {
     let (send_workload, recv_workload) = unbounded::<Option<WorkLoad<T>>>();

--- a/src/api/channel/mod.rs
+++ b/src/api/channel/mod.rs
@@ -227,7 +227,7 @@ impl Config {
     let (mut inner, pool) = self.setup()?;
 
     // TODO: make it user-settable
-    let input_len = self.enc.rdo_lookahead_frames as usize * 2;
+    let input_len = self.enc.speed_settings.rdo_lookahead_frames as usize * 2;
 
     let (send_frame, receive_frame) = bounded(input_len);
     let (send_packet, receive_packet) = unbounded();

--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -102,8 +102,6 @@ pub struct EncoderConfig {
   /// [`tile_cols`]: #structfield.tile_cols
   /// [`tile_rows`]: #structfield.tile_rows
   pub tiles: usize,
-  /// Number of frames to read ahead for the RDO lookahead computation.
-  pub rdo_lookahead_frames: usize,
 
   /// Settings which affect the encoding speed vs. quality trade-off.
   pub speed_settings: SpeedSettings,
@@ -160,7 +158,6 @@ impl EncoderConfig {
       tile_cols: 0,
       tile_rows: 0,
       tiles: 0,
-      rdo_lookahead_frames: 40,
       speed_settings: SpeedSettings::from_preset(speed),
     }
   }
@@ -230,7 +227,10 @@ impl fmt::Display for EncoderConfig {
       ("min_quantizer", self.min_quantizer.to_string()),
       ("low_latency", self.low_latency.to_string()),
       ("tune", self.tune.to_string()),
-      ("rdo_lookahead_frames", self.rdo_lookahead_frames.to_string()),
+      (
+        "rdo_lookahead_frames",
+        self.speed_settings.rdo_lookahead_frames.to_string(),
+      ),
       ("min_block_size", self.speed_settings.partition_range.min.to_string()),
       ("max_block_size", self.speed_settings.partition_range.max.to_string()),
       (

--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -249,8 +249,8 @@ impl fmt::Display for EncoderConfig {
       ("prediction_modes", self.speed_settings.prediction_modes.to_string()),
       ("include_near_mvs", self.speed_settings.include_near_mvs.to_string()),
       (
-        "no_scene_detection",
-        self.speed_settings.no_scene_detection.to_string(),
+        "scene_detection_mode",
+        self.speed_settings.scene_detection_mode.to_string(),
       ),
       ("cdef", self.speed_settings.cdef.to_string()),
       ("use_satd_subpel", self.speed_settings.use_satd_subpel.to_string()),

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -314,11 +314,11 @@ impl Config {
       return Err(InvalidRenderHeight(render_height));
     }
 
-    if config.rdo_lookahead_frames > MAX_RDO_LOOKAHEAD_FRAMES
-      || config.rdo_lookahead_frames < 1
+    if config.speed_settings.rdo_lookahead_frames > MAX_RDO_LOOKAHEAD_FRAMES
+      || config.speed_settings.rdo_lookahead_frames < 1
     {
       return Err(InvalidRdoLookaheadFrames {
-        actual: config.rdo_lookahead_frames,
+        actual: config.speed_settings.rdo_lookahead_frames,
         max: MAX_RDO_LOOKAHEAD_FRAMES,
         min: 1,
       });

--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -58,12 +58,10 @@ pub struct SpeedSettings {
   ///
   /// Enabled is slower.
   pub include_near_mvs: bool,
-  /// Disables scene-cut detection.
-  ///
-  /// Enabled is faster.
-  pub no_scene_detection: bool,
-  /// Fast scene detection mode, uses simple SAD instead of encoder cost estimates.
-  pub fast_scene_detection: SceneDetectionSpeed,
+
+  /// Which scene detection mode to use. Standard is slower, but best.
+  pub scene_detection_mode: SceneDetectionSpeed,
+
   /// Enables CDEF.
   pub cdef: bool,
   /// Enables LRF.
@@ -120,8 +118,7 @@ impl Default for SpeedSettings {
       rdo_lookahead_frames: 40,
       prediction_modes: PredictionModesSetting::ComplexAll,
       include_near_mvs: true,
-      no_scene_detection: false,
-      fast_scene_detection: SceneDetectionSpeed::Fast,
+      scene_detection_mode: SceneDetectionSpeed::Fast,
       cdef: true,
       lrf: false,
       sgr_complexity: SGRComplexityLevel::Full,
@@ -169,8 +166,7 @@ impl SpeedSettings {
       rdo_lookahead_frames: Self::rdo_lookahead_frames(speed),
       prediction_modes: Self::prediction_modes_preset(speed),
       include_near_mvs: Self::include_near_mvs_preset(speed),
-      no_scene_detection: Self::no_scene_detection_preset(speed),
-      fast_scene_detection: Self::fast_scene_detection_preset(speed),
+      scene_detection_mode: Self::scene_detection_mode_preset(speed),
       cdef: Self::cdef_preset(speed),
       lrf: Self::lrf_preset(speed),
       sgr_complexity: Self::sgr_complexity_preset(speed),
@@ -260,7 +256,7 @@ impl SpeedSettings {
     false
   }
 
-  const fn fast_scene_detection_preset(speed: usize) -> SceneDetectionSpeed {
+  const fn scene_detection_mode_preset(speed: usize) -> SceneDetectionSpeed {
     if speed <= 9 {
       SceneDetectionSpeed::Standard
     } else {
@@ -351,6 +347,9 @@ pub enum SceneDetectionSpeed {
   Fast,
   /// Scene detection using motion vectors and cost estimates
   Standard,
+  /// Completely disable scene detection and only place keyframes
+  /// at fixed intervals.
+  None,
 }
 
 impl fmt::Display for SceneDetectionSpeed {
@@ -361,6 +360,7 @@ impl fmt::Display for SceneDetectionSpeed {
       match self {
         SceneDetectionSpeed::Fast => "Fast",
         SceneDetectionSpeed::Standard => "Standard",
+        SceneDetectionSpeed::None => "None",
       }
     )
   }

--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -17,6 +17,7 @@ use std::fmt;
 // NOTE: Add Structures at the end.
 /// Contains the speed settings.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct SpeedSettings {
   /// Enables inter-frames to have multiple reference frames.
   ///

--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -40,6 +40,12 @@ pub struct SpeedSettings {
   ///
   /// Enabled is slower.
   pub encode_bottomup: bool,
+
+  /// The number of lookahead frames to be used for temporal RDO.
+  ///
+  /// Higher is slower.
+  pub rdo_lookahead_frames: usize,
+
   /// Enables searching transform size and type with RDO.
   ///
   /// Enabled is slower.
@@ -111,6 +117,7 @@ impl Default for SpeedSettings {
       tx_domain_rate: false,
       encode_bottomup: true,
       rdo_tx_decision: true,
+      rdo_lookahead_frames: 40,
       prediction_modes: PredictionModesSetting::ComplexAll,
       include_near_mvs: true,
       no_scene_detection: false,
@@ -159,6 +166,7 @@ impl SpeedSettings {
       tx_domain_rate: Self::tx_domain_rate_preset(speed),
       encode_bottomup: Self::encode_bottomup_preset(speed),
       rdo_tx_decision: Self::rdo_tx_decision_preset(speed),
+      rdo_lookahead_frames: Self::rdo_lookahead_frames(speed),
       prediction_modes: Self::prediction_modes_preset(speed),
       include_near_mvs: Self::include_near_mvs_preset(speed),
       no_scene_detection: Self::no_scene_detection_preset(speed),

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -397,7 +397,7 @@ impl<T: Pixel> ContextInner<T> {
   /// in order for FI lookahead to be full.
   pub fn needs_more_fi_lookahead(&self) -> bool {
     let ready_frames = self.get_rdo_lookahead_frames().count();
-    ready_frames < self.config.rdo_lookahead_frames + 1
+    ready_frames < self.config.speed_settings.rdo_lookahead_frames + 1
       && self.needs_more_frames(self.next_lookahead_frame)
   }
 
@@ -415,7 +415,7 @@ impl<T: Pixel> ContextInner<T> {
         output_frameno < self.output_frameno
       })
       .filter(|(_, data)| !data.fi.invalid && !data.fi.show_existing_frame)
-      .take(self.config.rdo_lookahead_frames + 1)
+      .take(self.config.speed_settings.rdo_lookahead_frames + 1)
   }
 
   fn next_keyframe_input_frameno(

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -33,7 +33,7 @@ fn setup_config(
   enc.chroma_sampling = chroma_sampling;
   enc.bitrate = bitrate;
   enc.speed_settings.no_scene_detection = no_scene_detection;
-  enc.rdo_lookahead_frames = rdo_lookahead_frames;
+  enc.speed_settings.rdo_lookahead_frames = rdo_lookahead_frames;
   if let Some(min_quantizer) = min_quantizer {
     enc.min_quantizer = min_quantizer;
   }
@@ -1890,7 +1890,7 @@ fn zero_width() {
 #[test]
 fn rdo_lookahead_frames_overflow() {
   let mut enc = EncoderConfig::default();
-  enc.rdo_lookahead_frames = usize::max_value();
+  enc.speed_settings.rdo_lookahead_frames = usize::max_value();
   let config = Config::new().with_encoder_config(enc);
   let res: Result<Context<u8>, _> = config.new_context();
   assert!(res.is_err());
@@ -1925,7 +1925,6 @@ fn log_q_exp_overflow() {
     tile_cols: 0,
     tile_rows: 0,
     tiles: 0,
-    rdo_lookahead_frames: 40,
     speed_settings: SpeedSettings {
       partition_range: PartitionRange::new(
         BlockSize::BLOCK_64X64,
@@ -1990,7 +1989,6 @@ fn guess_frame_subtypes_assert() {
     tile_cols: 0,
     tile_rows: 0,
     tiles: 0,
-    rdo_lookahead_frames: 40,
     speed_settings: SpeedSettings {
       partition_range: PartitionRange::new(
         BlockSize::BLOCK_64X64,
@@ -2003,6 +2001,7 @@ fn guess_frame_subtypes_assert() {
       tx_domain_rate: false,
       encode_bottomup: false,
       rdo_tx_decision: false,
+      rdo_lookahead_frames: 40,
       prediction_modes: PredictionModesSetting::Simple,
       include_near_mvs: false,
       no_scene_detection: true,

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -32,7 +32,9 @@ fn setup_config(
   enc.bit_depth = bit_depth;
   enc.chroma_sampling = chroma_sampling;
   enc.bitrate = bitrate;
-  enc.speed_settings.no_scene_detection = no_scene_detection;
+  if no_scene_detection {
+    enc.speed_settings.scene_detection_mode = SceneDetectionSpeed::None;
+  }
   enc.speed_settings.rdo_lookahead_frames = rdo_lookahead_frames;
   if let Some(min_quantizer) = min_quantizer {
     enc.min_quantizer = min_quantizer;
@@ -1939,8 +1941,7 @@ fn log_q_exp_overflow() {
       rdo_tx_decision: false,
       prediction_modes: PredictionModesSetting::Simple,
       include_near_mvs: false,
-      no_scene_detection: true,
-      fast_scene_detection: SceneDetectionSpeed::Fast,
+      scene_detection_mode: SceneDetectionSpeed::None,
       cdef: true,
       lrf: true,
       use_satd_subpel: false,
@@ -2004,8 +2005,7 @@ fn guess_frame_subtypes_assert() {
       rdo_lookahead_frames: 40,
       prediction_modes: PredictionModesSetting::Simple,
       include_near_mvs: false,
-      no_scene_detection: true,
-      fast_scene_detection: SceneDetectionSpeed::Fast,
+      scene_detection_mode: SceneDetectionSpeed::None,
       cdef: true,
       lrf: true,
       use_satd_subpel: false,

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -724,10 +724,8 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
   // rdo-lookahead-frames
   let maybe_rdo = matches.value_of("RDO_LOOKAHEAD_FRAMES");
   if maybe_rdo.is_some() {
-    cfg.rdo_lookahead_frames =
+    cfg.speed_settings.rdo_lookahead_frames =
       matches.value_of("RDO_LOOKAHEAD_FRAMES").unwrap().parse().unwrap();
-  } else {
-    cfg.rdo_lookahead_frames = SpeedSettings::rdo_lookahead_frames(speed)
   }
 
   cfg.tune = matches.value_of("TUNE").unwrap().parse().unwrap();

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -608,7 +608,7 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
   let mut cfg = EncoderConfig::with_speed_preset(speed);
 
   if matches.occurrences_of("SCENE_CHANGE_DETECTION_SPEED") != 0 {
-    cfg.speed_settings.fast_scene_detection = if scene_detection_speed == 0 {
+    cfg.speed_settings.scene_detection_mode = if scene_detection_speed == 0 {
       SceneDetectionSpeed::Standard
     } else {
       SceneDetectionSpeed::Fast
@@ -753,7 +753,7 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
   cfg.low_latency = matches.is_present("LOW_LATENCY");
   // Disables scene_detection
   if matches.is_present("NO_SCENE_DETECTION") {
-    cfg.speed_settings.no_scene_detection = true;
+    cfg.speed_settings.scene_detection_mode = SceneDetectionSpeed::None;
   }
 
   Ok(cfg)

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -694,7 +694,8 @@ unsafe fn option_match(
       enc.reservoir_frame_delay = Some(value.parse().map_err(|_| ())?)
     }
     "rdo_lookahead_frames" => {
-      enc.rdo_lookahead_frames = value.parse().map_err(|_| ())?
+      enc.speed_settings.rdo_lookahead_frames =
+        value.parse().map_err(|_| ())?
     }
     "low_latency" => enc.low_latency = value.parse().map_err(|_| ())?,
     "enable_timing_info" => {

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -167,7 +167,7 @@ impl Arbitrary for ArbitraryConfig {
     enc.tile_cols = Arbitrary::arbitrary(u)?;
     enc.tile_rows = Arbitrary::arbitrary(u)?;
     enc.tiles = Arbitrary::arbitrary(u)?;
-    enc.rdo_lookahead_frames = Arbitrary::arbitrary(u)?;
+    enc.speed_settings.rdo_lookahead_frames = Arbitrary::arbitrary(u)?;
     let config = Config::new().with_encoder_config(enc).with_threads(1);
     Ok(Self { config })
   }
@@ -232,7 +232,6 @@ impl Arbitrary for ArbitraryEncoder {
       tile_cols: u.int_in_range(0..=2)?,
       tile_rows: u.int_in_range(0..=2)?,
       tiles: u.int_in_range(0..=16)?,
-      rdo_lookahead_frames: Arbitrary::arbitrary(u)?,
 
       chroma_sampling: *u.choose(&[
         ChromaSampling::Cs420,

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -76,7 +76,7 @@ impl<T: Pixel> SceneChangeDetector<T> {
     let speed_mode = if encoder_config.low_latency {
       SceneDetectionSpeed::Fast
     } else {
-      encoder_config.speed_settings.fast_scene_detection
+      encoder_config.speed_settings.scene_detection_mode
     };
 
     // Scale factor for fast and medium scene detection
@@ -140,7 +140,9 @@ impl<T: Pixel> SceneChangeDetector<T> {
       return false;
     }
 
-    if self.encoder_config.speed_settings.no_scene_detection {
+    if self.encoder_config.speed_settings.scene_detection_mode
+      == SceneDetectionSpeed::None
+    {
       if let Some(true) = self.handle_min_max_intervals(distance) {
         return true;
       };


### PR DESCRIPTION
The impetus for this change is that the documentation for speed
settings, being a manually-maintained comment, would easily become out
of date and was difficult to maintain. The primary change this
introduces is that, rather than having a separate function for each
speed setting to determine when to enable it, the `from_preset` function
now sets all settings per speed level, with the `default()` being speed
0, and overriding as the speed increases. The idea is that this will
make it much easier to see which features are enabled at which speed
levels.

This also consolidates a couple of fields which were redundant, namely:
- `no_scene_detection` and `fast_scene_detection` are now one setting
  called `scene_detection_mode`
- `rdo_lookahead_frames` existed on EncoderConfig, but the function for
  setting it was in `SpeedSettings`. It has been moved to `SpeedSettings`,
  as even though it can be overridden by a CLI arg, it is primarily controlled
  by the speed preset.