### PR TITLE
Simplify importance block sum in `estimate_importance_block_difference`

### DIFF
--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -120,12 +120,13 @@ pub(crate) fn estimate_intra_costs<T: Pixel>(
 #[hawktracer(estimate_importance_block_difference)]
 pub(crate) fn estimate_importance_block_difference<T: Pixel>(
   frame: Arc<Frame<T>>, ref_frame: Arc<Frame<T>>,
-) -> Box<[u32]> {
+) -> f64 {
   let plane_org = &frame.planes[0];
   let plane_ref = &ref_frame.planes[0];
   let h_in_imp_b = plane_org.cfg.height / IMPORTANCE_BLOCK_SIZE;
   let w_in_imp_b = plane_org.cfg.width / IMPORTANCE_BLOCK_SIZE;
-  let mut inter_costs = Vec::with_capacity(h_in_imp_b * w_in_imp_b);
+
+  let mut imp_block_costs = 0;
 
   (0..h_in_imp_b).for_each(|y| {
     (0..w_in_imp_b).for_each(|x| {
@@ -165,10 +166,11 @@ pub(crate) fn estimate_importance_block_difference<T: Pixel>(
         - ((histogram_ref_sum + count / 2) / count))
         .abs();
 
-      inter_costs.push(mean as u32);
+      imp_block_costs += mean as u64;
     });
   });
-  inter_costs.into_boxed_slice()
+
+  imp_block_costs as f64 / (w_in_imp_b * h_in_imp_b) as f64
 }
 
 #[hawktracer(estimate_inter_costs)]

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -462,12 +462,8 @@ impl<T: Pixel> SceneChangeDetector<T> {
             / inter_costs.len() as f64
       });
       s.spawn(|_| {
-        let inter_costs =
-          estimate_importance_block_difference(frame2_imp_ref, frame1_imp_ref);
-
         imp_block_cost =
-          inter_costs.iter().map(|&cost| cost as u64).sum::<u64>() as f64
-            / inter_costs.len() as f64
+          estimate_importance_block_difference(frame2_imp_ref, frame1_imp_ref);
       });
     });
 

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -449,17 +449,13 @@ impl<T: Pixel> SceneChangeDetector<T> {
           / intra_costs.len() as f64
       });
       s.spawn(|_| {
-        let inter_costs = estimate_inter_costs(
+        mv_inter_cost = estimate_inter_costs(
           frame2_inter_ref,
           frame1,
           self.bit_depth,
           self.encoder_config,
           self.sequence.clone(),
         );
-
-        mv_inter_cost =
-          inter_costs.iter().map(|&cost| cost as u64).sum::<u64>() as f64
-            / inter_costs.len() as f64
       });
       s.spawn(|_| {
         imp_block_cost =


### PR DESCRIPTION
As far as I could tell, 8x8 blocks are always used, so dynamically counting the number of pixels is not necessary.