### PR TITLE
Use const generics for hadamard transforms

### DIFF
--- a/src/dist.rs
+++ b/src/dist.rs
@@ -144,12 +144,12 @@ pub(crate) mod rust {
 
   // SAFETY: The length of data must be 16.
   unsafe fn hadamard4x4(data: &mut [i32]) {
-    hadamard2d::<{ 4 * 4 }, 4, 4>(std::mem::transmute(data.as_mut_ptr()));
+    hadamard2d::<{ 4 * 4 }, 4, 4>(&mut *(data.as_mut_ptr() as *mut [i32; 16]));
   }
 
   // SAFETY: The length of data must be 64.
   unsafe fn hadamard8x8(data: &mut [i32]) {
-    hadamard2d::<{ 8 * 8 }, 8, 8>(std::mem::transmute(data.as_mut_ptr()));
+    hadamard2d::<{ 8 * 8 }, 8, 8>(&mut *(data.as_mut_ptr() as *mut [i32; 64]));
   }
 
   /// Sum of absolute transformed differences over a block.

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -62,30 +62,44 @@ pub(crate) mod rust {
 
   #[inline(always)]
   #[allow(clippy::identity_op, clippy::erasing_op)]
-  fn hadamard4_1d(data: &mut [i32], n: usize, stride0: usize, stride1: usize) {
-    for i in 0..n {
-      let sub: &mut [i32] = &mut data[i * stride0..];
-      let (a0, a1) = butterfly(sub[0 * stride1], sub[1 * stride1]);
-      let (a2, a3) = butterfly(sub[2 * stride1], sub[3 * stride1]);
+  fn hadamard4_1d<
+    const LEN: usize,
+    const N: usize,
+    const STRIDE0: usize,
+    const STRIDE1: usize,
+  >(
+    data: &mut [i32; LEN],
+  ) {
+    for i in 0..N {
+      let sub: &mut [i32] = &mut data[i * STRIDE0..];
+      let (a0, a1) = butterfly(sub[0 * STRIDE1], sub[1 * STRIDE1]);
+      let (a2, a3) = butterfly(sub[2 * STRIDE1], sub[3 * STRIDE1]);
       let (b0, b2) = butterfly(a0, a2);
       let (b1, b3) = butterfly(a1, a3);
-      sub[0 * stride1] = b0;
-      sub[1 * stride1] = b1;
-      sub[2 * stride1] = b2;
-      sub[3 * stride1] = b3;
+      sub[0 * STRIDE1] = b0;
+      sub[1 * STRIDE1] = b1;
+      sub[2 * STRIDE1] = b2;
+      sub[3 * STRIDE1] = b3;
     }
   }
 
   #[inline(always)]
   #[allow(clippy::identity_op, clippy::erasing_op)]
-  fn hadamard8_1d(data: &mut [i32], n: usize, stride0: usize, stride1: usize) {
-    for i in 0..n {
-      let sub: &mut [i32] = &mut data[i * stride0..];
+  fn hadamard8_1d<
+    const LEN: usize,
+    const N: usize,
+    const STRIDE0: usize,
+    const STRIDE1: usize,
+  >(
+    data: &mut [i32; LEN],
+  ) {
+    for i in 0..N {
+      let sub: &mut [i32] = &mut data[i * STRIDE0..];
 
-      let (a0, a1) = butterfly(sub[0 * stride1], sub[1 * stride1]);
-      let (a2, a3) = butterfly(sub[2 * stride1], sub[3 * stride1]);
-      let (a4, a5) = butterfly(sub[4 * stride1], sub[5 * stride1]);
-      let (a6, a7) = butterfly(sub[6 * stride1], sub[7 * stride1]);
+      let (a0, a1) = butterfly(sub[0 * STRIDE1], sub[1 * STRIDE1]);
+      let (a2, a3) = butterfly(sub[2 * STRIDE1], sub[3 * STRIDE1]);
+      let (a4, a5) = butterfly(sub[4 * STRIDE1], sub[5 * STRIDE1]);
+      let (a6, a7) = butterfly(sub[6 * STRIDE1], sub[7 * STRIDE1]);
 
       let (b0, b2) = butterfly(a0, a2);
       let (b1, b3) = butterfly(a1, a3);
@@ -97,33 +111,45 @@ pub(crate) mod rust {
       let (c2, c6) = butterfly(b2, b6);
       let (c3, c7) = butterfly(b3, b7);
 
-      sub[0 * stride1] = c0;
-      sub[1 * stride1] = c1;
-      sub[2 * stride1] = c2;
-      sub[3 * stride1] = c3;
-      sub[4 * stride1] = c4;
-      sub[5 * stride1] = c5;
-      sub[6 * stride1] = c6;
-      sub[7 * stride1] = c7;
+      sub[0 * STRIDE1] = c0;
+      sub[1 * STRIDE1] = c1;
+      sub[2 * STRIDE1] = c2;
+      sub[3 * STRIDE1] = c3;
+      sub[4 * STRIDE1] = c4;
+      sub[5 * STRIDE1] = c5;
+      sub[6 * STRIDE1] = c6;
+      sub[7 * STRIDE1] = c7;
     }
   }
 
   #[inline(always)]
-  fn hadamard2d(data: &mut [i32], (w, h): (usize, usize)) {
+  fn hadamard2d<const LEN: usize, const W: usize, const H: usize>(
+    data: &mut [i32; LEN],
+  ) {
     /*Vertical transform.*/
-    let vert_func = if h == 4 { hadamard4_1d } else { hadamard8_1d };
-    vert_func(data, w, 1, h);
+    let vert_func = if H == 4 {
+      hadamard4_1d::<LEN, W, 1, H>
+    } else {
+      hadamard8_1d::<LEN, W, 1, H>
+    };
+    vert_func(data);
     /*Horizontal transform.*/
-    let horz_func = if w == 4 { hadamard4_1d } else { hadamard8_1d };
-    horz_func(data, h, w, 1);
+    let horz_func = if W == 4 {
+      hadamard4_1d::<LEN, H, W, 1>
+    } else {
+      hadamard8_1d::<LEN, H, W, 1>
+    };
+    horz_func(data);
   }
 
-  fn hadamard4x4(data: &mut [i32]) {
-    hadamard2d(data, (4, 4));
+  // SAFETY: The length of data must be 16.
+  unsafe fn hadamard4x4(data: &mut [i32]) {
+    hadamard2d::<{ 4 * 4 }, 4, 4>(std::mem::transmute(data.as_mut_ptr()));
   }
 
-  fn hadamard8x8(data: &mut [i32]) {
-    hadamard2d(data, (8, 8));
+  // SAFETY: The length of data must be 64.
+  unsafe fn hadamard8x8(data: &mut [i32]) {
+    hadamard2d::<{ 8 * 8 }, 8, 8>(std::mem::transmute(data.as_mut_ptr()));
   }
 
   /// Sum of absolute transformed differences over a block.
@@ -183,7 +209,10 @@ pub(crate) mod rust {
         }
 
         // Perform the hadamard transform on the differences
-        tx2d(buf);
+        // SAFETY: A sufficient number elements exist for the size of the transform.
+        unsafe {
+          tx2d(buf);
+        }
 
         // Sum the absolute values of the transformed differences
         sum += buf.iter().map(|a| a.abs() as u64).sum::<u64>();


### PR DESCRIPTION
Using const generics allows the compiler to optimize the hadamard transforms significantly better: https://godbolt.org/z/YdWe7518h 