### PR TITLE
Add a mock around rayon for disabling threading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,9 @@ binaries = [
     "console",
     "av-metrics",
 ]
-default = ["binaries", "asm", "signal_support"]
+default = ["binaries", "asm", "threading", "signal_support"]
 asm = ["nasm-rs", "cc", "regex"]
+threading = ["rayon/threads"]
 signal_support = ["signal-hook"]
 dump_ivf = ["ivf"]
 quick_test = []
@@ -78,7 +79,7 @@ scan_fmt = { version = "0.2.3", optional = true, default-features = false }
 ivf = { version = "0.1", path = "ivf/", optional = true }
 v_frame = { version = "0.2.5", path = "v_frame/" }
 av-metrics = { version = "0.8.1", optional = true, default-features = false }
-rayon = "1.0"
+rayon = { package = "maybe-rayon", version = "0.1", default-features = false }
 crossbeam = { version = "0.8", optional = true }
 toml = { version = "0.5", optional = true }
 arrayvec = "0.7"


### PR DESCRIPTION
Profiling becomes considerably more difficult to read when rayon is
involved, because rayon nests many layers of function calls which
obscure where CPU and memory usage is actually occurring. This uses the
maybe-rayon crate as a wrapper around rayon, which by default passes
through to rayon with zero overhead, but by disabling the "threading"
feature in rav1e, the maybe-rayon crate will become a mock which calls
functions serially.

Examples:

Memory flamegraph with rayon:
![Screenshot_2022-03-24_10-49-12](https://user-images.githubusercontent.com/5951392/159943727-45e6d978-e948-48c9-96a8-b66a96a5625b.png)

Memory flamegraph without rayon:
![Screenshot_2022-03-24_10-48-05](https://user-images.githubusercontent.com/5951392/159943811-390ae186-6200-4d3b-8ae6-63b93c2081e8.png)
