### PR TITLE
Compute segmentation offsets dynamically

### DIFF
--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -108,6 +108,9 @@ pub struct EncoderConfig {
   /// [`tile_rows`]: #structfield.tile_rows
   pub tiles: usize,
 
+  /// Strength of variance AQ. Defaults to 1.0. Disabled automatically by Tune=Psnr.
+  pub aq_strength: f64,
+
   /// Settings which affect the encoding speed vs. quality trade-off.
   pub speed_settings: SpeedSettings,
 }
@@ -165,6 +168,7 @@ impl EncoderConfig {
       tile_cols: 0,
       tile_rows: 0,
       tiles: 0,
+      aq_strength: 1.0,
       speed_settings: SpeedSettings::from_preset(speed),
     }
   }

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1314,6 +1314,7 @@ impl<T: Pixel> ContextInner<T> {
             frame_data.fi.sequence.bit_depth,
             &mut coded_data.activity_scales,
           );
+          frame_data.fi.compute_spatiotemporal_scores();
         } else {
           coded_data.activity_mask = ActivityMask::default();
         }

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -2082,6 +2082,7 @@ fn log_q_exp_overflow() {
     tile_cols: 0,
     tile_rows: 0,
     tiles: 0,
+    aq_strength: 1.0,
     speed_settings: SpeedSettings {
       multiref: false,
       fast_deblock: true,
@@ -2159,6 +2160,7 @@ fn guess_frame_subtypes_assert() {
     tile_cols: 0,
     tile_rows: 0,
     tiles: 0,
+    aq_strength: 1.0,
     speed_settings: SpeedSettings {
       multiref: false,
       fast_deblock: true,

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -162,6 +162,15 @@ pub struct CliOptions {
   /// Still picture mode
   #[clap(long, help_heading = "ENCODE SETTINGS")]
   pub still_picture: bool,
+  /// Adjusts the strength of adaptive quantization
+  #[clap(
+    long,
+    value_parser,
+    hide = true,
+    default_value_t = 1.0,
+    help_heading = "ENCODE SETTINGS"
+  )]
+  pub aq_strength: f64,
   /// Uses grain synthesis to add photon noise to the resulting encode.
   /// Takes a strength value 0-64.
   #[cfg(feature = "unstable")]
@@ -600,6 +609,11 @@ fn parse_config(matches: &CliOptions) -> Result<EncoderConfig, CliError> {
 
   if cfg.tune == Tune::Psychovisual {
     cfg.speed_settings.transform.tx_domain_distortion = false;
+  }
+  if cfg.tune == Tune::Psnr {
+    cfg.aq_strength = 0.0;
+  } else {
+    cfg.aq_strength = matches.aq_strength;
   }
 
   cfg.tile_cols = matches.tile_cols;

--- a/src/context/partition_unit.rs
+++ b/src/context/partition_unit.rs
@@ -249,7 +249,9 @@ impl<'a> ContextWriter<'a> {
     symbol_with_update!(self, w, skip as u32, cdf, 2);
   }
 
-  pub fn get_segment_pred(&self, bo: TileBlockOffset) -> (u8, u8) {
+  pub fn get_segment_pred(
+    &self, bo: TileBlockOffset, last_active_segid: u8,
+  ) -> (u8, u8) {
     let mut prev_ul = -1;
     let mut prev_u = -1;
     let mut prev_l = -1;
@@ -288,7 +290,8 @@ impl<'a> ContextWriter<'a> {
     } else {
       r = if prev_ul == prev_u { prev_u } else { prev_l };
     }
-    (r as u8, cdf_index)
+
+    ((r as u8).min(last_active_segid), cdf_index)
   }
 
   pub fn write_cfl_alphas<W: Writer>(&mut self, w: &mut W, cfl: CFLParams) {
@@ -434,7 +437,7 @@ impl<'a> ContextWriter<'a> {
     &mut self, w: &mut W, bo: TileBlockOffset, bsize: BlockSize, skip: bool,
     last_active_segid: u8,
   ) {
-    let (pred, cdf_index) = self.get_segment_pred(bo);
+    let (pred, cdf_index) = self.get_segment_pred(bo, last_active_segid);
     if skip {
       self.bc.blocks.set_segmentation_idx(bo, bsize, pred);
       return;

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -232,6 +232,8 @@ impl Arbitrary for ArbitraryEncoder {
       tile_cols: u.int_in_range(0..=2)?,
       tile_rows: u.int_in_range(0..=2)?,
       tiles: u.int_in_range(0..=16)?,
+      aq_strength: *u
+        .choose(&[-1.0, -0.5, 0.0, 0.1, 0.5, 1.0, 1.5, 2.5, 69.0])?,
 
       chroma_sampling: *u.choose(&[
         ChromaSampling::Cs420,

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -7,13 +7,22 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use std::cmp::Ordering;
+
 use crate::context::*;
 use crate::header::PRIMARY_REF_NONE;
 use crate::partition::BlockSize;
+use crate::rdo::spatiotemporal_scale;
+use crate::rdo::DistortionScale;
 use crate::tiling::TileStateMut;
 use crate::util::Pixel;
 use crate::FrameInvariants;
 use crate::FrameState;
+
+pub const MAX_SEGMENTS: usize = 8;
+
+// This value was obtained through testing over multiple runs in AWCY.
+const BASE_AQ_MULT: f64 = -9.0;
 
 pub fn segmentation_optimize<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>,
@@ -31,40 +40,23 @@ pub fn segmentation_optimize<T: Pixel>(
       return;
     }
 
-    // A series of AWCY runs with deltas 13, 15, 17, 18, 19, 20, 21, 22, 23
-    // showed this to be the optimal one.
-    const TEMPORAL_RDO_QI_DELTA: i16 = 21;
-
     // Avoid going into lossless mode by never bringing qidx below 1.
     // Because base_q_idx changes more frequently than the segmentation
     // data, it is still possible for a segment to enter lossless, so
     // enforcement elsewhere is needed.
     let offset_lower_limit = 1 - fi.base_q_idx as i16;
 
-    // Fill in 3 slots with 0, delta, -delta. The slot IDs are also used in
-    // luma_chroma_mode_rdo() so if you change things here make sure to check
-    // that place too.
-    for i in 0..3 {
-      fs.segmentation.features[i][SegLvl::SEG_LVL_ALT_Q as usize] = true;
-      fs.segmentation.data[i][SegLvl::SEG_LVL_ALT_Q as usize] = match i {
-        0 => 0,
-        1 => TEMPORAL_RDO_QI_DELTA,
-        2 => (-TEMPORAL_RDO_QI_DELTA).max(offset_lower_limit),
-        _ => unreachable!(),
-      };
-    }
+    segmentation_optimize_inner(fi, fs, offset_lower_limit);
 
     /* Figure out parameters */
     fs.segmentation.preskip = false;
     fs.segmentation.last_active_segid = 0;
-    if fs.segmentation.enabled {
-      for i in 0..8 {
-        for j in 0..SegLvl::SEG_LVL_MAX as usize {
-          if fs.segmentation.features[i][j] {
-            fs.segmentation.last_active_segid = i as u8;
-            if j >= SegLvl::SEG_LVL_REF_FRAME as usize {
-              fs.segmentation.preskip = true;
-            }
+    for i in 0..MAX_SEGMENTS {
+      for j in 0..SegLvl::SEG_LVL_MAX as usize {
+        if fs.segmentation.features[i][j] {
+          fs.segmentation.last_active_segid = i as u8;
+          if j >= SegLvl::SEG_LVL_REF_FRAME as usize {
+            fs.segmentation.preskip = true;
           }
         }
       }
@@ -72,58 +64,199 @@ pub fn segmentation_optimize<T: Pixel>(
   }
 }
 
+fn segmentation_optimize_inner<T: Pixel>(
+  fi: &FrameInvariants<T>, fs: &mut FrameState<T>, offset_lower_limit: i16,
+) {
+  const AVG_SEG: f64 = 3.0;
+
+  let coded_data = fi.coded_frame_data.as_ref().unwrap();
+  let segments = &coded_data.imp_b_segments;
+  let mut seg_counts = [0usize; MAX_SEGMENTS];
+  segments.iter().for_each(|&seg| {
+    seg_counts[seg as usize % 8] += 1;
+  });
+
+  let mut num_neg = 0usize;
+  let mut num_pos = 0usize;
+  let mut tmp_delta = [0f64; MAX_SEGMENTS];
+  for i in 0..MAX_SEGMENTS {
+    tmp_delta[i] = (AVG_SEG - i as f64) * BASE_AQ_MULT * fi.config.aq_strength;
+    if tmp_delta[i] > 0f64 {
+      num_pos += 1;
+    } else if tmp_delta[i] < 0f64 {
+      num_neg += 1;
+    }
+  }
+
+  // We want at least 1/12 of the blocks in a segment in order to code it.
+  // In most cases this results in 3-4 segments being coded, which is optimal.
+  let threshold = segments.len() / 12;
+
+  let mut remap_segment_tab: [usize; MAX_SEGMENTS] = [0, 1, 2, 3, 4, 5, 6, 7];
+  let mut num_segments = MAX_SEGMENTS;
+
+  loop {
+    let mut changed = false;
+
+    if num_segments < 4 {
+      break;
+    }
+
+    for i in (0..MAX_SEGMENTS).rev() {
+      if seg_counts[remap_segment_tab[i]] >= threshold {
+        continue;
+      };
+      if seg_counts[remap_segment_tab[i]] == 0 {
+        continue;
+      }; /* Already eliminated */
+
+      let prev_id = remap_segment_tab[i];
+
+      #[derive(Debug, Default, Clone, Copy)]
+      struct ScoreTab {
+        idx: usize,
+        score: f64,
+      }
+      let mut s_array =
+        [ScoreTab { idx: usize::max_value(), score: std::f64::MAX };
+          MAX_SEGMENTS];
+
+      for j in 0..MAX_SEGMENTS {
+        s_array[j].idx = remap_segment_tab[j];
+        if (remap_segment_tab[j] == prev_id)
+          || (seg_counts[remap_segment_tab[j]] == 0)
+          || (((num_neg < 2) || (num_pos < 2))
+            && (tmp_delta[remap_segment_tab[j]].signum()
+              != tmp_delta[prev_id].signum()))
+        {
+          s_array[j].score = std::f64::MAX;
+        } else {
+          s_array[j].score =
+            (tmp_delta[remap_segment_tab[j]] - tmp_delta[prev_id]).abs();
+        }
+      }
+
+      s_array.sort_by(|a, b| {
+        (a.score).partial_cmp(&b.score).unwrap_or(Ordering::Less)
+      });
+
+      if s_array[0].score == std::f64::MAX {
+        continue;
+      }
+
+      /* Remap any old mappings to the current segment as well */
+      for j in 0..MAX_SEGMENTS {
+        if remap_segment_tab[j] == prev_id {
+          remap_segment_tab[j] = s_array[0].idx;
+        }
+      }
+
+      let num_2bins = seg_counts[remap_segment_tab[i]] + seg_counts[prev_id];
+      let mut ratio_new =
+        (seg_counts[remap_segment_tab[i]] as f64) / (num_2bins as f64);
+      let mut ratio_old = (seg_counts[prev_id] as f64) / (num_2bins as f64);
+
+      ratio_new *= tmp_delta[remap_segment_tab[i]];
+      ratio_old *= tmp_delta[prev_id];
+
+      num_pos -= (tmp_delta[prev_id] > 0f64) as usize;
+      num_neg -= (tmp_delta[prev_id] < 0f64) as usize;
+
+      tmp_delta[remap_segment_tab[i]] = ratio_new + ratio_old;
+      tmp_delta[prev_id] = std::f64::MAX;
+
+      seg_counts[remap_segment_tab[i]] += seg_counts[prev_id];
+      seg_counts[prev_id] = 0;
+
+      num_segments -= 1;
+
+      changed = true;
+      break;
+    }
+
+    if !changed {
+      break;
+    }
+  }
+
+  tmp_delta.iter_mut().for_each(|delta| {
+    if *delta > 0.0 {
+      // We want the strength of the bitrate reduction to be
+      // less than the strength of the bitrate increase.
+      *delta *= 0.8;
+    }
+  });
+
+  /* Get all unique values in the intentionally unsorted array (its a LUT) */
+  let mut uniq_array = [0usize; MAX_SEGMENTS];
+  let mut num_segments = 0;
+  for i in 0..MAX_SEGMENTS {
+    let mut seen_match = false;
+    for j in 0..num_segments {
+      if remap_segment_tab[i] == uniq_array[j] {
+        seen_match = true;
+      }
+    }
+    if !seen_match {
+      uniq_array[num_segments] = remap_segment_tab[i];
+      num_segments += 1;
+    }
+  }
+
+  let mut seg_delta = [0f64; MAX_SEGMENTS];
+  for i in 0..num_segments {
+    /* Collect all used segment deltas into the actual segment map */
+    seg_delta[i] = tmp_delta[uniq_array[i]];
+
+    /* Remap the LUT to make it match the layout of the seg deltaq map */
+    for j in 0..MAX_SEGMENTS {
+      if remap_segment_tab[j] == uniq_array[i] {
+        remap_segment_tab[j] = i;
+      }
+    }
+  }
+
+  fs.segmentation.segment_map = remap_segment_tab;
+
+  for i in 0..num_segments {
+    fs.segmentation.features[i][SegLvl::SEG_LVL_ALT_Q as usize] = true;
+    fs.segmentation.data[i][SegLvl::SEG_LVL_ALT_Q as usize] =
+      (seg_delta[i].round() as i16).max(offset_lower_limit);
+  }
+}
+
 pub fn select_segment<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &TileStateMut<'_, T>, tile_bo: TileBlockOffset,
   bsize: BlockSize, skip: bool,
 ) -> std::ops::RangeInclusive<u8> {
-  use crate::api::SegmentationLevel;
-  use crate::rdo::spatiotemporal_scale;
-  use arrayvec::ArrayVec;
-
   // If skip is true or segmentation is turned off, sidx is not coded.
   if skip || !fi.enable_segmentation {
     return 0..=0;
   }
 
-  let segment_2_is_lossless = fi.base_q_idx as i16
-    + ts.segmentation.data[2][SegLvl::SEG_LVL_ALT_Q as usize]
-    < 1;
-
-  if fi.config.speed_settings.segmentation == SegmentationLevel::Full {
-    return if segment_2_is_lossless { 0..=1 } else { 0..=2 };
-  }
-
   let frame_bo = ts.to_frame_block_offset(tile_bo);
   let scale = spatiotemporal_scale(fi, frame_bo, bsize);
 
-  // TODO: Replace this calculation with precomputed scale thresholds.
-  let seg_ac_q: ArrayVec<_, 3> = if fi.enable_segmentation {
-    use crate::quantize::ac_q;
-    (0..=2)
-      .map(|sidx| {
-        ac_q(
-          (fi.base_q_idx as i16
-            + ts.segmentation.data[sidx][SegLvl::SEG_LVL_ALT_Q as usize])
-            .max(0)
-            .min(255) as u8,
-          0,
-          fi.sequence.bit_depth,
-        )
-      })
-      .collect()
-  } else {
-    Default::default()
-  };
-
-  let sidx = if scale.mul_u64(seg_ac_q[1] as u64) < seg_ac_q[0] as u64 {
-    1
-  } else if !segment_2_is_lossless
-    && scale.mul_u64(seg_ac_q[2] as u64) > seg_ac_q[0] as u64
-  {
-    2
-  } else {
-    0
-  };
-
+  let sidx = ts.segmentation.segment_map
+    [segment_idx_from_distortion(scale) as usize % 8] as u8;
   sidx..=sidx
+}
+
+// These values were obtained based on thorough testing
+// around the idea that the resulting encode filesize
+// with dynamic segment maps should be, on average, the same as
+// with the static segment maps.
+// i.e. These values were found to improve perceptual quality
+// without significantly impacting filesize.
+pub fn segment_idx_from_distortion(s: DistortionScale) -> u8 {
+  match f64::from(s) {
+    s if s >= 2.0 => 0,
+    s if s >= 1.5 => 1,
+    s if s >= 1.15 => 2,
+    s if s >= 0.9 => 3,
+    s if s >= 0.8 => 4,
+    s if s >= 0.7 => 5,
+    s if s >= 0.625 => 6,
+    _ => 7,
+  }
 }


### PR DESCRIPTION
This changeset, in lieu of reusing variance calculations to do spatial AQ, factors in the fact that the spatiotemporal scales we have _already consider_ both spatial and temporal importance. Therefore, this changeset uses the existing metric and uses an assessment of the distribution of that metric within a frame to determine how many segments to use and what the deltaq offset should be for each of them, rather than using a constant set of +21/-21/0.

The segment splitting code in this changeset is originally from @cyanreg in #2247.

As an immediate followup to this pull request, I still plan to add luma-based AQ bias to provide more bits to dark areas and adapt AQ for HDR clips. Ideas for future improvements are also very welcome.

[AWCY](https://beta.arewecompressedyet.com/?job=master-c23559d7bb0e2c97fac4603588d0f53477b2019a&job=spatial_aq_09%402022-05-07T01%3A42%3A16.301Z) shows promising results--neutral metrics and, in my opinion, good psychovisual improvements.

Closes #752