### PR TITLE
Replace abs() as unsigned with dedicated alternative.

### DIFF
--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -1759,7 +1759,7 @@ impl<'a> ContextWriter<'a> {
     };
 
     for (&delta, cdf) in deltas.iter().zip(cdfs.iter_mut()) {
-      let abs = delta.abs() as u32;
+      let abs = delta.unsigned_abs() as u32;
 
       symbol_with_update!(self, w, cmp::min(abs, DELTA_LF_SMALL), cdf, 4);
 

--- a/src/context/partition_unit.rs
+++ b/src/context/partition_unit.rs
@@ -124,7 +124,7 @@ impl CFLParams {
   pub const fn from_alpha(u: i16, v: i16) -> CFLParams {
     CFLParams {
       sign: [CFLSign::from_alpha(u), CFLSign::from_alpha(v)],
-      scale: [u.abs() as u8, v.abs() as u8],
+      scale: [u.unsigned_abs() as u8, v.unsigned_abs() as u8],
     }
   }
 }

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -48,7 +48,7 @@ pub(crate) mod rust {
         .iter()
         .take(w)
         .zip(slice_ref)
-        .map(|(&a, &b)| (i32::cast_from(a) - i32::cast_from(b)).abs() as u32)
+        .map(|(&a, &b)| (i32::cast_from(a) - i32::cast_from(b)).unsigned_abs())
         .sum::<u32>();
     }
 
@@ -215,7 +215,7 @@ pub(crate) mod rust {
         }
 
         // Sum the absolute values of the transformed differences
-        sum += buf.iter().map(|a| a.abs() as u64).sum::<u64>();
+        sum += buf.iter().map(|a| a.unsigned_abs() as u64).sum::<u64>();
       }
     }
 

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1039,7 +1039,7 @@ pub(crate) mod rust {
       width: usize, height: usize, smooth_filter: bool, angle_delta: isize,
     ) -> u8 {
       let block_wh = width + height;
-      let abs_delta = angle_delta.abs() as usize;
+      let abs_delta = angle_delta.unsigned_abs();
 
       if smooth_filter {
         if block_wh <= 8 {
@@ -1102,7 +1102,7 @@ pub(crate) mod rust {
       width: usize, height: usize, smooth_filter: bool, angle_delta: isize,
     ) -> bool {
       let block_wh = width + height;
-      let abs_delta = angle_delta.abs() as usize;
+      let abs_delta = angle_delta.unsigned_abs();
 
       if abs_delta == 0 || abs_delta >= 40 {
         false

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -247,7 +247,7 @@ impl QuantizationContext {
     qcoeffs[0] = {
       let coeff: i32 =
         i32::cast_from(coeffs[0]) << (self.log_tx_scale as usize);
-      let abs_coeff = coeff.abs() as u32;
+      let abs_coeff = coeff.unsigned_abs();
       T::cast_from(copysign(
         divu_pair(abs_coeff + self.dc_offset, self.dc_mul_add),
         coeff,
@@ -288,7 +288,7 @@ impl QuantizationContext {
     let mut level_mode = 1;
     for &pos in scan.iter().take(eob).skip(1) {
       let coeff = i32::cast_from(coeffs[pos as usize]) << self.log_tx_scale;
-      let abs_coeff = coeff.abs() as u32;
+      let abs_coeff = coeff.unsigned_abs();
 
       let level0 = divu_pair(abs_coeff, self.ac_mul_add);
       let offset = if level0 > 1 - level_mode {

--- a/src/sad_plane.rs
+++ b/src/sad_plane.rs
@@ -43,7 +43,7 @@ pub(crate) mod rust {
           .iter()
           .zip(dst.iter())
           .map(|(&p1, &p2)| {
-            (i16::cast_from(p1) - i16::cast_from(p2)).abs() as u32
+            (i16::cast_from(p1) - i16::cast_from(p2)).unsigned_abs() as u32
           })
           .sum::<u32>() as u64
       })


### PR DESCRIPTION
This is an upcoming clippy lint. unsigned_abs() was added in Rust 1.51.0, meeting the current version requirement. This avoids a potential panic in debug mode. cargo test passed and sample bitstreams are identical.