### PR TITLE
Fix scale of motion estimation threshold

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -490,7 +490,7 @@ fn get_subset_predictors<T: Pixel>(
   // Undo normalization to 128x128 block size
   let min_sad = min_sad
     >> (MAX_MIB_SIZE_LOG2 * 2
-      - (bsize.width_mi_log2() + bsize.height_mi_log2() + ssdec as usize * 2));
+      - (bsize.width_mi_log2() + bsize.height_mi_log2()));
 
   let dec_mv = |mv: MotionVector| MotionVector {
     col: mv.col >> ssdec,


### PR DESCRIPTION
The min sad was being scaled to the size of the block on the fullres
plane, when it should to be scaled to the size of the block on the
subres plane.

Speed 10:
https://beta.arewecompressedyet.com/?job=master-5da2a86bc98d9-s10%402022-01-07T23%3A58%3A02.424Z&job=fix_normalization_s10%402022-01-10T20%3A21%3A49.554Z
Speed 6:
https://beta.arewecompressedyet.com/?job=master-5da2a86bc98d9%402022-01-07T21%3A00%3A58.566Z&job=fix_normalization%402022-01-10T19%3A37%3A01.387Z
Speed 5:
https://beta.arewecompressedyet.com/?job=master-5da2a86bc98d9-s5%402022-01-08T14%3A19%3A23.189Z&job=fix_normalization_s5%402022-01-10T19%3A39%3A14.571Z

It's maybe a little bit slower. Hard to tell, since awcy is very
inconsistent right now.

| speed       | 10      | 6       | 5       |
|-------------|---------|---------|---------|
| PSNR Y      | -0.1410 | -0.1033 | -0.1192 |
| PSNR Cb     | -0.0548 | 0.0491  | -0.2705 |
| PSNR Cr     | -0.2470 | -0.0655 | -0.0350 |
| CIEDE2000   | -0.1425 | 0.0140  | -0.0891 |
| SSIM        | -0.1511 | 0.0147  | -0.0629 |
| MS-SSIM     | -0.1609 | -0.0016 | -0.0675 |
| PSNR-HVS Y  | -0.1341 | -0.0633 | -0.0701 |
| PSNR-HVS Cb | 0.0707  | 0.1502  | -0.2429 |
| PSNR-HVS Cr | -0.3432 | -0.0086 | -0.0102 |
| PSNR-HVS    | -0.1316 | -0.0573 | -0.0685 |
| VMAF        | -0.1841 | -0.0609 | -0.2374 |
| VMAF-NEG    | -0.2061 | -0.0751 | -0.1618 |