### PR TITLE
Change non_square_partition feature to a threshold

### DIFF
--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -256,8 +256,12 @@ impl fmt::Display for EncoderConfig {
         self.speed_settings.partition.encode_bottomup.to_string(),
       ),
       (
-        "non_square_partition",
-        self.speed_settings.partition.non_square_partition.to_string(),
+        "non_square_partition_threshold",
+        self
+          .speed_settings
+          .partition
+          .non_square_partition_threshold
+          .to_string(),
       ),
       (
         "reduced_tx_set",

--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -77,7 +77,7 @@ impl Default for SpeedSettings {
       segmentation: SegmentationLevel::Full,
       partition: PartitionSpeedSettings {
         encode_bottomup: true,
-        non_square_partition: true,
+        non_square_partition_threshold: BlockSize::BLOCK_4X4,
         partition_range: PartitionRange::new(
           BlockSize::BLOCK_4X4,
           BlockSize::BLOCK_64X64,
@@ -116,7 +116,8 @@ impl SpeedSettings {
     }
 
     if speed >= 2 {
-      settings.partition.non_square_partition = false;
+      settings.partition.non_square_partition_threshold =
+        BlockSize::BLOCK_16X16;
     }
 
     if speed >= 3 {
@@ -124,6 +125,9 @@ impl SpeedSettings {
 
       settings.partition.partition_range =
         PartitionRange::new(BlockSize::BLOCK_8X8, BlockSize::BLOCK_64X64);
+      settings.partition.non_square_partition_threshold =
+        BlockSize::BLOCK_64X64;
+
       settings.prediction.prediction_modes =
         PredictionModesSetting::ComplexKeyframes;
     }
@@ -224,10 +228,9 @@ pub struct PartitionSpeedSettings {
   /// Enabled is slower.
   pub encode_bottomup: bool,
 
-  /// Use non-square partition type everywhere
-  ///
-  /// Enabled is slower.
-  pub non_square_partition: bool,
+  /// Allow non-square partition type outside of frame borders
+  /// on any blocks above this size.
+  pub non_square_partition_threshold: BlockSize,
 
   /// Range of partition sizes that can be used. Larger ranges are slower.
   ///

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -1940,7 +1940,7 @@ fn log_q_exp_overflow() {
           BlockSize::BLOCK_64X64,
         ),
         encode_bottomup: false,
-        non_square_partition: false,
+        non_square_partition_threshold: BlockSize::BLOCK_64X64,
       },
       transform: TransformSpeedSettings {
         reduced_tx_set: true,
@@ -2015,7 +2015,7 @@ fn guess_frame_subtypes_assert() {
           BlockSize::BLOCK_64X64,
         ),
         encode_bottomup: false,
-        non_square_partition: false,
+        non_square_partition_threshold: BlockSize::BLOCK_64X64,
       },
       transform: TransformSpeedSettings {
         reduced_tx_set: true,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2444,7 +2444,8 @@ fn encode_partition_bottomup<T: Pixel, W: Writer>(
     debug_assert!(is_square);
 
     let mut partition_types = ArrayVec::<PartitionType, 3>::new();
-    if fi.config.speed_settings.partition.non_square_partition
+    if bsize
+      > fi.config.speed_settings.partition.non_square_partition_threshold
       || is_straddle_x
       || is_straddle_y
     {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -160,6 +160,13 @@ impl PartialOrd for BlockSize {
   }
 }
 
+#[cfg(test)]
+impl Default for BlockSize {
+  fn default() -> Self {
+    BlockSize::BLOCK_64X64
+  }
+}
+
 impl BlockSize {
   pub const BLOCK_SIZES_ALL: usize = 22;
   pub const BLOCK_SIZES: usize = BlockSize::BLOCK_SIZES_ALL - 6; // BLOCK_SIZES_ALL minus 4:1 non-squares, six of them


### PR DESCRIPTION
To allow for more fine-tuned balancing of our speed levels,
this commit changes the boolean non_square_partition speed feature
to a block size threshold, below which non-square partitions will be
disabled, and above which non-square partitions will be tested.

Many tests were done on a local, quiet AWCY instance, producing
the following results (negative is better):

| Setting        | Encoding Time | MSSSIM | VMAF  | CIEDE2000 |
|----------------|---------------|--------|-------|-----------|
| Speed 2 >8x8   | 62.54         | -3.64  | -3.30 | -4.66     |
| Speed 2 >16x16 | 30.11         | -1.95  | -1.89 | -2.65     |
| Speed 2 >32x32 | 6.70          | -0.67  | -0.40 | -0.90     |
| Speed 3 >8x8   | 92.20         | -3.63  | -3.55 | -4.80     |
| Speed 3 >16x16 | 48.64         | -1.88  | -1.50 | -2.67     |
| Speed 3 >32x32 | 21.35         | -0.63  | -0.45 | -0.82     |

Results at speed >=4 were not significant, for both speed and quality,
presumably because top-down encoding is not as successful at utilizing
rectangular partitions as bottom-up encoding. Results across metrics not
listed were generally consistent, with chroma-based metrics showing a
larger improvement.

Based on this, this commit enables >16x16 at speed 2, and disables
rectangle partitions completely at speed 3.

Full AWCY changes at speed 2 (other levels unaffected):

![Firefox_Screenshot_2021-12-12T18-56-49 523Z](https://user-images.githubusercontent.com/5951392/145725800-07f482da-ff3c-4841-b9c6-edd64b75dd7f.png)
