### PR TITLE
Improve storage of invalid and SEF frame invariants

### DIFF
--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -186,7 +186,8 @@ pub(crate) fn estimate_inter_costs<T: Pixel>(
   let inter_cfg = InterConfig::new(&config);
   let last_fi = FrameInvariants::new_key_frame(Arc::new(config), sequence, 0);
   let mut fi =
-    FrameInvariants::new_inter_frame(&last_fi, &inter_cfg, 0, 1, 2, false);
+    FrameInvariants::new_inter_frame(&last_fi, &inter_cfg, 0, 1, 2, false)
+      .unwrap();
 
   // Compute the motion vectors.
   let mut fs = FrameState::new_with_frame_and_me_stats_and_rec(

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -437,8 +437,6 @@ pub unsafe extern fn rav1e_config_default() -> *mut Config {
 unsafe fn decode_slice<'a>(
   data: *mut *const u8, len: *mut size_t,
 ) -> (c_int, Option<&'a [u8]>) {
-  use std::convert::TryInto;
-
   if *len < 8 {
     return (8, None);
   }

--- a/src/header.rs
+++ b/src/header.rs
@@ -445,14 +445,14 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
     inter_cfg: &InterConfig,
   ) -> io::Result<()> {
     if fi.sequence.reduced_still_picture_hdr {
-      assert!(!fi.show_existing_frame);
+      assert!(!fi.is_show_existing_frame());
       assert!(fi.frame_type == FrameType::KEY);
       assert!(fi.show_frame);
       assert!(!fi.showable_frame);
     } else {
-      self.write_bit(fi.show_existing_frame)?;
+      self.write_bit(fi.is_show_existing_frame())?;
 
-      if fi.show_existing_frame {
+      if fi.is_show_existing_frame() {
         self.write(3, fi.frame_to_show_map_idx)?;
 
         //TODO:


### PR DESCRIPTION
Thie commit changes invalid frame invariants to be represented by a
`None` value, and for SEFs to no longer contain any additional data that
is only needed by coded frames (at the moment, this is only lookahead
data).

This results in a ~3% overall reduction in memory usage, and a ~1%
improvement in encode runtime at speed 6 (with low-latency=false).