### PR TITLE
Remove unnecessary clones from metrics calculation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ aom-sys = { version = "0.3.0", optional = true }
 scan_fmt = { version = "0.2.3", optional = true, default-features = false }
 ivf = { version = "0.1", path = "ivf/", optional = true }
 v_frame = { version = "0.2.5", path = "v_frame/" }
-av-metrics = { version = "0.7.1", optional = true, default-features = false }
+av-metrics = { version = "0.8.1", optional = true, default-features = false }
 rayon = "1.0"
 crossbeam = { version = "0.8", optional = true }
 toml = { version = "0.5", optional = true }

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -747,42 +747,31 @@ pub fn calculate_frame_metrics<T: Pixel>(
   frame1: &Frame<T>, frame2: &Frame<T>, bit_depth: usize, cs: ChromaSampling,
   metrics: MetricsEnabled,
 ) -> QualityMetrics {
-  let frame1_info = FrameInfo {
-    planes: frame1.planes.clone(),
-    bit_depth,
-    chroma_sampling: cs,
-  };
-
-  let frame2_info = FrameInfo {
-    planes: frame2.planes.clone(),
-    bit_depth,
-    chroma_sampling: cs,
-  };
-
   match metrics {
     MetricsEnabled::None => QualityMetrics::default(),
     MetricsEnabled::Psnr => QualityMetrics {
       psnr: Some(
-        psnr::calculate_frame_psnr(&frame1_info, &frame2_info).unwrap(),
+        psnr::calculate_frame_psnr(frame1, frame2, bit_depth, cs).unwrap(),
       ),
       ..Default::default()
     },
     MetricsEnabled::All => {
       let mut metrics = QualityMetrics {
         psnr: Some(
-          psnr::calculate_frame_psnr(&frame1_info, &frame2_info).unwrap(),
+          psnr::calculate_frame_psnr(frame1, frame2, bit_depth, cs).unwrap(),
         ),
         psnr_hvs: Some(
-          psnr_hvs::calculate_frame_psnr_hvs(&frame1_info, &frame2_info)
+          psnr_hvs::calculate_frame_psnr_hvs(frame1, frame2, bit_depth, cs)
             .unwrap(),
         ),
         ..Default::default()
       };
-      let ssim = ssim::calculate_frame_ssim(&frame1_info, &frame2_info);
+      let ssim = ssim::calculate_frame_ssim(frame1, frame2, bit_depth, cs);
       metrics.ssim = Some(ssim.unwrap());
-      let ms_ssim = ssim::calculate_frame_msssim(&frame1_info, &frame2_info);
+      let ms_ssim =
+        ssim::calculate_frame_msssim(frame1, frame2, bit_depth, cs);
       metrics.ms_ssim = Some(ms_ssim.unwrap());
-      let ciede = ciede::calculate_frame_ciede(&frame1_info, &frame2_info);
+      let ciede = ciede::calculate_frame_ciede(frame1, frame2, bit_depth, cs);
       metrics.ciede = Some(ciede.unwrap());
       // TODO APSNR
       // TODO VMAF


### PR DESCRIPTION
Due to the interface of av-metrics, we were cloning two uncompressed
frames of data for each encoded frame, even when not doing any metrics
calculation. The interface to av-metrics has been changed to support
passing a `&Frame`, allowing us to avoid the clones entirely.

This reduces the total allocation count by about 6%, and peak
memory usage and encoding time by 1% at all speeds.