### PR TITLE
Speed up estimate_inter_costs again

### DIFF
--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -6,7 +6,6 @@ use crate::dist::get_satd;
 use crate::encoder::{
   FrameInvariants, FrameState, Sequence, IMPORTANCE_BLOCK_SIZE,
 };
-use crate::frame::FrameAlloc;
 use crate::frame::{AsRegion, PlaneOffset};
 use crate::me::{estimate_tile_motion, FrameMEStats};
 use crate::partition::{get_intra_edges, BlockSize, REF_FRAMES};
@@ -14,10 +13,12 @@ use crate::predict::{IntraParam, PredictionMode};
 use crate::rayon::iter::*;
 use crate::tiling::{Area, PlaneRegion, TileRect};
 use crate::transform::TxSize;
-use crate::{Frame, Pixel};
+use crate::Pixel;
 use rust_hawktracer::*;
 use std::sync::Arc;
-use v_frame::pixel::{CastFromPrimitive, ChromaSampling};
+use v_frame::frame::Frame;
+use v_frame::pixel::CastFromPrimitive;
+use v_frame::plane::Plane;
 
 pub(crate) const IMP_BLOCK_MV_UNITS_PER_PIXEL: i64 = 8;
 pub(crate) const IMP_BLOCK_SIZE_IN_MV_UNITS: i64 =
@@ -193,7 +194,13 @@ pub(crate) fn estimate_inter_costs<T: Pixel>(
     Arc::clone(&frame),
     buffer,
     // We do not use this field, so we can avoid the expensive allocation
-    Arc::new(Frame::new(0, 0, ChromaSampling::Cs400)),
+    Arc::new(Frame {
+      planes: [
+        Plane::new(0, 0, 0, 0, 0, 0),
+        Plane::new(0, 0, 0, 0, 0, 0),
+        Plane::new(0, 0, 0, 0, 0, 0),
+      ],
+    }),
   );
   compute_motion_vectors(&mut fi, &mut fs, &inter_cfg);
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -418,14 +418,15 @@ impl<T: Pixel> FrameState<T> {
     )
   }
 
+  /// Does not create qres or hres versions of `frame`
   pub fn new_with_frame_and_me_stats_and_rec(
     fi: &FrameInvariants<T>, frame: Arc<Frame<T>>,
     me_stats: Arc<[FrameMEStats; REF_FRAMES]>, rec: Arc<Frame<T>>,
   ) -> Self {
     let rs = RestorationState::new(fi, &frame);
 
-    let hres = frame.planes[0].downsampled(fi.width, fi.height);
-    let qres = hres.downsampled(fi.width, fi.height);
+    let hres = Plane::new(0, 0, 0, 0, 0, 0);
+    let qres = Plane::new(0, 0, 0, 0, 0, 0);
 
     Self {
       sb_size_log2: fi.sb_size_log2(),

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -418,7 +418,13 @@ impl<T: Pixel> FrameState<T> {
     )
   }
 
-  /// Does not create qres or hres versions of `frame`
+  /// Similar to [`FrameState::new_with_frame`], but takes an `me_stats`
+  /// and `rec` to enable reusing the same underlying allocations to create
+  /// a `FrameState`
+  ///
+  /// This function primarily exists for [`estimate_inter_costs`], and so
+  /// it does not create hres or qres versions of `frame` as downscaling is
+  /// somewhat expensive and are not needed for [`estimate_inter_costs`].
   pub fn new_with_frame_and_me_stats_and_rec(
     fi: &FrameInvariants<T>, frame: Arc<Frame<T>>,
     me_stats: Arc<[FrameMEStats; REF_FRAMES]>, rec: Arc<Frame<T>>,


### PR DESCRIPTION
- Avoids downscaling and allocating hres and qres, since they are not used for inter cost estimation.
- Fixes optimization where allocation was supposed to be avoided, but was not completely eliminated because of padding.

Before this change (tested on yuv420p 1080p):

![image](https://user-images.githubusercontent.com/48274562/151751801-611b33e3-e13a-4d6d-9efa-82ae7e8f1435.png)

After this change:

![image](https://user-images.githubusercontent.com/48274562/151751824-5ea3880e-1de6-4d9c-b963-beaf78425e76.png)

