### PR TITLE
Improve codegen of av1_round_shift_array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ itertools = "0.10"
 simd_helpers = "0.1"
 wasm-bindgen = { version = "0.2.63", optional = true }
 rust_hawktracer = "0.7.0"
+arrayref = "0.3.6"
 
 [dependencies.image]
 version = "0.23"

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -319,13 +319,13 @@ pub fn av1_round_shift_array(arr: &mut [i32], size: usize, bit: i8) {
   }
   if bit > 0 {
     let bit = bit as usize;
-    for i in arr.iter_mut().take(size) {
+    arr.iter_mut().take(size).for_each(|i| {
       *i = round_shift(*i, bit);
-    }
+    })
   } else {
-    for i in arr.iter_mut().take(size) {
+    arr.iter_mut().take(size).for_each(|i| {
       *i <<= -bit;
-    }
+    })
   }
 }
 


### PR DESCRIPTION
- Switch to fixed-size arrays for avx2 transposes (more readable than copying tuples around), which brings in the arrayref crate, since it is safer than manually transmuting/casting
- Use `for_each` which for some reason allows autovectorization of `av1_round_shift_array` (https://godbolt.org/z/xMvv3bY6b)
- Slightly improve codegen of `round_shift_array_avx2` (https://godbolt.org/z/noYYbc7Gb) (also removed `size` parameter as it was never called with a different length then the length of the slice being passed)