### PR TITLE
Disable missing const fn clippy lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@
 #![allow(clippy::enum_variant_names)]
 // Performance lints
 #![warn(clippy::linkedlist)]
-#![warn(clippy::missing_const_for_fn)]
 #![warn(clippy::mutex_integer)]
 #![warn(clippy::suboptimal_flops)]
 // Correctness lints


### PR DESCRIPTION
This lint has too many false positives, and is becoming more annoying than useful.