### PR TITLE
Organize speed settings into sub-structs

### DIFF
--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -213,7 +213,7 @@ impl EncoderConfig {
     // multiple partition sizes properly. Unfortunately, when tx domain
     // distortion is used, distortion is only known at the tx block level which
     // might be bigger than 8x8. So temporal RDO is always disabled in that case.
-    !self.speed_settings.tx_domain_distortion
+    !self.speed_settings.transform.tx_domain_distortion
   }
 }
 
@@ -231,37 +231,65 @@ impl fmt::Display for EncoderConfig {
         "rdo_lookahead_frames",
         self.speed_settings.rdo_lookahead_frames.to_string(),
       ),
-      ("min_block_size", self.speed_settings.partition_range.min.to_string()),
-      ("max_block_size", self.speed_settings.partition_range.max.to_string()),
       (
         "multiref",
         (!self.low_latency || self.speed_settings.multiref).to_string(),
       ),
       ("fast_deblock", self.speed_settings.fast_deblock.to_string()),
-      ("reduced_tx_set", self.speed_settings.reduced_tx_set.to_string()),
-      (
-        "tx_domain_distortion",
-        self.speed_settings.tx_domain_distortion.to_string(),
-      ),
-      ("tx_domain_rate", self.speed_settings.tx_domain_rate.to_string()),
-      ("encode_bottomup", self.speed_settings.encode_bottomup.to_string()),
-      ("rdo_tx_decision", self.speed_settings.rdo_tx_decision.to_string()),
-      ("prediction_modes", self.speed_settings.prediction_modes.to_string()),
-      ("include_near_mvs", self.speed_settings.include_near_mvs.to_string()),
       (
         "scene_detection_mode",
         self.speed_settings.scene_detection_mode.to_string(),
       ),
       ("cdef", self.speed_settings.cdef.to_string()),
-      ("use_satd_subpel", self.speed_settings.use_satd_subpel.to_string()),
-      (
-        "non_square_partition",
-        self.speed_settings.non_square_partition.to_string(),
-      ),
+      ("lrf", self.speed_settings.lrf.to_string()),
       ("enable_timing_info", self.enable_timing_info.to_string()),
       (
+        "min_block_size",
+        self.speed_settings.partition.partition_range.min.to_string(),
+      ),
+      (
+        "max_block_size",
+        self.speed_settings.partition.partition_range.max.to_string(),
+      ),
+      (
+        "encode_bottomup",
+        self.speed_settings.partition.encode_bottomup.to_string(),
+      ),
+      (
+        "non_square_partition",
+        self.speed_settings.partition.non_square_partition.to_string(),
+      ),
+      (
+        "reduced_tx_set",
+        self.speed_settings.transform.reduced_tx_set.to_string(),
+      ),
+      (
+        "tx_domain_distortion",
+        self.speed_settings.transform.tx_domain_distortion.to_string(),
+      ),
+      (
+        "tx_domain_rate",
+        self.speed_settings.transform.tx_domain_rate.to_string(),
+      ),
+      (
+        "rdo_tx_decision",
+        self.speed_settings.transform.rdo_tx_decision.to_string(),
+      ),
+      (
+        "prediction_modes",
+        self.speed_settings.prediction.prediction_modes.to_string(),
+      ),
+      (
         "fine_directional_intra",
-        self.speed_settings.fine_directional_intra.to_string(),
+        self.speed_settings.prediction.fine_directional_intra.to_string(),
+      ),
+      (
+        "include_near_mvs",
+        self.speed_settings.motion.include_near_mvs.to_string(),
+      ),
+      (
+        "use_satd_subpel",
+        self.speed_settings.motion.use_satd_subpel.to_string(),
       ),
     ];
     write!(

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -221,7 +221,7 @@ impl Config {
 
     // FIXME: tx partition for intra not supported for chroma 422
     if chroma_sampling == ChromaSampling::Cs422 {
-      config.speed_settings.rdo_tx_decision = false;
+      config.speed_settings.transform.rdo_tx_decision = false;
     }
 
     let mut inner = ContextInner::new(&config);

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -1928,24 +1928,36 @@ fn log_q_exp_overflow() {
     tile_rows: 0,
     tiles: 0,
     speed_settings: SpeedSettings {
-      partition_range: PartitionRange::new(
-        BlockSize::BLOCK_64X64,
-        BlockSize::BLOCK_64X64,
-      ),
       multiref: false,
       fast_deblock: true,
-      reduced_tx_set: true,
-      tx_domain_distortion: true,
-      tx_domain_rate: false,
-      encode_bottomup: false,
-      rdo_tx_decision: false,
-      prediction_modes: PredictionModesSetting::Simple,
-      include_near_mvs: false,
+      rdo_lookahead_frames: 40,
       scene_detection_mode: SceneDetectionSpeed::None,
       cdef: true,
       lrf: true,
-      use_satd_subpel: false,
-      non_square_partition: false,
+      partition: PartitionSpeedSettings {
+        partition_range: PartitionRange::new(
+          BlockSize::BLOCK_64X64,
+          BlockSize::BLOCK_64X64,
+        ),
+        encode_bottomup: false,
+        non_square_partition: false,
+      },
+      transform: TransformSpeedSettings {
+        reduced_tx_set: true,
+        tx_domain_distortion: true,
+        tx_domain_rate: false,
+        rdo_tx_decision: false,
+        ..Default::default()
+      },
+      prediction: PredictionSpeedSettings {
+        prediction_modes: PredictionModesSetting::Simple,
+        ..Default::default()
+      },
+      motion: MotionSpeedSettings {
+        include_near_mvs: false,
+        use_satd_subpel: false,
+        ..Default::default()
+      },
       ..Default::default()
     },
   };
@@ -1991,25 +2003,36 @@ fn guess_frame_subtypes_assert() {
     tile_rows: 0,
     tiles: 0,
     speed_settings: SpeedSettings {
-      partition_range: PartitionRange::new(
-        BlockSize::BLOCK_64X64,
-        BlockSize::BLOCK_64X64,
-      ),
       multiref: false,
       fast_deblock: true,
-      reduced_tx_set: true,
-      tx_domain_distortion: true,
-      tx_domain_rate: false,
-      encode_bottomup: false,
-      rdo_tx_decision: false,
       rdo_lookahead_frames: 40,
-      prediction_modes: PredictionModesSetting::Simple,
-      include_near_mvs: false,
       scene_detection_mode: SceneDetectionSpeed::None,
       cdef: true,
       lrf: true,
-      use_satd_subpel: false,
-      non_square_partition: false,
+      partition: PartitionSpeedSettings {
+        partition_range: PartitionRange::new(
+          BlockSize::BLOCK_64X64,
+          BlockSize::BLOCK_64X64,
+        ),
+        encode_bottomup: false,
+        non_square_partition: false,
+      },
+      transform: TransformSpeedSettings {
+        reduced_tx_set: true,
+        tx_domain_distortion: true,
+        tx_domain_rate: false,
+        rdo_tx_decision: false,
+        ..Default::default()
+      },
+      prediction: PredictionSpeedSettings {
+        prediction_modes: PredictionModesSetting::Simple,
+        ..Default::default()
+      },
+      motion: MotionSpeedSettings {
+        include_near_mvs: false,
+        use_satd_subpel: false,
+        ..Default::default()
+      },
       ..Default::default()
     },
   };

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -731,7 +731,7 @@ fn parse_config(matches: &ArgMatches<'_>) -> Result<EncoderConfig, CliError> {
   cfg.tune = matches.value_of("TUNE").unwrap().parse().unwrap();
 
   if cfg.tune == Tune::Psychovisual {
-    cfg.speed_settings.tx_domain_distortion = false;
+    cfg.speed_settings.transform.tx_domain_distortion = false;
   }
 
   cfg.tile_cols = matches.value_of("TILE_COLS").unwrap().parse().unwrap();

--- a/src/me.rs
+++ b/src/me.rs
@@ -552,7 +552,7 @@ pub fn motion_estimation<T: Pixel>(
 
       let mut best = MotionSearchResult { mv: best.mv, cost: best.rd.cost };
 
-      let use_satd: bool = fi.config.speed_settings.use_satd_subpel;
+      let use_satd: bool = fi.config.speed_settings.motion.use_satd_subpel;
       if use_satd {
         best.cost = get_fullpel_mv_rd(
           fi,
@@ -792,7 +792,9 @@ fn full_pixel_me<T: Pixel>(
       24,
     );
 
-    if !fi.config.speed_settings.me_allow_full_search || best.rd.sad < thresh {
+    if !fi.config.speed_settings.motion.me_allow_full_search
+      || best.rd.sad < thresh
+    {
       return best;
     }
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -933,8 +933,9 @@ pub fn rdo_tx_size_type<T: Pixel>(
   let mut best_tx_size = tx_size;
   let mut best_rd = std::f64::MAX;
 
-  let do_rdo_tx_size =
-    fi.tx_mode_select && fi.config.speed_settings.rdo_tx_decision && !is_inter;
+  let do_rdo_tx_size = fi.tx_mode_select
+    && fi.config.speed_settings.transform.rdo_tx_decision
+    && !is_inter;
   let rdo_tx_depth = if do_rdo_tx_size { 2 } else { 0 };
   let mut cw_checkpoint: Option<ContextWriterCheckpoint> = None;
 
@@ -942,7 +943,7 @@ pub fn rdo_tx_size_type<T: Pixel>(
     let tx_set = get_tx_set(tx_size, is_inter, fi.use_reduced_tx_set);
 
     let do_rdo_tx_type = tx_set > TxSet::TX_SET_DCTONLY
-      && fi.config.speed_settings.rdo_tx_decision
+      && fi.config.speed_settings.transform.rdo_tx_decision
       && !is_inter
       && !skip;
 
@@ -1378,7 +1379,7 @@ fn inter_frame_rdo_mode_decision<T: Pixel>(
     if mv_stack.len() >= 2 {
       inter_mode_set.push((PredictionMode::GLOBALMV, i));
     }
-    let include_near_mvs = fi.config.speed_settings.include_near_mvs;
+    let include_near_mvs = fi.config.speed_settings.motion.include_near_mvs;
     if include_near_mvs {
       if mv_stack.len() >= 3 {
         inter_mode_set.push((PredictionMode::NEAR1MV, i));
@@ -1426,7 +1427,9 @@ fn inter_frame_rdo_mode_decision<T: Pixel>(
         ));
         for &x in RAV1E_INTER_COMPOUND_MODES {
           // exclude any NEAR mode based on speed setting
-          if fi.config.speed_settings.include_near_mvs || !x.has_nearmv() {
+          if fi.config.speed_settings.motion.include_near_mvs
+            || !x.has_nearmv()
+          {
             let mv_stack_idx = ref_frames_set.len() - 1;
             // exclude NEAR modes if the mv_stack is too short
             if !(x.has_nearmv() && x.ref_mv_idx() >= mv_stack.len()) {
@@ -1439,7 +1442,7 @@ fn inter_frame_rdo_mode_decision<T: Pixel>(
     }
   }
 
-  let num_modes_rdo = if fi.config.speed_settings.prediction_modes
+  let num_modes_rdo = if fi.config.speed_settings.prediction.prediction_modes
     >= PredictionModesSetting::ComplexAll
   {
     inter_mode_set.len()
@@ -1569,10 +1572,10 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
 
   // Reduce number of prediction modes at higher speed levels
   num_modes_rdo = if (fi.frame_type == FrameType::KEY
-    && fi.config.speed_settings.prediction_modes
+    && fi.config.speed_settings.prediction.prediction_modes
       >= PredictionModesSetting::ComplexKeyframes)
     || (fi.frame_type.has_inter()
-      && fi.config.speed_settings.prediction_modes
+      && fi.config.speed_settings.prediction.prediction_modes
         >= PredictionModesSetting::ComplexAll)
   {
     7
@@ -1700,7 +1703,7 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
     );
   });
 
-  if fi.config.speed_settings.fine_directional_intra
+  if fi.config.speed_settings.prediction.fine_directional_intra
     && bsize >= BlockSize::BLOCK_8X8
   {
     // Find the best angle delta for the current best prediction mode


### PR DESCRIPTION
The number of speed settings has grown to be quite large, and upcoming
work will add more speed settings. To help maintain readability and
extensibility of this structure, this commit breaks the speed settings
into sub-structs of related settings.