### PR TITLE
Init Motion Est: Refine mvs when subsampleing reduced

### DIFF
--- a/src/mc.rs
+++ b/src/mc.rs
@@ -68,6 +68,15 @@ impl ops::Mul<u16> for MotionVector {
   }
 }
 
+impl ops::Shr<u8> for MotionVector {
+  type Output = MotionVector;
+
+  #[inline]
+  fn shr(self, rhs: u8) -> MotionVector {
+    MotionVector { row: self.row >> rhs, col: self.col >> rhs }
+  }
+}
+
 impl ops::Shl<u8> for MotionVector {
   type Output = MotionVector;
 


### PR DESCRIPTION
After doubling the sample rate of motion estimation (e.g. quarter-res
to half-res), refine the search performed at the lower supsampling level
by searching a 3x3 region around the previous mv.

https://beta.arewecompressedyet.com/?job=crop_edge_init_me%402022-01-27T19%3A13%3A43.336Z&job=refine_me_ssdec2%402022-02-02T15%3A07%3A38.563Z

|  PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |    SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |    VMAF | VMAF-NEG |
|    ---: |    ---: |    ---: |      ---: |    ---: |    ---: |       ---: |        ---: |        ---: |     ---: |    ---: |     ---: |
| -0.1379 | -0.3436 |  0.0475 |   -0.2930 | -0.1618 | -0.1902 |    -0.1447 |     -0.3812 |      0.0422 |  -0.1501 | -0.1780 |  -0.1903 |