### PR TITLE
Treat IO paths as native os strings.

### DIFF
--- a/src/bin/muxer/ivf.rs
+++ b/src/bin/muxer/ivf.rs
@@ -63,9 +63,12 @@ cfg_if::cfg_if! {
 }
 
 impl IvfMuxer {
-  pub fn check_file(path: &str) -> Result<(), CliError> {
-    if is_file(path) {
-      eprint!("File '{}' already exists. Overwrite ? [y/N] ", path);
+  pub fn check_file<P: AsRef<Path>>(path: P) -> Result<(), CliError> {
+    if is_file(path.as_ref()) {
+      eprint!(
+        "File '{}' already exists. Overwrite ? [y/N] ",
+        path.as_ref().display()
+      );
       io::stdout().flush().unwrap();
 
       let mut option_input = String::new();
@@ -81,12 +84,14 @@ impl IvfMuxer {
     Ok(())
   }
 
-  pub fn open(path: &str) -> Result<Box<dyn Muxer + Send>, CliError> {
+  pub fn open<P: AsRef<Path>>(
+    path: P,
+  ) -> Result<Box<dyn Muxer + Send>, CliError> {
     let ivf = IvfMuxer {
-      output: match path {
-        "-" => Box::new(std::io::stdout()),
-        f => Box::new(
-          File::create(&f)
+      output: match path.as_ref().to_str() {
+        Some("-") => Box::new(std::io::stdout()),
+        _ => Box::new(
+          File::create(path)
             .map_err(|e| e.context("Cannot open output file"))?,
         ),
       },

--- a/src/bin/muxer/mod.rs
+++ b/src/bin/muxer/mod.rs
@@ -32,18 +32,21 @@ pub trait Muxer: Send {
   fn flush(&mut self) -> io::Result<()>;
 }
 
-pub fn create_muxer(
-  path: &str, overwrite: bool,
+pub fn create_muxer<P: AsRef<Path>>(
+  path: P, overwrite: bool,
 ) -> Result<Box<dyn Muxer + Send>, CliError> {
   if !overwrite {
-    IvfMuxer::check_file(path)?;
+    IvfMuxer::check_file(path.as_ref())?;
   }
 
-  if path == "-" {
-    return IvfMuxer::open(path);
+  if let Some(path) = path.as_ref().to_str() {
+    if path == "-" {
+      return IvfMuxer::open(path);
+    }
   }
 
-  let ext = Path::new(path)
+  let ext = path
+    .as_ref()
     .extension()
     .and_then(OsStr::to_str)
     .map(str::to_lowercase)


### PR DESCRIPTION
Treat input, output, first pass, second pass, and reconstruction IO paths as `OsString` to improve portability. This requires the corresponding arguments be allowed to be non-utf8. This is a first pass at the issue to support non-utf8 file systems (#2356).