### PR TITLE
Strongly type different variants of FrameInvariants

### DIFF
--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -215,6 +215,7 @@ pub(crate) fn estimate_inter_costs<T: Pixel>(
     IMPORTANCE_BLOCK_SIZE,
   );
 
+  let cpu_feature_level = fi.base().unwrap().cpu_feature_level;
   let mut inter_costs = 0;
   (0..h_in_imp_b).for_each(|y| {
     (0..w_in_imp_b).for_each(|x| {
@@ -245,7 +246,7 @@ pub(crate) fn estimate_inter_costs<T: Pixel>(
         bsize.width(),
         bsize.height(),
         bit_depth,
-        fi.cpu_feature_level,
+        cpu_feature_level,
       ) as u64;
     });
   });
@@ -256,8 +257,10 @@ pub(crate) fn estimate_inter_costs<T: Pixel>(
 pub(crate) fn compute_motion_vectors<T: Pixel>(
   fi: &mut FrameInvariants<T>, fs: &mut FrameState<T>, inter_cfg: &InterConfig,
 ) {
-  let mut blocks = FrameBlocks::new(fi.w_in_b, fi.h_in_b);
-  fi.sequence
+  let base_fi = fi.base().unwrap();
+  let mut blocks = FrameBlocks::new(base_fi.w_in_b, base_fi.h_in_b);
+  base_fi
+    .sequence
     .tiling
     .tile_iter_mut(fs, &mut blocks)
     .collect::<Vec<_>>()

--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -8,6 +8,7 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use super::*;
+use crate::BaseInvariants;
 
 use crate::predict::PredictionMode;
 
@@ -908,7 +909,7 @@ impl<'a> ContextWriter<'a> {
 
   fn add_extra_mv_candidate<T: Pixel>(
     blk: &Block, ref_frames: [RefType; 2],
-    mv_stack: &mut ArrayVec<CandidateMV, 9>, fi: &FrameInvariants<T>,
+    mv_stack: &mut ArrayVec<CandidateMV, 9>, fi: &BaseInvariants<T>,
     is_compound: bool, ref_id_count: &mut [usize; 2],
     ref_id_mvs: &mut [[MotionVector; 2]; 2], ref_diff_count: &mut [usize; 2],
     ref_diff_mvs: &mut [[MotionVector; 2]; 2],
@@ -1122,7 +1123,7 @@ impl<'a> ContextWriter<'a> {
   fn setup_mvref_list<T: Pixel>(
     &self, bo: TileBlockOffset, ref_frames: [RefType; 2],
     mv_stack: &mut ArrayVec<CandidateMV, 9>, bsize: BlockSize,
-    fi: &FrameInvariants<T>, is_compound: bool,
+    fi: &BaseInvariants<T>, is_compound: bool,
   ) -> usize {
     let (_rf, _rf_num) = (INTRA_FRAME, 1);
 
@@ -1418,7 +1419,7 @@ impl<'a> ContextWriter<'a> {
   pub fn find_mvrefs<T: Pixel>(
     &self, bo: TileBlockOffset, ref_frames: [RefType; 2],
     mv_stack: &mut ArrayVec<CandidateMV, 9>, bsize: BlockSize,
-    fi: &FrameInvariants<T>, is_compound: bool,
+    fi: &BaseInvariants<T>, is_compound: bool,
   ) -> usize {
     assert!(ref_frames[0] != NONE_FRAME);
     if ref_frames[0] != NONE_FRAME {

--- a/src/context/frame_header.rs
+++ b/src/context/frame_header.rs
@@ -61,8 +61,8 @@ impl<'a> ContextWriter<'a> {
     ContextWriter::ref_count_ctx(fwd_cnt, bwd_cnt)
   }
 
-  pub fn write_ref_frames<T: Pixel, W: Writer>(
-    &mut self, w: &mut W, fi: &FrameInvariants<T>, bo: TileBlockOffset,
+  pub fn write_ref_frames<W: Writer>(
+    &mut self, w: &mut W, reference_mode: ReferenceMode, bo: TileBlockOffset,
   ) {
     let rf = self.bc.blocks[bo].ref_frames;
     let sz = self.bc.blocks[bo].n4_w.min(self.bc.blocks[bo].n4_h);
@@ -70,7 +70,7 @@ impl<'a> ContextWriter<'a> {
     /* TODO: Handle multiple references */
     let comp_mode = self.bc.blocks[bo].has_second_ref();
 
-    if fi.reference_mode != ReferenceMode::SINGLE && sz >= 2 {
+    if reference_mode != ReferenceMode::SINGLE && sz >= 2 {
       let ctx = self.get_comp_mode_ctx(bo);
       let cdf = &mut self.fc.comp_mode_cdf[ctx];
       symbol_with_update!(self, w, comp_mode as u32, cdf, 2);

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -13,7 +13,6 @@
 
 use crate::color::ChromaSampling;
 use crate::ec::{Writer, OD_BITRES};
-use crate::encoder::FrameInvariants;
 use crate::entropymode::*;
 use crate::frame::*;
 use crate::header::ReferenceMode;

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -10,13 +10,12 @@
 use crate::api::FrameType;
 use crate::color::ChromaSampling::Cs400;
 use crate::context::*;
-use crate::encoder::FrameInvariants;
 use crate::partition::RefType::*;
 use crate::predict::PredictionMode::*;
 use crate::quantize::*;
 use crate::tiling::*;
 use crate::util::{clamp, ILog, Pixel};
-use crate::DeblockState;
+use crate::{BaseInvariants, DeblockState};
 use rust_hawktracer::*;
 use std::cmp;
 
@@ -1639,8 +1638,8 @@ fn sse_optimize<T: Pixel>(
 
 #[hawktracer(deblock_filter_optimize)]
 pub fn deblock_filter_optimize<T: Pixel, U: Pixel>(
-  fi: &FrameInvariants<T>, rec: &Tile<U>, input: &Tile<U>,
-  blocks: &TileBlocks, crop_w: usize, crop_h: usize,
+  fi: &BaseInvariants<T>, rec: &Tile<U>, input: &Tile<U>, blocks: &TileBlocks,
+  crop_w: usize, crop_h: usize,
 ) -> [u8; 4] {
   if fi.config.speed_settings.fast_deblock {
     let q = ac_q(fi.base_q_idx, 0, fi.sequence.bit_depth) as i32;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -105,6 +105,12 @@ pub enum FilterMode {
   SWITCHABLE = 4,
 }
 
+impl Default for FilterMode {
+  fn default() -> Self {
+    FilterMode::REGULAR
+  }
+}
+
 pub const SUBPEL_FILTER_SIZE: usize = 8;
 
 const SUBPEL_FILTERS: [[[i32; SUBPEL_FILTER_SIZE]; 16]; 6] = [

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -23,13 +23,13 @@ cfg_if::cfg_if! {
 
 use crate::context::{MAX_SB_SIZE_LOG2, MAX_TX_SIZE};
 use crate::cpu_features::CpuFeatureLevel;
-use crate::encoder::FrameInvariants;
 use crate::frame::*;
 use crate::mc::*;
 use crate::partition::*;
 use crate::tiling::*;
 use crate::transform::*;
 use crate::util::*;
+use crate::BaseInvariants;
 use std::convert::TryInto;
 
 pub const ANGLE_STEP: i8 = 3;
@@ -297,14 +297,14 @@ impl PredictionMode {
 
   /// Inter prediction with a single reference (i.e. not compound mode)
   pub fn predict_inter_single<T: Pixel>(
-    self, fi: &FrameInvariants<T>, tile_rect: TileRect, p: usize,
+    self, fi: &BaseInvariants<T>, tile_rect: TileRect, p: usize,
     po: PlaneOffset, dst: &mut PlaneRegionMut<'_, T>, width: usize,
     height: usize, ref_frame: RefType, mv: MotionVector,
   ) {
     assert!(!self.is_intra());
     let frame_po = tile_rect.to_frame_plane_offset(po);
 
-    let mode = fi.default_filter;
+    let mode = FilterMode::default();
 
     if let Some(ref rec) =
       fi.rec_buffer.frames[fi.ref_frames[ref_frame.to_index()] as usize]
@@ -328,7 +328,7 @@ impl PredictionMode {
 
   /// Inter prediction with two references.
   pub fn predict_inter_compound<T: Pixel>(
-    self, fi: &FrameInvariants<T>, tile_rect: TileRect, p: usize,
+    self, fi: &BaseInvariants<T>, tile_rect: TileRect, p: usize,
     po: PlaneOffset, dst: &mut PlaneRegionMut<'_, T>, width: usize,
     height: usize, ref_frames: [RefType; 2], mvs: [MotionVector; 2],
     buffer: &mut InterCompoundBuffers,
@@ -336,7 +336,7 @@ impl PredictionMode {
     assert!(!self.is_intra());
     let frame_po = tile_rect.to_frame_plane_offset(po);
 
-    let mode = fi.default_filter;
+    let mode = FilterMode::default();
 
     for i in 0..2 {
       if let Some(ref rec) =
@@ -375,7 +375,7 @@ impl PredictionMode {
   /// Inter prediction that determines whether compound mode is being used based
   /// on the second ['RefType'] in ['ref_frames'].
   pub fn predict_inter<T: Pixel>(
-    self, fi: &FrameInvariants<T>, tile_rect: TileRect, p: usize,
+    self, fi: &BaseInvariants<T>, tile_rect: TileRect, p: usize,
     po: PlaneOffset, dst: &mut PlaneRegionMut<'_, T>, width: usize,
     height: usize, ref_frames: [RefType; 2], mvs: [MotionVector; 2],
     compound_buffer: &mut InterCompoundBuffers,

--- a/src/tiling/tile_restoration_state.rs
+++ b/src/tiling/tile_restoration_state.rs
@@ -8,7 +8,7 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use crate::context::*;
-use crate::encoder::FrameInvariants;
+use crate::encoder::{BaseInvariants, FrameInvariants};
 use crate::lrf::*;
 use crate::util::Pixel;
 
@@ -238,7 +238,7 @@ macro_rules! tile_restoration_plane_common {
       // in the other tile to be part of the LRU for RDO purposes.
       pub fn restoration_unit_last_sb_for_rdo<T: Pixel>(
         &self,
-        fi: &FrameInvariants<T>,
+        fi: &BaseInvariants<T>,
         global_sbo: PlaneSuperBlockOffset,
         tile_sbo: TileSuperBlockOffset,
       ) -> bool {

--- a/src/tiling/tiler.rs
+++ b/src/tiling/tiler.rs
@@ -352,9 +352,13 @@ pub mod test {
     // These tests are all assuming SB-sized LRUs, so set that.
     sequence.enable_large_lru = false;
     let frame_rate = config.frame_rate();
-    let fi = FrameInvariants::new(config, Arc::new(sequence));
+    let base_fi = BaseInvariants::new(config, Arc::new(sequence));
+    let fb = FrameBlocks::new(base_fi.w_in_b, base_fi.h_in_b);
+    let fi = FrameInvariants::CodedFrame {
+      lookahead: Box::new(LookaheadData::new(&base_fi)),
+      base: base_fi,
+    };
     let fs = FrameState::new(&fi);
-    let fb = FrameBlocks::new(fi.w_in_b, fi.h_in_b);
 
     (fi, fs, fb, frame_rate)
   }
@@ -367,9 +371,9 @@ pub mod test {
     {
       // 2x2 tiles
       let ti = TilingInfo::from_target_tiles(
-        fi.sb_size_log2(),
-        fi.width,
-        fi.height,
+        fi.base().unwrap().sb_size_log2(),
+        fi.base().unwrap().width,
+        fi.base().unwrap().height,
         frame_rate,
         1,
         1,
@@ -391,9 +395,9 @@ pub mod test {
     {
       // 4x4 tiles requested, will actually get 3x3 tiles
       let ti = TilingInfo::from_target_tiles(
-        fi.sb_size_log2(),
-        fi.width,
-        fi.height,
+        fi.base().unwrap().sb_size_log2(),
+        fi.base().unwrap().width,
+        fi.base().unwrap().height,
         frame_rate,
         2,
         2,
@@ -437,9 +441,9 @@ pub mod test {
 
     // 4x4 tiles requested, will actually get 3x3 tiles
     let ti = TilingInfo::from_target_tiles(
-      fi.sb_size_log2(),
-      fi.width,
-      fi.height,
+      fi.base().unwrap().sb_size_log2(),
+      fi.base().unwrap().width,
+      fi.base().unwrap().height,
       frame_rate,
       2,
       2,
@@ -514,9 +518,9 @@ pub mod test {
 
     // 4x4 tiles requested, will actually get 3x3 tiles
     let ti = TilingInfo::from_target_tiles(
-      fi.sb_size_log2(),
-      fi.width,
-      fi.height,
+      fi.base().unwrap().sb_size_log2(),
+      fi.base().unwrap().width,
+      fi.base().unwrap().height,
       frame_rate,
       2,
       2,
@@ -553,9 +557,9 @@ pub mod test {
     {
       // 4x4 tiles requested, will actually get 3x3 tiles
       let ti = TilingInfo::from_target_tiles(
-        fi.sb_size_log2(),
-        fi.width,
-        fi.height,
+        fi.base().unwrap().sb_size_log2(),
+        fi.base().unwrap().width,
+        fi.base().unwrap().height,
         frame_rate,
         2,
         2,
@@ -617,9 +621,9 @@ pub mod test {
     let (fi, mut fs, mut fb, frame_rate) = setup(64, 80);
 
     let ti = TilingInfo::from_target_tiles(
-      fi.sb_size_log2(),
-      fi.width,
-      fi.height,
+      fi.base().unwrap().sb_size_log2(),
+      fi.base().unwrap().width,
+      fi.base().unwrap().height,
       frame_rate,
       2,
       2,
@@ -656,9 +660,9 @@ pub mod test {
     {
       // 2x2 tiles, each one containing 2×2 restoration units (1 super-block per restoration unit)
       let ti = TilingInfo::from_target_tiles(
-        fi.sb_size_log2(),
-        fi.width,
-        fi.height,
+        fi.base().unwrap().sb_size_log2(),
+        fi.base().unwrap().width,
+        fi.base().unwrap().height,
         frame_rate,
         1,
         1,
@@ -717,9 +721,9 @@ pub mod test {
     {
       // 4x4 tiles requested, will actually get 3x3 tiles
       let ti = TilingInfo::from_target_tiles(
-        fi.sb_size_log2(),
-        fi.width,
-        fi.height,
+        fi.base().unwrap().sb_size_log2(),
+        fi.base().unwrap().width,
+        fi.base().unwrap().height,
         frame_rate,
         2,
         2,
@@ -760,9 +764,9 @@ pub mod test {
     {
       // 4x4 tiles requested, will actually get 3x3 tiles
       let ti = TilingInfo::from_target_tiles(
-        fi.sb_size_log2(),
-        fi.width,
-        fi.height,
+        fi.base().unwrap().sb_size_log2(),
+        fi.base().unwrap().width,
+        fi.base().unwrap().height,
         frame_rate,
         2,
         2,


### PR DESCRIPTION
There are three distinct possible states for a FrameInvariants struct:
Normal frame, show existing frame, or invalid frame.
Currently, these are each represented by a separate boolean on the
struct. However, this results in some combinations which are not
valid, and wastes memory allocating fields that are not used for every
frame state.

This commit uses Rust's type system to define FrameInvariants as an enum
which is in one of the three valid states. In addition, this changes the
invalid state to an empty struct, and removes lookahead data from the
SEF struct, where it is not used. This results in a 3% reduction in
total encoder memory usage with default settings at speed 6, as well as
a 1-2% reduction in encoding time at speed 6 due to removal of
unnecessary allocations/clones.

Test against AWCY found output to be identical to previous.