### PR TITLE
Enable some more useful Clippy lints

### DIFF
--- a/benches/mc.rs
+++ b/benches/mc.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unit_arg)]
+
 use criterion::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;

--- a/benches/mc.rs
+++ b/benches/mc.rs
@@ -261,7 +261,7 @@ fn bench_prep_8tap_top_left_lbd(c: &mut Criterion) {
   let w = 640;
   let h = 480;
   let input_plane = new_plane::<u8>(&mut ra, w, h);
-  let mut dst = Aligned::<[i16; 128 * 128]>::uninitialized();
+  let mut dst = unsafe { Aligned::<[i16; 128 * 128]>::uninitialized() };
 
   let (row_frac, col_frac, src) = get_params(
     &input_plane,
@@ -292,7 +292,7 @@ fn bench_prep_8tap_top_lbd(c: &mut Criterion) {
   let w = 640;
   let h = 480;
   let input_plane = new_plane::<u8>(&mut ra, w, h);
-  let mut dst = Aligned::<[i16; 128 * 128]>::uninitialized();
+  let mut dst = unsafe { Aligned::<[i16; 128 * 128]>::uninitialized() };
 
   let (row_frac, col_frac, src) = get_params(
     &input_plane,
@@ -323,7 +323,7 @@ fn bench_prep_8tap_left_lbd(c: &mut Criterion) {
   let w = 640;
   let h = 480;
   let input_plane = new_plane::<u8>(&mut ra, w, h);
-  let mut dst = Aligned::<[i16; 128 * 128]>::uninitialized();
+  let mut dst = unsafe { Aligned::<[i16; 128 * 128]>::uninitialized() };
 
   let (row_frac, col_frac, src) = get_params(
     &input_plane,
@@ -354,7 +354,7 @@ fn bench_prep_8tap_center_lbd(c: &mut Criterion) {
   let w = 640;
   let h = 480;
   let input_plane = new_plane::<u8>(&mut ra, w, h);
-  let mut dst = Aligned::<[i16; 128 * 128]>::uninitialized();
+  let mut dst = unsafe { Aligned::<[i16; 128 * 128]>::uninitialized() };
 
   let (row_frac, col_frac, src) = get_params(
     &input_plane,
@@ -385,7 +385,7 @@ fn bench_prep_8tap_top_left_hbd(c: &mut Criterion) {
   let w = 640;
   let h = 480;
   let input_plane = new_plane::<u16>(&mut ra, w, h);
-  let mut dst = Aligned::<[i16; 128 * 128]>::uninitialized();
+  let mut dst = unsafe { Aligned::<[i16; 128 * 128]>::uninitialized() };
 
   let (row_frac, col_frac, src) = get_params(
     &input_plane,
@@ -416,7 +416,7 @@ fn bench_prep_8tap_top_hbd(c: &mut Criterion) {
   let w = 640;
   let h = 480;
   let input_plane = new_plane::<u16>(&mut ra, w, h);
-  let mut dst = Aligned::<[i16; 128 * 128]>::uninitialized();
+  let mut dst = unsafe { Aligned::<[i16; 128 * 128]>::uninitialized() };
 
   let (row_frac, col_frac, src) = get_params(
     &input_plane,
@@ -447,7 +447,7 @@ fn bench_prep_8tap_left_hbd(c: &mut Criterion) {
   let w = 640;
   let h = 480;
   let input_plane = new_plane::<u16>(&mut ra, w, h);
-  let mut dst = Aligned::<[i16; 128 * 128]>::uninitialized();
+  let mut dst = unsafe { Aligned::<[i16; 128 * 128]>::uninitialized() };
 
   let (row_frac, col_frac, src) = get_params(
     &input_plane,
@@ -478,7 +478,7 @@ fn bench_prep_8tap_center_hbd(c: &mut Criterion) {
   let w = 640;
   let h = 480;
   let input_plane = new_plane::<u16>(&mut ra, w, h);
-  let mut dst = Aligned::<[i16; 128 * 128]>::uninitialized();
+  let mut dst = unsafe { Aligned::<[i16; 128 * 128]>::uninitialized() };
 
   let (row_frac, col_frac, src) = get_params(
     &input_plane,

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -134,7 +134,7 @@ pub fn intra_bench<T: Pixel>(
   b: &mut Bencher, mode: PredictionMode, variant: PredictionVariant,
 ) {
   let mut rng = ChaChaRng::from_seed([0; 32]);
-  let mut edge_buf = Aligned::uninitialized();
+  let mut edge_buf = unsafe { Aligned::uninitialized() };
   let (mut block, ac) = generate_block::<T>(&mut rng, &mut edge_buf);
   let cpu = CpuFeatureLevel::default();
   let bitdepth = match T::type_enum() {

--- a/examples/simple_encoding.rs
+++ b/examples/simple_encoding.rs
@@ -12,12 +12,12 @@ use rav1e::config::SpeedSettings;
 use rav1e::*;
 
 fn main() {
-  let mut enc = EncoderConfig::default();
-
-  enc.width = 64;
-  enc.height = 96;
-
-  enc.speed_settings = SpeedSettings::from_preset(9);
+  let enc = EncoderConfig {
+    width: 64,
+    height: 96,
+    speed_settings: SpeedSettings::from_preset(9),
+    ..Default::default()
+  };
 
   let cfg = Config::new().with_encoder_config(enc);
 

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -65,7 +65,7 @@ impl ActivityMask {
   }
 }
 
-// Adapted from the source variance calculation in cdef_dist_wxh_8x8.
+// Adapted from the source variance calculation in `cdef_dist_wxh_8x8`.
 #[inline(never)]
 fn variance_8x8<T: Pixel>(src: &PlaneRegion<'_, T>) -> u32 {
   debug_assert!(src.plane_cfg.xdec == 0);
@@ -99,14 +99,14 @@ fn variance_8x8<T: Pixel>(src: &PlaneRegion<'_, T>) -> u32 {
   sum_s2 - ((sum_s * sum_s + 32) >> 6)
 }
 
-/// rsqrt result stored in fixed point w/ scaling such that:
-///   rsqrt = output.rsqrt_norm / (1 << output.shift)
+/// `rsqrt` result stored in fixed point w/ scaling such that:
+///   `rsqrt = output.rsqrt_norm / (1 << output.shift)`
 struct RsqrtOutput {
   norm: u16,
   shift: u8,
 }
 
-/// Fixed point rsqrt for ssim_boost
+/// Fixed point `rsqrt` for `ssim_boost`
 fn ssim_boost_rsqrt(x: u64) -> RsqrtOutput {
   const INSHIFT: u8 = 16;
   const OUTSHIFT: u8 = 14;
@@ -188,7 +188,7 @@ mod ssim_boost_tests {
   use super::*;
   use rand::Rng;
 
-  /// Test to make sure extreme values of ssim boost don't overflow.
+  /// Test to make sure extreme values of `ssim_boost` don't overflow.
   #[test]
   fn overflow_test() {
     // Test variance for 8x8 region with a bit depth of 12
@@ -198,7 +198,7 @@ mod ssim_boost_tests {
     apply_ssim_boost(max_pix_sse * 8 * 8, max_variance, max_variance, 12);
   }
 
-  /// Floating point reference version of ssim_boost
+  /// Floating point reference version of `ssim_boost`
   fn reference_ssim_boost(svar: u32, dvar: u32, bit_depth: usize) -> f64 {
     let coeff_shift = bit_depth - 8;
     let var_scale = 1f64 / (1 << (2 * coeff_shift)) as f64;
@@ -213,7 +213,7 @@ mod ssim_boost_tests {
     RATIO * (svar + dvar + C2) / f64::sqrt(C1 * C1 + svar * dvar)
   }
 
-  /// Test that ssim_boost has sufficient accuracy.
+  /// Test that `ssim_boost` has sufficient accuracy.
   #[test]
   fn accuracy_test() {
     let mut rng = rand::thread_rng();

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -124,7 +124,7 @@ fn ssim_boost_rsqrt(x: u64) -> RsqrtOutput {
   let rsqrt_shift: u8 = (OUTSHIFT as i16 + ((s + INSHIFT as i16) >> 1)) as u8;
 
   #[inline(always)]
-  fn mult16_16_q15(a: i32, b: i32) -> i32 {
+  const fn mult16_16_q15(a: i32, b: i32) -> i32 {
     (a * b) >> 15
   }
 

--- a/src/api/channel/by_gop.rs
+++ b/src/api/channel/by_gop.rs
@@ -309,11 +309,13 @@ impl Config {
     reassemble(recv, s, send_packet)
   }
 
-  /// Create a single pass by_gop encoder channel
+  /// Create a single pass by-gop encoder channel
   ///
   /// Drop the `FrameSender<T>` endpoint to flush the encoder.
   ///
+  /// # Errors
   ///
+  /// - Returns `InvalidConfig` if configuration is invalid.
   pub fn new_by_gop_channel<T: Pixel>(
     &self, slots: usize,
   ) -> Result<VideoDataChannel<T>, InvalidConfig> {

--- a/src/api/channel/data.rs
+++ b/src/api/channel/data.rs
@@ -123,7 +123,7 @@ impl RcDataReceiver {
     self.0.iter()
   }
 
-  pub fn summary_size(&self) -> usize {
+  pub const fn summary_size(&self) -> usize {
     crate::rate::TWOPASS_HEADER_SZ
   }
 }

--- a/src/api/channel/mod.rs
+++ b/src/api/channel/mod.rs
@@ -44,6 +44,10 @@ impl Config {
   /// Create a single pass encoder channel
   ///
   /// Drop the `FrameSender<T>` endpoint to flush the encoder.
+  ///
+  /// # Errors
+  ///
+  /// - Returns `InvalidConfig` if the configuration is invalid.
   pub fn new_channel<T: Pixel>(
     &self,
   ) -> Result<VideoDataChannel<T>, InvalidConfig> {
@@ -63,11 +67,20 @@ impl Config {
 
   /// Create a first pass encoder channel
   ///
-  /// The pass data information is available throguht
+  /// The pass data information is emitted through this channel.
   ///
   /// Drop the `FrameSender<T>` endpoint to flush the encoder.
-  /// The last buffer in the PassDataReceiver is the summary of the whole
+  /// The last buffer in the `PassDataReceiver` is the summary of the whole
   /// encoding process.
+  ///
+  /// # Errors
+  ///
+  /// - Returns `InvalidConfig` if the configuration is invalid.
+  ///
+  /// # Panics
+  ///
+  /// - If the channel cannot be created. An error should be raised before this,
+  ///   so a panic indicates a development error.
   pub fn new_firstpass_channel<T: Pixel>(
     &self,
   ) -> Result<(VideoDataChannel<T>, RcDataReceiver), InvalidConfig> {
@@ -93,6 +106,15 @@ impl Config {
   /// The encoding process require both frames and pass data to progress.
   ///
   /// Drop the `FrameSender<T>` endpoint to flush the encoder.
+  ///
+  /// # Errors
+  ///
+  /// - Returns `InvalidConfig` if the configuration is invalid.
+  ///
+  /// # Panics
+  ///
+  /// - If the channel cannot be created. An error should be raised before this,
+  ///   so a panic indicates a development error.
   pub fn new_secondpass_channel<T: Pixel>(
     &self,
   ) -> Result<(VideoDataChannel<T>, RcDataSender), InvalidConfig> {
@@ -118,8 +140,17 @@ impl Config {
   /// are sent through the `PassDataSender` endpoint
   ///
   /// Drop the `FrameSender<T>` endpoint to flush the encoder.
-  /// The last buffer in the PassDataReceiver is the summary of the whole
+  /// The last buffer in the `PassDataReceiver` is the summary of the whole
   /// encoding process.
+  ///
+  /// # Errors
+  ///
+  /// - Returns `InvalidConfig` if the configuration is invalid.
+  ///
+  /// # Panics
+  ///
+  /// - If the channel cannot be created. An error should be raised before this,
+  ///   so a panic indicates a development error.
   pub fn new_multipass_channel<T: Pixel>(
     &self,
   ) -> Result<(VideoDataChannel<T>, PassDataChannel), InvalidConfig> {

--- a/src/api/color.rs
+++ b/src/api/color.rs
@@ -193,7 +193,7 @@ impl ColorDescription {
 
 /// Allowed pixel value range
 ///
-/// C.f. VideoFullRangeFlag variable specified in ISO/IEC 23091-4/ITU-T H.273
+/// C.f. `VideoFullRangeFlag` variable specified in ISO/IEC 23091-4/ITU-T H.273
 #[wasm_bindgen]
 #[derive(
   ArgEnum, Debug, Clone, Copy, PartialEq, FromPrimitive, Serialize, Deserialize,

--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -107,7 +107,7 @@ pub struct EncoderConfig {
   pub speed_settings: SpeedSettings,
 }
 
-/// Default preset for EncoderConfig: it is a balance between quality and
+/// Default preset for `EncoderConfig`: it is a balance between quality and
 /// speed. See [`with_speed_preset()`].
 ///
 /// [`with_speed_preset()`]: struct.EncoderConfig.html#method.with_speed_preset

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -145,7 +145,7 @@ impl Config {
   ///
   /// `EncoderConfig` contains the settings impacting the
   /// codec features used in the produced bitstream.
-  pub fn with_encoder_config(mut self, enc: EncoderConfig) -> Self {
+  pub const fn with_encoder_config(mut self, enc: EncoderConfig) -> Self {
     self.enc = enc;
     self
   }
@@ -157,7 +157,7 @@ impl Config {
   ///
   /// If it is left unset, the encoder will use the default global
   /// threadpool provided by Rayon instead.
-  pub fn with_threads(mut self, threads: usize) -> Self {
+  pub const fn with_threads(mut self, threads: usize) -> Self {
     self.threads = threads;
     self
   }
@@ -165,7 +165,9 @@ impl Config {
   /// Set the rate control configuration
   ///
   /// The default configuration is single pass
-  pub fn with_rate_control(mut self, rate_control: RateControlConfig) -> Self {
+  pub const fn with_rate_control(
+    mut self, rate_control: RateControlConfig,
+  ) -> Self {
     self.rate_control = rate_control;
     self
   }
@@ -181,7 +183,7 @@ impl Config {
 
   #[cfg(feature = "unstable")]
   /// Set the maximum number of GOPs to encode in parallel
-  pub fn with_parallel_gops(mut self, slots: usize) -> Self {
+  pub const fn with_parallel_gops(mut self, slots: usize) -> Self {
     self.slots = slots;
     self
   }

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -136,14 +136,14 @@ pub struct Config {
 impl Config {
   /// Create a default configuration
   ///
-  /// same as Default::default()
+  /// same as `Default::default()`
   pub fn new() -> Self {
     Config::default()
   }
 
   /// Set the encoder configuration
   ///
-  /// EncoderConfig contains the settings impacting the
+  /// `EncoderConfig` contains the settings impacting the
   /// codec features used in the produced bitstream.
   pub fn with_encoder_config(mut self, enc: EncoderConfig) -> Self {
     self.enc = enc;
@@ -255,6 +255,10 @@ impl Config {
 
   /// Creates a [`Context`] with this configuration.
   ///
+  /// # Errors
+  ///
+  /// Returns `InvalidConfig` if the config is invalid.
+  ///
   /// # Examples
   ///
   /// ```
@@ -277,6 +281,10 @@ impl Config {
   }
 
   /// Validates the configuration.
+  ///
+  /// # Errors
+  ///
+  /// - Returns `InvalidConfig` if the tiling config is invalid.
   pub fn validate(&self) -> Result<(), InvalidConfig> {
     use InvalidConfig::*;
 
@@ -395,6 +403,10 @@ impl Config {
   /// Provide the tiling information for the current Config
   ///
   /// Useful for reporting and debugging.
+  ///
+  /// # Errors
+  ///
+  /// - Returns `InvalidConfig` if the tiling config is invalid.
   pub fn tiling_info(&self) -> Result<TilingInfo, InvalidConfig> {
     self.validate()?;
 

--- a/src/api/config/rate.rs
+++ b/src/api/config/rate.rs
@@ -63,7 +63,7 @@ impl RateControlConfig {
   /// Set a rate control summary
   ///
   /// Enable the second pass encoding mode
-  pub fn with_summary(mut self, summary: RateControlSummary) -> Self {
+  pub const fn with_summary(mut self, summary: RateControlSummary) -> Self {
     self.summary = Some(summary);
     self
   }
@@ -71,7 +71,7 @@ impl RateControlConfig {
   /// Emit the current pass data
   ///
   /// The pass data will be used in a second pass encoding session
-  pub fn with_emit_data(mut self, emit: bool) -> Self {
+  pub const fn with_emit_data(mut self, emit: bool) -> Self {
     self.emit_pass_data = emit;
     self
   }

--- a/src/api/config/rate.rs
+++ b/src/api/config/rate.rs
@@ -32,7 +32,7 @@ pub struct RateControlConfig {
 pub use crate::rate::RCSummary as RateControlSummary;
 
 impl RateControlSummary {
-  /// Deserializes a byte slice into a RateControlSummary
+  /// Deserializes a byte slice into a `RateControlSummary`
   pub(crate) fn from_slice(bytes: &[u8]) -> Result<Self, Error> {
     let mut de = RCDeserialize::default();
     let _ = de.buffer_fill(bytes, 0, TWOPASS_HEADER_SZ);
@@ -43,6 +43,10 @@ impl RateControlSummary {
 
 impl RateControlConfig {
   /// Create a rate control configuration from a serialized summary
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the serialized data is invalid.
   pub fn from_summary_slice(bytes: &[u8]) -> Result<Self, Error> {
     Ok(Self {
       summary: Some(RateControlSummary::from_slice(bytes)?),

--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -285,6 +285,11 @@ pub struct PartitionRange {
 
 impl PartitionRange {
   /// Creates a new partition range with min and max partition sizes.
+  ///
+  /// # Panics
+  ///
+  /// - Panics if `max` is larger than `min`.
+  /// - Panics if either `min` or `max` are not square.
   pub fn new(min: BlockSize, max: BlockSize) -> Self {
     assert!(max >= min);
     // Topdown search checks the min block size for PARTITION_SPLIT only, so

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -128,7 +128,7 @@ impl InterConfig {
   }
 
   /// Get the level of the current frame in the pyramid.
-  pub(crate) fn get_level(&self, idx_in_group_output: u64) -> u64 {
+  pub(crate) const fn get_level(&self, idx_in_group_output: u64) -> u64 {
     if !self.reorder {
       0
     } else if idx_in_group_output < self.pyramid_depth {
@@ -144,7 +144,7 @@ impl InterConfig {
     }
   }
 
-  pub(crate) fn get_slot_idx(&self, level: u64, order_hint: u32) -> u32 {
+  pub(crate) const fn get_slot_idx(&self, level: u64, order_hint: u32) -> u32 {
     // Frames with level == 0 are stored in slots 0..4, and frames with higher
     //  values of level in slots 4..8
     if level == 0 {
@@ -159,7 +159,7 @@ impl InterConfig {
     idx_in_group_output >= self.pyramid_depth
   }
 
-  pub(crate) fn get_show_existing_frame(
+  pub(crate) const fn get_show_existing_frame(
     &self, idx_in_group_output: u64,
   ) -> bool {
     // The self.reorder test here is redundant, but short-circuits the rest,
@@ -188,11 +188,11 @@ impl InterConfig {
     self.group_input_len
   }
 
-  pub(crate) fn keyframe_lookahead_distance(&self) -> u64 {
+  pub(crate) const fn keyframe_lookahead_distance(&self) -> u64 {
     self.max_reordering_latency() + 1
   }
 
-  pub(crate) fn allowed_ref_frames(&self) -> &[RefType] {
+  pub(crate) const fn allowed_ref_frames(&self) -> &[RefType] {
     use crate::partition::RefType::*;
     if self.reorder {
       &ALL_INTER_REFS

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -393,7 +393,7 @@ impl<T: Pixel> ContextInner<T> {
     lookahead_end < frames_needed && self.needs_more_frames(lookahead_end)
   }
 
-  /// Indicates whether more frames need to be processed into FrameInvariants
+  /// Indicates whether more frames need to be processed into `FrameInvariants`
   /// in order for FI lookahead to be full.
   pub fn needs_more_fi_lookahead(&self) -> bool {
     let ready_frames = self.get_rdo_lookahead_frames().count();
@@ -1504,9 +1504,9 @@ impl<T: Pixel> ContextInner<T> {
   }
 
   /// Counts the number of output frames of each subtype in the next
-  ///  reservoir_frame_delay temporal units (needed for rate control).
+  ///  `reservoir_frame_delay` temporal units (needed for rate control).
   /// Returns the number of output frames (excluding SEF frames) and output TUs
-  ///  until the last keyframe in the next reservoir_frame_delay temporal units,
+  ///  until the last keyframe in the next `reservoir_frame_delay` temporal units,
   ///  or the end of the interval, whichever comes first.
   /// The former is needed because it indicates the number of rate estimates we
   ///  will make.

--- a/src/api/util.rs
+++ b/src/api/util.rs
@@ -30,8 +30,13 @@ impl Opaque {
   }
 
   /// Attempt to downcast the opaque to a concrete type.
+  ///
+  /// # Errors
+  ///
+  /// Returns `Err(Self)` if the value could not be downcast to `T`.
   pub fn downcast<T: Any + Send + Sync>(self) -> Result<Box<T>, Opaque> {
     if self.0.is::<T>() {
+      // SAFETY: We verified the type of `T` before this cast.
       unsafe {
         let raw: *mut (dyn Any + Send + Sync) = Box::into_raw(self.0);
         Ok(Box::from_raw(raw as *mut T))

--- a/src/asm/shared/predict.rs
+++ b/src/asm/shared/predict.rs
@@ -24,8 +24,9 @@ mod test {
     let bit_depth = 8;
     let cpu = CpuFeatureLevel::default();
     let ac = [0i16; 32 * 32];
+    // SAFETY: We write to the array below before reading from it.
     let mut edge_buf: Aligned<[u8; 4 * MAX_TX_SIZE + 1]> =
-      Aligned::uninitialized();
+      unsafe { Aligned::uninitialized() };
     for i in 0..edge_buf.data.len() {
       edge_buf.data[i] = (i + 32).saturating_sub(2 * MAX_TX_SIZE).as_();
     }

--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -26,7 +26,9 @@ pub fn call_inverse_func<T: Pixel>(
   // Only use at most 32 columns and 32 rows of input coefficients.
   let input: &[T::Coeff] = &input[..width.min(32) * height.min(32)];
 
-  let mut copied: Aligned<[T::Coeff; 32 * 32]> = Aligned::uninitialized();
+  // SAFETY: We write to the array below before reading from it.
+  let mut copied: Aligned<[T::Coeff; 32 * 32]> =
+    unsafe { Aligned::uninitialized() };
 
   // Convert input to 16-bits.
   // TODO: Remove by changing inverse assembly to not overwrite its input
@@ -35,6 +37,7 @@ pub fn call_inverse_func<T: Pixel>(
   }
 
   // perform the inverse transform
+  // SAFETY: Calls Assembly code.
   unsafe {
     func(
       output.data_ptr_mut() as *mut _,
@@ -55,7 +58,9 @@ pub fn call_inverse_hbd_func<T: Pixel>(
   // Only use at most 32 columns and 32 rows of input coefficients.
   let input: &[T::Coeff] = &input[..width.min(32) * height.min(32)];
 
-  let mut copied: Aligned<[T::Coeff; 32 * 32]> = Aligned::uninitialized();
+  // SAFETY: We write to the array below before reading from it.
+  let mut copied: Aligned<[T::Coeff; 32 * 32]> =
+    unsafe { Aligned::uninitialized() };
 
   // Convert input to 16-bits.
   // TODO: Remove by changing inverse assembly to not overwrite its input
@@ -64,6 +69,7 @@ pub fn call_inverse_hbd_func<T: Pixel>(
   }
 
   // perform the inverse transform
+  // SAFETY: Calls Assembly code.
   unsafe {
     func(
       output.data_ptr_mut() as *mut _,
@@ -142,9 +148,13 @@ pub mod test {
       let src = &mut src_storage[..tx_size.area()];
       let mut dst =
         Plane::from_slice(&vec![0u8; tx_size.area()], tx_size.width());
-      let mut res_storage: Aligned<[i16; 64 * 64]> = Aligned::uninitialized();
+      // SAFETY: We write to the array below before reading from it.
+      let mut res_storage: Aligned<[i16; 64 * 64]> =
+        unsafe { Aligned::uninitialized() };
       let res = &mut res_storage.data[..tx_size.area()];
-      let mut freq_storage: Aligned<[i16; 64 * 64]> = Aligned::uninitialized();
+      // SAFETY: We write to the array below before reading from it.
+      let mut freq_storage: Aligned<[i16; 64 * 64]> =
+        unsafe { Aligned::uninitialized() };
       let freq = &mut freq_storage.data[..tx_size.area()];
       for ((r, s), d) in
         res.iter_mut().zip(src.iter_mut()).zip(dst.data.iter_mut())

--- a/src/asm/x86/dist/cdef_dist.rs
+++ b/src/asm/x86/dist/cdef_dist.rs
@@ -41,6 +41,9 @@ extern {
   );
 }
 
+/// # Panics
+///
+/// - If in `check_asm` mode, panics on mismatch between native and ASM results.
 #[allow(clippy::let_and_return)]
 pub fn cdef_dist_kernel<T: Pixel>(
   src: &PlaneRegion<'_, T>, dst: &PlaneRegion<'_, T>, w: usize, h: usize,
@@ -66,6 +69,7 @@ pub fn cdef_dist_kernel<T: Pixel>(
       if let Some(func) =
         CDEF_DIST_KERNEL_FNS[cpu.as_index()][kernel_fn_index(w, h)]
       {
+        // SAFETY: Calls Assembly code.
         unsafe {
           func(
             src.data_ptr() as *const _,

--- a/src/asm/x86/dist/hbd.rs
+++ b/src/asm/x86/dist/hbd.rs
@@ -209,11 +209,13 @@ unsafe fn hadamard8_1d(
 fn hadamard2d(data: *mut i32, (w, h): (usize, usize)) {
   /*Vertical transform.*/
   let vert_func = if h == 4 { hadamard4_1d } else { hadamard8_1d };
+  // SAFETY: Calls Assembly code.
   unsafe {
     vert_func(data, w, 1, h);
   }
   /*Horizontal transform.*/
   let horz_func = if w == 4 { hadamard4_1d } else { hadamard8_1d };
+  // SAFETY: Calls Assembly code.
   unsafe {
     horz_func(data, h, w, 1);
   }

--- a/src/asm/x86/dist/mod.rs
+++ b/src/asm/x86/dist/mod.rs
@@ -121,6 +121,9 @@ pub(crate) const fn to_index(bsize: BlockSize) -> usize {
   bsize as usize & (DIST_FNS_LENGTH - 1)
 }
 
+/// # Panics
+///
+/// - If in `check_asm` mode, panics on mismatch between native and ASM results.
 #[inline(always)]
 #[allow(clippy::let_and_return)]
 pub fn get_sad<T: Pixel>(
@@ -138,6 +141,7 @@ pub fn get_sad<T: Pixel>(
     (Err(_), _) => call_rust(),
     (Ok(bsize), PixelType::U8) => {
       match SAD_FNS[cpu.as_index()][to_index(bsize)] {
+        // SAFETY: Calls Assembly code.
         Some(func) => unsafe {
           (func)(
             src.data_ptr() as *const _,
@@ -151,6 +155,7 @@ pub fn get_sad<T: Pixel>(
     }
     (Ok(bsize), PixelType::U16) => {
       match SAD_HBD_FNS[cpu.as_index()][to_index(bsize)] {
+        // SAFETY: Calls Assembly code.
         Some(func) => unsafe {
           (func)(
             src.data_ptr() as *const _,
@@ -170,6 +175,9 @@ pub fn get_sad<T: Pixel>(
   dist
 }
 
+/// # Panics
+///
+/// - If in `check_asm` mode, panics on mismatch between native and ASM results.
 #[inline(always)]
 #[allow(clippy::let_and_return)]
 pub fn get_satd<T: Pixel>(
@@ -187,6 +195,7 @@ pub fn get_satd<T: Pixel>(
     (Err(_), _) => call_rust(),
     (Ok(bsize), PixelType::U8) => {
       match SATD_FNS[cpu.as_index()][to_index(bsize)] {
+        // SAFETY: Calls Assembly code.
         Some(func) => unsafe {
           (func)(
             src.data_ptr() as *const _,
@@ -200,6 +209,7 @@ pub fn get_satd<T: Pixel>(
     }
     (Ok(bsize), PixelType::U16) => {
       match SATD_HBD_FNS[cpu.as_index()][to_index(bsize)] {
+        // SAFETY: Calls Assembly code.
         // Because these are Rust intrinsics, don't use `T::to_asm_stride`.
         Some(func) => unsafe {
           (func)(

--- a/src/asm/x86/dist/sse.rs
+++ b/src/asm/x86/dist/sse.rs
@@ -107,7 +107,7 @@ pub fn get_weighted_sse<T: Pixel>(
   let ref_dist = call_rust();
 
   #[inline]
-  fn size_of_element<T: Sized>(_: &[T]) -> usize {
+  const fn size_of_element<T: Sized>(_: &[T]) -> usize {
     std::mem::size_of::<T>()
   }
 

--- a/src/asm/x86/dist/sse.rs
+++ b/src/asm/x86/dist/sse.rs
@@ -84,6 +84,9 @@ declare_asm_hbd_sse_fn![
   rav1e_weighted_sse_4x4_hbd_sse2
 ];
 
+/// # Panics
+///
+/// - If in `check_asm` mode, panics on mismatch between native and ASM results.
 #[inline(always)]
 #[allow(clippy::let_and_return)]
 pub fn get_weighted_sse<T: Pixel>(
@@ -112,6 +115,7 @@ pub fn get_weighted_sse<T: Pixel>(
     (Err(_), _) => call_rust(),
     (Ok(bsize), PixelType::U8) => {
       match SSE_FNS[cpu.as_index()][to_index(bsize)] {
+        // SAFETY: Calls Assembly code.
         Some(func) => unsafe {
           (func)(
             src.data_ptr() as *const _,
@@ -127,6 +131,7 @@ pub fn get_weighted_sse<T: Pixel>(
     }
     (Ok(bsize), PixelType::U16) => {
       match SSE_HBD_FNS[cpu.as_index()][to_index(bsize)] {
+        // SAFETY: Calls Assembly code.
         Some(func) => unsafe {
           (func)(
             src.data_ptr() as *const _,

--- a/src/asm/x86/ec.rs
+++ b/src/asm/x86/ec.rs
@@ -14,6 +14,8 @@ use std::arch::x86_64::*;
 #[inline(always)]
 pub fn update_cdf(cdf: &mut [u16], val: u32) {
   if cdf.len() == 4 {
+    // SAFETY: Calls Assembly code, which is only valid when the length of
+    // `cdf` is 4.
     return unsafe {
       update_cdf_4_sse2(cdf, val);
     };
@@ -99,6 +101,7 @@ mod test {
     let mut cdf2 = [7296, 3819, 1616, 0];
     for i in 0..4 {
       rust::update_cdf(&mut cdf, i);
+      // SAFETY: We are only testing on cdfs of size 4
       unsafe {
         super::update_cdf_4_sse2(&mut cdf2, i);
       }
@@ -109,6 +112,7 @@ mod test {
     let mut cdf2 = cdf;
     for i in 0..4 {
       rust::update_cdf(&mut cdf, i);
+      // SAFETY: We are only testing on cdfs of size 4
       unsafe {
         super::update_cdf_4_sse2(&mut cdf2, i);
       }

--- a/src/asm/x86/lrf.rs
+++ b/src/asm/x86/lrf.rs
@@ -26,6 +26,7 @@ pub fn sgrproj_box_ab_r1(
 ) {
   // only use 8-bit AVX2 assembly when bitdepth minus 8 equals 0
   if cpu >= CpuFeatureLevel::AVX2 && bdm8 == 0 {
+    // SAFETY: Calls Assembly code.
     return unsafe {
       sgrproj_box_ab_r1_avx2(
         af,
@@ -64,6 +65,7 @@ pub fn sgrproj_box_ab_r2(
 ) {
   // only use 8-bit AVX2 assembly when bitdepth minus 8 equals 0
   if cpu >= CpuFeatureLevel::AVX2 && bdm8 == 0 {
+    // SAFETY: Calls Assembly code.
     return unsafe {
       sgrproj_box_ab_r2_avx2(
         af,
@@ -99,6 +101,7 @@ pub fn sgrproj_box_f_r0<T: Pixel>(
   cpu: CpuFeatureLevel,
 ) {
   if cpu >= CpuFeatureLevel::AVX2 {
+    // SAFETY: Calls Assembly code.
     return unsafe {
       sgrproj_box_f_r0_avx2(f, y, w, cdeffed);
     };
@@ -113,6 +116,7 @@ pub fn sgrproj_box_f_r1<T: Pixel>(
   cdeffed: &PlaneSlice<T>, cpu: CpuFeatureLevel,
 ) {
   if cpu >= CpuFeatureLevel::AVX2 {
+    // SAFETY: Calls Assembly code.
     return unsafe {
       sgrproj_box_f_r1_avx2(af, bf, f, y, w, cdeffed);
     };
@@ -127,6 +131,7 @@ pub fn sgrproj_box_f_r2<T: Pixel>(
   y: usize, w: usize, cdeffed: &PlaneSlice<T>, cpu: CpuFeatureLevel,
 ) {
   if cpu >= CpuFeatureLevel::AVX2 {
+    // SAFETY: Calls Assembly code.
     return unsafe {
       sgrproj_box_f_r2_avx2(af, bf, f0, f1, y, w, cdeffed);
     };

--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -83,6 +83,13 @@ const fn get_2d_mode_idx(mode_x: FilterMode, mode_y: FilterMode) -> usize {
   (mode_x as usize + 4 * (mode_y as usize)) & 15
 }
 
+/// # Panics
+///
+/// - If `width` is not a power of 2
+/// - If `width` is not between 2 and 128
+/// - If `height` is odd
+/// - If `width * height` is greater than the length of `tmp1` or `tmp2`
+/// - If `width` and `height` do not fit within the bounds of `src`
 #[inline(always)]
 pub fn put_8tap<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, src: PlaneSlice<'_, T>, width: usize,
@@ -102,9 +109,9 @@ pub fn put_8tap<T: Pixel>(
     copy
   };
 
+  // SAFETY: The assembly only supports even heights and valid uncropped
+  //         widths
   unsafe {
-    // SAFETY: The assembly only supports even heights and valid uncropped
-    //         widths
     assert_eq!(height & 1, 0);
     assert!(width.is_power_of_two() && 2 <= width && width <= 128);
 
@@ -161,6 +168,13 @@ pub fn put_8tap<T: Pixel>(
   }
 }
 
+/// # Panics
+///
+/// - If `width` is not a power of 2
+/// - If `width` is not between 2 and 128
+/// - If `height` is odd
+/// - If `width * height` is greater than the length of `tmp1` or `tmp2`
+/// - If `width` and `height` do not fit within the bounds of `src`
 #[inline(always)]
 pub fn prep_8tap<T: Pixel>(
   tmp: &mut [i16], src: PlaneSlice<'_, T>, width: usize, height: usize,
@@ -180,9 +194,10 @@ pub fn prep_8tap<T: Pixel>(
     call_rust(&mut copy);
     copy
   };
+
+  // SAFETY: The assembly only supports even heights and valid uncropped
+  //         widths
   unsafe {
-    // SAFETY: The assembly only supports even heights and valid uncropped
-    //         widths
     assert_eq!(height & 1, 0);
     assert!(width.is_power_of_two() && 2 <= width && width <= 128);
 
@@ -232,6 +247,12 @@ pub fn prep_8tap<T: Pixel>(
   }
 }
 
+/// # Panics
+///
+/// - If `width` is not a power of 2
+/// - If `width` is not between 2 and 128
+/// - If `width * height` is greater than the length of `tmp1` or `tmp2`
+/// - If `width` and `height` do not fit within the bounds of `dst`
 pub fn mc_avg<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, tmp1: &[i16], tmp2: &[i16], width: usize,
   height: usize, bit_depth: usize, cpu: CpuFeatureLevel,
@@ -245,9 +266,10 @@ pub fn mc_avg<T: Pixel>(
     call_rust(&mut copy.as_region_mut());
     copy
   };
+
+  // SAFETY: The assembly only supports even heights and valid uncropped
+  //         widths
   unsafe {
-    // SAFETY: The assembly only supports even heights and valid uncropped
-    //         widths
     assert_eq!(height & 1, 0);
     assert!(width.is_power_of_two() && 2 <= width && width <= 128);
 

--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -163,6 +163,7 @@ pub fn dispatch_predict_intra<T: Pixel>(
     );
   };
 
+  // SAFETY: Calls Assembly code.
   unsafe {
     let stride = T::to_asm_stride(dst.plane_cfg.stride) as libc::ptrdiff_t;
     let w = tx_size.width() as libc::c_int;

--- a/src/asm/x86/quantize.rs
+++ b/src/asm/x86/quantize.rs
@@ -59,6 +59,7 @@ pub fn dequantize<T: Coefficient>(
   match T::Pixel::type_enum() {
     PixelType::U8 => {
       if let Some(func) = DEQUANTIZE_FNS[cpu.as_index()] {
+        // SAFETY: Calls Assembly code.
         unsafe {
           (func)(
             qindex,

--- a/src/asm/x86/sad_row.rs
+++ b/src/asm/x86/sad_row.rs
@@ -154,6 +154,10 @@ pub(crate) fn sad_row_internal<T: Pixel>(
       // helper macro to reduce boilerplate
       macro_rules! call_asm {
         ($func:ident, $src:expr, $dst:expr, $cpu:expr) => {
+          // SAFETY: Calls Assembly code.
+          //
+          // FIXME: Remove `allow` once https://github.com/rust-lang/rust-clippy/issues/8264 fixed
+          #[allow(clippy::undocumented_unsafe_blocks)]
           unsafe {
             let result =
               $func(mem::transmute($src), mem::transmute($dst)) as u64;

--- a/src/asm/x86/transform/forward.rs
+++ b/src/asm/x86/transform/forward.rs
@@ -490,12 +490,16 @@ unsafe fn forward_transform_avx2<T: Coefficient>(
   }
 }
 
+/// # Panics
+///
+/// - If called with an invalid combination of `tx_size` and `tx_type`
 pub fn forward_transform<T: Coefficient>(
   input: &[i16], output: &mut [T], stride: usize, tx_size: TxSize,
   tx_type: TxType, bd: usize, cpu: CpuFeatureLevel,
 ) {
   assert!(valid_av1_transform(tx_size, tx_type));
   if cpu >= CpuFeatureLevel::AVX2 {
+    // SAFETY: Calls Assembly code.
     unsafe {
       forward_transform_avx2(input, output, stride, tx_size, tx_type, bd);
     }

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -92,7 +92,7 @@ impl From<y4m::Error> for DecodeError {
   }
 }
 
-pub fn map_y4m_color_space(
+pub const fn map_y4m_color_space(
   color_space: y4m::Colorspace,
 ) -> (ChromaSampling, ChromaSamplePosition) {
   use crate::ChromaSamplePosition::*;

--- a/src/bin/muxer/y4m.rs
+++ b/src/bin/muxer/y4m.rs
@@ -41,6 +41,7 @@ pub fn write_y4m_frame<T: Pixel>(
     rec.planes[0].data_origin().chunks(stride_y).zip(rec_y.chunks_mut(pitch_y))
   {
     if y4m_details.bit_depth > 8 {
+      // SAFETY: This is essentially doing a transmute to u16, but safer.
       unsafe {
         line_out.copy_from_slice(slice::from_raw_parts::<u8>(
           line.as_ptr() as *const u8,
@@ -62,6 +63,7 @@ pub fn write_y4m_frame<T: Pixel>(
       .zip(rec_u.chunks_mut(pitch_uv))
     {
       if y4m_details.bit_depth > 8 {
+        // SAFETY: This is essentially doing a transmute to u16, but safer.
         unsafe {
           line_out.copy_from_slice(slice::from_raw_parts::<u8>(
             line.as_ptr() as *const u8,
@@ -81,6 +83,7 @@ pub fn write_y4m_frame<T: Pixel>(
       .zip(rec_v.chunks_mut(pitch_uv))
     {
       if y4m_details.bit_depth > 8 {
+        // SAFETY: This is essentially doing a transmute to u16, but safer.
         unsafe {
           line_out.copy_from_slice(slice::from_raw_parts::<u8>(
             line.as_ptr() as *const u8,

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -18,6 +18,7 @@
 #![allow(clippy::many_single_char_names)]
 // Performance lints
 #![warn(clippy::linkedlist)]
+#![warn(clippy::missing_const_for_fn)]
 #![warn(clippy::mutex_integer)]
 // Correctness lints
 #![warn(clippy::expl_impl_clone_on_copy)]

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -16,15 +16,18 @@
 #![allow(clippy::verbose_bit_mask)]
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::many_single_char_names)]
-#![warn(clippy::expl_impl_clone_on_copy)]
+// Performance lints
 #![warn(clippy::linkedlist)]
-#![warn(clippy::map_flatten)]
-#![warn(clippy::mem_forget)]
-#![warn(clippy::mut_mut)]
 #![warn(clippy::mutex_integer)]
+// Correctness lints
+#![warn(clippy::expl_impl_clone_on_copy)]
+#![warn(clippy::mem_forget)]
+#![warn(clippy::path_buf_push_overwrite)]
+// Clarity/formatting lints
+#![warn(clippy::map_flatten)]
+#![warn(clippy::mut_mut)]
 #![warn(clippy::needless_borrow)]
 #![warn(clippy::needless_continue)]
-#![warn(clippy::path_buf_push_overwrite)]
 #![warn(clippy::range_plus_one)]
 
 #[macro_use]

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -29,6 +29,11 @@
 #![warn(clippy::needless_borrow)]
 #![warn(clippy::needless_continue)]
 #![warn(clippy::range_plus_one)]
+// Documentation lints
+#![warn(clippy::doc_markdown)]
+#![warn(clippy::missing_errors_doc)]
+#![warn(clippy::missing_panics_doc)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 #[macro_use]
 extern crate log;
@@ -375,6 +380,7 @@ cfg_if::cfg_if! {
     }
   } else {
     fn print_rusage() {
+      // SAFETY: This uses an FFI, it is safe because we call it correctly.
       let (utime, stime, maxrss) = unsafe {
         let mut usage = std::mem::zeroed();
         let _ = libc::getrusage(libc::RUSAGE_SELF, &mut usage);

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -18,6 +18,7 @@
 #![allow(clippy::many_single_char_names)]
 // Performance lints
 #![warn(clippy::linkedlist)]
+#![warn(clippy::missing_const_for_fn)]
 #![warn(clippy::mutex_integer)]
 // Correctness lints
 #![warn(clippy::expl_impl_clone_on_copy)]

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -29,6 +29,11 @@
 #![warn(clippy::needless_borrow)]
 #![warn(clippy::needless_continue)]
 #![warn(clippy::range_plus_one)]
+// Documentation lints
+#![warn(clippy::doc_markdown)]
+#![warn(clippy::missing_errors_doc)]
+#![warn(clippy::missing_panics_doc)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 #[macro_use]
 extern crate log;
@@ -362,6 +367,7 @@ cfg_if::cfg_if! {
     }
   } else {
     fn print_rusage() {
+      // SAFETY: This uses an FFI, it is safe because we call it correctly.
       let (utime, stime, maxrss) = unsafe {
         let mut usage = std::mem::zeroed();
         let _ = libc::getrusage(libc::RUSAGE_SELF, &mut usage);

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -16,15 +16,18 @@
 #![allow(clippy::verbose_bit_mask)]
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::many_single_char_names)]
-#![warn(clippy::expl_impl_clone_on_copy)]
+// Performance lints
 #![warn(clippy::linkedlist)]
-#![warn(clippy::map_flatten)]
-#![warn(clippy::mem_forget)]
-#![warn(clippy::mut_mut)]
 #![warn(clippy::mutex_integer)]
+// Correctness lints
+#![warn(clippy::expl_impl_clone_on_copy)]
+#![warn(clippy::mem_forget)]
+#![warn(clippy::path_buf_push_overwrite)]
+// Clarity/formatting lints
+#![warn(clippy::map_flatten)]
+#![warn(clippy::mut_mut)]
 #![warn(clippy::needless_borrow)]
 #![warn(clippy::needless_continue)]
-#![warn(clippy::path_buf_push_overwrite)]
 #![warn(clippy::range_plus_one)]
 
 #[macro_use]

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -17,6 +17,8 @@
 #![deny(missing_docs)]
 // Basically everything will be unsafe since this is a FFI
 #![allow(clippy::undocumented_unsafe_blocks)]
+// const extern fns are unstable
+#![allow(clippy::missing_const_for_fn)]
 
 use std::slice;
 use std::sync::Arc;
@@ -142,7 +144,7 @@ pub enum EncoderStatus {
 }
 
 impl EncoderStatus {
-  fn to_c(&self) -> *const u8 {
+  const fn to_c(&self) -> *const u8 {
     use self::EncoderStatus::*;
     match self {
       Success => "Normal operation\0".as_ptr(),
@@ -325,7 +327,7 @@ impl EncContext {
     }
   }
 
-  fn config(&self) -> rav1e::EncoderConfig {
+  const fn config(&self) -> rav1e::EncoderConfig {
     match self {
       EncContext::U8(ctx) => ctx.config,
       EncContext::U16(ctx) => ctx.config,

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -394,6 +394,9 @@ pub fn cdef_analyze_superblock<T: Pixel>(
 //   tile boundary), the filtering process ignores input pixels that
 //   don't exist.
 
+/// # Panics
+///
+/// - If called with invalid parameters
 pub fn cdef_filter_superblock<T: Pixel>(
   fi: &FrameInvariants<T>, input: &Frame<T>, output: &mut TileMut<'_, T>,
   blocks: &TileBlocks<'_>, tile_sbo: TileSuperBlockOffset, cdef_index: u8,
@@ -511,6 +514,9 @@ pub fn cdef_filter_superblock<T: Pixel>(
               }
             };
 
+            // SAFETY: `cdef_filter_block` may call Assembly code.
+            // The asserts here verify that we are not calling it
+            // with invalid parameters.
             unsafe {
               assert!(
                 input.planes[p].cfg.width as isize

--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -34,7 +34,7 @@ pub const COMP_GROUP_IDX_CONTEXTS: usize = 6;
 pub const COEFF_CONTEXT_MAX_WIDTH: usize = MAX_TILE_WIDTH / MI_SIZE;
 
 /// Absolute offset in blocks, where a block is defined
-/// to be an N*N square where N = (1 << BLOCK_TO_PLANE_SHIFT).
+/// to be an `N*N` square where `N == (1 << BLOCK_TO_PLANE_SHIFT)`.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BlockOffset {
   pub x: usize,
@@ -42,12 +42,12 @@ pub struct BlockOffset {
 }
 
 /// Absolute offset in blocks inside a plane, where a block is defined
-/// to be an N*N square where N = (1 << BLOCK_TO_PLANE_SHIFT).
+/// to be an `N*N` square where `N == (1 << BLOCK_TO_PLANE_SHIFT)`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PlaneBlockOffset(pub BlockOffset);
 
 /// Absolute offset in blocks inside a tile, where a block is defined
-/// to be an N*N square where N = (1 << BLOCK_TO_PLANE_SHIFT).
+/// to be an `N*N` square where `N == (1 << BLOCK_TO_PLANE_SHIFT)`.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct TileBlockOffset(pub BlockOffset);
 
@@ -763,6 +763,9 @@ impl<'a> ContextWriter<'a> {
     symbol_with_update!(self, w, enable as u32, cdf, 2);
   }
 
+  /// # Panics
+  ///
+  /// - If called with `enable: true` (not yet implemented
   pub fn write_use_palette_mode<W: Writer>(
     &mut self, w: &mut W, enable: bool, bsize: BlockSize, bo: TileBlockOffset,
     luma_mode: PredictionMode, chroma_mode: PredictionMode, xdec: usize,
@@ -1415,6 +1418,9 @@ impl<'a> ContextWriter<'a> {
     mode_context
   }
 
+  /// # Panics
+  ///
+  /// - If the first ref frame is not set (`NONE_FRAME`)
   pub fn find_mvrefs<T: Pixel>(
     &self, bo: TileBlockOffset, ref_frames: [RefType; 2],
     mv_stack: &mut ArrayVec<CandidateMV, 9>, bsize: BlockSize,
@@ -1649,6 +1655,9 @@ impl<'a> ContextWriter<'a> {
     }
   }
 
+  /// # Panics
+  ///
+  /// - If `mode` is not an inter mode
   pub fn write_compound_mode<W: Writer>(
     &mut self, w: &mut W, mode: PredictionMode, ctx: usize,
   ) {
@@ -1711,6 +1720,9 @@ impl<'a> ContextWriter<'a> {
     symbol_with_update!(self, w, drl_mode as u32, cdf, 2);
   }
 
+  /// # Panics
+  ///
+  /// - If the MV is invalid
   pub fn write_mv<W: Writer>(
     &mut self, w: &mut W, mv: MotionVector, ref_mv: MotionVector,
     mv_precision: MvSubpelPrecision,
@@ -1891,8 +1903,9 @@ impl<'a> ContextWriter<'a> {
       }
     }
 
+    // SAFETY: We write to the array below before reading from it.
     let mut coeff_contexts: Aligned<[i8; MAX_CODED_TX_SQUARE]> =
-      Aligned::uninitialized();
+      unsafe { Aligned::uninitialized() };
 
     self.get_nz_map_contexts(
       levels,

--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -1468,7 +1468,7 @@ impl<'a> ContextWriter<'a> {
   }
 
   #[inline]
-  pub fn ref_count_ctx(counts0: u8, counts1: u8) -> usize {
+  pub const fn ref_count_ctx(counts0: u8, counts1: u8) -> usize {
     if counts0 < counts1 {
       0
     } else if counts0 == counts1 {

--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -722,7 +722,7 @@ impl<'a> ContextWriter<'a> {
     cw
   }
 
-  pub fn cdf_element_prob(cdf: &[u16], element: usize) -> u16 {
+  pub const fn cdf_element_prob(cdf: &[u16], element: usize) -> u16 {
     (if element > 0 { cdf[element - 1] } else { 32768 })
       - (if element + 1 < cdf.len() { cdf[element] } else { 0 })
   }

--- a/src/context/frame_header.rs
+++ b/src/context/frame_header.rs
@@ -61,6 +61,9 @@ impl<'a> ContextWriter<'a> {
     ContextWriter::ref_count_ctx(fwd_cnt, bwd_cnt)
   }
 
+  /// # Panics
+  ///
+  /// - If the `comp_mode` setting does not match the reference mode and size.
   pub fn write_ref_frames<T: Pixel, W: Writer>(
     &mut self, w: &mut W, fi: &FrameInvariants<T>, bo: TileBlockOffset,
   ) {
@@ -162,6 +165,9 @@ impl<'a> ContextWriter<'a> {
     self.fc.count_lrf_switchable(w, rs, filter, pli)
   }
 
+  /// # Panics
+  ///
+  /// - If the LRF has already been written for this superblock
   pub fn write_lrf<W: Writer>(
     &mut self, w: &mut W, rs: &mut TileRestorationStateMut,
     sbo: TileSuperBlockOffset, pli: usize,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -93,7 +93,7 @@ impl FieldMap {
 }
 
 #[inline]
-pub fn av1_get_coded_tx_size(tx_size: TxSize) -> TxSize {
+pub const fn av1_get_coded_tx_size(tx_size: TxSize) -> TxSize {
   match tx_size {
     TX_64X64 | TX_64X32 | TX_32X64 => TX_32X32,
     TX_16X64 => TX_16X32,
@@ -133,7 +133,7 @@ pub const MV_UPP: i32 = 1 << MV_IN_USE_BITS;
 pub const MV_LOW: i32 = -(1 << MV_IN_USE_BITS);
 
 #[inline(always)]
-pub fn av1_get_mv_joint(mv: MotionVector) -> MvJointType {
+pub const fn av1_get_mv_joint(mv: MotionVector) -> MvJointType {
   if mv.row == 0 {
     return if mv.col == 0 {
       MvJointType::MV_JOINT_ZERO
@@ -159,7 +159,7 @@ pub fn mv_joint_horizontal(joint_type: MvJointType) -> bool {
     || joint_type == MvJointType::MV_JOINT_HNZVNZ
 }
 #[inline(always)]
-pub fn mv_class_base(mv_class: usize) -> u32 {
+pub const fn mv_class_base(mv_class: usize) -> u32 {
   if mv_class != MV_CLASS_0 {
     (CLASS0_SIZE << (mv_class as usize + 2)) as u32
   } else {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -184,6 +184,10 @@ pub fn get_mv_class(z: u32, offset: &mut u32) -> usize {
 }
 
 impl<'a> ContextWriter<'a> {
+  /// # Panics
+  ///
+  /// - If the `comp` is 0
+  /// - If the `comp` is outside the bounds of `MV_LOW` and `MV_UPP`
   pub fn encode_mv_component<W: Writer>(
     &mut self, w: &mut W, comp: i32, axis: usize, precision: MvSubpelPrecision,
   ) {

--- a/src/context/partition_unit.rs
+++ b/src/context/partition_unit.rs
@@ -68,7 +68,7 @@ pub enum CFLSign {
 }
 
 impl CFLSign {
-  pub fn from_alpha(a: i16) -> CFLSign {
+  pub const fn from_alpha(a: i16) -> CFLSign {
     [CFL_SIGN_NEG, CFL_SIGN_ZERO, CFL_SIGN_POS][(a.signum() + 1) as usize]
   }
 }
@@ -121,7 +121,7 @@ impl CFLParams {
     cfl_sign_value[self.sign[uv] as usize] * (self.scale[uv] as i16)
   }
   #[inline]
-  pub fn from_alpha(u: i16, v: i16) -> CFLParams {
+  pub const fn from_alpha(u: i16, v: i16) -> CFLParams {
     CFLParams {
       sign: [CFLSign::from_alpha(u), CFLSign::from_alpha(v)],
       scale: [u.abs() as u8, v.abs() as u8],

--- a/src/context/partition_unit.rs
+++ b/src/context/partition_unit.rs
@@ -92,16 +92,25 @@ impl Default for CFLParams {
 }
 
 impl CFLParams {
+  /// # Panics
+  ///
+  /// - If either current sign is zero
   #[inline]
   pub fn joint_sign(self) -> u32 {
     assert!(self.sign[0] != CFL_SIGN_ZERO || self.sign[1] != CFL_SIGN_ZERO);
     (self.sign[0] as u32) * (CFL_SIGNS as u32) + (self.sign[1] as u32) - 1
   }
+  /// # Panics
+  ///
+  /// - If the sign at index `uv` is zero
   #[inline]
   pub fn context(self, uv: usize) -> usize {
     assert!(self.sign[uv] != CFL_SIGN_ZERO);
     (self.sign[uv] as usize - 1) * CFL_SIGNS + (self.sign[1 - uv] as usize)
   }
+  /// # Panics
+  ///
+  /// - If the sign at index `uv` is zero
   #[inline]
   pub fn index(self, uv: usize) -> u32 {
     assert!(self.sign[uv] != CFL_SIGN_ZERO && self.scale[uv] != 0);
@@ -296,6 +305,10 @@ impl<'a> ContextWriter<'a> {
     }
   }
 
+  /// # Panics
+  ///
+  /// - If called with an 8x8 or larger `bsize`
+  /// - If called with a `PartitionType` incompatible with the current block.
   pub fn write_partition(
     &mut self, w: &mut impl Writer, bo: TileBlockOffset, p: PartitionType,
     bsize: BlockSize,
@@ -442,6 +455,9 @@ impl<'a> ContextWriter<'a> {
 }
 
 impl<'a> BlockContext<'a> {
+  /// # Panics
+  ///
+  /// - If called with a non-square `bsize`
   pub fn partition_plane_context(
     &self, bo: TileBlockOffset, bsize: BlockSize,
   ) -> usize {
@@ -457,6 +473,9 @@ impl<'a> BlockContext<'a> {
     (left * 2 + above) as usize + bsl as usize * PARTITION_PLOFFSET
   }
 
+  /// # Panics
+  ///
+  /// - If the block size is invalid for subsampling
   pub fn reset_skip_context(
     &mut self, bo: TileBlockOffset, bsize: BlockSize, xdec: usize,
     ydec: usize, cs: ChromaSampling,
@@ -500,6 +519,9 @@ impl<'a> BlockContext<'a> {
     above_skip as usize + left_skip as usize
   }
 
+  /// # Panics
+  ///
+  /// - If called with a non-square `bsize`
   pub fn update_partition_context(
     &mut self, bo: TileBlockOffset, subsize: BlockSize, bsize: BlockSize,
   ) {

--- a/src/context/superblock_unit.rs
+++ b/src/context/superblock_unit.rs
@@ -33,7 +33,7 @@ pub const MAX_SB_IN_IMP_B: usize = 1
     - BLOCK_TO_PLANE_SHIFT);
 
 /// Absolute offset in superblocks, where a superblock is defined
-/// to be an N*N square where N = (1 << SUPERBLOCK_TO_PLANE_SHIFT).
+/// to be an `N*N` square where `N == (1 << SUPERBLOCK_TO_PLANE_SHIFT)`.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SuperBlockOffset {
   pub x: usize,
@@ -41,12 +41,12 @@ pub struct SuperBlockOffset {
 }
 
 /// Absolute offset in superblocks inside a plane, where a superblock is defined
-/// to be an N*N square where N = (1 << SUPERBLOCK_TO_PLANE_SHIFT).
+/// to be an `N*N` square where `N == (1 << SUPERBLOCK_TO_PLANE_SHIFT)`.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PlaneSuperBlockOffset(pub SuperBlockOffset);
 
 /// Absolute offset in superblocks inside a tile, where a superblock is defined
-/// to be an N*N square where N = (1 << SUPERBLOCK_TO_PLANE_SHIFT).
+/// to be an `N*N` square where `N == (1 << SUPERBLOCK_TO_PLANE_SHIFT)`.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TileSuperBlockOffset(pub SuperBlockOffset);
 

--- a/src/context/transform_unit.rs
+++ b/src/context/transform_unit.rs
@@ -772,7 +772,7 @@ impl<'a> ContextWriter<'a> {
   }
 
   #[inline]
-  pub fn get_txsize_entropy_ctx(tx_size: TxSize) -> usize {
+  pub const fn get_txsize_entropy_ctx(tx_size: TxSize) -> usize {
     (tx_size.sqr() as usize + tx_size.sqr_up() as usize + 1) >> 1
   }
 
@@ -794,7 +794,7 @@ impl<'a> ContextWriter<'a> {
   // work in the spec, use the log of block height in our calculations instead
   // of block width.
   #[inline]
-  pub fn get_txb_bhl(tx_size: TxSize) -> usize {
+  pub const fn get_txb_bhl(tx_size: TxSize) -> usize {
     av1_get_coded_tx_size(tx_size).height_log2()
   }
 

--- a/src/context/transform_unit.rs
+++ b/src/context/transform_unit.rs
@@ -523,6 +523,9 @@ pub struct TXB_CTX {
 }
 
 impl<'a> ContextWriter<'a> {
+  /// # Panics
+  ///
+  /// - If an invalid combination of `tx_type` and `tx_size` is passed
   pub fn write_tx_type<W: Writer>(
     &mut self, w: &mut W, tx_size: TxSize, tx_type: TxType,
     y_mode: PredictionMode, is_inter: bool, use_reduced_tx_set: bool,
@@ -795,6 +798,9 @@ impl<'a> ContextWriter<'a> {
     av1_get_coded_tx_size(tx_size).height_log2()
   }
 
+  /// # Panics
+  ///
+  /// - If `eob` is prior to the start of the group
   #[inline]
   pub fn get_eob_pos_token(eob: usize, extra: &mut u32) -> u32 {
     let t = if eob < 33 {

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -30,7 +30,7 @@ impl CpuFeatureLevel {
   }
 
   #[inline(always)]
-  pub fn as_index(self) -> usize {
+  pub const fn as_index(self) -> usize {
     self as usize
   }
 }

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -227,10 +227,10 @@ pub(crate) mod rust {
   /// Computes weighted sum of squared error.
   ///
   /// Each scale is applied to a 4x4 region in the provided inputs. Each scale
-  /// value is a fixed point number, currently ['DistortionScale'].
+  /// value is a fixed point number, currently [`DistortionScale`].
   ///
-  /// Implementations can require alignment (bw (block width) for ['src1'] and
-  /// ['src2'] and bw/4 for scale).
+  /// Implementations can require alignment (`bw` (block width) for [`src1`] and
+  /// [`src2`] and `bw/4` for `scale`).
   #[inline(never)]
   pub fn get_weighted_sse<T: Pixel>(
     src1: &PlaneRegion<'_, T>, src2: &PlaneRegion<'_, T>, scale: &[u32],

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -28,66 +28,66 @@ const EC_PROB_SHIFT: u32 = 6;
 const EC_MIN_PROB: u32 = 4;
 type ec_window = u32;
 
-/// Public trait interface to a bitstream Writer: a Counter can be
+/// Public trait interface to a bitstream `Writer`: a `Counter` can be
 /// used to count bits for cost analysis without actually storing
-/// anything (using a new::WriterCounter() as a Writer), to record
-/// tokens for later writing (using a new::WriterRecorder() as a
-/// Writer) to write actual final bits out using a range encoder
-/// (using a new::WriterEncoder() as a Writer).  A WriterRecorder's
-/// contents can be replayed into a WriterEncoder.
+/// anything (using a new `WriterCounter` as a `Writer`), to record
+/// tokens for later writing (using a new `WriterRecorder` as a
+/// `Writer`) to write actual final bits out using a range encoder
+/// (using a new `WriterEncoder` as a `Writer`).  A `WriterRecorder`'s
+/// contents can be replayed into a `WriterEncoder`.
 pub trait Writer {
-  /// Write a symbol s, using the passed in cdf reference; leaves cdf unchanged
+  /// Write a symbol `s`, using the passed in cdf reference; leaves `cdf` unchanged
   fn symbol(&mut self, s: u32, cdf: &[u16]);
-  /// return approximate number of fractional bits in OD_BITRES
-  /// precision to write a symbol s using the passed in cdf reference;
-  /// leaves cdf unchanged
+  /// return approximate number of fractional bits in `OD_BITRES`
+  /// precision to write a symbol `s` using the passed in cdf reference;
+  /// leaves `cdf` unchanged
   fn symbol_bits(&self, s: u32, cdf: &[u16]) -> u32;
-  /// Write a symbol s, using the passed in cdf reference; updates the referenced cdf.
+  /// Write a symbol `s`, using the passed in cdf reference; updates the referenced cdf.
   fn symbol_with_update<const CDF_LEN: usize>(
     &mut self, s: u32, cdf: &mut [u16; CDF_LEN], log: &mut CDFContextLog,
   );
   /// Write a bool using passed in probability
   fn bool(&mut self, val: bool, f: u16);
-  /// Write a single bit with flat proability
+  /// Write a single bit with flat probability
   fn bit(&mut self, bit: u16);
-  /// Write literal bits with flat probability
+  /// Write literal `bits` with flat probability
   fn literal(&mut self, bits: u8, s: u32);
-  /// Write passed level as a golomb code
+  /// Write passed `level` as a golomb code
   fn write_golomb(&mut self, level: u32);
-  /// Write a value v in [0, n-1] quasi-uniformly
+  /// Write a value `v` in `[0, n-1]` quasi-uniformly
   fn write_quniform(&mut self, n: u32, v: u32);
-  /// Return fractional bits needed to write Write a value v in [0,
-  /// n-1] quasi-uniformly
+  /// Return fractional bits needed to write a value `v` in `[0, n-1]`
+  /// quasi-uniformly
   fn count_quniform(&self, n: u32, v: u32) -> u32;
-  /// Write symbol v in [0, n-1] with parameter k as finite subexponential
+  /// Write symbol `v` in `[0, n-1]` with parameter `k` as finite subexponential
   fn write_subexp(&mut self, n: u32, k: u8, v: u32);
-  /// Return fractional bits needed to write symbol v in [0, n-1] with
+  /// Return fractional bits needed to write symbol v in `[0, n-1]` with
   /// parameter k as finite subexponential
   fn count_subexp(&self, n: u32, k: u8, v: u32) -> u32;
-  /// Write symbol v in [0, n-1] with parameter k as finite
-  /// subexponential based on a reference ref also in [0, n-1].
+  /// Write symbol `v` in `[0, n-1]` with parameter `k` as finite
+  /// subexponential based on a reference `r` also in `[0, n-1]`.
   fn write_unsigned_subexp_with_ref(&mut self, v: u32, mx: u32, k: u8, r: u32);
-  /// Return fractional bits beed to write symbol v in [0, n-1] with
-  /// parameter k as finite subexponential based on a reference ref
-  /// also in [0, n-1].
+  /// Return fractional bits needed to write symbol `v` in `[0, n-1]` with
+  /// parameter `k` as finite subexponential based on a reference `r`
+  /// also in `[0, n-1]`.
   fn count_unsigned_subexp_with_ref(
     &self, v: u32, mx: u32, k: u8, r: u32,
   ) -> u32;
-  /// Write symbol v in [-(n-1), n-1] with parameter k as finite
-  /// subexponential based on a reference ref also in [-(n-1), n-1].
+  /// Write symbol v in `[-(n-1), n-1]` with parameter k as finite
+  /// subexponential based on a reference ref also in `[-(n-1), n-1]`.
   fn write_signed_subexp_with_ref(
     &mut self, v: i32, low: i32, high: i32, k: u8, r: i32,
   );
-  /// Return fractional bits needed to write symbol v in [-(n-1), n-1]
-  /// with parameter k as finite subexponential based on a reference
-  /// ref also in [-(n-1), n-1].
+  /// Return fractional bits needed to write symbol `v` in `[-(n-1), n-1]`
+  /// with parameter `k` as finite subexponential based on a reference
+  /// `r` also in `[-(n-1), n-1]`.
   fn count_signed_subexp_with_ref(
     &self, v: i32, low: i32, high: i32, k: u8, r: i32,
   ) -> u32;
   /// Return current length of range-coded bitstream in integer bits
   fn tell(&mut self) -> u32;
   /// Return current length of range-coded bitstream in fractional
-  /// bits with OD_BITRES decimal precision
+  /// bits with `OD_BITRES` decimal precision
   fn tell_frac(&mut self) -> u32;
   /// Save current point in coding/recording to a checkpoint
   fn checkpoint(&mut self) -> WriterCheckpoint;
@@ -97,8 +97,8 @@ pub trait Writer {
   fn add_bits_frac(&mut self, bits_frac: u32);
 }
 
-/// StorageBackend is an internal trait used to tie a specific Writer
-/// implementation's storage to the generic Writer.  It would be
+/// `StorageBackend` is an internal trait used to tie a specific `Writer`
+/// implementation's storage to the generic `Writer`.  It would be
 /// private, but Rust is deprecating 'private trait in a public
 /// interface' support.
 pub trait StorageBackend {
@@ -482,7 +482,8 @@ impl WriterBase<WriterEncoder> {
   }
 }
 
-/// Generic/shared implementation for Writers with StorageBackends (ie, Encoders and Recorders)
+/// Generic/shared implementation for `Writer`s with `StorageBackend`s
+/// (ie, `Encoder`s and `Recorder`s)
 impl<S> Writer for WriterBase<S>
 where
   WriterBase<S>: StorageBackend,
@@ -496,8 +497,9 @@ where
     self.symbol(if val { 1 } else { 0 }, &[f, 0]);
   }
   /// Encode a single boolean value.
-  /// `val`: The value to encode (false or true).
-  /// `f`: The probability that the val is true, scaled by 32768.
+  ///
+  /// - `val`: The value to encode (`false` or `true`).
+  /// - `f`: The probability that the `val` is `true`, scaled by `32768`.
   fn bit(&mut self, bit: u16) {
     self.bool(bit == 1, 16384);
   }
@@ -507,16 +509,18 @@ where
   }
   /// Encode a literal bitstring, bit by bit in MSB order, with flat
   /// probability.
-  /// 'bits': Length of bitstring
-  /// 's': Bit string to encode
+  ///
+  /// - 'bits': Length of bitstring
+  /// - 's': Bit string to encode
   fn literal(&mut self, bits: u8, s: u32) {
     for bit in (0..bits).rev() {
       self.bit((1 & (s >> bit)) as u16);
     }
   }
   /// Encodes a symbol given a cumulative distribution function (CDF) table in Q15.
-  /// `s`: The index of the symbol to encode.
-  /// `cdf`: The CDF, such that symbol s falls in the range
+  ///
+  /// - `s`: The index of the symbol to encode.
+  /// - `cdf`: The CDF, such that symbol s falls in the range
   ///        `[s > 0 ? cdf[s - 1] : 0, cdf[s])`.
   ///       The values must be monotonically non-decreasing, and the last value
   ///       must be greater than 32704. There should be at most 16 values.
@@ -528,17 +532,24 @@ where
     debug_assert!(s < cdf.len());
     // The above is stricter than the following overflow check: s <= cdf.len()
     let nms = cdf.len() - s;
-    let fl = if s > 0 { unsafe { *cdf.get_unchecked(s - 1) } } else { 32768 };
+    let fl = if s > 0 {
+      // SAFETY: We asserted that s is less than the length of the cdf
+      unsafe { *cdf.get_unchecked(s - 1) }
+    } else {
+      32768
+    };
+    // SAFETY: We asserted that s is less than the length of the cdf
     let fh = unsafe { *cdf.get_unchecked(s) };
     debug_assert!((fh >> EC_PROB_SHIFT) <= (fl >> EC_PROB_SHIFT));
     debug_assert!(fl <= 32768);
     self.store(fl, fh, nms as u16);
   }
   /// Encodes a symbol given a cumulative distribution function (CDF)
-  /// table in Q15, then updates the CDF probabilities to relect we've
+  /// table in Q15, then updates the CDF probabilities to reflect we've
   /// written one more symbol 's'.
-  /// `s`: The index of the symbol to encode.
-  /// `cdf`: The CDF, such that symbol s falls in the range
+  ///
+  /// - `s`: The index of the symbol to encode.
+  /// - `cdf`: The CDF, such that symbol s falls in the range
   ///        `[s > 0 ? cdf[s - 1] : 0, cdf[s])`.
   ///       The values must be monotonically non-decreasing, and the last value
   ///       must be greater 32704. There should be at most 16 values.
@@ -559,8 +570,9 @@ where
   }
   /// Returns approximate cost for a symbol given a cumulative
   /// distribution function (CDF) table and current write state.
-  /// `s`: The index of the symbol to encode.
-  /// `cdf`: The CDF, such that symbol s falls in the range
+  ///
+  /// - `s`: The index of the symbol to encode.
+  /// - `cdf`: The CDF, such that symbol s falls in the range
   ///        `[s > 0 ? cdf[s - 1] : 0, cdf[s])`.
   ///       The values must be monotonically non-decreasing, and the last value
   ///       must be greater than 32704. There should be at most 16 values.
@@ -600,7 +612,8 @@ where
     Self::frac_compute((bits + sh + 9) as u32, r << d) - pre
   }
   /// Encode a golomb to the bitstream.
-  /// 'level': passed in value to encode
+  ///
+  /// - 'level': passed in value to encode
   fn write_golomb(&mut self, level: u32) {
     let x = level + 1;
     let length = 32 - x.leading_zeros();
@@ -613,9 +626,9 @@ where
       self.bit(((x >> i) & 0x01) as u16);
     }
   }
-  /// Write a value v in [0, n-1] quasi-uniformly
-  /// n: size of interval
-  /// v: value to encode
+  /// Write a value `v` in `[0, n-1]` quasi-uniformly
+  /// - `n`: size of interval
+  /// - `v`: value to encode
   fn write_quniform(&mut self, n: u32, v: u32) {
     if n > 1 {
       let l = msb(n as i32) as u8 + 1;
@@ -628,9 +641,9 @@ where
       }
     }
   }
-  /// Returns QOD_BITRES bits for a value v in [0, n-1] quasi-uniformly
-  /// n: size of interval
-  /// v: value to encode
+  /// Returns `QOD_BITRES` bits for a value `v` in `[0, n-1]` quasi-uniformly
+  /// - `n`: size of interval
+  /// - `v`: value to encode
   fn count_quniform(&self, n: u32, v: u32) -> u32 {
     let mut bits = 0;
     if n > 1 {
@@ -643,10 +656,11 @@ where
     }
     bits
   }
-  /// Write symbol v in [0, n-1] with parameter k as finite subexponential
-  /// n: size of interval
-  /// k: 'parameter'
-  /// v: value to encode
+  /// Write symbol `v` in `[0, n-1]` with parameter `k` as finite subexponential
+  ///
+  /// - `n`: size of interval
+  /// - `k`: "parameter"
+  /// - `v`: value to encode
   fn write_subexp(&mut self, n: u32, k: u8, v: u32) {
     let mut i = 0;
     let mut mk = 0;
@@ -669,10 +683,12 @@ where
       }
     }
   }
-  /// Returns QOD_BITRES bits for symbol v in [0, n-1] with parameter k as finite subexponential
-  /// n: size of interval
-  /// k: 'parameter'
-  /// v: value to encode
+  /// Returns `QOD_BITRES` bits for symbol `v` in `[0, n-1]` with parameter `k`
+  /// as finite subexponential
+  ///
+  /// - `n`: size of interval
+  /// - `k`: "parameter"
+  /// - `v`: value to encode
   fn count_subexp(&self, n: u32, k: u8, v: u32) -> u32 {
     let mut i = 0;
     let mut mk = 0;
@@ -697,12 +713,13 @@ where
     }
     bits
   }
-  /// Write symbol v in [0, n-1] with parameter k as finite
-  /// subexponential based on a reference ref also in [0, n-1].
-  /// v: value to encode
-  /// n: size of interval
-  /// k: 'parameter'
-  /// r: reference
+  /// Write symbol `v` in `[0, n-1]` with parameter `k` as finite
+  /// subexponential based on a reference `r` also in `[0, n-1]`.
+  ///
+  /// - `v`: value to encode
+  /// - `n`: size of interval
+  /// - `k`: "parameter"
+  /// - `r`: reference
   fn write_unsigned_subexp_with_ref(&mut self, v: u32, n: u32, k: u8, r: u32) {
     if (r << 1) <= n {
       self.write_subexp(n, k, Self::recenter(r, v));
@@ -710,12 +727,14 @@ where
       self.write_subexp(n, k, Self::recenter(n - 1 - r, n - 1 - v));
     }
   }
-  /// Returns QOD_BITRES bits for symbol v in [0, n-1] with parameter k as finite
-  /// subexponential based on a reference ref also in [0, n-1].
-  /// v: value to encode
-  /// n: size of interval
-  /// k: 'parameter'
-  /// r: reference
+  /// Returns `QOD_BITRES` bits for symbol `v` in `[0, n-1]`
+  /// with parameter `k` as finite subexponential based on a
+  /// reference `r` also in `[0, n-1]`.
+  ///
+  /// - `v`: value to encode
+  /// - `n`: size of interval
+  /// - `k`: "parameter"
+  /// - `r`: reference
   fn count_unsigned_subexp_with_ref(
     &self, v: u32, n: u32, k: u8, r: u32,
   ) -> u32 {
@@ -725,12 +744,13 @@ where
       self.count_subexp(n, k, Self::recenter(n - 1 - r, n - 1 - v))
     }
   }
-  /// Write symbol v in [-(n-1), n-1] with parameter k as finite
-  /// subexponential based on a reference ref also in [-(n-1), n-1].
-  /// v: value to encode
-  /// n: size of interval
-  /// k: 'parameter'
-  /// r: reference
+  /// Write symbol `v` in `[-(n-1), n-1]` with parameter `k` as finite
+  /// subexponential based on a reference `r` also in `[-(n-1), n-1]`.
+  ///
+  /// - `v`: value to encode
+  /// - `n`: size of interval
+  /// - `k`: "parameter"
+  /// - `r`: reference
   fn write_signed_subexp_with_ref(
     &mut self, v: i32, low: i32, high: i32, k: u8, r: i32,
   ) {
@@ -741,12 +761,15 @@ where
       (r - low) as u32,
     );
   }
-  /// Returns QOD_BITRES bits for symbol v in [-(n-1), n-1] with parameter k as finite
-  /// subexponential based on a reference ref also in [-(n-1), n-1].
-  /// v: value to encode
-  /// n: size of interval
-  /// k: 'parameter'
-  /// r: reference
+  /// Returns `QOD_BITRES` bits for symbol `v` in `[-(n-1), n-1]`
+  /// with parameter `k` as finite subexponential based on a
+  /// reference `r` also in `[-(n-1), n-1]`.
+  ///
+  /// - `v`: value to encode
+  /// - `n`: size of interval
+  /// - `k`: "parameter"
+  /// - `r`: reference
+
   fn count_signed_subexp_with_ref(
     &self, v: i32, low: i32, high: i32, k: u8, r: i32,
   ) -> u32 {
@@ -760,7 +783,8 @@ where
   /// Returns the number of bits "used" by the encoded symbols so far.
   /// This same number can be computed in either the encoder or the
   /// decoder, and is suitable for making coding decisions.  The value
-  /// will be the same whether using an Encoder or Recorder.
+  /// will be the same whether using an `Encoder` or `Recorder`.
+  ///
   /// Return: The integer number of bits.
   ///         This will always be slightly larger than the exact value (e.g., all
   ///          rounding error is in the positive direction).
@@ -773,7 +797,8 @@ where
   /// Returns the number of bits "used" by the encoded symbols so far.
   /// This same number can be computed in either the encoder or the
   /// decoder, and is suitable for making coding decisions. The value
-  /// will be the same whether using an Encoder or Recorder.
+  /// will be the same whether using an `Encoder` or `Recorder`.
+  ///
   /// Return: The number of bits scaled by `2**OD_BITRES`.
   ///         This will always be slightly larger than the exact value (e.g., all
   ///          rounding error is in the positive direction).
@@ -781,14 +806,15 @@ where
     Self::frac_compute(self.tell(), self.rng as u32) + self.fake_bits_frac
   }
   /// Save current point in coding/recording to a checkpoint that can
-  /// be restored later.  A WriterCheckpoint can be generated for an
-  /// Encoder or Recorder, but can only be used to rollback the Writer
+  /// be restored later.  A `WriterCheckpoint` can be generated for an
+  /// `Encoder` or `Recorder`, but can only be used to rollback the `Writer`
   /// instance from which it was generated.
   fn checkpoint(&mut self) -> WriterCheckpoint {
     StorageBackend::checkpoint(self)
   }
-  /// Roll back a given Writer to the state saved in the WriterCheckpoint
-  /// 'wc': Saved Writer state/posiiton to restore
+  /// Roll back a given `Writer` to the state saved in the `WriterCheckpoint`
+  ///
+  /// - 'wc': Saved `Writer` state/posiiton to restore
   fn rollback(&mut self, wc: &WriterCheckpoint) {
     StorageBackend::rollback(self, wc)
   }
@@ -797,13 +823,25 @@ where
 pub trait BCodeWriter {
   fn recenter_nonneg(&mut self, r: u16, v: u16) -> u16;
   fn recenter_finite_nonneg(&mut self, n: u16, r: u16, v: u16) -> u16;
+  /// # Errors
+  ///
+  /// - Returns `std::io::Error` if the writer cannot be written to.
   fn write_quniform(&mut self, n: u16, v: u16) -> Result<(), std::io::Error>;
+  /// # Errors
+  ///
+  /// - Returns `std::io::Error` if the writer cannot be written to.
   fn write_subexpfin(
     &mut self, n: u16, k: u16, v: u16,
   ) -> Result<(), std::io::Error>;
+  /// # Errors
+  ///
+  /// - Returns `std::io::Error` if the writer cannot be written to.
   fn write_refsubexpfin(
     &mut self, n: u16, k: u16, r: i16, v: i16,
   ) -> Result<(), std::io::Error>;
+  /// # Errors
+  ///
+  /// - Returns `std::io::Error` if the writer cannot be written to.
   fn write_s_refsubexpfin(
     &mut self, n: u16, k: u16, r: i16, v: i16,
   ) -> Result<(), std::io::Error>;

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -1080,12 +1080,12 @@ mod test {
 
     let mut r = Reader::new(&b);
 
-    assert_eq!(r.bool(1), false);
-    assert_eq!(r.bool(2), true);
-    assert_eq!(r.bool(3), false);
-    assert_eq!(r.bool(1), true);
-    assert_eq!(r.bool(2), true);
-    assert_eq!(r.bool(3), false);
+    assert!(!r.bool(1));
+    assert!(r.bool(2));
+    assert!(!r.bool(3));
+    assert!(r.bool(1));
+    assert!(r.bool(2));
+    assert!(!r.bool(3));
   }
 
   #[test]
@@ -1145,15 +1145,15 @@ mod test {
     let mut r = Reader::new(&b);
 
     assert_eq!(r.symbol(&cdf), 0);
-    assert_eq!(r.bool(2), true);
+    assert!(r.bool(2));
     assert_eq!(r.symbol(&cdf), 0);
-    assert_eq!(r.bool(2), true);
+    assert!(r.bool(2));
     assert_eq!(r.symbol(&cdf), 0);
-    assert_eq!(r.bool(2), true);
+    assert!(r.bool(2));
     assert_eq!(r.symbol(&cdf), 1);
-    assert_eq!(r.bool(1), true);
+    assert!(r.bool(1));
     assert_eq!(r.symbol(&cdf), 1);
-    assert_eq!(r.bool(2), false);
+    assert!(!r.bool(2));
     assert_eq!(r.symbol(&cdf), 1);
     assert_eq!(r.symbol(&cdf), 2);
     assert_eq!(r.symbol(&cdf), 2);

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -165,7 +165,7 @@ pub struct WriterCheckpoint {
 /// Constructor for a counting Writer
 impl WriterCounter {
   #[inline]
-  pub fn new() -> WriterBase<WriterCounter> {
+  pub const fn new() -> WriterBase<WriterCounter> {
     WriterBase::new(WriterCounter { bytes: 0 })
   }
 }
@@ -173,7 +173,7 @@ impl WriterCounter {
 /// Constructor for a recording Writer
 impl WriterRecorder {
   #[inline]
-  pub fn new() -> WriterBase<WriterRecorder> {
+  pub const fn new() -> WriterBase<WriterRecorder> {
     WriterBase::new(WriterRecorder { storage: Vec::new(), bytes: 0 })
   }
 }
@@ -181,7 +181,7 @@ impl WriterRecorder {
 /// Constructor for a encoding Writer
 impl WriterEncoder {
   #[inline]
-  pub fn new() -> WriterBase<WriterEncoder> {
+  pub const fn new() -> WriterBase<WriterEncoder> {
     WriterBase::new(WriterEncoder { precarry: Vec::new(), low: 0 })
   }
 }
@@ -318,20 +318,20 @@ impl<S> WriterBase<S> {
   /// Internal constructor called by the subtypes that implement the
   /// actual encoder and Recorder.
   #[inline]
+  #[cfg(not(feature = "desync_finder"))]
+  const fn new(storage: S) -> Self {
+    WriterBase { rng: 0x8000, cnt: -9, fake_bits_frac: 0, s: storage }
+  }
+
+  #[inline]
+  #[cfg(feature = "desync_finder")]
   fn new(storage: S) -> Self {
-    #[cfg(feature = "desync_finder")]
-    {
-      WriterBase {
-        rng: 0x8000,
-        cnt: -9,
-        debug: std::env::var_os("RAV1E_DEBUG").is_some(),
-        fake_bits_frac: 0,
-        s: storage,
-      }
-    }
-    #[cfg(not(feature = "desync_finder"))]
-    {
-      WriterBase { rng: 0x8000, cnt: -9, fake_bits_frac: 0, s: storage }
+    WriterBase {
+      rng: 0x8000,
+      cnt: -9,
+      debug: std::env::var_os("RAV1E_DEBUG").is_some(),
+      fake_bits_frac: 0,
+      s: storage,
     }
   }
 
@@ -387,7 +387,7 @@ impl<S> WriterBase<S> {
     nbits - l
   }
 
-  fn recenter(r: u32, v: u32) -> u32 {
+  const fn recenter(r: u32, v: u32) -> u32 {
     if v > (r << 1) {
       v
     } else if v >= r {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -121,7 +121,7 @@ const DELTA_FRAME_ID_LENGTH: u32 = 14;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Sequence {
-  // OBU Sequence header of AV1
+  /// OBU Sequence header of AV1
   pub profile: u8,
   pub num_bits_width: u32,
   pub num_bits_height: u32,
@@ -139,46 +139,65 @@ pub struct Sequence {
   pub delta_frame_id_length: u32,
   pub use_128x128_superblock: bool,
   pub order_hint_bits_minus_1: u32,
-  pub force_screen_content_tools: u32, // 0 - force off
-  // 1 - force on
-  // 2 - adaptive
-  pub force_integer_mv: u32, // 0 - Not to force. MV can be in 1/4 or 1/8
-  // 1 - force to integer
-  // 2 - adaptive
-  pub still_picture: bool, // Video is a single frame still picture
-  pub reduced_still_picture_hdr: bool, // Use reduced header for still picture
-  pub enable_filter_intra: bool, // enables/disables filter_intra
-  pub enable_intra_edge_filter: bool, // enables/disables corner/edge filtering and upsampling
-  pub enable_interintra_compound: bool, // enables/disables interintra_compound
-  pub enable_masked_compound: bool,   // enables/disables masked compound
-  pub enable_dual_filter: bool,       // 0 - disable dual interpolation filter
-  // 1 - enable vert/horiz filter selection
-  pub enable_order_hint: bool, // 0 - disable order hint, and related tools
-  // jnt_comp, ref_frame_mvs, frame_sign_bias
-  // if 0, enable_jnt_comp and
-  // enable_ref_frame_mvs must be set zs 0.
-  pub enable_jnt_comp: bool, // 0 - disable joint compound modes
-  // 1 - enable it
-  pub enable_ref_frame_mvs: bool, // 0 - disable ref frame mvs
-  // 1 - enable it
-  pub enable_warped_motion: bool, // 0 - disable warped motion for sequence
-  // 1 - enable it for the sequence
-  pub enable_superres: bool, // 0 - Disable superres for the sequence, and disable
-  //     transmitting per-frame superres enabled flag.
-  // 1 - Enable superres for the sequence, and also
-  //     enable per-frame flag to denote if superres is
-  //     enabled for that frame.
-  pub enable_cdef: bool,        // To turn on/off CDEF
-  pub enable_restoration: bool, // To turn on/off loop restoration
-  pub enable_large_lru: bool, // To turn on/off larger-than-superblock loop restoration units
-  pub enable_delayed_loopfilter_rdo: bool, // allow encoder to delay loop filter RDO/coding until after frame reconstruciton is complete
+  /// 0 - force off
+  /// 1 - force on
+  /// 2 - adaptive
+  pub force_screen_content_tools: u32,
+  /// 0 - Not to force. MV can be in 1/4 or 1/8
+  /// 1 - force to integer
+  /// 2 - adaptive
+  pub force_integer_mv: u32,
+  /// Video is a single frame still picture
+  pub still_picture: bool,
+  /// Use reduced header for still picture
+  pub reduced_still_picture_hdr: bool,
+  /// enables/disables filter_intra
+  pub enable_filter_intra: bool,
+  /// enables/disables corner/edge filtering and upsampling
+  pub enable_intra_edge_filter: bool,
+  /// enables/disables interintra_compound
+  pub enable_interintra_compound: bool,
+  /// enables/disables masked compound
+  pub enable_masked_compound: bool,
+  /// 0 - disable dual interpolation filter
+  /// 1 - enable vert/horiz filter selection
+  pub enable_dual_filter: bool,
+  /// 0 - disable order hint, and related tools
+  /// jnt_comp, ref_frame_mvs, frame_sign_bias
+  /// if 0, enable_jnt_comp and
+  /// enable_ref_frame_mvs must be set zs 0.
+  pub enable_order_hint: bool,
+  /// 0 - disable joint compound modes
+  /// 1 - enable it
+  pub enable_jnt_comp: bool,
+  /// 0 - disable ref frame mvs
+  /// 1 - enable it
+  pub enable_ref_frame_mvs: bool,
+  /// 0 - disable warped motion for sequence
+  /// 1 - enable it for the sequence
+  pub enable_warped_motion: bool,
+  /// 0 - Disable superres for the sequence, and disable
+  ///     transmitting per-frame superres enabled flag.
+  /// 1 - Enable superres for the sequence, and also
+  ///     enable per-frame flag to denote if superres is
+  ///     enabled for that frame.
+  pub enable_superres: bool,
+  /// To turn on/off CDEF
+  pub enable_cdef: bool,
+  /// To turn on/off loop restoration
+  pub enable_restoration: bool,
+  /// To turn on/off larger-than-superblock loop restoration units
+  pub enable_large_lru: bool,
+  /// allow encoder to delay loop filter RDO/coding until after frame reconstruciton is complete
+  pub enable_delayed_loopfilter_rdo: bool,
   pub operating_points_cnt_minus_1: usize,
   pub operating_point_idc: [u16; MAX_NUM_OPERATING_POINTS],
   pub display_model_info_present_flag: bool,
   pub decoder_model_info_present_flag: bool,
-  pub level: [[usize; 2]; MAX_NUM_OPERATING_POINTS], // minor, major
-  pub tier: [usize; MAX_NUM_OPERATING_POINTS], // seq_tier in the spec. One bit: 0
-  // or 1.
+  /// minor, major
+  pub level: [[usize; 2]; MAX_NUM_OPERATING_POINTS],
+  /// seq_tier in the spec. One bit: 0 or 1.
+  pub tier: [usize; MAX_NUM_OPERATING_POINTS],
   pub film_grain_params_present: bool,
   pub timing_info_present: bool,
   pub tiling: TilingInfo,
@@ -186,6 +205,9 @@ pub struct Sequence {
 }
 
 impl Sequence {
+  /// # Panics
+  ///
+  /// Panics if the resulting tile sizes would be too large.
   pub fn new(config: &EncoderConfig) -> Sequence {
     let width_bits = 32 - (config.width as u32).leading_zeros();
     let height_bits = 32 - (config.height as u32).leading_zeros();
@@ -688,6 +710,9 @@ pub(crate) const fn pos_to_lvl(pos: u64, pyramid_depth: u64) -> u64 {
 
 impl<T: Pixel> FrameInvariants<T> {
   #[allow(clippy::erasing_op, clippy::identity_op)]
+  /// # Panics
+  ///
+  /// - If the size of `T` does not match the sequence's bit depth
   pub fn new(config: Arc<EncoderConfig>, sequence: Arc<Sequence>) -> Self {
     assert!(
       sequence.bit_depth <= mem::size_of::<T>() * 8,
@@ -815,7 +840,7 @@ impl<T: Pixel> FrameInvariants<T> {
     fi
   }
 
-  /// Returns the created FrameInvariants, or `None` if this should be
+  /// Returns the created `FrameInvariants`, or `None` if this should be
   /// a placeholder frame.
   pub(crate) fn new_inter_frame(
     previous_coded_fi: &Self, inter_cfg: &InterConfig,
@@ -1114,6 +1139,9 @@ impl<T: Pixel> fmt::Display for FrameInvariants<T> {
   }
 }
 
+/// # Errors
+///
+/// - If the frame packet cannot be written to
 pub fn write_temporal_delimiter(packet: &mut dyn io::Write) -> io::Result<()> {
   packet.write_all(&TEMPORAL_DELIMITER)?;
   Ok(())
@@ -1196,9 +1224,14 @@ fn get_qidx<T: Pixel>(
   qidx
 }
 
-// For a transform block,
-// predict, transform, quantize, write coefficients to a bitstream,
-// dequantize, inverse-transform.
+/// For a transform block,
+/// predict, transform, quantize, write coefficients to a bitstream,
+/// dequantize, inverse-transform.
+///
+/// # Panics
+///
+/// - If the block size is invalid for subsampling
+/// - If a tx type other than DCT is used for 64x64 blocks
 pub fn encode_tx_block<T: Pixel, W: Writer>(
   fi: &FrameInvariants<T>,
   ts: &mut TileStateMut<'_, T>,
@@ -1299,13 +1332,18 @@ pub fn encode_tx_block<T: Pixel, W: Writer>(
   }
 
   let coded_tx_area = av1_get_coded_tx_size(tx_size).area();
-  let mut residual_storage: Aligned<[i16; 64 * 64]> = Aligned::uninitialized();
+  // SAFETY: We write to the array below before reading from it.
+  let mut residual_storage: Aligned<[i16; 64 * 64]> =
+    unsafe { Aligned::uninitialized() };
+  // SAFETY: We write to the array below before reading from it.
   let mut coeffs_storage: Aligned<[T::Coeff; 64 * 64]> =
-    Aligned::uninitialized();
+    unsafe { Aligned::uninitialized() };
+  // SAFETY: We write to the array below before reading from it.
   let mut qcoeffs_storage: Aligned<[MaybeUninit<T::Coeff>; 32 * 32]> =
-    Aligned::uninitialized();
+    unsafe { Aligned::uninitialized() };
+  // SAFETY: We write to the array below before reading from it.
   let mut rcoeffs_storage: Aligned<[T::Coeff; 32 * 32]> =
-    Aligned::uninitialized();
+    unsafe { Aligned::uninitialized() };
   let residual = &mut residual_storage.data[..tx_size.area()];
   let coeffs = &mut coeffs_storage.data[..tx_size.area()];
   let qcoeffs = init_slice_repeat_mut(
@@ -1447,6 +1485,9 @@ pub fn encode_tx_block<T: Pixel, W: Writer>(
   (has_coeff, tx_dist)
 }
 
+/// # Panics
+///
+/// - If the block size is invalid for subsampling
 pub fn motion_compensate<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, luma_mode: PredictionMode, ref_frames: [RefType; 2],
@@ -1711,6 +1752,10 @@ pub fn encode_block_pre_cdef<T: Pixel, W: Writer>(
   cw.bc.cdef_coded
 }
 
+/// # Panics
+///
+/// - If chroma and luma do not match for inter modes
+/// - If an invalid motion vector is found
 pub fn encode_block_post_cdef<T: Pixel, W: Writer>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, w: &mut W, luma_mode: PredictionMode,
@@ -2013,6 +2058,9 @@ pub fn encode_block_post_cdef<T: Pixel, W: Writer>(
   }
 }
 
+/// # Panics
+///
+/// - If the block size is invalid for subsampling
 pub fn luma_ac<T: Pixel>(
   ac: &mut [i16], ts: &mut TileStateMut<'_, T>, tile_bo: TileBlockOffset,
   bsize: BlockSize, tx_size: TxSize, fi: &FrameInvariants<T>,
@@ -2083,6 +2131,9 @@ pub fn luma_ac<T: Pixel>(
   }
 }
 
+/// # Panics
+///
+/// - If attempting to encode a lossless block (not yet supported)
 pub fn write_tx_blocks<T: Pixel, W: Writer>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, w: &mut W, luma_mode: PredictionMode,
@@ -2097,7 +2148,8 @@ pub fn write_tx_blocks<T: Pixel, W: Writer>(
   assert_ne!(qidx, 0); // lossless is not yet supported
 
   let PlaneConfig { xdec, ydec, .. } = ts.input.planes[1].cfg;
-  let mut ac: Aligned<[i16; 32 * 32]> = Aligned::uninitialized();
+  // SAFETY: We write to the array below before reading from it.
+  let mut ac: Aligned<[i16; 32 * 32]> = unsafe { Aligned::uninitialized() };
   let mut partition_has_coeff: bool = false;
   let mut tx_dist = ScaledDistortion::zero();
   let do_chroma =
@@ -3521,10 +3573,14 @@ fn write_tile_group_header(tile_start_and_end_present_flag: bool) -> Vec<u8> {
   buf
 }
 
-// Write a packet containing only the placeholder that tells the decoder
-// to present the already decoded frame present at `frame_to_show_map_idx`
-//
-// See `av1-spec` Section 6.8.2 and 7.18.
+/// Write a packet containing only the placeholder that tells the decoder
+/// to present the already decoded frame present at `frame_to_show_map_idx`
+///
+/// See `av1-spec` Section 6.8.2 and 7.18.
+///
+/// # Panics
+///
+/// - If the frame packets cannot be written
 pub fn encode_show_existing_frame<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>, inter_cfg: &InterConfig,
 ) -> Vec<u8> {
@@ -3588,6 +3644,9 @@ fn get_initial_segmentation<T: Pixel>(
   segmentation.unwrap_or_default()
 }
 
+/// # Panics
+///
+/// - If the frame packets cannot be written
 pub fn encode_frame<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>, inter_cfg: &InterConfig,
 ) -> Vec<u8> {

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -54,7 +54,7 @@ pub(crate) trait FrameAlloc {
 
 impl<T: Pixel> FrameAlloc for Frame<T> {
   /// Creates a new frame with the given parameters.
-  /// new function calls new_with_padding function which takes luma_padding
+  /// new function calls `new_with_padding` function which takes `luma_padding`
   /// as parameter
   fn new(
     width: usize, height: usize, chroma_sampling: ChromaSampling,

--- a/src/header.rs
+++ b/src/header.rs
@@ -76,7 +76,7 @@ pub enum ObuMetaType {
 }
 
 impl ObuMetaType {
-  fn size(self) -> u64 {
+  const fn size(self) -> u64 {
     use self::ObuMetaType::*;
     match self {
       OBU_META_HDR_CLL => 4,
@@ -96,7 +96,7 @@ impl<W: io::Write> ULEB128Writer for BitWriter<W, BigEndian> {
     // Disallow values larger than 32-bits to ensure consistent behavior on 32 and
     // 64 bit targets: value is typically used to determine buffer allocation size
     // when decoded.
-    fn uleb_size_in_bytes(mut value: u64) -> usize {
+    const fn uleb_size_in_bytes(mut value: u64) -> usize {
       let mut size = 0;
       loop {
         size += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 #![allow(clippy::enum_variant_names)]
 // Performance lints
 #![warn(clippy::linkedlist)]
+#![warn(clippy::missing_const_for_fn)]
 #![warn(clippy::mutex_integer)]
 // Correctness lints
 #![warn(clippy::expl_impl_clone_on_copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,15 +48,18 @@
 #![allow(clippy::comparison_chain)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::enum_variant_names)]
-#![warn(clippy::expl_impl_clone_on_copy)]
+// Performance lints
 #![warn(clippy::linkedlist)]
-#![warn(clippy::map_flatten)]
-#![warn(clippy::mem_forget)]
-#![warn(clippy::mut_mut)]
 #![warn(clippy::mutex_integer)]
+// Correctness lints
+#![warn(clippy::expl_impl_clone_on_copy)]
+#![warn(clippy::mem_forget)]
+#![warn(clippy::path_buf_push_overwrite)]
+// Clarity/formatting lints
+#![warn(clippy::map_flatten)]
+#![warn(clippy::mut_mut)]
 #![warn(clippy::needless_borrow)]
 #![warn(clippy::needless_continue)]
-#![warn(clippy::path_buf_push_overwrite)]
 #![warn(clippy::range_plus_one)]
 
 // Override assert! and assert_eq! in tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,11 @@
 #![warn(clippy::needless_borrow)]
 #![warn(clippy::needless_continue)]
 #![warn(clippy::range_plus_one)]
+// Documentation lints
+#![warn(clippy::doc_markdown)]
+#![warn(clippy::missing_errors_doc)]
+#![warn(clippy::missing_panics_doc)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 // Override assert! and assert_eq! in tests
 #[cfg(test)]
@@ -242,7 +247,8 @@ mod rdo_tables;
 #[macro_use]
 mod util;
 mod cdef;
-mod context;
+#[doc(hidden)]
+pub mod context;
 mod deblock;
 mod encoder;
 mod entropymode;
@@ -259,7 +265,8 @@ pub mod scenechange;
 mod scenechange;
 mod segmentation;
 mod stats;
-mod tiling;
+#[doc(hidden)]
+pub mod tiling;
 mod token_cdfs;
 
 mod api;
@@ -331,6 +338,11 @@ pub mod version {
   /// Major version component
   ///
   /// It is increased every time a release presents a incompatible API change.
+  ///
+  /// # Panics
+  ///
+  /// Will panic if package is not built with Cargo,
+  /// or if the package version is not a valid triplet of integers.
   pub fn major() -> u64 {
     env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap()
   }
@@ -338,19 +350,29 @@ pub mod version {
   ///
   /// It is increased every time a release presents new functionalities are added
   /// in a backwards-compatible manner.
+  ///
+  /// # Panics
+  ///
+  /// Will panic if package is not built with Cargo,
+  /// or if the package version is not a valid triplet of integers.
   pub fn minor() -> u64 {
     env!("CARGO_PKG_VERSION_MINOR").parse().unwrap()
   }
   /// Patch version component
   ///
   /// It is increased every time a release provides only backwards-compatible bugfixes.
+  ///
+  /// # Panics
+  ///
+  /// Will panic if package is not built with Cargo,
+  /// or if the package version is not a valid triplet of integers.
   pub fn patch() -> u64 {
     env!("CARGO_PKG_VERSION_PATCH").parse().unwrap()
   }
 
   /// Version information as presented in `[package]` `version`.
   ///
-  /// e.g. `0.1.0``
+  /// e.g. `0.1.0`
   ///
   /// Can be parsed by [semver](https://crates.io/crates/semver).
   pub fn short() -> String {

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -86,7 +86,7 @@ const SGRPROJ_ALL_SETS: &[u8] =
 // 1st, 3rd, ... smallest params of each group.
 const SGRPROJ_REDUCED_SETS: &[u8] = &[1, 3, 5, 7, 9, 11, 13, 15];
 
-pub fn get_sgr_sets(complexity: SGRComplexityLevel) -> &'static [u8] {
+pub const fn get_sgr_sets(complexity: SGRComplexityLevel) -> &'static [u8] {
   match complexity {
     SGRComplexityLevel::Full => SGRPROJ_ALL_SETS,
     SGRComplexityLevel::Reduced => SGRPROJ_REDUCED_SETS,
@@ -137,7 +137,7 @@ impl Default for RestorationFilter {
 }
 
 impl RestorationFilter {
-  pub fn notequal(self, cmp: RestorationFilter) -> bool {
+  pub const fn notequal(self, cmp: RestorationFilter) -> bool {
     match self {
       RestorationFilter::None {} => !matches!(cmp, RestorationFilter::None {}),
       RestorationFilter::Sgrproj { set, xqd } => {
@@ -359,7 +359,7 @@ fn sgrproj_sum_finish(
 }
 
 // Using an integral image, compute the sum of a square region
-fn get_integral_square(
+const fn get_integral_square(
   iimg: &[u32], stride: usize, x: usize, y: usize, size: usize,
 ) -> u32 {
   // Cancel out overflow in iimg by using wrapping arithmetic

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -38,12 +38,12 @@ impl MotionVector {
   }
 
   #[inline]
-  pub fn is_zero(self) -> bool {
+  pub const fn is_zero(self) -> bool {
     self.row == 0 && self.col == 0
   }
 
   #[inline]
-  pub fn is_valid(self) -> bool {
+  pub const fn is_valid(self) -> bool {
     use crate::context::{MV_LOW, MV_UPP};
     ((MV_LOW as i16) < self.row && self.row < (MV_UPP as i16))
       && ((MV_LOW as i16) < self.col && self.col < (MV_UPP as i16))

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -277,6 +277,8 @@ pub(crate) mod rust {
           for c in 0..width {
             dst_slice[c] = T::cast_from(
               round_shift(
+                // SAFETY: We pass this a raw pointer, but it's created from a
+                // checked slice, so we are safe.
                 unsafe {
                   run_filter(src_slice[c..].as_ptr(), ref_stride, y_filter)
                 },
@@ -297,6 +299,8 @@ pub(crate) mod rust {
             dst_slice[c] = T::cast_from(
               round_shift(
                 round_shift(
+                  // SAFETY: We pass this a raw pointer, but it's created from a
+                  // checked slice, so we are safe.
                   unsafe { run_filter(src_slice[c..].as_ptr(), 1, x_filter) },
                   7 - intermediate_bits,
                 ),
@@ -317,6 +321,8 @@ pub(crate) mod rust {
             let src_slice = &offset_slice[r];
             for c in cg..(cg + 8).min(width) {
               intermediate[8 * r + (c - cg)] = round_shift(
+                // SAFETY: We pass this a raw pointer, but it's created from a
+                // checked slice, so we are safe.
                 unsafe { run_filter(src_slice[c..].as_ptr(), 1, x_filter) },
                 7 - intermediate_bits,
               ) as i16;
@@ -328,6 +334,8 @@ pub(crate) mod rust {
             for c in cg..(cg + 8).min(width) {
               dst_slice[c] = T::cast_from(
                 round_shift(
+                  // SAFETY: We pass this a raw pointer, but it's created from a
+                  // checked slice, so we are safe.
                   unsafe {
                     run_filter(
                       intermediate[8 * r + c - cg..].as_ptr(),
@@ -383,6 +391,8 @@ pub(crate) mod rust {
           let src_slice = &offset_slice[r];
           for c in 0..width {
             tmp[r * width + c] = (round_shift(
+              // SAFETY: We pass this a raw pointer, but it's created from a
+              // checked slice, so we are safe.
               unsafe {
                 run_filter(src_slice[c..].as_ptr(), ref_stride, y_filter)
               },
@@ -397,6 +407,8 @@ pub(crate) mod rust {
           let src_slice = &offset_slice[r];
           for c in 0..width {
             tmp[r * width + c] = (round_shift(
+              // SAFETY: We pass this a raw pointer, but it's created from a
+              // checked slice, so we are safe.
               unsafe { run_filter(src_slice[c..].as_ptr(), 1, x_filter) },
               7 - intermediate_bits,
             ) - prep_bias) as i16;
@@ -412,6 +424,8 @@ pub(crate) mod rust {
             let src_slice = &offset_slice[r];
             for c in cg..(cg + 8).min(width) {
               intermediate[8 * r + (c - cg)] = round_shift(
+                // SAFETY: We pass this a raw pointer, but it's created from a
+                // checked slice, so we are safe.
                 unsafe { run_filter(src_slice[c..].as_ptr(), 1, x_filter) },
                 7 - intermediate_bits,
               ) as i16;
@@ -421,6 +435,8 @@ pub(crate) mod rust {
           for r in 0..height {
             for c in cg..(cg + 8).min(width) {
               tmp[r * width + c] = (round_shift(
+                // SAFETY: We pass this a raw pointer, but it's created from a
+                // checked slice, so we are safe.
                 unsafe {
                   run_filter(
                     intermediate[8 * r + c - cg..].as_ptr(),

--- a/src/me.rs
+++ b/src/me.rs
@@ -105,7 +105,7 @@ impl MotionSearchResult {
 
   /// Check if the value should be considered to be empty.
   #[inline(always)]
-  fn is_empty(&self) -> bool {
+  const fn is_empty(&self) -> bool {
     self.cost == u64::MAX
   }
 }
@@ -126,7 +126,7 @@ impl MVCandidateRD {
   /// cost value. The idea is that comparing to any valid rd output, the search
   /// result will always be replaced.
   #[inline(always)]
-  fn empty() -> MVCandidateRD {
+  const fn empty() -> MVCandidateRD {
     MVCandidateRD { sad: u32::MAX, cost: u64::MAX }
   }
 }
@@ -156,7 +156,7 @@ impl FullpelSearchResult {
 
   /// Check if the value should be considered to be empty.
   #[inline(always)]
-  fn is_empty(&self) -> bool {
+  const fn is_empty(&self) -> bool {
     self.rd.cost == u64::MAX
   }
 }
@@ -748,7 +748,7 @@ struct FullpelConfig {
 
 impl FullpelConfig {
   /// Configuration for motion estimation with full search and sub-sampling disabled.
-  fn create_motion_estimation_config() -> Self {
+  const fn create_motion_estimation_config() -> Self {
     FullpelConfig {
       corner: MVSamplingMode::CORNER { right: true, bottom: true },
       extensive_search: false,

--- a/src/me.rs
+++ b/src/me.rs
@@ -1383,7 +1383,8 @@ fn subpel_diamond_search<T: Pixel>(
   // Metadata for subpel scratch pad.
   let cfg = PlaneConfig::new(mc_w, mc_h, 0, 0, 0, 0, std::mem::size_of::<T>());
   // Stack allocation for subpel scratch pad.
-  let mut buf: Aligned<[T; 128 * 128]> = Aligned::uninitialized();
+  // SAFETY: We write to the array below before reading from it.
+  let mut buf: Aligned<[T; 128 * 128]> = unsafe { Aligned::uninitialized() };
   let mut tmp_region = PlaneRegionMut::from_slice(
     &mut buf.data,
     &cfg,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -190,7 +190,7 @@ impl BlockSize {
   ///
   /// - Returns `InvalidBlockSize` if the given `w` and `h` do not produce
   ///   a valid block size.
-  pub fn from_width_and_height_opt(
+  pub const fn from_width_and_height_opt(
     w: usize, h: usize,
   ) -> Result<BlockSize, InvalidBlockSize> {
     match (w, h) {
@@ -234,12 +234,12 @@ impl BlockSize {
   }
 
   #[inline]
-  pub fn width(self) -> usize {
+  pub const fn width(self) -> usize {
     1 << self.width_log2()
   }
 
   #[inline]
-  pub fn width_log2(self) -> usize {
+  pub const fn width_log2(self) -> usize {
     match self {
       BLOCK_4X4 | BLOCK_4X8 | BLOCK_4X16 => 2,
       BLOCK_8X4 | BLOCK_8X8 | BLOCK_8X16 | BLOCK_8X32 => 3,
@@ -251,12 +251,12 @@ impl BlockSize {
   }
 
   #[inline]
-  pub fn width_mi_log2(self) -> usize {
+  pub const fn width_mi_log2(self) -> usize {
     self.width_log2() - 2
   }
 
   #[inline]
-  pub fn width_mi(self) -> usize {
+  pub const fn width_mi(self) -> usize {
     self.width() >> MI_SIZE_LOG2
   }
 
@@ -267,12 +267,12 @@ impl BlockSize {
   }
 
   #[inline]
-  pub fn height(self) -> usize {
+  pub const fn height(self) -> usize {
     1 << self.height_log2()
   }
 
   #[inline]
-  pub fn height_log2(self) -> usize {
+  pub const fn height_log2(self) -> usize {
     match self {
       BLOCK_4X4 | BLOCK_8X4 | BLOCK_16X4 => 2,
       BLOCK_4X8 | BLOCK_8X8 | BLOCK_16X8 | BLOCK_32X8 => 3,
@@ -284,12 +284,12 @@ impl BlockSize {
   }
 
   #[inline]
-  pub fn height_mi_log2(self) -> usize {
+  pub const fn height_mi_log2(self) -> usize {
     self.height_log2() - 2
   }
 
   #[inline]
-  pub fn height_mi(self) -> usize {
+  pub const fn height_mi(self) -> usize {
     self.height() >> MI_SIZE_LOG2
   }
 
@@ -300,7 +300,7 @@ impl BlockSize {
   }
 
   #[inline]
-  pub fn tx_size(self) -> TxSize {
+  pub const fn tx_size(self) -> TxSize {
     match self {
       BLOCK_4X4 => TX_4X4,
       BLOCK_4X8 => TX_4X8,
@@ -331,7 +331,7 @@ impl BlockSize {
   /// - Returns `InvalidBlockSize` if the given block size cannot
   ///   be subsampled in the requested way.
   #[inline]
-  pub fn subsampled_size(
+  pub const fn subsampled_size(
     self, xdec: usize, ydec: usize,
   ) -> Result<BlockSize, InvalidBlockSize> {
     Ok(match (xdec, ydec) {
@@ -387,17 +387,19 @@ impl BlockSize {
   }
 
   #[inline]
-  pub fn is_sqr(self) -> bool {
+  pub const fn is_sqr(self) -> bool {
     self.width_log2() == self.height_log2()
   }
 
   #[inline]
-  pub fn is_sub8x8(self, xdec: usize, ydec: usize) -> bool {
+  pub const fn is_sub8x8(self, xdec: usize, ydec: usize) -> bool {
     xdec != 0 && self.width_log2() == 2 || ydec != 0 && self.height_log2() == 2
   }
 
   #[inline]
-  pub fn sub8x8_offset(self, xdec: usize, ydec: usize) -> (isize, isize) {
+  pub const fn sub8x8_offset(
+    self, xdec: usize, ydec: usize,
+  ) -> (isize, isize) {
     let offset_x = if xdec != 0 && self.width_log2() == 2 { -1 } else { 0 };
     let offset_y = if ydec != 0 && self.height_log2() == 2 { -1 } else { 0 };
 
@@ -408,7 +410,7 @@ impl BlockSize {
   ///
   /// - Returns `InvalidBlockSize` if the block size cannot be split
   ///   in the requested way.
-  pub fn subsize(
+  pub const fn subsize(
     self, partition: PartitionType,
   ) -> Result<BlockSize, InvalidBlockSize> {
     use PartitionType::*;
@@ -455,7 +457,7 @@ impl BlockSize {
     })
   }
 
-  pub fn is_rect_tx_allowed(self) -> bool {
+  pub const fn is_rect_tx_allowed(self) -> bool {
     !matches!(
       self,
       BLOCK_4X4

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -121,7 +121,7 @@ pub enum PredictionVariant {
 
 impl PredictionVariant {
   #[inline]
-  fn new(x: usize, y: usize) -> Self {
+  const fn new(x: usize, y: usize) -> Self {
     match (x, y) {
       (0, 0) => PredictionVariant::NONE,
       (_, 0) => PredictionVariant::LEFT,
@@ -138,7 +138,7 @@ impl Default for PredictionMode {
   }
 }
 
-pub fn intra_mode_to_angle(mode: PredictionMode) -> isize {
+pub const fn intra_mode_to_angle(mode: PredictionMode) -> isize {
   match mode {
     PredictionMode::V_PRED => 90,
     PredictionMode::H_PRED => 180,
@@ -267,7 +267,7 @@ impl PredictionMode {
   }
 
   #[inline(always)]
-  pub fn angle_delta_count(self) -> i8 {
+  pub const fn angle_delta_count(self) -> i8 {
     match self {
       PredictionMode::V_PRED
       | PredictionMode::H_PRED
@@ -626,7 +626,7 @@ static sm_weight_arrays: [u8; 2 * MAX_TX_SIZE] = [
 ];
 
 #[inline(always)]
-fn get_scaled_luma_q0(alpha_q3: i16, ac_pred_q3: i16) -> i32 {
+const fn get_scaled_luma_q0(alpha_q3: i16, ac_pred_q3: i16) -> i32 {
   let scaled_luma_q6 = (alpha_q3 as i32) * (ac_pred_q3 as i32);
   let abs_scaled_luma_q0 = (scaled_luma_q6.abs() + 32) >> 6;
   if scaled_luma_q6 < 0 {
@@ -1035,7 +1035,7 @@ pub(crate) mod rust {
     #[allow(clippy::collapsible_if)]
     #[allow(clippy::collapsible_else_if)]
     #[allow(clippy::needless_return)]
-    fn select_ief_strength(
+    const fn select_ief_strength(
       width: usize, height: usize, smooth_filter: bool, angle_delta: isize,
     ) -> u8 {
       let block_wh = width + height;
@@ -1098,7 +1098,7 @@ pub(crate) mod rust {
       return 0;
     }
 
-    fn select_ief_upsample(
+    const fn select_ief_upsample(
       width: usize, height: usize, smooth_filter: bool, angle_delta: isize,
     ) -> bool {
       let block_wh = width + height;
@@ -1262,7 +1262,7 @@ pub(crate) mod rust {
       left_edge = &left_filtered[..];
     }
 
-    fn dr_intra_derivative(p_angle: usize) -> usize {
+    const fn dr_intra_derivative(p_angle: usize) -> usize {
       match p_angle {
         3 => 1023,
         6 => 547,

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -122,7 +122,7 @@ fn divu_gen(d: u32) -> (u32, u32, u32) {
 }
 
 #[inline]
-fn divu_pair(x: u32, d: (u32, u32, u32)) -> u32 {
+const fn divu_pair(x: u32, d: (u32, u32, u32)) -> u32 {
   let x = x as u64;
   let (a, b, shift) = d;
   let shift = shift as u64;
@@ -133,7 +133,7 @@ fn divu_pair(x: u32, d: (u32, u32, u32)) -> u32 {
 }
 
 #[inline]
-fn copysign(value: u32, signed: i32) -> i32 {
+const fn copysign(value: u32, signed: i32) -> i32 {
   if signed < 0 {
     -(value as i32)
   } else {

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -131,8 +131,7 @@ const ATANH_LOG2: &[i64; 32] = &[
 // Computes the binary exponential of logq57.
 // input: a log base 2 in Q57 format.
 // output: a 64 bit integer in Q0 (no fraction).
-// TODO: Mark const once we can use local variables in a const function.
-pub(crate) fn bexp64(logq57: i64) -> i64 {
+pub(crate) const fn bexp64(logq57: i64) -> i64 {
   let ipart = (logq57 >> 57) as i32;
   if ipart < 0 {
     return 0;
@@ -228,7 +227,6 @@ pub(crate) fn bexp64(logq57: i64) -> i64 {
 // Computes the binary log of w.
 // input: a 64-bit integer in Q0 (no fraction).
 // output: a 64-bit log in Q57.
-// TODO: Mark const once we can use local variables in a const function.
 fn blog64(w: i64) -> i64 {
   let mut w = w;
   if w <= 0 {
@@ -308,7 +306,7 @@ const fn q24_to_q57(v: i32) -> i64 {
 // log_scale: A binary logarithm in Q24 format.
 // Return: The binary exponential in Q24 format, saturated to 2**47 - 1 if
 //  log_scale was too large.
-fn bexp_q24(log_scale: i32) -> i64 {
+const fn bexp_q24(log_scale: i32) -> i64 {
   if log_scale < 23 << 24 {
     let ret = bexp64(((log_scale as i64) << 33) + q57(24));
     if ret < (1i64 << 47) - 1 {
@@ -337,7 +335,6 @@ pub struct IIRBessel2 {
 
 // alpha is Q24 in the range [0,0.5).
 // The return value is 5.12.
-// TODO: Mark const once we can use local variables in a const function.
 fn warp_alpha(alpha: i32) -> i32 {
   let i = ((alpha * 36) >> 24).min(16);
   let t0 = ROUGH_TAN_LOOKUP[i as usize];
@@ -1447,11 +1444,11 @@ impl RCState {
     dropped
   }
 
-  pub fn needs_trial_encode(&self, fti: usize) -> bool {
+  pub const fn needs_trial_encode(&self, fti: usize) -> bool {
     self.target_bitrate > 0 && self.nframes[fti] == 0
   }
 
-  pub(crate) fn ready(&self) -> bool {
+  pub(crate) const fn ready(&self) -> bool {
     match self.twopass_state {
       PASS_SINGLE => true,
       PASS_1 => self.pass1_data_retrieved,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -57,7 +57,7 @@ pub enum RDOType {
 
 impl RDOType {
   #[inline]
-  pub fn needs_tx_dist(self) -> bool {
+  pub const fn needs_tx_dist(self) -> bool {
     match self {
       // Pixel-domain distortion and exact ec rate
       RDOType::PixelDistRealRate => false,
@@ -68,7 +68,7 @@ impl RDOType {
     }
   }
   #[inline]
-  pub fn needs_coeff_rate(self) -> bool {
+  pub const fn needs_coeff_rate(self) -> bool {
     match self {
       RDOType::PixelDistRealRate => true,
       RDOType::TxDistRealRate => true,
@@ -222,7 +222,7 @@ pub fn sse_wxh<T: Pixel, F: Fn(Area, BlockSize) -> DistortionScale>(
   ))
 }
 
-pub fn clip_visible_bsize(
+pub const fn clip_visible_bsize(
   frame_w: usize, frame_h: usize, bsize: BlockSize, x: usize, y: usize,
 ) -> (usize, usize) {
   let blk_w = bsize.width();
@@ -585,7 +585,7 @@ impl DistortionScale {
   /// Multiply, round and shift
   /// Internal implementation, so don't use multiply trait.
   #[inline]
-  pub fn mul_u64(self, dist: u64) -> u64 {
+  pub const fn mul_u64(self, dist: u64) -> u64 {
     (self.0 as u64 * dist + (1 << Self::SHIFT >> 1)) >> Self::SHIFT
   }
 }
@@ -749,7 +749,7 @@ pub fn rdo_tx_size_type<T: Pixel>(
 }
 
 #[inline]
-fn dmv_in_range(mv: MotionVector, ref_mv: MotionVector) -> bool {
+const fn dmv_in_range(mv: MotionVector, ref_mv: MotionVector) -> bool {
   let diff_row = mv.row as i32 - ref_mv.row as i32;
   let diff_col = mv.col as i32 - ref_mv.col as i32;
   diff_row >= MV_LOW

--- a/src/tiling/plane_region.rs
+++ b/src/tiling/plane_region.rs
@@ -77,7 +77,7 @@ impl Area {
   /// the returned rect will be aligned to a 4x4 chroma block.
   /// This is necessary for `compute_distortion` and `rdo_cfl_alpha` as
   /// the subsampled chroma block covers multiple luma blocks.
-  pub fn to_rect(
+  pub const fn to_rect(
     &self, xdec: usize, ydec: usize, parent_width: usize, parent_height: usize,
   ) -> Rect {
     match *self {

--- a/src/tiling/plane_region.rs
+++ b/src/tiling/plane_region.rs
@@ -724,7 +724,7 @@ fn frame_block_offset() {
     let bo = BlockOffset { x: 0, y: 0 };
     assert_eq!(
       pr.to_frame_block_offset(TileBlockOffset(bo)),
-      PlaneBlockOffset { 0: bo }
+      PlaneBlockOffset(bo)
     );
     assert_eq!(
       pr.to_frame_block_offset(TileBlockOffset(bo)),
@@ -738,7 +738,7 @@ fn frame_block_offset() {
     let bo = BlockOffset { x: 1, y: 1 };
     assert_eq!(
       pr.to_frame_block_offset(TileBlockOffset(bo)),
-      PlaneBlockOffset { 0: bo }
+      PlaneBlockOffset(bo)
     );
     assert_eq!(
       pr.to_frame_block_offset(TileBlockOffset(bo)),
@@ -752,7 +752,7 @@ fn frame_block_offset() {
     let bo = BlockOffset { x: 1, y: 1 };
     assert_eq!(
       pr.to_frame_block_offset(TileBlockOffset(bo)),
-      PlaneBlockOffset { 0: bo }
+      PlaneBlockOffset(bo)
     );
   }
   {
@@ -762,7 +762,7 @@ fn frame_block_offset() {
     let bo = BlockOffset { x: 2, y: 2 };
     assert_eq!(
       pr.to_frame_block_offset(TileBlockOffset(bo)),
-      PlaneBlockOffset { 0: bo }
+      PlaneBlockOffset(bo)
     );
     assert_eq!(
       pr.to_frame_block_offset(TileBlockOffset(bo)),

--- a/src/tiling/tile.rs
+++ b/src/tiling/tile.rs
@@ -132,12 +132,16 @@ macro_rules! tile_common {
         }
       }
 
-      // Return a view to a subregion of a Tile
-      //
-      // The subregion must be included in (i.e. must not exceed) this Tile.
-      //
-      // It is described by an `Area`, relative to the luma plane of
-      // this region.
+      /// Return a view to a subregion of a Tile
+      ///
+      /// The subregion must be included in (i.e. must not exceed) this Tile.
+      ///
+      /// It is described by an `Area`, relative to the luma plane of
+      /// this region.
+      ///
+      /// # Panics
+      ///
+      /// - If the requested dimensions are larger than the plane size
       #[inline(always)]
       pub fn subregion(&self, area: Area) -> Tile<'_, T> {
         let tile_rect = area.to_rect(

--- a/src/tiling/tile_blocks.rs
+++ b/src/tiling/tile_blocks.rs
@@ -18,7 +18,7 @@ use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
 use std::slice;
 
-/// Tiled view of FrameBlocks
+/// Tiled view of `FrameBlocks`
 #[derive(Debug)]
 pub struct TileBlocks<'a> {
   data: *const Block,
@@ -31,7 +31,7 @@ pub struct TileBlocks<'a> {
   phantom: PhantomData<&'a Block>,
 }
 
-/// Mutable tiled view of FrameBlocks
+/// Mutable tiled view of `FrameBlocks`
 #[derive(Debug)]
 pub struct TileBlocksMut<'a> {
   data: *mut Block,
@@ -150,6 +150,10 @@ macro_rules! tile_blocks_common {
       #[inline(always)]
       fn index(&self, index: usize) -> &Self::Output {
         assert!(index < self.rows);
+        // SAFETY: The above assert ensures we do not access OOB data.
+        //
+        // FIXME: Remove `allow` once https://github.com/rust-lang/rust-clippy/issues/8264 fixed
+        #[allow(clippy::undocumented_unsafe_blocks)]
         unsafe {
           let ptr = self.data.add(index * self.frame_cols);
           slice::from_raw_parts(ptr, self.cols)
@@ -293,6 +297,7 @@ impl IndexMut<usize> for TileBlocksMut<'_> {
   #[inline(always)]
   fn index_mut(&mut self, index: usize) -> &mut Self::Output {
     assert!(index < self.rows);
+    // SAFETY: The above assert ensures we do not access OOB data.
     unsafe {
       let ptr = self.data.add(index * self.frame_cols);
       slice::from_raw_parts_mut(ptr, self.cols)

--- a/src/tiling/tile_restoration_state.rs
+++ b/src/tiling/tile_restoration_state.rs
@@ -17,7 +17,7 @@ use std::ops::{Index, IndexMut};
 use std::ptr;
 use std::slice;
 
-/// Tiled view of RestorationUnits
+/// Tiled view of `RestorationUnits`
 #[derive(Debug)]
 pub struct TileRestorationUnits<'a> {
   data: *const RestorationUnit,
@@ -26,11 +26,12 @@ pub struct TileRestorationUnits<'a> {
   y: usize,
   cols: usize,
   rows: usize,
-  stride: usize, // number of cols in the underlying FrameRestorationUnits
+  /// number of cols in the underlying `FrameRestorationUnits`
+  stride: usize,
   phantom: PhantomData<&'a RestorationUnit>,
 }
 
-/// Mutable tiled view of RestorationUnits
+/// Mutable tiled view of `RestorationUnits`
 #[derive(Debug)]
 pub struct TileRestorationUnitsMut<'a> {
   data: *mut RestorationUnit,
@@ -39,7 +40,8 @@ pub struct TileRestorationUnitsMut<'a> {
   y: usize,
   cols: usize,
   rows: usize,
-  stride: usize, // number of cols in the underlying FrameRestorationUnits
+  /// number of cols in the underlying `FrameRestorationUnits`
+  stride: usize,
   phantom: PhantomData<&'a mut RestorationUnit>,
 }
 
@@ -105,6 +107,10 @@ macro_rules! tile_restoration_units_common {
       #[inline(always)]
       fn index(&self, index: usize) -> &Self::Output {
         assert!(index < self.rows);
+        // SAFETY: The above assert ensures we do not access OOB data.
+        //
+        // FIXME: Remove `allow` once https://github.com/rust-lang/rust-clippy/issues/8264 fixed
+        #[allow(clippy::undocumented_unsafe_blocks)]
         unsafe {
           let ptr = self.data.add(index * self.stride);
           slice::from_raw_parts(ptr, self.cols)
@@ -136,6 +142,7 @@ impl IndexMut<usize> for TileRestorationUnitsMut<'_> {
   #[inline(always)]
   fn index_mut(&mut self, index: usize) -> &mut Self::Output {
     assert!(index < self.rows);
+    // SAFETY: The above assert ensures we do not access OOB data.
     unsafe {
       let ptr = self.data.add(index * self.stride);
       slice::from_raw_parts_mut(ptr, self.cols)
@@ -143,7 +150,7 @@ impl IndexMut<usize> for TileRestorationUnitsMut<'_> {
   }
 }
 
-/// Tiled view of RestorationPlane
+/// Tiled view of `RestorationPlane`
 #[derive(Debug)]
 pub struct TileRestorationPlane<'a> {
   pub rp_cfg: &'a RestorationPlaneConfig,
@@ -152,7 +159,7 @@ pub struct TileRestorationPlane<'a> {
   pub units: TileRestorationUnits<'a>,
 }
 
-/// Mutable tiled view of RestorationPlane
+/// Mutable tiled view of `RestorationPlane`
 #[derive(Debug)]
 pub struct TileRestorationPlaneMut<'a> {
   pub rp_cfg: &'a RestorationPlaneConfig,
@@ -297,13 +304,13 @@ impl<'a> TileRestorationPlaneMut<'a> {
   }
 }
 
-/// Tiled view of RestorationState
+/// Tiled view of `RestorationState`
 #[derive(Debug)]
 pub struct TileRestorationState<'a> {
   pub planes: [TileRestorationPlane<'a>; MAX_PLANES],
 }
 
-/// Mutable tiled view of RestorationState
+/// Mutable tiled view of `RestorationState`
 #[derive(Debug)]
 pub struct TileRestorationStateMut<'a> {
   pub planes: [TileRestorationPlaneMut<'a>; MAX_PLANES],

--- a/src/tiling/tile_restoration_state.rs
+++ b/src/tiling/tile_restoration_state.rs
@@ -196,7 +196,7 @@ macro_rules! tile_restoration_plane_common {
       // superblock belongs to.  The stretch boolean indicates if a
       // superblock that belongs to a stretched LRU should return an
       // index (stretch == true) or None (stretch == false).
-      pub fn restoration_unit_index(&self, sbo: TileSuperBlockOffset, stretch: bool)
+      pub const fn restoration_unit_index(&self, sbo: TileSuperBlockOffset, stretch: bool)
         -> Option<(usize, usize)> {
         if self.units.rows > 0 && self.units.cols > 0 {
           // is this a stretch block?

--- a/src/tiling/tile_state.rs
+++ b/src/tiling/tile_state.rs
@@ -23,25 +23,25 @@ use crate::util::*;
 use std::ops::{Index, IndexMut};
 use std::sync::Arc;
 
-/// Tiled view of FrameState
+/// Tiled view of `FrameState`
 ///
-/// Contrary to PlaneRegionMut and TileMut, there is no const version:
+/// Contrary to `PlaneRegionMut` and `TileMut`, there is no const version:
 ///  - in practice, we don't need it;
 ///  - it would require to instantiate a const version of every of its inner
 ///    tiled views recursively.
 ///
-/// # TileState fields
+/// # `TileState` fields
 ///
-/// The way the FrameState fields are mapped depend on how they are accessed
+/// The way the `FrameState` fields are mapped depend on how they are accessed
 /// tile-wise and frame-wise.
 ///
-/// Some fields (like "qc") are only used during tile-encoding, so they are only
-/// stored in TileState.
+/// Some fields (like `qc`) are only used during tile-encoding, so they are only
+/// stored in `TileState`.
 ///
-/// Some other fields (like "input" or "segmentation") are not written
-/// tile-wise, so they just reference the matching field in FrameState.
+/// Some other fields (like `input` or `segmentation`) are not written
+/// tile-wise, so they just reference the matching field in `FrameState`.
 ///
-/// Some others (like "rec") are written tile-wise, but must be accessible
+/// Some others (like `rec`) are written tile-wise, but must be accessible
 /// frame-wise once the tile views vanish (e.g. for deblocking).
 #[derive(Debug)]
 pub struct TileStateMut<'a, T: Pixel> {

--- a/src/tiling/tiler.rs
+++ b/src/tiling/tiler.rs
@@ -513,7 +513,7 @@ pub mod test {
   }
 
   #[inline]
-  fn b_area(region: &TileBlocksMut<'_>) -> (usize, usize, usize, usize) {
+  const fn b_area(region: &TileBlocksMut<'_>) -> (usize, usize, usize, usize) {
     (region.x(), region.y(), region.cols(), region.rows())
   }
 

--- a/src/transform/forward_shared.rs
+++ b/src/transform/forward_shared.rs
@@ -141,7 +141,7 @@ impl Txfm2DFlipCfg {
   }
 
   /// Determine the flip config, returning `(ud_flip, lr_flip)`
-  fn get_flip_cfg(tx_type: TxType) -> (bool, bool) {
+  const fn get_flip_cfg(tx_type: TxType) -> (bool, bool) {
     use self::TxType::*;
     match tx_type {
       DCT_DCT | ADST_DCT | DCT_ADST | ADST_ADST | IDTX | V_DCT | H_DCT

--- a/src/transform/forward_shared.rs
+++ b/src/transform/forward_shared.rs
@@ -116,6 +116,9 @@ pub struct Txfm2DFlipCfg {
 }
 
 impl Txfm2DFlipCfg {
+  /// # Panics
+  ///
+  /// - If called with an invalid combination of `tx_size` and `tx_type`
   pub fn fwd(tx_type: TxType, tx_size: TxSize, bd: usize) -> Self {
     let tx_type_1d_col = VTX_TAB[tx_type as usize];
     let tx_type_1d_row = HTX_TAB[tx_type as usize];
@@ -137,7 +140,7 @@ impl Txfm2DFlipCfg {
     }
   }
 
-  /// Determine the flip config, returning (ud_flip, lr_flip)
+  /// Determine the flip config, returning `(ud_flip, lr_flip)`
   fn get_flip_cfg(tx_type: TxType) -> (bool, bool) {
     use self::TxType::*;
     match tx_type {

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -43,6 +43,9 @@ static SINPI_INV: [i32; 5] = [0, 1321, 2482, 3344, 3803];
 
 const INV_COS_BIT: usize = 12;
 
+/// # Panics
+///
+/// - If `input` or `output` have fewer than 4 items.
 pub fn av1_idct4(input: &[i32], output: &mut [i32], range: usize) {
   assert!(input.len() >= 4);
   assert!(output.len() >= 4);
@@ -70,6 +73,9 @@ pub fn av1_iflipadst4(input: &[i32], output: &mut [i32], range: usize) {
   output[..4].reverse();
 }
 
+/// # Panics
+///
+/// - If `input` or `output` have fewer than 4 items.
 #[inline(always)]
 pub fn av1_iadst4(input: &[i32], output: &mut [i32], _range: usize) {
   assert!(input.len() >= 4);
@@ -126,6 +132,9 @@ pub fn av1_iidentity4(input: &[i32], output: &mut [i32], _range: usize) {
     .for_each(|(outp, inp)| *outp = round_shift(SQRT2 * *inp, 12));
 }
 
+/// # Panics
+///
+/// - If `input` or `output` have fewer than 8 items.
 pub fn av1_idct8(input: &[i32], output: &mut [i32], range: usize) {
   assert!(input.len() >= 8);
   assert!(output.len() >= 8);
@@ -180,6 +189,9 @@ pub fn av1_iflipadst8(input: &[i32], output: &mut [i32], range: usize) {
   output[..8].reverse();
 }
 
+/// # Panics
+///
+/// - If `input` or `output` have fewer than 8 items.
 #[inline(always)]
 pub fn av1_iadst8(input: &[i32], output: &mut [i32], range: usize) {
   assert!(input.len() >= 8);

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -128,12 +128,12 @@ impl TxSize {
   pub const TX_SIZES_ALL: usize = 14 + 5;
 
   #[inline]
-  pub fn width(self) -> usize {
+  pub const fn width(self) -> usize {
     1 << self.width_log2()
   }
 
   #[inline]
-  pub fn width_log2(self) -> usize {
+  pub const fn width_log2(self) -> usize {
     match self {
       TX_4X4 | TX_4X8 | TX_4X16 => 2,
       TX_8X8 | TX_8X4 | TX_8X16 | TX_8X32 => 3,
@@ -144,17 +144,17 @@ impl TxSize {
   }
 
   #[inline]
-  pub fn width_index(self) -> usize {
+  pub const fn width_index(self) -> usize {
     self.width_log2() - TX_4X4.width_log2()
   }
 
   #[inline]
-  pub fn height(self) -> usize {
+  pub const fn height(self) -> usize {
     1 << self.height_log2()
   }
 
   #[inline]
-  pub fn height_log2(self) -> usize {
+  pub const fn height_log2(self) -> usize {
     match self {
       TX_4X4 | TX_8X4 | TX_16X4 => 2,
       TX_8X8 | TX_4X8 | TX_16X8 | TX_32X8 => 3,
@@ -165,32 +165,32 @@ impl TxSize {
   }
 
   #[inline]
-  pub fn height_index(self) -> usize {
+  pub const fn height_index(self) -> usize {
     self.height_log2() - TX_4X4.height_log2()
   }
 
   #[inline]
-  pub fn width_mi(self) -> usize {
+  pub const fn width_mi(self) -> usize {
     self.width() >> MI_SIZE_LOG2
   }
 
   #[inline]
-  pub fn area(self) -> usize {
+  pub const fn area(self) -> usize {
     1 << self.area_log2()
   }
 
   #[inline]
-  pub fn area_log2(self) -> usize {
+  pub const fn area_log2(self) -> usize {
     self.width_log2() + self.height_log2()
   }
 
   #[inline]
-  pub fn height_mi(self) -> usize {
+  pub const fn height_mi(self) -> usize {
     self.height() >> MI_SIZE_LOG2
   }
 
   #[inline]
-  pub fn block_size(self) -> BlockSize {
+  pub const fn block_size(self) -> BlockSize {
     match self {
       TX_4X4 => BLOCK_4X4,
       TX_8X8 => BLOCK_8X8,
@@ -215,7 +215,7 @@ impl TxSize {
   }
 
   #[inline]
-  pub fn sqr(self) -> TxSize {
+  pub const fn sqr(self) -> TxSize {
     match self {
       TX_4X4 | TX_4X8 | TX_8X4 | TX_4X16 | TX_16X4 => TX_4X4,
       TX_8X8 | TX_8X16 | TX_16X8 | TX_8X32 | TX_32X8 => TX_8X8,
@@ -226,7 +226,7 @@ impl TxSize {
   }
 
   #[inline]
-  pub fn sqr_up(self) -> TxSize {
+  pub const fn sqr_up(self) -> TxSize {
     match self {
       TX_4X4 => TX_4X4,
       TX_8X8 | TX_4X8 | TX_8X4 => TX_8X8,
@@ -263,7 +263,7 @@ impl TxSize {
   }
 
   #[inline]
-  pub fn is_rect(self) -> bool {
+  pub const fn is_rect(self) -> bool {
     self.width_log2() != self.height_log2()
   }
 }
@@ -293,7 +293,7 @@ pub fn get_rect_tx_log_ratio(col: usize, row: usize) -> i8 {
 
 // performs half a butterfly
 #[inline]
-fn half_btf(w0: i32, in0: i32, w1: i32, in1: i32, bit: usize) -> i32 {
+const fn half_btf(w0: i32, in0: i32, w1: i32, in1: i32, bit: usize) -> i32 {
   // Ensure defined behaviour for when w0*in0 + w1*in1 is negative and
   //   overflows, but w0*in0 + w1*in1 + rounding isn't.
   let result = (w0 * in0).wrapping_add(w1 * in1);
@@ -337,7 +337,7 @@ enum TxType1D {
   IDTX,
 }
 
-fn get_1d_tx_types(tx_type: TxType) -> (TxType1D, TxType1D) {
+const fn get_1d_tx_types(tx_type: TxType) -> (TxType1D, TxType1D) {
   match tx_type {
     TxType::DCT_DCT => (TxType1D::DCT, TxType1D::DCT),
     TxType::ADST_DCT => (TxType1D::ADST, TxType1D::DCT),
@@ -397,7 +397,7 @@ const HTX_TAB: [TxType1D; TX_TYPES] = [
 ];
 
 #[inline]
-pub fn valid_av1_transform(tx_size: TxSize, tx_type: TxType) -> bool {
+pub const fn valid_av1_transform(tx_size: TxSize, tx_type: TxType) -> bool {
   let size_sq = tx_size.sqr_up();
   use TxSize::*;
   use TxType::*;

--- a/src/util/align.rs
+++ b/src/util/align.rs
@@ -60,7 +60,7 @@ impl<T> AlignedBoxedSlice<T> {
     }
   }
 
-  fn layout(len: usize) -> Layout {
+  const fn layout(len: usize) -> Layout {
     // SAFETY: We are ensuring that `align` is non-zero and is a multiple of 2.
     unsafe {
       Layout::from_size_align_unchecked(

--- a/src/util/uninit.rs
+++ b/src/util/uninit.rs
@@ -17,7 +17,7 @@ pub fn init_slice_repeat_mut<T: Copy>(
     *a = MaybeUninit::new(value);
   }
 
-  // Defined behavior, since all elements of slice are initialized
+  // SAFETY: Defined behavior, since all elements of slice are initialized
   unsafe { assume_slice_init_mut(slice) }
 }
 

--- a/tests/doctests.rs
+++ b/tests/doctests.rs
@@ -35,7 +35,9 @@ fn receive_packet() -> Result<(), Box<dyn std::error::Error>> {
       Ok(_packet) => { /* Mux the packet. */ }
       Err(EncoderStatus::Encoded) => (),
       Err(EncoderStatus::LimitReached) => break,
-      Err(err) => Err(err)?,
+      Err(err) => {
+        return Err(err.into());
+      }
     }
   }
   Ok(())
@@ -90,10 +92,12 @@ fn encode_frames(
 
 #[test]
 fn encoding() -> Result<(), Box<dyn std::error::Error>> {
-  let mut enc = EncoderConfig::default();
-  // So it runs faster.
-  enc.width = 16;
-  enc.height = 16;
+  let enc = EncoderConfig {
+    // So it runs faster.
+    width: 16,
+    height: 16,
+    ..Default::default()
+  };
   let cfg = Config::new().with_encoder_config(enc);
   let mut ctx: Context<u8> = cfg.new_context()?;
 


### PR DESCRIPTION
This is an ongoing WIP, I have many non-default lints that I'd like to enable because I believe they could be useful. Due to the amount of work and code changes, I'm splitting it up over multiple PRs over however many days it takes.

For now, this PR starts with:
- [doc_markdown](https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown)
- [missing_errors_doc](https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc)
- [missing_panics_doc](https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc)
- [undocumented_unsafe_blocks](https://rust-lang.github.io/rust-clippy/master/index.html#undocumented_unsafe_blocks)
- [missing_const_for_fn](https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn)