### PR TITLE
Silence unused variable warning.

### DIFF
--- a/src/asm/aarch64/dist.rs
+++ b/src/asm/aarch64/dist.rs
@@ -91,7 +91,7 @@ pub fn get_sad<T: Pixel>(
         None => call_rust(),
       }
     }
-    (Ok(bsize), PixelType::U16) => call_rust(),
+    (Ok(_bsize), PixelType::U16) => call_rust(),
   };
 
   #[cfg(feature = "check_asm")]


### PR DESCRIPTION
Silence unused variable warning. This only shows up on aarch64 builds.