### PR TITLE
Remove uses of Arc::make_mut to avoid clones

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -12,8 +12,36 @@ mod align;
 mod cdf;
 mod uninit;
 
+use std::sync::Arc;
+
 pub use v_frame::math::*;
 pub use v_frame::pixel::*;
 
 pub use align::*;
 pub use uninit::*;
+
+// There does exist `Arc::get_mut_unchecked` to do this,
+// but it is currently nightly only.
+// And because the Arc fields are private, we have to do something much more annoying.
+//
+// Once `get_mut_unchecked` is stable in stdlib, we should use that instead.
+//
+// Why does it matter so much that this exists?
+// `Arc::make_mut` may clone the inner data without our awareness.
+// That may (although has not, somehow) cause issues with data consistency.
+// But the issue we have encountered is that these clones make rav1e slower.
+// If we know that we are not writing to the same part of this Arc as another thread,
+// such as when tiling, we can avoid the clone.
+pub(crate) unsafe fn arc_get_mut_unsafe<T>(this: &mut Arc<T>) -> &mut T {
+  let count = Arc::strong_count(this);
+  let raw = Arc::into_raw(Arc::clone(this));
+  for _ in 0..count {
+    Arc::decrement_strong_count(raw);
+  }
+  let inner = Arc::get_mut(this).unwrap();
+  for _ in 0..count {
+    Arc::increment_strong_count(raw);
+  }
+  Arc::from_raw(raw);
+  inner
+}


### PR DESCRIPTION
Profiling revealed there to be a measurable number of clones coming out of `TileStateMut::new`, which was traceable to usage of `Arc::make_mut`. A characteristic of `Arc::make_mut` is that it will clone the inner data when a thread attempts to write to it. In theory, I have concerns that this could cause data inconsistencies, although that does not seem to have happened in practice in rav1e. However, the clones are avoidable, because each place where we use `Arc::make_mut` can be safely assumed to be independent--i.e. there is never more than one thread accessing the same portion of the data.

640x360 with 1 tile: 1.5% memory usage reduction
640x360 with 4 tiles: 4% memory usage reduction
1920x1080 with 4 tiles: 6% memory usage reduction

No measurable runtime improvement with 1 tile.
~1% runtime improvement with 4 tiles.