### PR TITLE
Move complex pred modes for keyframes to s2

### DIFF
--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -124,6 +124,9 @@ impl SpeedSettings {
     if speed >= 2 {
       settings.partition.non_square_partition_threshold =
         BlockSize::BLOCK_16X16;
+
+      settings.prediction.prediction_modes =
+        PredictionModesSetting::ComplexKeyframes;
     }
 
     if speed >= 3 {
@@ -133,9 +136,6 @@ impl SpeedSettings {
         PartitionRange::new(BlockSize::BLOCK_8X8, BlockSize::BLOCK_64X64);
       settings.partition.non_square_partition_threshold =
         BlockSize::BLOCK_64X64;
-
-      settings.prediction.prediction_modes =
-        PredictionModesSetting::ComplexKeyframes;
     }
 
     if speed >= 4 {


### PR DESCRIPTION
Currently the speed gap for speeds 1-3 is very unbalanced.
Speed 2 is only 20% faster than speed 1, while speed 3 is 150% faster
than speed 2. After this change, speed 2 becomes 50% faster than speed
1, and speed 3 becomes 50% faster than speed 2. Impact on metrics at
speed 2 is very small: [AWCY](https://bit.ly/3q0sJrl)