### PR TITLE
Enable suboptimal_flops clippy lint

### DIFF
--- a/ivf/src/lib.rs
+++ b/ivf/src/lib.rs
@@ -21,6 +21,7 @@
 #![warn(clippy::linkedlist)]
 #![warn(clippy::missing_const_for_fn)]
 #![warn(clippy::mutex_integer)]
+#![warn(clippy::suboptimal_flops)]
 // Correctness lints
 #![warn(clippy::expl_impl_clone_on_copy)]
 #![warn(clippy::mem_forget)]

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -20,6 +20,7 @@
 #![warn(clippy::linkedlist)]
 #![warn(clippy::missing_const_for_fn)]
 #![warn(clippy::mutex_integer)]
+#![warn(clippy::suboptimal_flops)]
 // Correctness lints
 #![warn(clippy::expl_impl_clone_on_copy)]
 #![warn(clippy::mem_forget)]

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -20,6 +20,7 @@
 #![warn(clippy::linkedlist)]
 #![warn(clippy::missing_const_for_fn)]
 #![warn(clippy::mutex_integer)]
+#![warn(clippy::suboptimal_flops)]
 // Correctness lints
 #![warn(clippy::expl_impl_clone_on_copy)]
 #![warn(clippy::mem_forget)]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -60,7 +60,7 @@ pub enum CDEFSearchMethod {
 
 #[inline(always)]
 fn poly2(q: f32, a: f32, b: f32, c: f32, max: i32) -> i32 {
-  clamp((q * q * a + q * b + c).round() as i32, 0, max)
+  clamp((q * q).mul_add(a, q.mul_add(b, c)).round() as i32, 0, max)
 }
 
 pub static TEMPORAL_DELIMITER: [u8; 2] = [0x12, 0x00];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 #![warn(clippy::linkedlist)]
 #![warn(clippy::missing_const_for_fn)]
 #![warn(clippy::mutex_integer)]
+#![warn(clippy::suboptimal_flops)]
 // Correctness lints
 #![warn(clippy::expl_impl_clone_on_copy)]
 #![warn(clippy::mem_forget)]

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -577,7 +577,8 @@ impl DistortionScale {
   #[inline]
   pub fn new(scale: f64) -> Self {
     Self(
-      (scale * (1 << Self::SHIFT) as f64 + 0.5)
+      scale
+        .mul_add((1 << Self::SHIFT) as f64, 0.5)
         .min(((1 << Self::BITS as u64) - 1) as f64) as u32,
     )
   }
@@ -666,7 +667,7 @@ pub fn compute_rd_cost<T: Pixel>(
   fi: &FrameInvariants<T>, rate: u32, distortion: ScaledDistortion,
 ) -> f64 {
   let rate_in_bits = (rate as f64) / ((1 << OD_BITRES) as f64);
-  distortion.0 as f64 + fi.lambda * rate_in_bits
+  fi.lambda.mul_add(rate_in_bits, distortion.0 as f64)
 }
 
 pub fn rdo_tx_size_type<T: Pixel>(

--- a/v_frame/src/lib.rs
+++ b/v_frame/src/lib.rs
@@ -20,6 +20,7 @@
 #![warn(clippy::linkedlist)]
 #![warn(clippy::missing_const_for_fn)]
 #![warn(clippy::mutex_integer)]
+#![warn(clippy::suboptimal_flops)]
 // Correctness lints
 #![warn(clippy::expl_impl_clone_on_copy)]
 #![warn(clippy::mem_forget)]


### PR DESCRIPTION
Uses single-operation mul_add for more accurate and performant
floating-point math.