### PR TITLE
Speed up estimate_inter_costs

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -418,6 +418,32 @@ impl<T: Pixel> FrameState<T> {
     )
   }
 
+  pub fn new_with_frame_and_me_stats_and_rec(
+    fi: &FrameInvariants<T>, frame: Arc<Frame<T>>,
+    me_stats: Arc<[FrameMEStats; REF_FRAMES]>, rec: Arc<Frame<T>>,
+  ) -> Self {
+    let rs = RestorationState::new(fi, &frame);
+
+    let hres = frame.planes[0].downsampled(fi.width, fi.height);
+    let qres = hres.downsampled(fi.width, fi.height);
+
+    Self {
+      sb_size_log2: fi.sb_size_log2(),
+      input: frame,
+      input_hres: Arc::new(hres),
+      input_qres: Arc::new(qres),
+      rec,
+      cdfs: CDFContext::new(0),
+      context_update_tile_id: 0,
+      max_tile_size_bytes: 0,
+      deblock: Default::default(),
+      segmentation: Default::default(),
+      restoration: rs,
+      frame_me_stats: me_stats,
+      enc_stats: Default::default(),
+    }
+  }
+
   pub fn new_with_frame(
     fi: &FrameInvariants<T>, frame: Arc<Frame<T>>,
   ) -> Self {

--- a/src/me.rs
+++ b/src/me.rs
@@ -55,12 +55,16 @@ impl FrameMEStats {
     }
   }
   pub fn new_arc_array(cols: usize, rows: usize) -> Arc<[Self; REF_FRAMES]> {
-    let stats = (0..REF_FRAMES)
-      .map(|_| FrameMEStats::new(cols, rows))
-      .collect::<ArrayVec<_, REF_FRAMES>>()
-      .into_inner()
-      .unwrap();
-    Arc::new(stats)
+    Arc::new([
+      FrameMEStats::new(cols, rows),
+      FrameMEStats::new(cols, rows),
+      FrameMEStats::new(cols, rows),
+      FrameMEStats::new(cols, rows),
+      FrameMEStats::new(cols, rows),
+      FrameMEStats::new(cols, rows),
+      FrameMEStats::new(cols, rows),
+      FrameMEStats::new(cols, rows),
+    ])
   }
 }
 


### PR DESCRIPTION
This reuses very expensive allocations of `FrameMEStats` instead of allocating for every time `estimate_inter_costs` is called.

Speed difference for `estimate_inter_costs` for 1080p yuv420p:

Before:

![image](https://user-images.githubusercontent.com/48274562/151691622-942b9b17-8c44-4485-82af-8b8ec6822bb2.png)

After:

![image](https://user-images.githubusercontent.com/48274562/151691634-7dc56931-f05d-48ea-aa48-9e444129c7f7.png)
