### PR TITLE
Silence repetitive warning on Rust nightly

### DIFF
--- a/src/transform/forward_shared.rs
+++ b/src/transform/forward_shared.rs
@@ -162,7 +162,7 @@ macro_rules! store_coeffs {
 
 macro_rules! impl_1d_tx {
 () => {
-  impl_1d_tx! {allow(), }
+  impl_1d_tx! {allow(unused_attributes), }
 };
 
 ($m:meta, $($s:ident),*) => {


### PR DESCRIPTION
On the latest Rust nightly, compilation produces a large number of
identical warnings within this macro, stating:

attribute `allow` with an empty list has no effect

This commit silences the warnings by adding an item (ironically, the lint
being triggered by the empty list) to the allow list.