### PR TITLE
Update to Edition 2021

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         conf:
           - beta-build
-          - 1.54.0-tests
+          - 1.56.0-tests
           - aom-tests
           - dav1d-tests
           - no-asm-tests
@@ -59,8 +59,8 @@ jobs:
         include:
           - conf: beta-build
             toolchain: beta
-          - conf: 1.54.0-tests
-            toolchain: 1.54.0
+          - conf: 1.56.0-tests
+            toolchain: 1.56.0
           - conf: aom-tests
             toolchain: stable
           - conf: dav1d-tests
@@ -125,7 +125,7 @@ jobs:
           echo "$NASM_SHA256 nasm_${NASM_VERSION}_amd64.deb" >> CHECKSUMS
       - name: Add aom
         if: >
-          matrix.conf == '1.54.0-tests' || matrix.conf == 'aom-tests' ||
+          matrix.conf == '1.56.0-tests' || matrix.conf == 'aom-tests' ||
           matrix.conf == 'grcov-coveralls'
         env:
           LINK: http://debian-archive.trafficmanager.net/debian/pool/main/a/aom
@@ -141,7 +141,7 @@ jobs:
           echo "$AOM_LIB3_SHA256 libaom3_${AOM3_VERSION}_amd64.deb" >> CHECKSUMS
       - name: Add dav1d
         if: >
-          matrix.conf == '1.54.0-tests' || matrix.conf == 'dav1d-tests' ||
+          matrix.conf == '1.56.0-tests' || matrix.conf == 'dav1d-tests' ||
           matrix.conf == 'grcov-coveralls' || matrix.conf == 'fuzz' || matrix.conf == 'no-asm-tests'
         env:
           LINK: http://debian-archive.trafficmanager.net/debian/pool/main/d/dav1d
@@ -216,8 +216,8 @@ jobs:
       - name: Start sccache server
         run: |
           sccache --start-server
-      - name: Run 1.54.0 tests
-        if: matrix.toolchain == '1.54.0' && matrix.conf == '1.54.0-tests'
+      - name: Run 1.56.0 tests
+        if: matrix.toolchain == '1.56.0' && matrix.conf == '1.56.0-tests'
         run: |
           cargo test --workspace --verbose \
                      --features=decode_test,decode_test_dav1d,quick_test,capi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rav1e"
 version = "0.5.0"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
 edition = "2018"
-rust-version = "1.54.0"
+rust-version = "1.56.0"
 build = "build.rs"
 include = [
     "/Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rav1e"
 version = "0.5.0"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.56.0"
 build = "build.rs"
 include = [

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For the foreseeable future, a weekly pre-release of rav1e will be [published](ht
 
 ### Toolchain: Rust
 
-rav1e currently requires Rust 1.54.0 or later to build.
+rav1e currently requires Rust 1.56.0 or later to build.
 
 ### Dependency: NASM
 Some `x86_64`-specific optimizations require [NASM](https://nasm.us/) `2.14.02` or newer and are enabled by default.

--- a/build.rs
+++ b/build.rs
@@ -220,7 +220,7 @@ fn build_asm_files() {
 fn rustc_version_check() {
   // This should match the version in the CI
   // Make sure to updated README.md when this changes.
-  const REQUIRED_VERSION: &str = "1.54.0";
+  const REQUIRED_VERSION: &str = "1.56.0";
   if version().unwrap() < Version::parse(REQUIRED_VERSION).unwrap() {
     eprintln!("rav1e requires rustc >= {}.", REQUIRED_VERSION);
     exit(1);

--- a/ivf/Cargo.toml
+++ b/ivf/Cargo.toml
@@ -2,11 +2,10 @@
 name = "ivf"
 version = "0.1.1"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
-edition = "2018"
+edition = "2021"
 description = "Simple ivf muxer"
 license = "BSD-2-Clause"
 homepage = "https://github.com/xiph/rav1e"
 
 [dependencies]
 bitstream-io = "1"
-

--- a/v_frame/Cargo.toml
+++ b/v_frame/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.5"
 description = "Video Frame data structures, part of rav1e"
 license = "BSD-2-Clause"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/xiph/rav1e/"
 
 [features]


### PR DESCRIPTION
dav1d-sys has updated to edition 2021, forcing us to raise our minimum supported Rust version to 1.56. Since we are now raising the minimum version, it makes sense to update ourselves to edition 2021 at the same time.