### PR TITLE
Rewrite x86 SAD row intrinsics in ASM

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -108,6 +108,7 @@ fn build_nasm_files() {
     "src/x86/mc_sse.asm",
     "src/x86/mc16_sse.asm",
     "src/x86/me.asm",
+    "src/x86/sad_row.asm",
     "src/x86/sad_sse2.asm",
     "src/x86/sad_avx.asm",
     "src/x86/satd.asm",

--- a/src/asm/x86/sad_row.rs
+++ b/src/asm/x86/sad_row.rs
@@ -7,143 +7,25 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use debug_unreachable::debug_unreachable;
-
 use crate::cpu_features::CpuFeatureLevel;
 use crate::sad_row::*;
 use crate::util::{Pixel, PixelType};
 
-#[cfg(target_arch = "x86")]
-use std::arch::x86::*;
-#[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
-
-use std::arch::asm;
 use std::mem;
 
-/// SAFETY: src and dst must be the same length
-#[inline(always)]
-unsafe fn sad_scalar(src: &[u8], dst: &[u8]) -> i64 {
-  if src.len() != dst.len() {
-    debug_unreachable!()
-  }
-
-  let mut sum = 0;
-
-  for i in 0..src.len() {
-    // We use inline assembly here to force the compiler to not auto-vectorize the loop,
-    // since it is already vectorized manually.
-    asm!(
-      "add {sum}, {x}",
-      sum = out(reg) sum,
-      x = in(reg) (*src.get_unchecked(i) as i64 - *dst.get_unchecked(i) as i64).abs(),
-      options(nostack)
-    );
-  }
-
-  sum
-}
-
-/// SAFETY: src and dst must be the same length and less than 32 elements
-#[inline]
-#[target_feature(enable = "sse2")]
-unsafe fn sad_below32_8bpc_sse2(src: &[u8], dst: &[u8]) -> i64 {
-  if src.len() != dst.len() {
-    debug_unreachable!()
-  }
-
-  let mut offset = 0;
-
-  let mut sum = if src.len() >= 16 {
-    let src_u8x16 = _mm_load_si128(src.as_ptr() as *const _);
-    let dst_u8x16 = _mm_load_si128(dst.as_ptr() as *const _);
-    let result = _mm_sad_epu8(src_u8x16, dst_u8x16);
-    let sum = mem::transmute::<_, [i64; 2]>(result).iter().sum::<i64>();
-
-    // cannot overflow because src.len() >= 16
-    let remaining = src.len() - 16;
-
-    if remaining != 0 {
-      offset = 16;
+macro_rules! decl_sad_row_fn {
+  ($($f:ident),+) => {
+    extern {
+      $(
+        fn $f(
+          src: *const u8, dst: *const u8, len: libc::size_t,
+        ) -> u64;
+      )*
     }
-
-    sum
-  } else {
-    0
   };
-
-  sum += sad_scalar(src.get_unchecked(offset..), dst.get_unchecked(offset..));
-
-  sum
 }
 
-/// SAFETY: src and dst must be the same length
-#[inline]
-#[target_feature(enable = "avx2")]
-unsafe fn sad_8bpc_avx2(src: &[u8], dst: &[u8]) -> i64 {
-  if src.len() != dst.len() {
-    debug_unreachable!()
-  }
-
-  let src_chunks = src.chunks_exact(32);
-  let dst_chunks = dst.chunks_exact(32);
-
-  let (src_rem, dst_rem) = (src_chunks.remainder(), dst_chunks.remainder());
-
-  let main_sum = src_chunks
-    .zip(dst_chunks)
-    .map(|(src_chunk, dst_chunk)| {
-      let src = _mm256_load_si256(src_chunk.as_ptr() as *const _);
-      let dst = _mm256_load_si256(dst_chunk.as_ptr() as *const _);
-
-      _mm256_sad_epu8(src, dst)
-    })
-    .reduce(|a, b| _mm256_add_epi32(a, b));
-
-  let mut sum = if let Some(main_sum) = main_sum {
-    mem::transmute::<_, [i64; 4]>(main_sum).iter().sum::<i64>()
-  } else {
-    0
-  };
-
-  sum += sad_below32_8bpc_sse2(src_rem, dst_rem);
-
-  sum
-}
-
-/// SAFETY: src and dst must be the same length
-#[inline]
-#[target_feature(enable = "sse2")]
-unsafe fn sad_8bpc_sse2(src: &[u8], dst: &[u8]) -> i64 {
-  if src.len() != dst.len() {
-    debug_unreachable!()
-  }
-
-  let src_chunks = src.chunks_exact(16);
-  let dst_chunks = dst.chunks_exact(16);
-
-  let (src_rem, dst_rem) = (src_chunks.remainder(), dst_chunks.remainder());
-
-  let main_sum = src_chunks
-    .zip(dst_chunks)
-    .map(|(src_chunk, dst_chunk)| {
-      let src = _mm_load_si128(src_chunk.as_ptr() as *const _);
-      let dst = _mm_load_si128(dst_chunk.as_ptr() as *const _);
-
-      _mm_sad_epu8(src, dst)
-    })
-    .reduce(|a, b| _mm_add_epi32(a, b));
-
-  let mut sum = if let Some(main_sum) = main_sum {
-    mem::transmute::<_, [i64; 2]>(main_sum).iter().sum::<i64>()
-  } else {
-    0
-  };
-
-  sum += sad_scalar(src_rem, dst_rem);
-
-  sum
-}
+decl_sad_row_fn!(rav1e_sad_row_8bpc_sse2, rav1e_sad_row_8bpc_avx2);
 
 pub(crate) fn sad_row_internal<T: Pixel>(
   src: &[T], dst: &[T], cpu: CpuFeatureLevel,
@@ -161,7 +43,7 @@ pub(crate) fn sad_row_internal<T: Pixel>(
           #[allow(clippy::undocumented_unsafe_blocks)]
           unsafe {
             let result =
-              $func(mem::transmute($src), mem::transmute($dst)) as u64;
+              $func(mem::transmute(($src).as_ptr()), mem::transmute(($dst).as_ptr()), src.len()) as u64;
 
             #[cfg(feature = "check_asm")]
             assert_eq!(result, rust::sad_row_internal($src, $dst, $cpu));
@@ -172,9 +54,9 @@ pub(crate) fn sad_row_internal<T: Pixel>(
       }
 
       if cpu >= CpuFeatureLevel::AVX2 {
-        call_asm!(sad_8bpc_avx2, src, dst, cpu)
+        call_asm!(rav1e_sad_row_8bpc_avx2, src, dst, cpu)
       } else if cpu >= CpuFeatureLevel::SSE2 {
-        call_asm!(sad_8bpc_sse2, src, dst, cpu)
+        call_asm!(rav1e_sad_row_8bpc_sse2, src, dst, cpu)
       } else {
         rust::sad_row_internal(src, dst, cpu)
       }

--- a/src/x86/sad_row.asm
+++ b/src/x86/sad_row.asm
@@ -1,0 +1,149 @@
+; Copyright (c) 2022, The rav1e contributors. All rights reserved
+;
+; This source code is subject to the terms of the BSD 2 Clause License and
+; the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+; was not distributed with this source code in the LICENSE file, you can
+; obtain it at www.aomedia.org/license/software. If the Alliance for Open
+; Media Patent License 1.0 was not distributed with this source code in the
+; PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+%include "config.asm"
+%include "ext/x86/x86inc.asm"
+
+SECTION_RODATA
+
+align 32
+mask_lut: db \
+ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0, 0, \
+-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 0,
+
+SECTION .text
+
+%if ARCH_X86_64
+
+%macro SAD_ROW_FN 0
+cglobal sad_row_8bpc, 3, 5, 8, p1, p2, len, \
+                      resid_simd, resid
+  ; always need to zero first register
+  pxor    xm0, xm0
+  mov     resid_simdq, lenq
+  mov     residq,  lenq
+  and     residd, mmsize - 1
+  and     resid_simdq, -(mmsize)
+  jz     .residual
+  ; need to zero 2 more registers
+  pxor    xm1, xm1
+  pxor    xm2, xm2
+  ; len = num elements processed by unrolled loop
+  and     lenq, -(4*mmsize)
+  jz     .lt_4x
+  add     p1q, lenq
+  add     p2q, lenq
+  sub     resid_simdq, lenq
+  ; last register needed for unrolled loop
+  vpxor   xm3, xm3
+  neg     lenq
+.loop:
+  mova        m4,     [p1q + lenq + 0*mmsize]
+  mova        m5,     [p1q + lenq + 1*mmsize]
+  mova        m6,     [p1q + lenq + 2*mmsize]
+  mova        m7,     [p1q + lenq + 3*mmsize]
+
+  psadbw      m4, m4, [p2q + lenq + 0*mmsize]
+  psadbw      m5, m5, [p2q + lenq + 1*mmsize]
+  psadbw      m6, m6, [p2q + lenq + 2*mmsize]
+  psadbw      m7, m7, [p2q + lenq + 3*mmsize]
+
+  paddq       m0, m4
+  paddq       m1, m5
+  paddq       m2, m6
+  paddq       m3, m7
+
+  add         lenq, 4*mmsize
+  jnz        .loop
+
+  vpaddq      m2, m3
+.lt_4x:
+  ; jump to correct place for residual vector reduction
+  test      resid_simdd, resid_simdd
+  jz       .residual_setup
+  cmp       resid_simdd, 1*mmsize
+  je       .r1
+  cmp       resid_simdd, 2*mmsize
+  je       .r2
+  ; add residual vectors in reverse order
+  mova      m6,     [p1q + lenq + 2*mmsize]
+  psadbw    m6, m6, [p2q + lenq + 2*mmsize]
+  paddq     m2, m6
+.r2:
+  mova      m5,     [p1q + lenq + 1*mmsize]
+  psadbw    m5, m5, [p2q + lenq + 1*mmsize]
+  paddq     m1, m5
+.r1:
+  mova      m4,     [p1q + lenq + 0*mmsize]
+  psadbw    m4, m4, [p2q + lenq + 0*mmsize]
+  paddq     m0, m4
+.residual_setup:
+  paddq     m1, m2
+  paddq     m0, m1
+  test  residd, residd
+  jz       .hsum
+.residual:
+  DEFINE_ARGS p1, p2, mask_ptr, resid_simd, resid
+  lea   mask_ptrq, [mask_lut]
+  shl      residd, 5
+  mova     m1,     [mask_ptrq + residq]
+  ; read residual elements and zero out elements
+  ; past the end of the array with mask in m1
+  pand     m2, m1, [p1q + resid_simdq]
+  pand     m3, m1, [p2q + resid_simdq]
+  psadbw   m1, m2, m3
+  paddq    m0, m1
+.hsum:
+%if mmsize == 32
+  vextracti128  xm1, ym0, 1
+  paddq         xm0, xm1
+%endif
+  pshufd        xm1, xm0, q0032
+  paddq         xm0, xm1
+  movq          rax, xm0
+  RET
+%endmacro
+
+INIT_XMM sse2
+SAD_ROW_FN
+
+INIT_YMM avx2
+SAD_ROW_FN
+
+%endif ; ARCH_X86_64


### PR DESCRIPTION
This speeds up the sad_row functions mainly by avoiding a residual loop altogether, and avoiding mixing 128 bit and 256 bit vector instructions which causes slow downs on some CPUs. Instead of using a scalar residual loop to clean up the elements that don't fit into the SIMD register and unroll size, this code always uses vector instructions and just reads past the end of the array and masks out the irrelevant bytes (similar to glibc's AVX2 memchr implementation).

This also actually ends up de-duplicating some code between the SSE2 and AVX2 versions of the code, since a single macro is now used to generate both versions of the function.

Maybe in the future this function could just operate over 2 entire planes instead of just a row, this way there would be less looping overhead between rows (sad_row is only used on each row of an entire plane to get the SAD between 2 planes). 