### PR TITLE
Variance-based Spatial AQ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,6 @@ arrayref = "0.3.6"
 const_fn_assert = "0.1.2"
 nom = { version = "7.0.0", optional = true }
 new_debug_unreachable = "1.0.4"
-statrs = "0.15.0"
 
 [dependencies.image]
 version = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ arrayref = "0.3.6"
 const_fn_assert = "0.1.2"
 nom = { version = "7.0.0", optional = true }
 new_debug_unreachable = "1.0.4"
+statrs = "0.15.0"
 
 [dependencies.image]
 version = "0.23"

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -9,18 +9,14 @@
 
 use crate::frame::*;
 use crate::rdo::DistortionScale;
-use crate::segmentation::MAX_SEGMENTS;
 use crate::tiling::*;
 use crate::util::*;
 use itertools::izip;
 use rust_hawktracer::*;
-use statrs::statistics::Data;
-use statrs::statistics::OrderStatistics;
 
 #[derive(Debug, Default, Clone)]
 pub struct ActivityMask {
   pub variances: Box<[u32]>,
-  pub segments: Box<[u8]>,
 }
 
 impl ActivityMask {
@@ -57,25 +53,7 @@ impl ActivityMask {
       }
     }
 
-    // Compute initial segmentation choices for variance AQ
-    // We take the 95th percentile of variances here to get a less skewed sample.
-    // Otherwise segment 0 becomes heavily oversaturated.
-    let mut fdata = Data::new(
-      variances.iter().map(|&var| var as f64).collect::<Box<[f64]>>(),
-    );
-    let max_var = fdata.percentile(95);
-    let segments = variances
-      .iter()
-      .map(|var| {
-        clamp(
-          (*var as f64 / max_var * MAX_SEGMENTS as f64).floor(),
-          0.0,
-          (MAX_SEGMENTS - 1) as f64,
-        ) as u8
-      })
-      .collect();
-
-    ActivityMask { variances: variances.into_boxed_slice(), segments }
+    ActivityMask { variances: variances.into_boxed_slice() }
   }
 
   #[hawktracer(activity_mask_fill_scales)]

--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -108,6 +108,9 @@ pub struct EncoderConfig {
   /// [`tile_rows`]: #structfield.tile_rows
   pub tiles: usize,
 
+  /// Strength of variance AQ. Defaults to 1.0. Disabled automatically by Tune=Psnr.
+  pub aq_strength: f64,
+
   /// Settings which affect the encoding speed vs. quality trade-off.
   pub speed_settings: SpeedSettings,
 }
@@ -165,6 +168,7 @@ impl EncoderConfig {
       tile_cols: 0,
       tile_rows: 0,
       tiles: 0,
+      aq_strength: 1.0,
       speed_settings: SpeedSettings::from_preset(speed),
     }
   }
@@ -253,6 +257,12 @@ impl EncoderConfig {
         timestamp >= entry.start_time && timestamp < entry.end_time
       })
     })
+  }
+
+  /// Whether we should build data such as lookahead intra costs and block importances.
+  #[inline]
+  pub fn need_psy_lookahead_data(&self) -> bool {
+    self.temporal_rdo() || self.aq_strength > f64::EPSILON
   }
 }
 

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1294,8 +1294,10 @@ impl<T: Pixel> ContextInner<T> {
         {
           let frame =
             self.frame_q[&frame_data.fi.input_frameno].as_ref().unwrap();
-          coded_data.activity_mask =
-            ActivityMask::from_plane(&frame.planes[0]);
+          coded_data.activity_mask = ActivityMask::from_plane(
+            &frame.planes[0],
+            frame_data.fi.sequence.bit_depth,
+          );
           coded_data.activity_mask.fill_scales(
             frame_data.fi.sequence.bit_depth,
             &mut coded_data.activity_scales,

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1300,6 +1300,7 @@ impl<T: Pixel> ContextInner<T> {
             frame_data.fi.sequence.bit_depth,
             &mut coded_data.activity_scales,
           );
+          frame_data.fi.compute_spatiotemporal_scores();
         } else {
           coded_data.activity_mask = ActivityMask::default();
         }

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -2082,6 +2082,7 @@ fn log_q_exp_overflow() {
     tile_cols: 0,
     tile_rows: 0,
     tiles: 0,
+    aq_strength: 1.0,
     speed_settings: SpeedSettings {
       multiref: false,
       fast_deblock: true,
@@ -2159,6 +2160,7 @@ fn guess_frame_subtypes_assert() {
     tile_cols: 0,
     tile_rows: 0,
     tiles: 0,
+    aq_strength: 1.0,
     speed_settings: SpeedSettings {
       multiref: false,
       fast_deblock: true,

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -247,6 +247,13 @@ pub fn parse_cli() -> Result<CliOptions, CliError> {
         .takes_value(true)
     )
     .arg(
+      Arg::new("AQ_STRENGTH")
+        .help("Adjusts the strength of spatial adaptive quantization")
+        .long("aq-strength")
+        .takes_value(true)
+        .hide(true)
+    )
+    .arg(
       Arg::new("TUNE")
         .help("Quality tuning")
         .long("tune")
@@ -765,6 +772,12 @@ fn parse_config(matches: &ArgMatches) -> Result<EncoderConfig, CliError> {
 
   if cfg.tune == Tune::Psychovisual {
     cfg.speed_settings.transform.tx_domain_distortion = false;
+  }
+  if cfg.tune == Tune::Psnr {
+    cfg.aq_strength = 0.0;
+  }
+  if let Some(aq_str) = matches.value_of("AQ_STRENGTH") {
+    cfg.aq_strength = aq_str.parse().unwrap();
   }
 
   cfg.tile_cols = matches.value_of("TILE_COLS").unwrap().parse().unwrap();

--- a/src/context/partition_unit.rs
+++ b/src/context/partition_unit.rs
@@ -249,7 +249,9 @@ impl<'a> ContextWriter<'a> {
     symbol_with_update!(self, w, skip as u32, cdf, 2);
   }
 
-  pub fn get_segment_pred(&self, bo: TileBlockOffset) -> (u8, u8) {
+  pub fn get_segment_pred(
+    &self, bo: TileBlockOffset, last_active_segid: u8,
+  ) -> (u8, u8) {
     let mut prev_ul = -1;
     let mut prev_u = -1;
     let mut prev_l = -1;
@@ -288,7 +290,8 @@ impl<'a> ContextWriter<'a> {
     } else {
       r = if prev_ul == prev_u { prev_u } else { prev_l };
     }
-    (r as u8, cdf_index)
+
+    ((r as u8).min(last_active_segid), cdf_index)
   }
 
   pub fn write_cfl_alphas<W: Writer>(&mut self, w: &mut W, cfl: CFLParams) {
@@ -434,7 +437,7 @@ impl<'a> ContextWriter<'a> {
     &mut self, w: &mut W, bo: TileBlockOffset, bsize: BlockSize, skip: bool,
     last_active_segid: u8,
   ) {
-    let (pred, cdf_index) = self.get_segment_pred(bo);
+    let (pred, cdf_index) = self.get_segment_pred(bo, last_active_segid);
     if skip {
       self.bc.blocks.set_segmentation_idx(bo, bsize, pred);
       return;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1163,7 +1163,6 @@ impl<T: Pixel> FrameInvariants<T> {
     let coded_data = self.coded_frame_data.as_ref().unwrap();
     let mut scores = vec![0.; coded_data.w_in_imp_b * coded_data.h_in_imp_b]
       .into_boxed_slice();
-    let bd_shift = self.sequence.bit_depth - 8;
     let bsize = BlockSize::from_width_and_height(
       IMPORTANCE_BLOCK_SIZE,
       IMPORTANCE_BLOCK_SIZE,
@@ -1194,9 +1193,8 @@ impl<T: Pixel> FrameInvariants<T> {
               // which is centered at 1.0. Higher values mean we want to
               // give a higher qindex while lower values mean we want a
               // lower qindex.
-              let variance = *variance >> bd_shift;
               scores[imp_b_idx] =
-                (variance as f32).ln() * f64::from(scale) as f32;
+                (*variance as f32).ln() * f64::from(scale) as f32;
             }
           }
         }
@@ -1207,7 +1205,7 @@ impl<T: Pixel> FrameInvariants<T> {
       .map(|score| {
         // This formula was arrived at by some experimentation.
         // Ranges for the raw score could reasonably be anywhere from 1.5 to 18.
-        clamp(((*score - 2.5) * 0.5).floor() as i8, 0, 7) as u8
+        clamp(((*score - 3.5) * 0.4).floor() as i8, 0, 7) as u8
       })
       .collect();
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1205,16 +1205,8 @@ impl<T: Pixel> FrameInvariants<T> {
     let segments = scores
       .iter()
       .map(|score| {
-        // This approximates fitting a curve like this, without branching:
-        // seg 0 = <2
-        // seg 1 = 2-2.5
-        // seg 2 = 2.5-3
-        // seg 3 = 3-3.5
-        // seg 4 = 3.5-4
-        // seg 5 = 4.5-5
-        // seg 6 = 5-6
-        // seg 7 = >6
-        clamp(((*score - 1.5) * 1.8).floor() as i8, 0, 7) as u8
+        // This formula was arrived at by some experimentation
+        clamp(((*score - 2.5) * 1.5).floor() as i8, 0, 7) as u8
       })
       .collect();
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1196,7 +1196,7 @@ impl<T: Pixel> FrameInvariants<T> {
               // lower qindex.
               let variance = *variance >> bd_shift;
               scores[imp_b_idx] =
-                (variance as f32).log10() * f64::from(scale) as f32;
+                (variance as f32).ln() * f64::from(scale) as f32;
             }
           }
         }
@@ -1205,8 +1205,9 @@ impl<T: Pixel> FrameInvariants<T> {
     let segments = scores
       .iter()
       .map(|score| {
-        // This formula was arrived at by some experimentation
-        clamp(((*score - 2.5) * 1.5).floor() as i8, 0, 7) as u8
+        // This formula was arrived at by some experimentation.
+        // Ranges for the raw score could reasonably be anywhere from 1.5 to 18.
+        clamp(((*score - 2.5) * 0.5).floor() as i8, 0, 7) as u8
       })
       .collect();
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1189,13 +1189,11 @@ impl<T: Pixel> FrameInvariants<T> {
               // The reasoning for this computation is as follows:
               // The variances follow an exponential curve. We want to flatten that
               // so that we have more of a linear scale of variances to sort
-              // into segments. Before doing that, we multiply by the
-              // spatiotemporal scale, which is centered at 1.0.
-              // Higher values mean we want to give a higher qindex while
-              // lower values mean we want a lower qindex.
+              // into segments. We then multiply by the spatiotemporal scale,
+              // which is centered at 1.0. Higher values mean we want to give
+              // a higher qindex while lower values mean we want a lower qindex.
               // We then subtract 1 so that the base value for a minimal variance is 0.
-              // This gives us a total range of about 0-5.
-              let score = ((*variance as f64) * f64::from(scale)).log10();
+              let score = (*variance as f64).log10() * f64::from(scale).sqrt();
               scores[imp_b_idx] = (score as f32 - 1.0).max(0.0);
             }
           }
@@ -1206,13 +1204,13 @@ impl<T: Pixel> FrameInvariants<T> {
     let segments = scores
       .iter()
       .map(|&s| match s {
-        s if s < 1.75 => 0,
-        s if s < 2.55 => 1,
-        s if s < 3.2 => 2,
-        s if s < 3.75 => 3,
-        s if s < 4.2 => 4,
-        s if s < 4.5 => 5,
-        s if s < 4.75 => 6,
+        s if s < 1.9 => 0,
+        s if s < 3.1 => 1,
+        s if s < 4.2 => 2,
+        s if s < 5.2 => 3,
+        s if s < 6.1 => 4,
+        s if s < 6.9 => 5,
+        s if s < 7.6 => 6,
         _ => 7,
       })
       .collect();

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -232,6 +232,8 @@ impl Arbitrary for ArbitraryEncoder {
       tile_cols: u.int_in_range(0..=2)?,
       tile_rows: u.int_in_range(0..=2)?,
       tiles: u.int_in_range(0..=16)?,
+      aq_strength: *u
+        .choose(&[-1.0, -0.5, 0.0, 0.1, 0.5, 1.0, 1.5, 2.5, 69.0])?,
 
       chroma_sampling: *u.choose(&[
         ChromaSampling::Cs420,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -804,7 +804,7 @@ fn luma_chroma_mode_rdo<T: Pixel>(
 
     let mut zero_distortion = false;
 
-    for sidx in select_segment(fi, ts, tile_bo, bsize, skip) {
+    for sidx in select_segment(fi, ts, tile_bo, is_chroma_block, bsize, skip) {
       cw.bc.blocks.set_segmentation_idx(tile_bo, bsize, sidx);
 
       let (tx_size, tx_type) = rdo_tx_size_type(

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -76,7 +76,7 @@ pub fn segmentation_optimize<T: Pixel>(
 fn segmentation_optimize_aq<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>, offset_lower_limit: i16,
 ) {
-  const AVG_SEG: f64 = 2.0;
+  const AVG_SEG: f64 = 3.2;
 
   let coded_data = fi.coded_frame_data.as_ref().unwrap();
   let segments = &coded_data.segments;

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -7,13 +7,28 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use std::cmp::Ordering;
+
+use crate::api::SegmentationLevel;
 use crate::context::*;
+use crate::encoder::IMPORTANCE_BLOCK_SIZE;
 use crate::header::PRIMARY_REF_NONE;
 use crate::partition::BlockSize;
+use crate::quantize::ac_q;
+use crate::rdo::spatiotemporal_scale;
 use crate::tiling::TileStateMut;
 use crate::util::Pixel;
 use crate::FrameInvariants;
 use crate::FrameState;
+use arrayvec::ArrayVec;
+use v_frame::math::clamp;
+
+pub const MAX_SEGMENTS: usize = 8;
+
+// A series of AWCY runs with deltas 13, 15, 17, 18, 19, 20, 21, 22, 23
+// showed this to be the optimal one.
+const TEMPORAL_RDO_QI_DELTA: i16 = 21;
+const BASE_AQ_MULT: f64 = -7.0;
 
 pub fn segmentation_optimize<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>,
@@ -31,40 +46,27 @@ pub fn segmentation_optimize<T: Pixel>(
       return;
     }
 
-    // A series of AWCY runs with deltas 13, 15, 17, 18, 19, 20, 21, 22, 23
-    // showed this to be the optimal one.
-    const TEMPORAL_RDO_QI_DELTA: i16 = 21;
-
     // Avoid going into lossless mode by never bringing qidx below 1.
     // Because base_q_idx changes more frequently than the segmentation
     // data, it is still possible for a segment to enter lossless, so
     // enforcement elsewhere is needed.
     let offset_lower_limit = 1 - fi.base_q_idx as i16;
 
-    // Fill in 3 slots with 0, delta, -delta. The slot IDs are also used in
-    // luma_chroma_mode_rdo() so if you change things here make sure to check
-    // that place too.
-    for i in 0..3 {
-      fs.segmentation.features[i][SegLvl::SEG_LVL_ALT_Q as usize] = true;
-      fs.segmentation.data[i][SegLvl::SEG_LVL_ALT_Q as usize] = match i {
-        0 => 0,
-        1 => TEMPORAL_RDO_QI_DELTA,
-        2 => (-TEMPORAL_RDO_QI_DELTA).max(offset_lower_limit),
-        _ => unreachable!(),
-      };
+    if fi.config.aq_strength > f64::EPSILON {
+      segmentation_optimize_aq(fi, fs, offset_lower_limit);
+    } else {
+      segmentation_optimize_no_aq(fs, offset_lower_limit);
     }
 
     /* Figure out parameters */
     fs.segmentation.preskip = false;
     fs.segmentation.last_active_segid = 0;
-    if fs.segmentation.enabled {
-      for i in 0..8 {
-        for j in 0..SegLvl::SEG_LVL_MAX as usize {
-          if fs.segmentation.features[i][j] {
-            fs.segmentation.last_active_segid = i as u8;
-            if j >= SegLvl::SEG_LVL_REF_FRAME as usize {
-              fs.segmentation.preskip = true;
-            }
+    for i in 0..MAX_SEGMENTS {
+      for j in 0..SegLvl::SEG_LVL_MAX as usize {
+        if fs.segmentation.features[i][j] {
+          fs.segmentation.last_active_segid = i as u8;
+          if j >= SegLvl::SEG_LVL_REF_FRAME as usize {
+            fs.segmentation.preskip = true;
           }
         }
       }
@@ -72,14 +74,202 @@ pub fn segmentation_optimize<T: Pixel>(
   }
 }
 
+fn segmentation_optimize_aq<T: Pixel>(
+  fi: &FrameInvariants<T>, fs: &mut FrameState<T>, offset_lower_limit: i16,
+) {
+  // This is the amount we skew the average segment in order to obtain a similar average qindex
+  // to when AQ is disabled.
+  const AVG_SEG_ADJUSTMENT: f64 = 1.0;
+
+  let coded_data = fi.coded_frame_data.as_ref().unwrap();
+  let mut segments = coded_data.activity_mask.segments.clone();
+  apply_temporal_rdo_adjustments(&mut segments, fi, fs);
+
+  let mut seg_counts = [0usize; MAX_SEGMENTS];
+  segments.iter().for_each(|&seg| {
+    // SAFETY: In `apply_temporal_rdo_adjustments` we ensured that all segments are within the range of 0-7
+    unsafe {
+      *seg_counts.get_unchecked_mut(seg as usize) += 1;
+    }
+  });
+  let avg_seg = (seg_counts
+    .iter()
+    .copied()
+    .enumerate()
+    .fold(0, |acc, (seg, count)| acc + (seg + 1) * count)
+    as f64
+    / segments.len() as f64)
+    - 1.0
+    + AVG_SEG_ADJUSTMENT;
+  let avg_seg = clamp(avg_seg, 0.0, MAX_SEGMENTS as f64 - 1.0);
+
+  let mut num_neg = 0usize;
+  let mut num_pos = 0usize;
+  let mut tmp_delta = [0f64; MAX_SEGMENTS];
+  for i in 0..MAX_SEGMENTS {
+    tmp_delta[i] = (avg_seg - i as f64) * BASE_AQ_MULT * fi.config.aq_strength;
+    if tmp_delta[i] > 0f64 {
+      num_pos += 1;
+    } else if tmp_delta[i] < 0f64 {
+      num_neg += 1;
+    }
+  }
+
+  // We want at least 5% of the blocks in a segment in order to code it
+  let threshold = segments.len() / 20;
+
+  let mut remap_segment_tab: [usize; MAX_SEGMENTS] = [0, 1, 2, 3, 4, 5, 6, 7];
+  let mut num_segments = MAX_SEGMENTS;
+
+  loop {
+    let mut changed = false;
+
+    if num_segments < 4 {
+      break;
+    }
+
+    for i in (0..MAX_SEGMENTS).rev() {
+      if seg_counts[remap_segment_tab[i]] >= threshold {
+        continue;
+      };
+      if seg_counts[remap_segment_tab[i]] == 0 {
+        continue;
+      }; /* Already eliminated */
+
+      let prev_id = remap_segment_tab[i];
+
+      #[derive(Debug, Default, Clone, Copy)]
+      struct ScoreTab {
+        idx: usize,
+        score: f64,
+      }
+      let mut s_array =
+        [ScoreTab { idx: usize::max_value(), score: std::f64::MAX };
+          MAX_SEGMENTS];
+
+      for j in 0..MAX_SEGMENTS {
+        s_array[j].idx = remap_segment_tab[j];
+        if (remap_segment_tab[j] == prev_id)
+          || (seg_counts[remap_segment_tab[j]] == 0)
+          || (((num_neg < 2) || (num_pos < 2))
+            && (tmp_delta[remap_segment_tab[j]].signum()
+              != tmp_delta[prev_id].signum()))
+        {
+          s_array[j].score = std::f64::MAX;
+        } else {
+          s_array[j].score =
+            (tmp_delta[remap_segment_tab[j]] - tmp_delta[prev_id]).abs();
+        }
+      }
+
+      s_array.sort_by(|a, b| {
+        (a.score).partial_cmp(&b.score).unwrap_or(Ordering::Less)
+      });
+
+      if s_array[0].score == std::f64::MAX {
+        continue;
+      }
+
+      /* Remap any old mappings to the current segment as well */
+      for j in 0..MAX_SEGMENTS {
+        if remap_segment_tab[j] == prev_id {
+          remap_segment_tab[j] = s_array[0].idx;
+        }
+      }
+
+      let num_2bins = seg_counts[remap_segment_tab[i]] + seg_counts[prev_id];
+      let mut ratio_new =
+        (seg_counts[remap_segment_tab[i]] as f64) / (num_2bins as f64);
+      let mut ratio_old = (seg_counts[prev_id] as f64) / (num_2bins as f64);
+
+      ratio_new *= tmp_delta[remap_segment_tab[i]];
+      ratio_old *= tmp_delta[prev_id];
+
+      num_pos -= (tmp_delta[prev_id] > 0f64) as usize;
+      num_neg -= (tmp_delta[prev_id] < 0f64) as usize;
+
+      tmp_delta[remap_segment_tab[i]] = ratio_new + ratio_old;
+      tmp_delta[prev_id] = std::f64::MAX;
+
+      seg_counts[remap_segment_tab[i]] += seg_counts[prev_id];
+      seg_counts[prev_id] = 0;
+
+      num_segments -= 1;
+
+      changed = true;
+      break;
+    }
+
+    if !changed {
+      break;
+    }
+  }
+
+  /* Get all unique values in the intentionally unsorted array (its a LUT) */
+  let mut uniq_array = [0usize; MAX_SEGMENTS];
+  let mut num_segments = 0;
+  for i in 0..MAX_SEGMENTS {
+    let mut seen_match = false;
+    for j in 0..num_segments {
+      if remap_segment_tab[i] == uniq_array[j] {
+        seen_match = true;
+      }
+    }
+    if !seen_match {
+      uniq_array[num_segments] = remap_segment_tab[i];
+      num_segments += 1;
+    }
+  }
+
+  let mut seg_delta = [0f64; MAX_SEGMENTS];
+  for i in 0..num_segments {
+    /* Collect all used segment deltas into the actual segment map */
+    seg_delta[i] = tmp_delta[uniq_array[i]];
+
+    /* Remap the LUT to make it match the layout of the seg deltaq map */
+    for j in 0..MAX_SEGMENTS {
+      if remap_segment_tab[j] == uniq_array[i] {
+        remap_segment_tab[j] = i;
+      }
+    }
+  }
+
+  fs.segmentation.activity_lut = remap_segment_tab;
+
+  for i in 0..num_segments {
+    fs.segmentation.features[i][SegLvl::SEG_LVL_ALT_Q as usize] = true;
+    fs.segmentation.data[i][SegLvl::SEG_LVL_ALT_Q as usize] =
+      (seg_delta[i].round() as i16).max(offset_lower_limit);
+  }
+
+  fs.segmentation.segmentation_mask = segments
+    .iter()
+    .map(|&seg| {
+      // SAFETY: We know that every segment is between 0-7
+      unsafe { *remap_segment_tab.get_unchecked(seg as usize) as u8 }
+    })
+    .collect();
+}
+
+fn segmentation_optimize_no_aq<T: Pixel>(
+  fs: &mut FrameState<T>, offset_lower_limit: i16,
+) {
+  // Fill in 3 slots with 0, delta, -delta.
+  for i in 0..3 {
+    fs.segmentation.features[i][SegLvl::SEG_LVL_ALT_Q as usize] = true;
+    fs.segmentation.data[i][SegLvl::SEG_LVL_ALT_Q as usize] = match i {
+      0 => 0,
+      1 => TEMPORAL_RDO_QI_DELTA,
+      2 => (-TEMPORAL_RDO_QI_DELTA).max(offset_lower_limit),
+      _ => unreachable!(),
+    };
+  }
+}
+
 pub fn select_segment<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &TileStateMut<'_, T>, tile_bo: TileBlockOffset,
-  bsize: BlockSize, skip: bool,
+  is_chroma_block: bool, bsize: BlockSize, skip: bool,
 ) -> std::ops::RangeInclusive<u8> {
-  use crate::api::SegmentationLevel;
-  use crate::rdo::spatiotemporal_scale;
-  use arrayvec::ArrayVec;
-
   // If skip is true or segmentation is turned off, sidx is not coded.
   if skip || !fi.enable_segmentation {
     return 0..=0;
@@ -89,41 +279,111 @@ pub fn select_segment<T: Pixel>(
     + ts.segmentation.data[2][SegLvl::SEG_LVL_ALT_Q as usize]
     < 1;
 
-  if fi.config.speed_settings.segmentation == SegmentationLevel::Full {
+  if fi.config.speed_settings.segmentation == SegmentationLevel::Full
+    && fi.config.aq_strength.abs() < f64::EPSILON
+  {
     return if segment_2_is_lossless { 0..=1 } else { 0..=2 };
   }
 
+  if fi.config.aq_strength > f64::EPSILON {
+    // Fetch the precomputed segment index for variance AQ
+    let plane_cfg = &ts.input.planes[if is_chroma_block { 1 } else { 0 }].cfg;
+    let tile_offset = tile_bo.plane_offset(plane_cfg);
+    let plane_offset = ts.sbo.plane_offset(plane_cfg);
+    let x_in_imp_b = ((tile_offset.x + plane_offset.x) << plane_cfg.xdec)
+      as usize
+      / IMPORTANCE_BLOCK_SIZE;
+    let y_in_imp_b = ((tile_offset.y + plane_offset.y) << plane_cfg.ydec)
+      as usize
+      / IMPORTANCE_BLOCK_SIZE;
+    let w_in_imp_b = &fi.coded_frame_data.as_ref().unwrap().w_in_imp_b;
+
+    let seg =
+      ts.segmentation.segmentation_mask[y_in_imp_b * w_in_imp_b + x_in_imp_b];
+    return seg..=seg;
+  }
+
+  // With temporal RDO only (no AQ), compute the index now.
   let frame_bo = ts.to_frame_block_offset(tile_bo);
+  let sidx =
+    get_temporal_rdo_sidx(fi, ts, frame_bo, bsize, segment_2_is_lossless)
+      as u8;
+
+  sidx..=sidx
+}
+
+fn get_temporal_rdo_sidx<T: Pixel>(
+  fi: &FrameInvariants<T>, ts: &TileStateMut<'_, T>,
+  frame_bo: PlaneBlockOffset, bsize: BlockSize, segment_2_is_lossless: bool,
+) -> usize {
   let scale = spatiotemporal_scale(fi, frame_bo, bsize);
 
   // TODO: Replace this calculation with precomputed scale thresholds.
-  let seg_ac_q: ArrayVec<_, 3> = if fi.enable_segmentation {
-    use crate::quantize::ac_q;
-    (0..=2)
-      .map(|sidx| {
-        ac_q(
-          (fi.base_q_idx as i16
-            + ts.segmentation.data[sidx][SegLvl::SEG_LVL_ALT_Q as usize])
-            .max(0)
-            .min(255) as u8,
-          0,
-          fi.sequence.bit_depth,
-        )
-      })
-      .collect()
-  } else {
-    Default::default()
-  };
+  let seg_ac_q: ArrayVec<_, 3> = seg_ac_q(fi, ts);
 
-  let sidx = if scale.mul_u64(seg_ac_q[1] as u64) < seg_ac_q[0] as u64 {
+  if scale.mul_u64(seg_ac_q[1] as u64) < seg_ac_q[0] as u64 {
+    // Use higher qindex
     1
   } else if !segment_2_is_lossless
     && scale.mul_u64(seg_ac_q[2] as u64) > seg_ac_q[0] as u64
   {
+    // Use lower qindex
     2
   } else {
+    // Do not modify qindex
     0
-  };
+  }
+}
 
-  sidx..=sidx
+fn seg_ac_q<T: Pixel>(
+  fi: &FrameInvariants<T>, ts: &TileStateMut<T>,
+) -> ArrayVec<i16, 3> {
+  (0..=2)
+    .map(|sidx| {
+      ac_q(
+        (fi.base_q_idx as i16
+          + ts.segmentation.data[sidx][SegLvl::SEG_LVL_ALT_Q as usize])
+          .max(0)
+          .min(255) as u8,
+        0,
+        fi.sequence.bit_depth,
+      )
+    })
+    .collect()
+}
+
+fn apply_temporal_rdo_adjustments<T: Pixel>(
+  segments: &mut [u8], fi: &FrameInvariants<T>, fs: &mut FrameState<T>,
+) {
+  let w_in_imp_b = fi.coded_frame_data.as_ref().unwrap().w_in_imp_b;
+  let ts = fs.as_tile_state_mut();
+  for (i, segment) in segments.iter_mut().enumerate() {
+    // The activity masks are in 16x16 blocks, so we will iterate by 16x16 here as well.
+    let frame_bo = PlaneBlockOffset(BlockOffset {
+      x: (i % w_in_imp_b) << 1,
+      y: (i / w_in_imp_b) << 1,
+    });
+
+    // Apply temporal RDO bias
+    let trdo_sidx =
+      get_temporal_rdo_sidx(fi, &ts, frame_bo, BlockSize::BLOCK_16X16, false);
+    // TODO: Use more gradual adjustments
+    match trdo_sidx {
+      0 => {
+        *segment += 2;
+      }
+      1 => {
+        *segment += 4;
+      }
+      2 => {
+        *segment = (*segment).saturating_sub(1);
+      }
+      _ => unreachable!(),
+    };
+
+    // Clamp
+    if *segment >= MAX_SEGMENTS as u8 {
+      *segment = MAX_SEGMENTS as u8 - 1;
+    }
+  }
 }

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -113,8 +113,8 @@ fn segmentation_optimize_aq<T: Pixel>(
     }
   }
 
-  // We want at least 10% of the blocks in a segment in order to code it
-  let threshold = segments.len() / 10;
+  // We want at least 20% of the blocks in a segment in order to code it
+  let threshold = segments.len() / 5;
 
   let mut remap_segment_tab: [usize; MAX_SEGMENTS] = [0, 1, 2, 3, 4, 5, 6, 7];
   let mut num_segments = MAX_SEGMENTS;


### PR DESCRIPTION
Co-authored by @cyanreg 

This changeset revives #2247 with a more minimal implementation, simply basing AQ off of the existing variance calculations per 8x8 block. This changeset does not have a noticeable impact on encoding speed.

As an immediate followup to this pull request, I plan to add luma-based AQ bias to provide more bits to dark areas and adapt AQ for HDR clips. Ideas for future improvements are also very welcome.

This changeset does harm metrics, as expected of a psy change. The AWCY links are posted below both for details and for aomanalyzer links to compare before/after images.

[AWCY](https://bit.ly/3joZ5Za)