### PR TITLE
Use const generics for downscaling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ rust_hawktracer = "0.7.0"
 arrayref = "0.3.6"
 const_fn_assert = "0.1.2"
 nom = { version = "7.0.0", optional = true }
+new_debug_unreachable = "1.0.4"
 
 [dependencies.image]
 version = "0.23"

--- a/src/asm/x86/sad_row.rs
+++ b/src/asm/x86/sad_row.rs
@@ -7,6 +7,8 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use debug_unreachable::debug_unreachable;
+
 use crate::cpu_features::CpuFeatureLevel;
 use crate::sad_row::*;
 use crate::util::{Pixel, PixelType};
@@ -17,14 +19,13 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 use std::arch::asm;
-use std::hint::unreachable_unchecked;
 use std::mem;
 
 /// SAFETY: src and dst must be the same length
 #[inline(always)]
 unsafe fn sad_scalar(src: &[u8], dst: &[u8]) -> i64 {
   if src.len() != dst.len() {
-    unreachable_unchecked()
+    debug_unreachable!()
   }
 
   let mut sum = 0;
@@ -48,7 +49,7 @@ unsafe fn sad_scalar(src: &[u8], dst: &[u8]) -> i64 {
 #[target_feature(enable = "sse2")]
 unsafe fn sad_below32_8bpc_sse2(src: &[u8], dst: &[u8]) -> i64 {
   if src.len() != dst.len() {
-    unreachable_unchecked()
+    debug_unreachable!()
   }
 
   let mut offset = 0;
@@ -81,7 +82,7 @@ unsafe fn sad_below32_8bpc_sse2(src: &[u8], dst: &[u8]) -> i64 {
 #[target_feature(enable = "avx2")]
 unsafe fn sad_8bpc_avx2(src: &[u8], dst: &[u8]) -> i64 {
   if src.len() != dst.len() {
-    unreachable_unchecked()
+    debug_unreachable!()
   }
 
   let src_chunks = src.chunks_exact(32);
@@ -115,7 +116,7 @@ unsafe fn sad_8bpc_avx2(src: &[u8], dst: &[u8]) -> i64 {
 #[target_feature(enable = "sse2")]
 unsafe fn sad_8bpc_sse2(src: &[u8], dst: &[u8]) -> i64 {
   if src.len() != dst.len() {
-    unreachable_unchecked()
+    debug_unreachable!()
   }
 
   let src_chunks = src.chunks_exact(16);

--- a/src/asm/x86/transform/forward.rs
+++ b/src/asm/x86/transform/forward.rs
@@ -15,6 +15,7 @@ use crate::util::*;
 use std::mem::MaybeUninit;
 
 use arrayref::{array_mut_ref, array_ref};
+use debug_unreachable::debug_unreachable;
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
@@ -273,7 +274,7 @@ unsafe fn shift_right(a: I32X8, shift: u8) -> I32X8 {
 #[inline]
 unsafe fn round_shift_array_avx2(arr: &mut [I32X8], bit: i8) {
   if arr.len() % 4 != 0 {
-    std::hint::unreachable_unchecked();
+    debug_unreachable!();
   }
 
   if bit == 0 {

--- a/src/scenechange/fast.rs
+++ b/src/scenechange/fast.rs
@@ -5,11 +5,13 @@ use crate::{
   encoder::Sequence,
   frame::{Frame, Plane},
   sad_row,
+  scenechange::fast_idiv,
 };
+use debug_unreachable::debug_unreachable;
 use rust_hawktracer::*;
 use v_frame::pixel::Pixel;
 
-use super::{SceneChangeDetector, ScenecutResult};
+use super::{ScaleFunction, SceneChangeDetector, ScenecutResult};
 
 /// Experiments have determined this to be an optimal threshold
 pub(super) const FAST_THRESHOLD: f64 = 18.0;
@@ -21,15 +23,66 @@ impl<T: Pixel> SceneChangeDetector<T> {
   pub(super) fn fast_scenecut(
     &mut self, frame1: Arc<Frame<T>>, frame2: Arc<Frame<T>>,
   ) -> ScenecutResult {
-    if self.scale_factor == 1 {
-      if let Some(frame_buffer) = self.frame_ref_buffer.as_deref_mut() {
+    if let Some(scale_func) = &self.scale_func {
+      // downscale both frames for faster comparison
+      if let Some((frame_buffer, is_initialized)) =
+        &mut self.downscaled_frame_buffer
+      {
+        let frame_buffer = &mut *frame_buffer;
+        if *is_initialized {
+          frame_buffer.swap(0, 1);
+          (scale_func.downscale_in_place)(
+            &frame2.planes[0],
+            &mut frame_buffer[1],
+          );
+        } else {
+          // both frames are in an irrelevant and invalid state, so we have to reinitialize
+          // them, but we can reuse their allocations
+          (scale_func.downscale_in_place)(
+            &frame1.planes[0],
+            &mut frame_buffer[0],
+          );
+          (scale_func.downscale_in_place)(
+            &frame2.planes[0],
+            &mut frame_buffer[1],
+          );
+          *is_initialized = true;
+        }
+      } else {
+        self.downscaled_frame_buffer = Some((
+          [
+            (scale_func.downscale)(&frame1.planes[0]),
+            (scale_func.downscale)(&frame2.planes[0]),
+          ],
+          true, // the frame buffer is initialized and in a valid state
+        ));
+      }
+
+      if let Some((frame_buffer, _)) = &self.downscaled_frame_buffer {
+        let frame_buffer = &*frame_buffer;
+        let delta = self.delta_in_planes(&frame_buffer[0], &frame_buffer[1]);
+
+        ScenecutResult {
+          threshold: self.threshold as f64,
+          inter_cost: delta as f64,
+          imp_block_cost: delta as f64,
+          forward_adjusted_cost: delta as f64,
+          backward_adjusted_cost: delta as f64,
+        }
+      } else {
+        // SAFETY: `downscaled_frame_buffer` is always initialized to `Some(..)` with a valid state
+        // before this if/else block is reached.
+        unsafe { debug_unreachable!() }
+      }
+    } else {
+      if let Some(frame_buffer) = &mut self.frame_ref_buffer {
         frame_buffer.swap(0, 1);
         frame_buffer[1] = frame2;
       } else {
-        self.frame_ref_buffer = Some(Box::new([frame1, frame2]));
+        self.frame_ref_buffer = Some([frame1, frame2]);
       }
 
-      if let Some(frame_buffer) = self.frame_ref_buffer.as_deref() {
+      if let Some(frame_buffer) = &self.frame_ref_buffer {
         let delta = self.delta_in_planes(
           &frame_buffer[0].planes[0],
           &frame_buffer[1].planes[0],
@@ -43,50 +96,9 @@ impl<T: Pixel> SceneChangeDetector<T> {
           forward_adjusted_cost: delta as f64,
         }
       } else {
-        unreachable!()
-      }
-    } else {
-      // downscale both frames for faster comparison
-      if let Some((frame_buffer, is_initialized)) =
-        &mut self.downscaled_frame_buffer
-      {
-        let frame_buffer = &mut **frame_buffer;
-        if *is_initialized {
-          frame_buffer.swap(0, 1);
-          frame2.planes[0]
-            .downscale_in_place(self.scale_factor, &mut frame_buffer[1]);
-        } else {
-          // both frames are in an irrelevant and invalid state, so we have to reinitialize
-          // them, but we can reuse their allocations
-          frame1.planes[0]
-            .downscale_in_place(self.scale_factor, &mut frame_buffer[0]);
-          frame2.planes[0]
-            .downscale_in_place(self.scale_factor, &mut frame_buffer[1]);
-          *is_initialized = true;
-        }
-      } else {
-        self.downscaled_frame_buffer = Some((
-          Box::new([
-            frame1.planes[0].downscale(self.scale_factor),
-            frame2.planes[0].downscale(self.scale_factor),
-          ]),
-          true, // the frame buffer is initialized and in a valid state
-        ));
-      }
-
-      if let Some((frame_buffer, _)) = &self.downscaled_frame_buffer {
-        let frame_buffer = &**frame_buffer;
-        let delta = self.delta_in_planes(&frame_buffer[0], &frame_buffer[1]);
-
-        ScenecutResult {
-          threshold: self.threshold as f64,
-          inter_cost: delta as f64,
-          imp_block_cost: delta as f64,
-          forward_adjusted_cost: delta as f64,
-          backward_adjusted_cost: delta as f64,
-        }
-      } else {
-        unreachable!()
+        // SAFETY: `frame_ref_buffer` is always initialized to `Some(..)` at the start
+        // of this code block if it was `None`.
+        unsafe { debug_unreachable!() }
       }
     }
   }
@@ -108,34 +120,36 @@ impl<T: Pixel> SceneChangeDetector<T> {
 }
 
 /// Scaling factor for frame in scene detection
-pub(super) fn detect_scale_factor(
+pub(super) fn detect_scale_factor<T: Pixel>(
   sequence: &Arc<Sequence>, speed_mode: SceneDetectionSpeed,
-) -> usize {
+) -> Option<ScaleFunction<T>> {
   let small_edge =
     cmp::min(sequence.max_frame_height, sequence.max_frame_width) as usize;
-  let scale_factor = if speed_mode == SceneDetectionSpeed::Fast {
+  let scale_func = if speed_mode == SceneDetectionSpeed::Fast {
     match small_edge {
-      0..=240 => 1,
-      241..=480 => 2,
-      481..=720 => 4,
-      721..=1080 => 8,
-      1081..=1600 => 16,
-      1601..=usize::MAX => 32,
-      _ => 1,
+      0..=240 => None,
+      241..=480 => Some(ScaleFunction::from_scale::<2>()),
+      481..=720 => Some(ScaleFunction::from_scale::<4>()),
+      721..=1080 => Some(ScaleFunction::from_scale::<8>()),
+      1081..=1600 => Some(ScaleFunction::from_scale::<16>()),
+      1601..=usize::MAX => Some(ScaleFunction::from_scale::<32>()),
+      _ => None,
     }
   } else {
-    1
+    None
   };
 
-  if scale_factor != 1 {
+  if let Some(scale_factor) = scale_func.as_ref().map(|x| x.factor) {
     debug!(
       "Scene detection scale factor {}, [{},{}] -> [{},{}]",
       scale_factor,
       sequence.max_frame_width,
       sequence.max_frame_height,
-      sequence.max_frame_width as usize / scale_factor,
-      sequence.max_frame_height as usize / scale_factor
+      // SAFETY: We ensure that scale_factor is set based on nonzero powers of 2.
+      unsafe { fast_idiv(sequence.max_frame_width as usize, scale_factor) },
+      unsafe { fast_idiv(sequence.max_frame_height as usize, scale_factor) }
     );
   }
-  scale_factor
+
+  scale_func
 }

--- a/v_frame/Cargo.toml
+++ b/v_frame/Cargo.toml
@@ -21,3 +21,4 @@ noop_proc_macro = "0.3.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 wasm-bindgen = { version = "0.2.63", optional = true }
 rust_hawktracer = "0.7.0"
+new_debug_unreachable = "1.0.4"

--- a/v_frame/src/pixel.rs
+++ b/v_frame/src/pixel.rs
@@ -87,6 +87,7 @@ impl_cast_from_pixel_to_primitive!(i32);
 impl_cast_from_pixel_to_primitive!(u32);
 
 /// Types that can be used as pixel types.
+#[derive(PartialEq, Eq)]
 pub enum PixelType {
   /// 8 bits per pixel, stored in a `u8`.
   U8,


### PR DESCRIPTION
The main bottleneck of the fast scene detection mode is the internal downscaling which is performed. This PR changes the downscaling code to be specialized for each chosen scale factor (rather than one function which handles all scale factors), which in turn enables several optimizations in the compiler that are not possible for a general downscaling function. Overall, this PR's new downscaling is over 6x faster when compiling with AVX2 enabled, benchmarked on a 1280x720 yuv420p video.

Other changes:
- Remove rayon threading from `downscale_in_place`, as it seemed to prevent auto-vectorization by the compiler
- Allocate `frame_ref_buffer` and `downscaled_frame_buffer` on the stack instead of the heap
- Remove initialization checks with `unreachable_unchecked` (which originally existed because of borrow checker limitations)

Comparison of performance:

Before this PR:

![image](https://user-images.githubusercontent.com/48274562/166078608-acc0e1ca-69ec-4687-83d4-cd5796959748.png)

After this PR:

![image](https://user-images.githubusercontent.com/48274562/166078620-5fce5d78-cb94-4ce1-a16f-65d78a9abcaf.png)

With this PR, `fast_scenecut` in total (on the tested 720p clip) is about 5.9x faster (0.798 ms vs 0.135 ms average wall duration, which amounts to a difference of 1253 fps and 7407 fps throughput).