### PR TITLE
Add x86 assembly for cdef distortion

### DIFF
--- a/benches/rdo.rs
+++ b/benches/rdo.rs
@@ -16,6 +16,7 @@ fn init_plane_u8(width: usize, height: usize, seed: u8) -> Plane<u8> {
 }
 
 pub fn cdef_dist_wxh_8x8(c: &mut Criterion) {
+  let cpu = CpuFeatureLevel::default();
   let src1 = init_plane_u8(8, 8, 1);
   let src2 = init_plane_u8(8, 8, 2);
 
@@ -28,6 +29,7 @@ pub fn cdef_dist_wxh_8x8(c: &mut Criterion) {
         8,
         8,
         |_, _| DistortionScale::default(),
+        cpu,
       )
     })
   });

--- a/build.rs
+++ b/build.rs
@@ -111,6 +111,7 @@ fn build_nasm_files() {
     "src/x86/sad_sse2.asm",
     "src/x86/sad_avx.asm",
     "src/x86/satd.asm",
+    "src/x86/cdef_dist.asm",
     "src/x86/sse.asm",
     "src/x86/cdef_rav1e.asm",
     "src/x86/cdef_sse.asm",

--- a/src/asm/x86/dist/cdef_dist.rs
+++ b/src/asm/x86/dist/cdef_dist.rs
@@ -1,0 +1,261 @@
+// Copyright (c) 2022, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+use crate::activity::apply_ssim_boost;
+use crate::cpu_features::CpuFeatureLevel;
+use crate::dist::*;
+use crate::tiling::PlaneRegion;
+use crate::util::Pixel;
+use crate::util::PixelType;
+
+type CdefDistKernelFn = unsafe extern fn(
+  src: *const u8,
+  src_stride: isize,
+  dst: *const u8,
+  dst_stride: isize,
+  ret_ptr: *mut u32,
+);
+
+extern {
+  fn rav1e_cdef_dist_kernel_4x4_sse2(
+    src: *const u8, src_stride: isize, dst: *const u8, dst_stride: isize,
+    ret_ptr: *mut u32,
+  );
+  fn rav1e_cdef_dist_kernel_4x8_sse2(
+    src: *const u8, src_stride: isize, dst: *const u8, dst_stride: isize,
+    ret_ptr: *mut u32,
+  );
+  fn rav1e_cdef_dist_kernel_8x4_sse2(
+    src: *const u8, src_stride: isize, dst: *const u8, dst_stride: isize,
+    ret_ptr: *mut u32,
+  );
+  fn rav1e_cdef_dist_kernel_8x8_sse2(
+    src: *const u8, src_stride: isize, dst: *const u8, dst_stride: isize,
+    ret_ptr: *mut u32,
+  );
+}
+
+#[allow(clippy::let_and_return)]
+pub fn cdef_dist_kernel<T: Pixel>(
+  src: &PlaneRegion<'_, T>, dst: &PlaneRegion<'_, T>, w: usize, h: usize,
+  bit_depth: usize, cpu: CpuFeatureLevel,
+) -> u32 {
+  debug_assert!(src.plane_cfg.xdec == 0);
+  debug_assert!(src.plane_cfg.ydec == 0);
+  debug_assert!(dst.plane_cfg.xdec == 0);
+  debug_assert!(dst.plane_cfg.ydec == 0);
+
+  // Limit kernel to 8x8
+  debug_assert!(w <= 8);
+  debug_assert!(h <= 8);
+
+  let call_rust =
+    || -> u32 { rust::cdef_dist_kernel(dst, src, w, h, bit_depth, cpu) };
+  #[cfg(feature = "check_asm")]
+  let ref_dist = call_rust();
+
+  let mut ret_buf = [0u32; 3];
+  match T::type_enum() {
+    PixelType::U8 => {
+      if let Some(func) =
+        CDEF_DIST_KERNEL_FNS[cpu.as_index()][kernel_fn_index(w, h)]
+      {
+        unsafe {
+          func(
+            src.data_ptr() as *const _,
+            T::to_asm_stride(src.plane_cfg.stride),
+            dst.data_ptr() as *const _,
+            T::to_asm_stride(dst.plane_cfg.stride),
+            ret_buf.as_mut_ptr(),
+          )
+        }
+      } else {
+        return call_rust();
+      }
+    }
+    PixelType::U16 => return call_rust(),
+  }
+
+  let svar = ret_buf[0];
+  let dvar = ret_buf[1];
+  let sse = ret_buf[2];
+
+  let dist = apply_ssim_boost(sse, svar, dvar, bit_depth);
+  #[cfg(feature = "check_asm")]
+  assert_eq!(
+    dist, ref_dist,
+    "CDEF Distortion {}x{}: Assembly doesn't match reference code.",
+    w, h
+  );
+
+  dist
+}
+
+/// Store functions in a 8x8 grid. Most will be empty.
+const CDEF_DIST_KERNEL_FNS_LENGTH: usize = 8 * 8;
+
+const fn kernel_fn_index(w: usize, h: usize) -> usize {
+  ((w - 1) << 3) | (h - 1)
+}
+
+static CDEF_DIST_KERNEL_FNS_SSE2: [Option<CdefDistKernelFn>;
+  CDEF_DIST_KERNEL_FNS_LENGTH] = {
+  let mut out: [Option<CdefDistKernelFn>; CDEF_DIST_KERNEL_FNS_LENGTH] =
+    [None; CDEF_DIST_KERNEL_FNS_LENGTH];
+
+  out[kernel_fn_index(4, 4)] = Some(rav1e_cdef_dist_kernel_4x4_sse2);
+  out[kernel_fn_index(4, 8)] = Some(rav1e_cdef_dist_kernel_4x8_sse2);
+  out[kernel_fn_index(8, 4)] = Some(rav1e_cdef_dist_kernel_8x4_sse2);
+  out[kernel_fn_index(8, 8)] = Some(rav1e_cdef_dist_kernel_8x8_sse2);
+
+  out
+};
+
+cpu_function_lookup_table!(
+  CDEF_DIST_KERNEL_FNS:
+    [[Option<CdefDistKernelFn>; CDEF_DIST_KERNEL_FNS_LENGTH]],
+  default: [None; CDEF_DIST_KERNEL_FNS_LENGTH],
+  [SSE2]
+);
+
+#[cfg(test)]
+pub mod test {
+  use super::*;
+  use crate::frame::*;
+  use crate::tiling::Area;
+  use rand::{thread_rng, Rng};
+
+  fn random_planes<T: Pixel>(bd: usize) -> (Plane<T>, Plane<T>) {
+    let mut rng = thread_rng();
+
+    // Two planes with different strides
+    let mut input_plane = Plane::new(640, 480, 0, 0, 128 + 8, 128 + 8);
+    let mut rec_plane = Plane::new(640, 480, 0, 0, 2 * 128 + 8, 2 * 128 + 8);
+
+    for rows in input_plane.as_region_mut().rows_iter_mut() {
+      for c in rows {
+        *c = T::cast_from(rng.gen_range(0u16..(1 << bd)));
+      }
+    }
+
+    for rows in rec_plane.as_region_mut().rows_iter_mut() {
+      for c in rows {
+        *c = T::cast_from(rng.gen_range(0u16..(1 << bd)));
+      }
+    }
+
+    (input_plane, rec_plane)
+  }
+
+  /// Create planes with the max values for pixels.
+  fn max_planes<T: Pixel>(bd: usize) -> (Plane<T>, Plane<T>) {
+    // Two planes with different strides
+    let mut input_plane = Plane::new(640, 480, 0, 0, 128 + 8, 128 + 8);
+    let mut rec_plane = Plane::new(640, 480, 0, 0, 2 * 128 + 8, 2 * 128 + 8);
+
+    for rows in input_plane.as_region_mut().rows_iter_mut() {
+      for c in rows {
+        *c = T::cast_from((1 << bd) - 1);
+      }
+    }
+
+    for rows in rec_plane.as_region_mut().rows_iter_mut() {
+      for c in rows {
+        *c = T::cast_from((1 << bd) - 1);
+      }
+    }
+
+    (input_plane, rec_plane)
+  }
+
+  /// Create planes with the max difference between the two values.
+  fn max_diff_planes<T: Pixel>(bd: usize) -> (Plane<T>, Plane<T>) {
+    // Two planes with different strides
+    let mut input_plane = Plane::new(640, 480, 0, 0, 128 + 8, 128 + 8);
+    let mut rec_plane = Plane::new(640, 480, 0, 0, 2 * 128 + 8, 2 * 128 + 8);
+
+    for rows in input_plane.as_region_mut().rows_iter_mut() {
+      for c in rows {
+        *c = T::cast_from(0);
+      }
+    }
+
+    for rows in rec_plane.as_region_mut().rows_iter_mut() {
+      for c in rows {
+        *c = T::cast_from((1 << bd) - 1);
+      }
+    }
+
+    (input_plane, rec_plane)
+  }
+
+  #[test]
+  fn cdef_dist_simd_random() {
+    cdef_diff_tester(8, random_planes::<u8>);
+  }
+
+  #[test]
+  fn cdef_dist_simd_large() {
+    cdef_diff_tester(8, max_planes::<u8>);
+  }
+
+  #[test]
+  fn cdef_dist_simd_large_diff() {
+    cdef_diff_tester(8, max_diff_planes::<u8>);
+  }
+
+  fn cdef_diff_tester<T: Pixel>(
+    bd: usize, gen_planes: fn(bd: usize) -> (Plane<T>, Plane<T>),
+  ) {
+    let (src_plane, dst_plane) = gen_planes(bd);
+
+    let mut fail = false;
+
+    for w in 1..=8 {
+      for h in 1..=8 {
+        // Test alignment by choosing starting location based on width.
+        let area = Area::StartingAt { x: if w <= 4 { 4 } else { 8 }, y: 40 };
+
+        let src_region = src_plane.region(area);
+        let dst_region = dst_plane.region(area);
+
+        let rust = rust::cdef_dist_kernel(
+          &src_region,
+          &dst_region,
+          w,
+          h,
+          bd,
+          CpuFeatureLevel::default(),
+        );
+
+        let simd = cdef_dist_kernel(
+          &src_region,
+          &dst_region,
+          w,
+          h,
+          bd,
+          CpuFeatureLevel::default(),
+        );
+
+        if simd != rust {
+          eprintln!(
+            "CDEF Distortion {}x{}: Assembly doesn't match reference code \
+          \t {} (asm) != {} (ref)",
+            w, h, simd, rust
+          );
+          fail = true;
+        }
+      }
+
+      if fail {
+        panic!();
+      }
+    }
+  }
+}

--- a/src/asm/x86/dist/mod.rs
+++ b/src/asm/x86/dist/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, The rav1e contributors. All rights reserved
+// Copyright (c) 2019-2022, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
@@ -7,6 +7,7 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+pub use self::cdef_dist::*;
 use self::hbd::*;
 pub use self::sse::*;
 use crate::cpu_features::CpuFeatureLevel;
@@ -15,6 +16,7 @@ use crate::partition::BlockSize;
 use crate::tiling::*;
 use crate::util::*;
 
+mod cdef_dist;
 mod hbd;
 mod sse;
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2001-2016, Alliance for Open Media. All rights reserved
-// Copyright (c) 2017-2021, The rav1e contributors. All rights reserved
+// Copyright (c) 2017-2022, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
@@ -36,9 +36,7 @@ use crate::predict::{
 use crate::rdo_tables::*;
 use crate::tiling::*;
 use crate::transform::{TxSet, TxSize, TxType, RAV1E_TX_TYPES};
-use crate::util::{
-  init_slice_repeat_mut, Aligned, CastFromPrimitive, ILog, Pixel,
-};
+use crate::util::{init_slice_repeat_mut, Aligned, Pixel};
 use crate::write_tx_blocks;
 use crate::write_tx_tree;
 use crate::Tune;
@@ -139,245 +137,10 @@ pub fn estimate_rate(qindex: u8, ts: TxSize, fast_distortion: u64) -> u64 {
   (y0 + (((fast_distortion as i64 - x0) * slope) >> 8)).max(0) as u64
 }
 
-/// Number of bits of precision used in `AREA_DIVISORS`
-const AREA_DIVISOR_BITS: u8 = 14;
-
-/// Lookup table for 2^`AREA_DIVISOR_BITS` / (1 + x)
-#[rustfmt::skip]
-const AREA_DIVISORS: [u16; 64] = [
-  16384, 8192, 5461, 4096, 3277, 2731, 2341, 2048, 1820, 1638, 1489, 1365, 1260,
-   1170, 1092, 1024,  964,  910,  862,  819,  780,  745,  712,  683,  655,  630,
-    607,  585,  565,  546,  529,  512,  496,  482,  468,  455,  443,  431,  420,
-    410,  400,  390,  381,  372,  364,  356,  349,  341,  334,  328,  321,  315,
-    309,  303,  298,  293,  287,  282,  278,  273,  269,  264,  260,  256,
-];
-
-/// Computes a distortion metric of the sum of squares weighted by activity.
-/// w and h should be <= 8.
-#[inline(never)]
-fn cdef_dist_kernel<T: Pixel>(
-  src1: &PlaneRegion<'_, T>, src2: &PlaneRegion<'_, T>, w: usize, h: usize,
-  bit_depth: usize,
-) -> RawDistortion {
-  // TODO: Investigate using different constants in ssim boost for block sizes
-  // smaller than 8x8.
-
-  debug_assert!(src1.plane_cfg.xdec == 0);
-  debug_assert!(src1.plane_cfg.ydec == 0);
-  debug_assert!(src2.plane_cfg.xdec == 0);
-  debug_assert!(src2.plane_cfg.ydec == 0);
-
-  // Limit kernel to 8x8
-  debug_assert!(w <= 8);
-  debug_assert!(h <= 8);
-
-  // Compute the following summations.
-  let mut sum_s: u32 = 0; // sum(src1_{i,j})
-  let mut sum_d: u32 = 0; // sum(src2_{i,j})
-  let mut sum_s2: u32 = 0; // sum(src1_{i,j}^2)
-  let mut sum_d2: u32 = 0; // sum(src2_{i,j}^2)
-  let mut sum_sd: u32 = 0; // sum(src1_{i,j} * src2_{i,j})
-  for j in 0..h {
-    let row1 = &src1[j][0..w];
-    let row2 = &src2[j][0..w];
-    for (s, d) in row1.iter().zip(row2) {
-      let s: u32 = u32::cast_from(*s);
-      let d: u32 = u32::cast_from(*d);
-      sum_s += s;
-      sum_d += d;
-
-      sum_s2 += s * s;
-      sum_d2 += d * d;
-      sum_sd += s * d;
-    }
-  }
-
-  // To get the distortion, compute sum of squared error and apply a weight
-  // based on the variance of the two planes.
-  let sse = sum_d2 + sum_s2 - 2 * sum_sd;
-
-  // Convert to 64-bits to avoid overflow when squaring
-  let sum_s = sum_s as u64;
-  let sum_d = sum_d as u64;
-
-  // Calculate the variance (more accurately variance*area) of each plane.
-  // var[iance] = avg(X^2) - avg(X)^2 = sum(X^2) / n - sum(X)^2 / n^2
-  //    (n = # samples i.e. area)
-  // var * n = sum(X^2) - sum(X)^2 / n
-  // When w and h are powers of two, this can be done via shifting.
-  let div = AREA_DIVISORS[w * h - 1] as u64;
-  let div_shift = AREA_DIVISOR_BITS;
-  // Due to rounding, negative values can occur when w or h aren't powers of
-  // two. Saturate to avoid underflow.
-  let mut svar = sum_s2.saturating_sub(
-    ((sum_s * sum_s * div + (1 << div_shift >> 1)) >> div_shift) as u32,
-  );
-  let mut dvar = sum_d2.saturating_sub(
-    ((sum_d * sum_d * div + (1 << div_shift >> 1)) >> div_shift) as u32,
-  );
-
-  // Scale variances up to 8x8 size.
-  //   scaled variance = var * (8x8) / wxh
-  // For 8x8, this is a nop. For powers of 2, this is doable with shifting.
-  // TODO: It should be possible and faster to do this adjustment in ssim boost
-  let scale_shift = AREA_DIVISOR_BITS - 6;
-  svar = ((svar as u64 * div + (1 << scale_shift >> 1)) >> scale_shift) as u32;
-  dvar = ((dvar as u64 * div + (1 << scale_shift >> 1)) >> scale_shift) as u32;
-
-  RawDistortion(apply_ssim_boost(sse, svar, dvar, bit_depth) as u64)
-}
-
-/// rsqrt result stored in fixed point w/ scaling such that:
-///   rsqrt = output.rsqrt_norm / (1 << output.shift)
-struct RsqrtOutput {
-  norm: u16,
-  shift: u8,
-}
-
-/// Fixed point rsqrt for ssim_boost
-fn ssim_boost_rsqrt(x: u64) -> RsqrtOutput {
-  const INSHIFT: u8 = 16;
-  const OUTSHIFT: u8 = 14;
-
-  let k = ((x.ilog() - 1) >> 1) as i16;
-  /*t is x in the range [0.25, 1) in QINSHIFT, or x*2^(-s).
-  Shift by log2(x) - log2(0.25*(1 << INSHIFT)) to ensure 0.25 lower bound.*/
-  let s: i16 = 2 * k - (INSHIFT as i16 - 2);
-  let t: u16 = if s > 0 { x >> s } else { x << -s } as u16;
-
-  /*We want to express od_rsqrt() in terms of od_rsqrt_norm(), which is
-   defined as (2^OUTSHIFT)/sqrt(t*(2^-INSHIFT)) with t=x*(2^-s).
-  This simplifies to 2^(OUTSHIFT+(INSHIFT/2)+(s/2))/sqrt(x), so the caller
-   needs to shift right by OUTSHIFT + INSHIFT/2 + s/2.*/
-  let rsqrt_shift: u8 = (OUTSHIFT as i16 + ((s + INSHIFT as i16) >> 1)) as u8;
-
-  #[inline(always)]
-  fn mult16_16_q15(a: i32, b: i32) -> i32 {
-    (a * b) >> 15
-  }
-
-  /* Reciprocal sqrt approximation where the input is in the range [0.25,1) in
-  Q16 and the output is in the range (1.0, 2.0] in Q14). */
-
-  /* Range of n is [-16384,32767] ([-0.5,1) in Q15). */
-  let n: i32 = t as i32 - 32768;
-  debug_assert!(n >= -16384);
-
-  /* Get a rough guess for the root.
-  The optimal minimax quadratic approximation (using relative error) is
-   r = 1.437799046117536+n*(-0.823394375837328+n*0.4096419668459485).
-  Coefficients here, and the final result r, are Q14. */
-  let rsqrt: i32 = 23557 + mult16_16_q15(n, -13490 + mult16_16_q15(n, 6711));
-
-  debug_assert!((16384..32768).contains(&rsqrt));
-  RsqrtOutput { norm: rsqrt as u16, shift: rsqrt_shift }
-}
-
-#[inline(always)]
-pub fn ssim_boost(svar: u32, dvar: u32, bit_depth: usize) -> DistortionScale {
-  DistortionScale(apply_ssim_boost(
-    DistortionScale::default().0,
-    svar,
-    dvar,
-    bit_depth,
-  ))
-}
-
-/// Apply ssim boost to a given input
-#[inline(always)]
-fn apply_ssim_boost(
-  input: u32, svar: u32, dvar: u32, bit_depth: usize,
-) -> u32 {
-  let coeff_shift = bit_depth - 8;
-
-  // Scale dvar and svar to lbd range to prevent overflows.
-  let svar = (svar >> (2 * coeff_shift)) as u64;
-  let dvar = (dvar >> (2 * coeff_shift)) as u64;
-
-  // The two constants were tuned for CDEF, but can probably be better tuned
-  //   for use in general RDO
-  const C1: u64 = 4033;
-  const C2: u64 = 16384;
-  const RATIO_SHIFT: u8 = 14;
-  const RATIO: u64 = (((C1 << (RATIO_SHIFT + 1)) / C2) + 1) >> 1;
-
-  //          C1        (svar + dvar + C2)
-  // input * ---- * --------------------------
-  //          C2     sqrt(C1^2 + svar * dvar)
-  let rsqrt = ssim_boost_rsqrt((C1 * C1) + svar * dvar);
-  ((input as u64
-    * (((RATIO * (svar + dvar + C2) as u64) * rsqrt.norm as u64)
-      >> RATIO_SHIFT))
-    >> rsqrt.shift) as u32
-}
-
-#[cfg(test)]
-mod ssim_boost_tests {
-  use super::*;
-  use rand::Rng;
-
-  /// Test to make sure extreme values of ssim boost don't overflow.
-  #[test]
-  fn overflow_test() {
-    // Test variance for 8x8 region with a bit depth of 12
-    let max_pix_diff = (1 << 12) - 1;
-    let max_pix_sse = max_pix_diff * max_pix_diff;
-    let max_variance = max_pix_diff * 8 * 8 / 4;
-    apply_ssim_boost(max_pix_sse * 8 * 8, max_variance, max_variance, 12);
-  }
-
-  /// Floating point reference version of ssim_boost
-  fn reference_ssim_boost(svar: u32, dvar: u32, bit_depth: usize) -> f64 {
-    let coeff_shift = bit_depth - 8;
-    let var_scale = 1f64 / (1 << (2 * coeff_shift)) as f64;
-    let svar = svar as f64 * var_scale;
-    let dvar = dvar as f64 * var_scale;
-    // These constants are from ssim boost and need to be updated if the
-    //  constants in ssim boost change.
-    const C1: f64 = 4033f64;
-    const C2: f64 = 16384f64;
-    const RATIO: f64 = C1 / C2;
-
-    RATIO * (svar + dvar + C2) / f64::sqrt(C1 * C1 + svar * dvar)
-  }
-
-  /// Test that ssim_boost has sufficient accuracy.
-  #[test]
-  fn accuracy_test() {
-    let mut rng = rand::thread_rng();
-
-    let mut max_relative_error = 0f64;
-    let bd = 12;
-
-    // Test different log scale ranges for the variance.
-    // Each scale is tested multiple times with randomized variances.
-    for scale in 0..(bd + 3 * 2 - 2) {
-      for _ in 0..40 {
-        let svar = rng.gen_range(0..(1 << scale));
-        let dvar = rng.gen_range(0..(1 << scale));
-
-        let float = reference_ssim_boost(svar, dvar, 12);
-        let fixed =
-          apply_ssim_boost(1 << 23, svar, dvar, 12) as f64 / (1 << 23) as f64;
-
-        // Compare the two versions
-        max_relative_error =
-          max_relative_error.max(f64::abs(1f64 - fixed / float));
-      }
-    }
-
-    assert!(
-      max_relative_error < 0.05,
-      "SSIM boost error too high. Measured max relative error: {}.",
-      max_relative_error
-    );
-  }
-}
-
 #[allow(unused)]
 pub fn cdef_dist_wxh<T: Pixel, F: Fn(Area, BlockSize) -> DistortionScale>(
   src1: &PlaneRegion<'_, T>, src2: &PlaneRegion<'_, T>, w: usize, h: usize,
-  bit_depth: usize, compute_bias: F,
+  bit_depth: usize, compute_bias: F, cpu: CpuFeatureLevel,
 ) -> Distortion {
   debug_assert!(src1.plane_cfg.xdec == 0);
   debug_assert!(src1.plane_cfg.ydec == 0);
@@ -391,13 +154,14 @@ pub fn cdef_dist_wxh<T: Pixel, F: Fn(Area, BlockSize) -> DistortionScale>(
       let kernel_w = (w - x).min(8);
       let area = Area::StartingAt { x: x as isize, y: y as isize };
 
-      let value = cdef_dist_kernel(
+      let value = RawDistortion(cdef_dist_kernel(
         &src1.subregion(area),
         &src2.subregion(area),
         kernel_w,
         kernel_h,
         bit_depth,
-      );
+        cpu,
+      ) as u64);
 
       // cdef is always called on non-subsampled planes, so BLOCK_8X8 is
       // correct here.
@@ -520,6 +284,7 @@ fn compute_distortion<T: Pixel>(
           bsize,
         )
       },
+      fi.cpu_feature_level,
     ),
     Tune::Psnr => sse_wxh(
       &input_region,
@@ -2200,14 +1965,15 @@ fn rdo_loop_plane_error<T: Pixel>(
           // For loop filters, We intentionally use cdef_dist even with
           // `--tune Psnr`. Using SSE instead gives no PSNR gain but has a
           // significant negative impact on other metrics and visual quality.
-          //cdef_dist_wxh_8x8(&src_region, &test_region, fi.sequence.bit_depth)
-          cdef_dist_kernel(
+          RawDistortion(cdef_dist_kernel(
             &src_region,
             &test_region,
             8,
             8,
             fi.sequence.bit_depth,
-          ) * bias
+            fi.cpu_feature_level,
+          ) as u64)
+            * bias
         } else {
           sse_wxh(
             &src_region,

--- a/src/x86/cdef_dist.asm
+++ b/src/x86/cdef_dist.asm
@@ -1,0 +1,233 @@
+; Copyright (c) 2022, The rav1e contributors. All rights reserved
+;
+; This source code is subject to the terms of the BSD 2 Clause License and
+; the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+; was not distributed with this source code in the LICENSE file, you can
+; obtain it at www.aomedia.org/license/software. If the Alliance for Open
+; Media Patent License 1.0 was not distributed with this source code in the
+; PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+%include "config.asm"
+%include "ext/x86/x86inc.asm"
+
+SECTION .text
+
+%if ARCH_X86_64
+
+; m0: zero register
+; m1: src input
+; m2: dst input
+; m3 = sum(src_{i,j})
+; m4 = sum(src_{i,j}^2)
+; m5 = sum(dst_{i,j})
+; m6 = sum(dst_{i,j}^2)
+; m7 = sum(src_{i,j} * dst_{i,j})
+; m8: tmp register
+%macro CDEF_DIST_W8_SSE2 0
+    psadbw              m8, m1, m0 ; sum pixel values
+    paddd               m3, m8     ; accumulate
+    punpcklbw           m1, m0     ; convert to 16-bits
+    pmaddwd             m8, m1, m1 ; square and horz add
+    paddd               m4, m8     ; accumulate
+    psadbw              m8, m2, m0 ; same as above, but for dst
+    paddd               m5, m8
+    punpcklbw           m2, m0
+    pmaddwd             m8, m2, m2
+    paddd               m6, m8
+    pmaddwd             m8, m1, m2 ; src_{i,j} * dst_{i,j} (and horz add)
+    paddd               m7, m8
+%endmacro
+
+; Refine sums into variances and sse
+; parameter: scale log2 relative to 8x8
+%macro CDEF_DIST_REFINE_SSE2 1
+    ; Compute [sum(src)^2, sum(dst)^2]
+    punpckldq           m3, m5 ; store sums in a single vector
+    pcmpeqd             m0, m0 ; -1 (for rounding)
+    pmaddwd             m3, m3
+
+    ; Divide by area and round
+    pslld               m0, 5 - %1
+    psubd               m3, m0 ; + (1 << (5 - %1))
+    psrld               m3, 6 - %1
+
+    pshufd              m0, m7, q3232 ; reduce sum(src * dst)
+    punpckldq           m1, m4, m6    ; reduce [sum(src^2), sum(dst^2)]
+    paddd               m7, m0
+    punpckhdq           m4, m6
+    paddd               m1, m4
+    paddd               m7, m7 ; 2 * sum(src * dst) [Partially reduced; len 2]
+    pshufd              m0, m1, q3232
+
+    ; Equivelent to:
+    ; paddd m1, m0
+    ; psubd m0, m1, m7 ; sse = sum(src^2) + sum(dst^2) - sum(src * dst)
+    ; but with fewer dependancies
+    psubd               m7, m1
+    paddd               m1, m0 ; [sum(src^2), sum(dst^2)]
+    psubd               m0, m7 ; sse (Needs reducing; len 2)
+
+    psubd               m1, m3 ; [src variance, dst variance]
+    ; Scale up the variances up to 8x8
+    ; TODO: this can be handled inside ssim boost in the future
+%if %1 != 0
+    pslld               m1, %1
+%endif
+    movq        [ret_ptrq], m1
+
+    ; Final reduce for sse
+    pshuflw             m2, m0, q3232
+    paddd               m0, m2
+    movd      [ret_ptrq+8], m0
+%endmacro
+
+INIT_XMM sse2
+cglobal cdef_dist_kernel_4x4, 5, 5, 9, \
+        src, src_stride, dst, dst_stride, ret_ptr
+    pxor                m0, m0
+    movd                m1, [srcq]
+    movd                m2, [srcq+src_strideq]
+    punpckldq           m1, m2
+    movd                m2, [dstq]
+    movd                m8, [dstq+dst_strideq]
+    lea               srcq, [srcq+2*src_strideq]
+    lea               dstq, [dstq+2*dst_strideq]
+    punpckldq           m2, m8
+    psadbw              m3, m1, m0
+    punpcklbw           m1, m0
+    pmaddwd             m4, m1, m1
+    psadbw              m5, m2, m0
+    punpcklbw           m2, m0
+    pmaddwd             m6, m2, m2
+    pmaddwd             m7, m1, m2
+
+    movd                m1, [srcq]
+    movd                m2, [srcq+src_strideq]
+    punpckldq           m1, m2
+    movd                m2, [dstq]
+    movd                m8, [dstq+dst_strideq]
+    punpckldq           m2, m8
+    CDEF_DIST_W8_SSE2
+
+    CDEF_DIST_REFINE_SSE2 2
+    RET
+
+cglobal cdef_dist_kernel_4x8, 5, 7, 9, \
+        src, src_stride, dst, dst_stride, ret_ptr, src_stride3, dst_stride3
+    lea       src_stride3q, [src_strideq*3]
+    lea       dst_stride3q, [dst_strideq*3]
+
+    pxor                m0, m0
+    movd                m1, [srcq]
+    movd                m2, [srcq+src_strideq]
+    punpckldq           m1, m2
+    movd                m2, [dstq]
+    movd                m8, [dstq+dst_strideq]
+    punpckldq           m2, m8
+    psadbw              m3, m1, m0
+    punpcklbw           m1, m0
+    pmaddwd             m4, m1, m1
+    psadbw              m5, m2, m0
+    punpcklbw           m2, m0
+    pmaddwd             m6, m2, m2
+    pmaddwd             m7, m1, m2
+
+    movd                m1, [srcq+2*src_strideq]
+    movd                m2, [srcq+src_stride3q]
+    punpckldq           m1, m2
+    movd                m2, [dstq+2*dst_strideq]
+    movd                m8, [dstq+dst_stride3q]
+    lea               srcq, [srcq+4*src_strideq]
+    lea               dstq, [dstq+4*dst_strideq]
+    punpckldq           m2, m8
+    CDEF_DIST_W8_SSE2
+    movd                m1, [srcq]
+    movd                m2, [srcq+src_strideq]
+    punpckldq           m1, m2
+    movd                m2, [dstq]
+    movd                m8, [dstq+dst_strideq]
+    punpckldq           m2, m8
+    CDEF_DIST_W8_SSE2
+    movd                m1, [srcq+2*src_strideq]
+    movd                m2, [srcq+src_stride3q]
+    punpckldq           m1, m2
+    movd                m2, [dstq+2*dst_strideq]
+    movd                m8, [dstq+dst_stride3q]
+    punpckldq           m2, m8
+    CDEF_DIST_W8_SSE2
+
+    CDEF_DIST_REFINE_SSE2 1
+    RET
+
+cglobal cdef_dist_kernel_8x4, 5, 5, 9, \
+        src, src_stride, dst, dst_stride, ret_ptr
+    pxor                m0, m0
+    movq                m1, [srcq]
+    psadbw              m3, m1, m0
+    punpcklbw           m1, m0
+    pmaddwd             m4, m1, m1
+    movq                m2, [dstq]
+    psadbw              m5, m2, m0
+    punpcklbw           m2, m0
+    pmaddwd             m6, m2, m2
+    pmaddwd             m7, m1, m2
+
+    movq                m1, [srcq+src_strideq]
+    movq                m2, [dstq+dst_strideq]
+    lea               srcq, [srcq+2*src_strideq]
+    lea               dstq, [dstq+2*dst_strideq]
+    CDEF_DIST_W8_SSE2
+    movq                m1, [srcq]
+    movq                m2, [dstq]
+    CDEF_DIST_W8_SSE2
+    movq                m1, [srcq+src_strideq]
+    movq                m2, [dstq+dst_strideq]
+    CDEF_DIST_W8_SSE2
+
+    CDEF_DIST_REFINE_SSE2 1
+    RET
+
+cglobal cdef_dist_kernel_8x8, 5, 7, 9, \
+        src, src_stride, dst, dst_stride, ret_ptr, src_stride3, dst_stride3
+    lea       src_stride3q, [src_strideq*3]
+    lea       dst_stride3q, [dst_strideq*3]
+
+    pxor                m0, m0
+    movq                m1, [srcq]
+    psadbw              m3, m1, m0
+    punpcklbw           m1, m0
+    pmaddwd             m4, m1, m1
+    movq                m2, [dstq]
+    psadbw              m5, m2, m0
+    punpcklbw           m2, m0
+    pmaddwd             m6, m2, m2
+    pmaddwd             m7, m1, m2
+
+    movq                m1, [srcq+src_strideq]
+    movq                m2, [dstq+dst_strideq]
+    CDEF_DIST_W8_SSE2
+    movq                m1, [srcq+2*src_strideq]
+    movq                m2, [dstq+2*dst_strideq]
+    CDEF_DIST_W8_SSE2
+    movq                m1, [srcq+src_stride3q]
+    movq                m2, [dstq+dst_stride3q]
+    CDEF_DIST_W8_SSE2
+    lea               srcq, [srcq+src_strideq*4]
+    lea               dstq, [dstq+dst_strideq*4]
+
+    movq                m1, [srcq]
+    movq                m2, [dstq]
+    CDEF_DIST_W8_SSE2
+    movq                m1, [srcq+src_strideq]
+    movq                m2, [dstq+dst_strideq]
+    CDEF_DIST_W8_SSE2
+    movq                m1, [srcq+2*src_strideq]
+    movq                m2, [dstq+2*dst_strideq]
+    CDEF_DIST_W8_SSE2
+    movq                m1, [srcq+src_stride3q]
+    movq                m2, [dstq+dst_stride3q]
+    CDEF_DIST_W8_SSE2
+
+    CDEF_DIST_REFINE_SSE2 0
+    RET
+%endif ; ARCH_X86_64


### PR DESCRIPTION
Around ~7% faster on speed 2. It should be roughly the same for most
speed levels.

It would have been more, but some recent patches seem to have allowed
autovecterization to happen again.