### PR TITLE
Display info for all y4m error types

### DIFF
--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -402,8 +402,21 @@ fn run() -> Result<(), error::CliError> {
       .saturating_add(1024),
   };
   let mut y4m_dec = match y4m::Decoder::new_with_limits(cli.io.input, limit) {
-    Err(_) => {
-      return Err(CliError::new("Could not input video. Is it a y4m file?"))
+    Err(e) => {
+      return Err(CliError::new(match e {
+        y4m::Error::ParseError(_) => {
+          "Could not parse input video. Is it a y4m file?"
+        }
+        y4m::Error::IoError(_) => {
+          "Could not read input file. Check that the path is correct and you have read permissions."
+        }
+        y4m::Error::UnknownColorspace => {
+          "Unknown colorspace or unsupported bit depth."
+        }
+        y4m::Error::OutOfMemory => "The video's frame size exceeds the limit.",
+        y4m::Error::EOF => "Unexpected end of input.",
+        y4m::Error::BadInput => "Bad y4m input parameters provided.",
+      }))
     }
     Ok(d) => d,
   };

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -396,13 +396,17 @@ fn run() -> Result<(), error::CliError> {
     Err(e) => {
       return Err(CliError::new(match e {
         y4m::Error::ParseError(_) => {
-          "Could not input video. Is it a y4m file?"
+          "Could not parse input video. Is it a y4m file?"
+        }
+        y4m::Error::IoError(_) => {
+          "Could not read input file. Check that the path is correct and you have read permissions."
         }
         y4m::Error::UnknownColorspace => {
           "Unknown colorspace or unsupported bit depth."
         }
         y4m::Error::OutOfMemory => "The video's frame size exceeds the limit.",
-        _ => unreachable!(),
+        y4m::Error::EOF => "Unexpected end of input.",
+        y4m::Error::BadInput => "Bad y4m input parameters provided.",
       }))
     }
     Ok(d) => d,


### PR DESCRIPTION
A user on Discord reported that rav1e was reaching an unreachable
branch, which was in this section of the codebase. This commit
explicitly returns an error message for each potential type of y4m
error, instead of assuming that some are unreachable.