### PR TITLE
Avoid multiple inlining of residual loop in SAD intrinsics

### DIFF
--- a/src/asm/x86/sad_row.rs
+++ b/src/asm/x86/sad_row.rs
@@ -51,25 +51,29 @@ unsafe fn sad_below32_8bpc_sse2(src: &[u8], dst: &[u8]) -> i64 {
     unreachable_unchecked()
   }
 
-  if src.len() >= 16 {
+  let mut offset = 0;
+
+  let mut sum = if src.len() >= 16 {
     let src_u8x16 = _mm_load_si128(src.as_ptr() as *const _);
     let dst_u8x16 = _mm_load_si128(dst.as_ptr() as *const _);
     let result = _mm_sad_epu8(src_u8x16, dst_u8x16);
-    let mut sum = mem::transmute::<_, [i64; 2]>(result).iter().sum::<i64>();
+    let sum = mem::transmute::<_, [i64; 2]>(result).iter().sum::<i64>();
 
     // cannot overflow because src.len() >= 16
     let remaining = src.len() - 16;
 
     if remaining != 0 {
-      let src_extra = src.get_unchecked(16..);
-      let dst_extra = dst.get_unchecked(16..);
-      sum += sad_scalar(src_extra, dst_extra);
+      offset = 16;
     }
 
     sum
   } else {
-    sad_scalar(src, dst)
-  }
+    0
+  };
+
+  sum += sad_scalar(src.get_unchecked(offset..), dst.get_unchecked(offset..));
+
+  sum
 }
 
 /// SAFETY: src and dst must be the same length
@@ -85,29 +89,25 @@ unsafe fn sad_8bpc_avx2(src: &[u8], dst: &[u8]) -> i64 {
 
   let (src_rem, dst_rem) = (src_chunks.remainder(), dst_chunks.remainder());
 
-  if src_chunks.len() == 0 {
-    sad_below32_8bpc_sse2(src_rem, dst_rem)
+  let main_sum = src_chunks
+    .zip(dst_chunks)
+    .map(|(src_chunk, dst_chunk)| {
+      let src = _mm256_load_si256(src_chunk.as_ptr() as *const _);
+      let dst = _mm256_load_si256(dst_chunk.as_ptr() as *const _);
+
+      _mm256_sad_epu8(src, dst)
+    })
+    .reduce(|a, b| _mm256_add_epi32(a, b));
+
+  let mut sum = if let Some(main_sum) = main_sum {
+    mem::transmute::<_, [i64; 4]>(main_sum).iter().sum::<i64>()
   } else {
-    let main_sum = src_chunks
-      .zip(dst_chunks)
-      .map(|(src_chunk, dst_chunk)| {
-        let src = _mm256_load_si256(src_chunk.as_ptr() as *const _);
-        let dst = _mm256_load_si256(dst_chunk.as_ptr() as *const _);
+    0
+  };
 
-        _mm256_sad_epu8(src, dst)
-      })
-      .reduce(|a, b| _mm256_add_epi32(a, b))
-      .unwrap_or_else(|| unreachable_unchecked());
+  sum += sad_below32_8bpc_sse2(src_rem, dst_rem);
 
-    let mut main_sum =
-      mem::transmute::<_, [i64; 4]>(main_sum).iter().sum::<i64>();
-
-    if !src_rem.is_empty() {
-      main_sum += sad_below32_8bpc_sse2(src_rem, dst_rem);
-    }
-
-    main_sum
-  }
+  sum
 }
 
 /// SAFETY: src and dst must be the same length
@@ -123,29 +123,25 @@ unsafe fn sad_8bpc_sse2(src: &[u8], dst: &[u8]) -> i64 {
 
   let (src_rem, dst_rem) = (src_chunks.remainder(), dst_chunks.remainder());
 
-  if src_chunks.len() == 0 {
-    sad_scalar(src_rem, dst_rem)
+  let main_sum = src_chunks
+    .zip(dst_chunks)
+    .map(|(src_chunk, dst_chunk)| {
+      let src = _mm_load_si128(src_chunk.as_ptr() as *const _);
+      let dst = _mm_load_si128(dst_chunk.as_ptr() as *const _);
+
+      _mm_sad_epu8(src, dst)
+    })
+    .reduce(|a, b| _mm_add_epi32(a, b));
+
+  let mut sum = if let Some(main_sum) = main_sum {
+    mem::transmute::<_, [i64; 2]>(main_sum).iter().sum::<i64>()
   } else {
-    let main_sum = src_chunks
-      .zip(dst_chunks)
-      .map(|(src_chunk, dst_chunk)| {
-        let src = _mm_load_si128(src_chunk.as_ptr() as *const _);
-        let dst = _mm_load_si128(dst_chunk.as_ptr() as *const _);
+    0
+  };
 
-        _mm_sad_epu8(src, dst)
-      })
-      .reduce(|a, b| _mm_add_epi32(a, b))
-      .unwrap_or_else(|| unreachable_unchecked());
+  sum += sad_scalar(src_rem, dst_rem);
 
-    let mut main_sum =
-      mem::transmute::<_, [i64; 2]>(main_sum).iter().sum::<i64>();
-
-    if !src_rem.is_empty() {
-      main_sum += sad_scalar(src_rem, dst_rem);
-    }
-
-    main_sum
-  }
+  sum
 }
 
 pub(crate) fn sad_row_internal<T: Pixel>(

--- a/src/asm/x86/sad_row.rs
+++ b/src/asm/x86/sad_row.rs
@@ -20,7 +20,7 @@ use std::arch::asm;
 use std::hint::unreachable_unchecked;
 use std::mem;
 
-/// SAFETY: src and dst must be the same length and less than 16 elements
+/// SAFETY: src and dst must be the same length
 #[inline(always)]
 unsafe fn sad_scalar(src: &[u8], dst: &[u8]) -> i64 {
   if src.len() != dst.len() {


### PR DESCRIPTION
Before, `sad_scalar` was called in multiple different places for `sad_8bpc_avx2` and `sad_8bpc_sse2`, thus causing the residual loop to be inlined more than once. This PR improves the SAD intrinsics so that the residual loop is only called once for each of these functions, which ultimately avoids slightly bloated generated assembly.

Comparison of generated assembly: https://godbolt.org/z/xKzqv8Yss 