### PR TITLE
Add safety asserts for mc assembly callers

### DIFF
--- a/src/asm/aarch64/mc.rs
+++ b/src/asm/aarch64/mc.rs
@@ -101,11 +101,23 @@ pub fn put_8tap<T: Pixel>(
     call_rust(&mut copy.as_region_mut());
     copy
   };
-  match T::type_enum() {
-    PixelType::U8 => {
-      match PUT_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
-        Some(func) => unsafe {
-          (func)(
+  unsafe {
+    // SAFETY: The assembly only supports even heights and valid uncropped
+    //         widths
+    assert_eq!(height & 1, 0);
+    assert!(width.is_power_of_two() && 2 <= width && width <= 128);
+
+    // SAFETY: Check bounds of dst
+    assert!(dst.rect().width >= width && dst.rect().height >= height);
+
+    // SAFETY: Check bounds of src
+    assert!(src.accessible(width + 4, height + 4));
+    assert!(src.accessible_neg(3, 3));
+
+    match T::type_enum() {
+      PixelType::U8 => {
+        match PUT_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
+          Some(func) => (func)(
             dst.data_ptr_mut() as *mut _,
             T::to_asm_stride(dst.plane_cfg.stride),
             src.as_ptr() as *const _,
@@ -114,15 +126,13 @@ pub fn put_8tap<T: Pixel>(
             height as i32,
             col_frac,
             row_frac,
-          );
-        },
-        None => call_rust(dst),
+          ),
+          None => call_rust(dst),
+        }
       }
-    }
-    PixelType::U16 if bit_depth > 8 => {
-      match PUT_HBD_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
-        Some(func) => unsafe {
-          (func)(
+      PixelType::U16 if bit_depth > 8 => {
+        match PUT_HBD_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
+          Some(func) => (func)(
             dst.data_ptr_mut() as *mut _,
             T::to_asm_stride(dst.plane_cfg.stride),
             src.as_ptr() as *const _,
@@ -132,12 +142,12 @@ pub fn put_8tap<T: Pixel>(
             col_frac,
             row_frac,
             (1 << bit_depth) - 1,
-          );
-        },
-        None => call_rust(dst),
+          ),
+          None => call_rust(dst),
+        }
       }
+      _ => call_rust(dst),
     }
-    _ => call_rust(dst),
   }
   #[cfg(feature = "check_asm")]
   {
@@ -157,6 +167,10 @@ pub fn prep_8tap<T: Pixel>(
   col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,
   bit_depth: usize, cpu: CpuFeatureLevel,
 ) {
+  // The assembly only supports even heights and valid uncropped widths
+  assert_eq!(height & 1, 0);
+  assert!(width.is_power_of_two() && (2 <= width || width <= 128));
+
   let call_rust = |tmp: &mut [i16]| {
     rust::prep_8tap(
       tmp, src, width, height, col_frac, row_frac, mode_x, mode_y, bit_depth,
@@ -170,11 +184,22 @@ pub fn prep_8tap<T: Pixel>(
     call_rust(&mut copy);
     copy
   };
-  match T::type_enum() {
-    PixelType::U8 => {
-      match PREP_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
-        Some(func) => unsafe {
-          (func)(
+  unsafe {
+    // SAFETY: The assembly only supports even heights and valid uncropped
+    //         widths
+    assert_eq!(height & 1, 0);
+    assert!(width.is_power_of_two() && 2 <= width && width <= 128);
+
+    // SAFETY: Check length of tmp
+    assert!(tmp.len() >= width * height);
+
+    // SAFETY: Check bounds of src
+    assert!(src.accessible(width + 4, height + 4));
+    assert!(src.accessible_neg(3, 3));
+    match T::type_enum() {
+      PixelType::U8 => {
+        match PREP_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
+          Some(func) => (func)(
             tmp.as_mut_ptr(),
             src.as_ptr() as *const _,
             T::to_asm_stride(src.plane.cfg.stride),
@@ -182,15 +207,13 @@ pub fn prep_8tap<T: Pixel>(
             height as i32,
             col_frac,
             row_frac,
-          );
-        },
-        None => call_rust(tmp),
+          ),
+          None => call_rust(tmp),
+        }
       }
-    }
-    PixelType::U16 if bit_depth > 8 => {
-      match PREP_HBD_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
-        Some(func) => unsafe {
-          (func)(
+      PixelType::U16 if bit_depth > 8 => {
+        match PREP_HBD_FNS[cpu.as_index()][get_2d_mode_idx(mode_x, mode_y)] {
+          Some(func) => (func)(
             tmp.as_mut_ptr() as *mut _,
             src.as_ptr() as *const _,
             T::to_asm_stride(src.plane.cfg.stride),
@@ -199,12 +222,12 @@ pub fn prep_8tap<T: Pixel>(
             col_frac,
             row_frac,
             (1 << bit_depth) - 1,
-          );
-        },
-        None => call_rust(tmp),
+          ),
+          None => call_rust(tmp),
+        }
       }
+      _ => call_rust(tmp),
     }
-    _ => call_rust(tmp),
   }
   #[cfg(feature = "check_asm")]
   {
@@ -216,6 +239,10 @@ pub fn mc_avg<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
   height: usize, bit_depth: usize, cpu: CpuFeatureLevel,
 ) {
+  // The assembly only supports even heights and valid uncropped widths
+  assert_eq!(height & 1, 0);
+  assert!(width.is_power_of_two() && (2 <= width || width <= 128));
+
   let call_rust = |dst: &mut PlaneRegionMut<'_, T>| {
     rust::mc_avg(dst, tmp1, tmp2, width, height, bit_depth, cpu);
   };
@@ -225,23 +252,32 @@ pub fn mc_avg<T: Pixel>(
     call_rust(&mut copy.as_region_mut());
     copy
   };
-  match T::type_enum() {
-    PixelType::U8 => match AVG_FNS[cpu.as_index()] {
-      Some(func) => unsafe {
-        (func)(
+  unsafe {
+    // SAFETY: The assembly only supports even heights and valid uncropped
+    //         widths
+    assert_eq!(height & 1, 0);
+    assert!(width.is_power_of_two() && 2 <= width && width <= 128);
+
+    // SAFETY: Check bounds of dst
+    assert!(dst.rect().width >= width && dst.rect().height >= height);
+
+    // SAFETY: Check length of tmp1 & tmp2
+    assert!(tmp1.len() >= width * height);
+    assert!(tmp2.len() >= width * height);
+    match T::type_enum() {
+      PixelType::U8 => match AVG_FNS[cpu.as_index()] {
+        Some(func) => (func)(
           dst.data_ptr_mut() as *mut _,
           T::to_asm_stride(dst.plane_cfg.stride),
           tmp1.as_ptr(),
           tmp2.as_ptr(),
           width as i32,
           height as i32,
-        );
+        ),
+        None => call_rust(dst),
       },
-      None => call_rust(dst),
-    },
-    PixelType::U16 if bit_depth > 8 => match AVG_HBD_FNS[cpu.as_index()] {
-      Some(func) => unsafe {
-        (func)(
+      PixelType::U16 if bit_depth > 8 => match AVG_HBD_FNS[cpu.as_index()] {
+        Some(func) => (func)(
           dst.data_ptr_mut() as *mut _,
           T::to_asm_stride(dst.plane_cfg.stride),
           tmp1.as_ptr(),
@@ -249,11 +285,11 @@ pub fn mc_avg<T: Pixel>(
           width as i32,
           height as i32,
           (1 << bit_depth) - 1,
-        );
+        ),
+        None => call_rust(dst),
       },
-      None => call_rust(dst),
-    },
-    _ => call_rust(dst),
+      _ => call_rust(dst),
+    }
   }
   #[cfg(feature = "check_asm")]
   {

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -243,6 +243,10 @@ pub(crate) mod rust {
     height: usize, col_frac: i32, row_frac: i32, mode_x: FilterMode,
     mode_y: FilterMode, bit_depth: usize, _cpu: CpuFeatureLevel,
   ) {
+    // The assembly only supports even heights and valid uncropped widths
+    assert_eq!(height & 1, 0);
+    assert!(width.is_power_of_two() && 2 <= width && width <= 128);
+
     let ref_stride = src.plane.cfg.stride;
     let y_filter = get_filter(mode_y, row_frac, height);
     let x_filter = get_filter(mode_x, col_frac, width);
@@ -344,6 +348,10 @@ pub(crate) mod rust {
     col_frac: i32, row_frac: i32, mode_x: FilterMode, mode_y: FilterMode,
     bit_depth: usize, _cpu: CpuFeatureLevel,
   ) {
+    // The assembly only supports even heights and valid uncropped widths
+    assert_eq!(height & 1, 0);
+    assert!(width.is_power_of_two() && 2 <= width && width <= 128);
+
     let ref_stride = src.plane.cfg.stride;
     let y_filter = get_filter(mode_y, row_frac, height);
     let x_filter = get_filter(mode_x, col_frac, width);
@@ -425,6 +433,10 @@ pub(crate) mod rust {
     dst: &mut PlaneRegionMut<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
     height: usize, bit_depth: usize, _cpu: CpuFeatureLevel,
   ) {
+    // The assembly only supports even heights and valid uncropped widths
+    assert_eq!(height & 1, 0);
+    assert!(width.is_power_of_two() && 2 <= width && width <= 128);
+
     let max_sample_val = ((1 << bit_depth) - 1) as i32;
     let intermediate_bits = 4 - if bit_depth == 12 { 2 } else { 0 };
     let prep_bias = if bit_depth == 8 { 0 } else { PREP_BIAS * 2 };

--- a/v_frame/src/plane.rs
+++ b/v_frame/src/plane.rs
@@ -776,6 +776,24 @@ impl<'a, T: Pixel> PlaneSlice<'a, T> {
     self.plane.data[new_y * self.plane.cfg.stride + new_x]
   }
 
+  /// Checks if `add_y` and `add_x` lies in the allocated bounds of the
+  /// underlying plane.
+  pub fn accessible(&self, add_x: usize, add_y: usize) -> bool {
+    let y =
+      (self.y + add_y as isize + self.plane.cfg.yorigin as isize) as usize;
+    let x =
+      (self.x + add_x as isize + self.plane.cfg.xorigin as isize) as usize;
+    y < self.plane.cfg.alloc_height && x < self.plane.cfg.stride
+  }
+
+  /// Checks if -`sub_x` and -`sub_y` lies in the allocated bounds of the
+  /// underlying plane.
+  pub fn accessible_neg(&self, sub_x: usize, sub_y: usize) -> bool {
+    let y = self.y - sub_y as isize + self.plane.cfg.yorigin as isize;
+    let x = self.x - sub_x as isize + self.plane.cfg.xorigin as isize;
+    y >= 0 && x >= 0
+  }
+
   pub fn row(&self, y: usize) -> &[T] {
     let y = (self.y + y as isize + self.plane.cfg.yorigin as isize) as usize;
     let x = (self.x + self.plane.cfg.xorigin as isize) as usize;


### PR DESCRIPTION
put, prep, and avg now check bounds and width/height before calling
assembly functions.