### PR TITLE
Fix memory leak when temporal RDO not in use

### DIFF
--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -475,6 +475,11 @@ impl<T: Pixel> SceneChangeDetector<T> {
         intra_cost = intra_costs.iter().map(|&cost| cost as u64).sum::<u64>()
           as f64
           / intra_costs.len() as f64;
+        // If we're not using temporal RDO, we won't need these costs later,
+        // so remove them from the cache to avoid a memory leak
+        if !self.encoder_config.temporal_rdo() {
+          self.intra_costs.remove(&input_frameno);
+        };
       });
       s.spawn(|_| {
         mv_inter_cost = estimate_inter_costs(


### PR DESCRIPTION
The cached intra costs ended up using a non-trivial amount of memory, so
we need to ensure they are not kept around when they are not needed.
In the case of temporal RDO, these are already removed from the cache
when we move them into the FrameInvariants.