### PR TITLE
Handle edges by cropping in initial motion estimation

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1108,7 +1108,15 @@ fn inter_frame_rdo_mode_decision<T: Pixel>(
       pmv[1] = mv_stack[1].this_mv;
     }
 
-    let res = motion_estimation(fi, ts, bsize, tile_bo, ref_frames[0], pmv);
+    let res = motion_estimation(
+      fi,
+      ts,
+      bsize.width(),
+      bsize.height(),
+      tile_bo,
+      ref_frames[0],
+      pmv,
+    );
     let b_me = res.0;
 
     mvs_from_me.push([b_me, MotionVector::default()]);


### PR DESCRIPTION
The old code partitions to handle edges.
|  PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |    SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |    VMAF | VMAF-NEG |
|    ---: |    ---: |    ---: |      ---: |    ---: |    ---: |       ---: |        ---: |        ---: |     ---: |    ---: |     ---: |
| -0.0015 |  0.0376 | -0.0965 |    0.0117 | -0.0389 | -0.0521 |    -0.0404 |     -0.1133 |     -0.0595 |  -0.0368 | -0.0292 |  -0.0377 |