### PR TITLE
Reimplement sad_row as sad_plane

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -108,7 +108,7 @@ fn build_nasm_files() {
     "src/x86/mc_sse.asm",
     "src/x86/mc16_sse.asm",
     "src/x86/me.asm",
-    "src/x86/sad_row.asm",
+    "src/x86/sad_plane.asm",
     "src/x86/sad_sse2.asm",
     "src/x86/sad_avx.asm",
     "src/x86/satd.asm",

--- a/src/asm/x86/mod.rs
+++ b/src/asm/x86/mod.rs
@@ -14,5 +14,5 @@ pub mod lrf;
 pub mod mc;
 pub mod predict;
 pub mod quantize;
-pub mod sad_row;
+pub mod sad_plane;
 pub mod transform;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ mod mc;
 mod me;
 mod rate;
 mod recon_intra;
-mod sad_row;
+mod sad_plane;
 mod scan_order;
 #[cfg(feature = "scenechange")]
 pub mod scenechange;

--- a/src/sad_plane.rs
+++ b/src/sad_plane.rs
@@ -9,11 +9,13 @@
 
 cfg_if::cfg_if! {
   if #[cfg(nasm_x86_64)] {
-    use crate::asm::x86::sad_row::*;
+    use crate::asm::x86::sad_plane::*;
   } else {
     use self::rust::*;
   }
 }
+
+use v_frame::plane::Plane;
 
 use crate::cpu_features::CpuFeatureLevel;
 use crate::util::{CastFromPrimitive, Pixel};
@@ -23,14 +25,29 @@ pub(crate) mod rust {
   use crate::cpu_features::CpuFeatureLevel;
 
   #[inline]
-  pub(crate) fn sad_row_internal<T: Pixel>(
-    src: &[T], dst: &[T], _cpu: CpuFeatureLevel,
+  pub(crate) fn sad_plane_internal<T: Pixel>(
+    src: &Plane<T>, dst: &Plane<T>, _cpu: CpuFeatureLevel,
   ) -> u64 {
+    debug_assert!(src.cfg.width == dst.cfg.width);
+
+    let width = src.cfg.width;
+
     src
-      .iter()
-      .zip(dst.iter())
-      .map(|(&p1, &p2)| (i16::cast_from(p1) - i16::cast_from(p2)).abs() as u32)
-      .sum::<u32>() as u64
+      .rows_iter()
+      .zip(dst.rows_iter())
+      .map(|(src, dst)| {
+        let src = src.get(..width).unwrap_or(src);
+        let dst = dst.get(..width).unwrap_or(dst);
+
+        src
+          .iter()
+          .zip(dst.iter())
+          .map(|(&p1, &p2)| {
+            (i16::cast_from(p1) - i16::cast_from(p2)).abs() as u32
+          })
+          .sum::<u32>() as u64
+      })
+      .sum()
   }
 }
 
@@ -38,8 +55,8 @@ pub(crate) mod rust {
 ///
 /// This differs from other SAD functions in that it operates over a row
 /// (or line) of unknown length rather than a `PlaneRegion<T>`.
-pub(crate) fn sad_row<T: Pixel>(
-  src: &[T], dst: &[T], cpu: CpuFeatureLevel,
+pub(crate) fn sad_plane<T: Pixel>(
+  src: &Plane<T>, dst: &Plane<T>, cpu: CpuFeatureLevel,
 ) -> u64 {
-  sad_row_internal(src, dst, cpu)
+  sad_plane_internal(src, dst, cpu)
 }

--- a/src/scenechange/fast.rs
+++ b/src/scenechange/fast.rs
@@ -4,7 +4,7 @@ use crate::{
   api::SceneDetectionSpeed,
   encoder::Sequence,
   frame::{Frame, Plane},
-  sad_row,
+  sad_plane,
   scenechange::fast_idiv,
 };
 use debug_unreachable::debug_unreachable;
@@ -106,15 +106,8 @@ impl<T: Pixel> SceneChangeDetector<T> {
   /// Calculates the average sum of absolute difference (SAD) per pixel between 2 planes
   #[hawktracer(delta_in_planes)]
   fn delta_in_planes(&self, plane1: &Plane<T>, plane2: &Plane<T>) -> f64 {
-    let mut delta = 0;
+    let delta = sad_plane::sad_plane(plane1, plane2, self.cpu_feature_level);
 
-    let lines = plane1.rows_iter().zip(plane2.rows_iter());
-
-    for (l1, l2) in lines {
-      let l1 = l1.get(..plane1.cfg.width).unwrap_or(l1);
-      let l2 = l2.get(..plane1.cfg.width).unwrap_or(l2);
-      delta += sad_row::sad_row(l1, l2, self.cpu_feature_level);
-    }
     delta as f64 / self.pixels as f64
   }
 }


### PR DESCRIPTION
This should remove any overhead of Rust having to loop through each row and call the ASM implementation of sad_row, and instead allow a new sad_plane function to iterate over the rows by itself.