### PR TITLE
Integrate new dav1d assembly (0.9.2) 

### DIFF
--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -356,16 +356,16 @@ macro_rules! decl_mc_fns {
 }
 
 decl_mc_fns!(
-  (REGULAR, REGULAR, rav1e_put_8tap_regular),
-  (REGULAR, SMOOTH, rav1e_put_8tap_regular_smooth),
-  (REGULAR, SHARP, rav1e_put_8tap_regular_sharp),
-  (SMOOTH, REGULAR, rav1e_put_8tap_smooth_regular),
-  (SMOOTH, SMOOTH, rav1e_put_8tap_smooth),
-  (SMOOTH, SHARP, rav1e_put_8tap_smooth_sharp),
-  (SHARP, REGULAR, rav1e_put_8tap_sharp_regular),
-  (SHARP, SMOOTH, rav1e_put_8tap_sharp_smooth),
-  (SHARP, SHARP, rav1e_put_8tap_sharp),
-  (BILINEAR, BILINEAR, rav1e_put_bilin)
+  (REGULAR, REGULAR, rav1e_put_8tap_regular_8bpc),
+  (REGULAR, SMOOTH, rav1e_put_8tap_regular_smooth_8bpc),
+  (REGULAR, SHARP, rav1e_put_8tap_regular_sharp_8bpc),
+  (SMOOTH, REGULAR, rav1e_put_8tap_smooth_regular_8bpc),
+  (SMOOTH, SMOOTH, rav1e_put_8tap_smooth_8bpc),
+  (SMOOTH, SHARP, rav1e_put_8tap_smooth_sharp_8bpc),
+  (SHARP, REGULAR, rav1e_put_8tap_sharp_regular_8bpc),
+  (SHARP, SMOOTH, rav1e_put_8tap_sharp_smooth_8bpc),
+  (SHARP, SHARP, rav1e_put_8tap_sharp_8bpc),
+  (BILINEAR, BILINEAR, rav1e_put_bilin_8bpc)
 );
 
 cpu_function_lookup_table!(
@@ -479,16 +479,16 @@ macro_rules! decl_mct_fns {
 }
 
 decl_mct_fns!(
-  (REGULAR, REGULAR, rav1e_prep_8tap_regular),
-  (REGULAR, SMOOTH, rav1e_prep_8tap_regular_smooth),
-  (REGULAR, SHARP, rav1e_prep_8tap_regular_sharp),
-  (SMOOTH, REGULAR, rav1e_prep_8tap_smooth_regular),
-  (SMOOTH, SMOOTH, rav1e_prep_8tap_smooth),
-  (SMOOTH, SHARP, rav1e_prep_8tap_smooth_sharp),
-  (SHARP, REGULAR, rav1e_prep_8tap_sharp_regular),
-  (SHARP, SMOOTH, rav1e_prep_8tap_sharp_smooth),
-  (SHARP, SHARP, rav1e_prep_8tap_sharp),
-  (BILINEAR, BILINEAR, rav1e_prep_bilin)
+  (REGULAR, REGULAR, rav1e_prep_8tap_regular_8bpc),
+  (REGULAR, SMOOTH, rav1e_prep_8tap_regular_smooth_8bpc),
+  (REGULAR, SHARP, rav1e_prep_8tap_regular_sharp_8bpc),
+  (SMOOTH, REGULAR, rav1e_prep_8tap_smooth_regular_8bpc),
+  (SMOOTH, SMOOTH, rav1e_prep_8tap_smooth_8bpc),
+  (SMOOTH, SHARP, rav1e_prep_8tap_smooth_sharp_8bpc),
+  (SHARP, REGULAR, rav1e_prep_8tap_sharp_regular_8bpc),
+  (SHARP, SMOOTH, rav1e_prep_8tap_sharp_smooth_8bpc),
+  (SHARP, SHARP, rav1e_prep_8tap_sharp_8bpc),
+  (BILINEAR, BILINEAR, rav1e_prep_bilin_8bpc)
 );
 
 cpu_function_lookup_table!(
@@ -553,22 +553,22 @@ cpu_function_lookup_table!(
 );
 
 extern {
-  fn rav1e_avg_ssse3(
+  fn rav1e_w_avg_8bpc_ssse3(
     dst: *mut u8, dst_stride: libc::ptrdiff_t, tmp1: *const i16,
     tmp2: *const i16, w: i32, h: i32,
   );
 
-  fn rav1e_avg_avx2(
+  fn rav1e_w_avg_8bpc_avx2(
     dst: *mut u8, dst_stride: libc::ptrdiff_t, tmp1: *const i16,
     tmp2: *const i16, w: i32, h: i32,
   );
 
-  fn rav1e_avg_16bpc_ssse3(
+  fn rav1e_w_avg_16bpc_ssse3(
     dst: *mut u16, dst_stride: libc::ptrdiff_t, tmp1: *const i16,
     tmp2: *const i16, w: i32, h: i32, bitdepth_max: i32,
   );
 
-  fn rav1e_avg_16bpc_avx2(
+  fn rav1e_w_avg_16bpc_avx2(
     dst: *mut u16, dst_stride: libc::ptrdiff_t, tmp1: *const i16,
     tmp2: *const i16, w: i32, h: i32, bitdepth_max: i32,
   );
@@ -577,13 +577,16 @@ extern {
 cpu_function_lookup_table!(
   AVG_FNS: [Option<AvgFn>],
   default: None,
-  [(SSSE3, Some(rav1e_avg_ssse3)), (AVX2, Some(rav1e_avg_avx2))]
+  [(SSSE3, Some(rav1e_w_avg_8bpc_ssse3)), (AVX2, Some(rav1e_w_avg_8bpc_avx2))]
 );
 
 cpu_function_lookup_table!(
   AVG_HBD_FNS: [Option<AvgHBDFn>],
   default: None,
-  [(SSSE3, Some(rav1e_avg_16bpc_ssse3)), (AVX2, Some(rav1e_avg_16bpc_avx2))]
+  [
+    (SSSE3, Some(rav1e_w_avg_16bpc_ssse3)),
+    (AVX2, Some(rav1e_w_avg_16bpc_avx2))
+  ]
 );
 
 #[cfg(test)]

--- a/src/ext/x86/x86inc.asm
+++ b/src/ext/x86/x86inc.asm
@@ -1339,26 +1339,50 @@ INIT_XMM
     %elif %0 >= 9
         __instr %6, %7, %8, %9
     %elif %0 == 8
-        %if avx_enabled && %5
+        %if avx_enabled && __sizeofreg >= 16 && %4 == 0
             %xdefine __src1 %7
             %xdefine __src2 %8
-            %ifnum regnumof%7
-                %ifnum regnumof%8
-                    %if regnumof%7 < 8 && regnumof%8 >= 8 && regnumof%8 < 16 && sizeof%8 <= 32
-                        ; Most VEX-encoded instructions require an additional byte to encode when
-                        ; src2 is a high register (e.g. m8..15). If the instruction is commutative
-                        ; we can swap src1 and src2 when doing so reduces the instruction length.
-                        %xdefine __src1 %8
-                        %xdefine __src2 %7
+            %if %5
+                %ifnum regnumof%7
+                    %ifnum regnumof%8
+                        %if regnumof%7 < 8 && regnumof%8 >= 8 && regnumof%8 < 16 && sizeof%8 <= 32
+                            ; Most VEX-encoded instructions require an additional byte to encode when
+                            ; src2 is a high register (e.g. m8..15). If the instruction is commutative
+                            ; we can swap src1 and src2 when doing so reduces the instruction length.
+                            %xdefine __src1 %8
+                            %xdefine __src2 %7
+                        %endif
                     %endif
+                %elifnum regnumof%8 ; put memory operands in src2 when possible
+                    %xdefine __src1 %8
+                    %xdefine __src2 %7
+                %else
+                    %assign __emulate_avx 1
+                %endif
+            %elifnnum regnumof%7
+                ; EVEX allows imm8 shift instructions to be used with memory operands,
+                ; but VEX does not. This handles those special cases.
+                %ifnnum %8
+                    %assign __emulate_avx 1
+                %elif notcpuflag(avx512)
+                    %assign __emulate_avx 1
                 %endif
             %endif
-            __instr %6, __src1, __src2
+            %if __emulate_avx ; a separate load is required
+                %if %3
+                    vmovaps %6, %7
+                %else
+                    vmovdqa %6, %7
+                %endif
+                __instr %6, %8
+            %else
+                __instr %6, __src1, __src2
+            %endif
         %else
             __instr %6, %7, %8
         %endif
     %elif %0 == 7
-        %if avx_enabled && %5
+        %if avx_enabled && __sizeofreg >= 16 && %5
             %xdefine __src1 %6
             %xdefine __src2 %7
             %ifnum regnumof%6

--- a/src/ext/x86/x86inc.asm
+++ b/src/ext/x86/x86inc.asm
@@ -1,7 +1,7 @@
 ;*****************************************************************************
 ;* x86inc.asm: x86 abstraction layer
 ;*****************************************************************************
-;* Copyright (C) 2005-2020 x264 project
+;* Copyright (C) 2005-2021 x264 project
 ;*
 ;* Authors: Loren Merritt <lorenm@u.washington.edu>
 ;*          Henrik Gramner <henrik@gramner.com>
@@ -1139,8 +1139,7 @@ INIT_XMM
     %endif
     %xdefine %%tmp %%f %+ 0
     %ifnum %%tmp
-        RESET_MM_PERMUTATION
-        AVX512_MM_PERMUTATION
+        DEFINE_MMREGS mmtype
         %assign %%i 0
         %rep num_mmregs
             %xdefine %%tmp %%f %+ %%i

--- a/src/ext/x86/x86inc.asm
+++ b/src/ext/x86/x86inc.asm
@@ -79,6 +79,11 @@
     %define mangle(x) x
 %endif
 
+; Use VEX-encoding even in non-AVX functions
+%ifndef FORCE_VEX_ENCODING
+    %define FORCE_VEX_ENCODING 0
+%endif
+
 %macro SECTION_RODATA 0-1 16
     %ifidn __OUTPUT_FORMAT__,win32
         SECTION .rdata align=%1
@@ -1008,7 +1013,7 @@ BRANCH_INSTR jz, je, jnz, jne, jl, jle, jnl, jnle, jg, jge, jng, jnge, ja, jae, 
 %endmacro
 
 %macro INIT_XMM 0-1+
-    %assign avx_enabled 0
+    %assign avx_enabled FORCE_VEX_ENCODING
     %define RESET_MM_PERMUTATION INIT_XMM %1
     %define mmsize 16
     %define mova movdqa

--- a/src/ext/x86/x86inc.asm
+++ b/src/ext/x86/x86inc.asm
@@ -349,6 +349,28 @@ DECLARE_REG_TMP_SIZE 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14
 %define vzeroupper_required (mmsize > 16 && (ARCH_X86_64 == 0 || xmm_regs_used > 16 || notcpuflag(avx512)))
 %define high_mm_regs (16*cpuflag(avx512))
 
+; Large stack allocations on Windows need to use stack probing in order
+; to guarantee that all stack memory is committed before accessing it.
+; This is done by ensuring that the guard page(s) at the end of the
+; currently committed pages are touched prior to any pages beyond that.
+%if WIN64
+    %assign STACK_PROBE_SIZE 8192
+%elifidn __OUTPUT_FORMAT__, win32
+    %assign STACK_PROBE_SIZE 4096
+%else
+    %assign STACK_PROBE_SIZE 0
+%endif
+
+%macro PROBE_STACK 1 ; stack_size
+    %if STACK_PROBE_SIZE
+        %assign %%i STACK_PROBE_SIZE
+        %rep %1 / STACK_PROBE_SIZE
+            mov eax, [rsp-%%i]
+            %assign %%i %%i+STACK_PROBE_SIZE
+        %endrep
+    %endif
+%endmacro
+
 %macro ALLOC_STACK 0-2 0, 0 ; stack_size, n_xmm_regs (for win64 only)
     %ifnum %1
         %if %1 != 0
@@ -369,6 +391,7 @@ DECLARE_REG_TMP_SIZE 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14
             %if required_stack_alignment <= STACK_ALIGNMENT
                 ; maintain the current stack alignment
                 %assign stack_size_padded stack_size + %%pad + ((-%%pad-stack_offset-gprsize) & (STACK_ALIGNMENT-1))
+                PROBE_STACK stack_size_padded
                 SUB rsp, stack_size_padded
             %else
                 %assign %%reg_num (regs_used - 1)
@@ -384,6 +407,7 @@ DECLARE_REG_TMP_SIZE 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14
                     %xdefine rstkm rstk
                 %endif
                 %assign stack_size_padded stack_size + ((%%pad + required_stack_alignment-1) & ~(required_stack_alignment-1))
+                PROBE_STACK stack_size_padded
                 mov rstk, rsp
                 and rsp, ~(required_stack_alignment-1)
                 sub rsp, stack_size_padded

--- a/src/x86/cdef16_avx2.asm
+++ b/src/x86/cdef16_avx2.asm
@@ -30,27 +30,30 @@
 
 SECTION_RODATA
 
-tap_table: dw 4, 2, 3, 3, 2, 1
-           db -1 * 16 + 1, -2 * 16 + 2
-           db  0 * 16 + 1, -1 * 16 + 2
-           db  0 * 16 + 1,  0 * 16 + 2
-           db  0 * 16 + 1,  1 * 16 + 2
-           db  1 * 16 + 1,  2 * 16 + 2
-           db  1 * 16 + 0,  2 * 16 + 1
-           db  1 * 16 + 0,  2 * 16 + 0
-           db  1 * 16 + 0,  2 * 16 - 1
-           ; the last 6 are repeats of the first 6 so we don't need to & 7
-           db -1 * 16 + 1, -2 * 16 + 2
-           db  0 * 16 + 1, -1 * 16 + 2
-           db  0 * 16 + 1,  0 * 16 + 2
-           db  0 * 16 + 1,  1 * 16 + 2
-           db  1 * 16 + 1,  2 * 16 + 2
-           db  1 * 16 + 0,  2 * 16 + 1
+%macro DIR_TABLE 1 ; stride
+    db  1 * %1 + 0,  2 * %1 + 0
+    db  1 * %1 + 0,  2 * %1 - 2
+    db -1 * %1 + 2, -2 * %1 + 4
+    db  0 * %1 + 2, -1 * %1 + 4
+    db  0 * %1 + 2,  0 * %1 + 4
+    db  0 * %1 + 2,  1 * %1 + 4
+    db  1 * %1 + 2,  2 * %1 + 4
+    db  1 * %1 + 0,  2 * %1 + 2
+    db  1 * %1 + 0,  2 * %1 + 0
+    db  1 * %1 + 0,  2 * %1 - 2
+    db -1 * %1 + 2, -2 * %1 + 4
+    db  0 * %1 + 2, -1 * %1 + 4
+%endmacro
 
-dir_shift: times 2 dw 0x4000
-           times 2 dw 0x1000
+dir_table4: DIR_TABLE 16
+dir_table8: DIR_TABLE 32
+pri_taps:   dw  4, 4, 3, 3, 2, 2, 3, 3
 
-pw_2048:   times 2 dw 2048
+dir_shift:  times 2 dw 0x4000
+            times 2 dw 0x1000
+
+pw_2048:    times 2 dw 2048
+pw_m16384:  times 2 dw -16384
 
 cextern cdef_dir_8bpc_avx2.main
 
@@ -64,406 +67,804 @@ SECTION .text
 %endrep
 %endmacro
 
-%macro ACCUMULATE_TAP 6 ; tap_offset, shift, strength, mul_tap, w, stride
-    ; load p0/p1
-    movsx         offq, byte [dirq+kq+%1]       ; off1
-%if %5 == 4
-    movq           xm5, [stkq+offq*2+%6*0]      ; p0
-    movq           xm6, [stkq+offq*2+%6*2]
-    movhps         xm5, [stkq+offq*2+%6*1]
-    movhps         xm6, [stkq+offq*2+%6*3]
-    vinserti128     m5, xm6, 1
+%macro CDEF_FILTER 2 ; w, h
+    DEFINE_ARGS dst, stride, dir, pridmp, pri, sec, tmp
+    movifnidn     prid, r4m
+    movifnidn     secd, r5m
+    mov           dird, r6m
+    vpbroadcastd    m8, [base+pw_2048]
+    lea           dirq, [base+dir_table%1+dirq*2]
+    test          prid, prid
+    jz .sec_only
+%if WIN64
+    vpbroadcastw    m6, prim
+    movaps  [rsp+16*0], xmm9
+    movaps  [rsp+16*1], xmm10
 %else
-    movu           xm5, [stkq+offq*2+%6*0]      ; p0
-    vinserti128     m5, [stkq+offq*2+%6*1], 1
+    movd           xm6, prid
+    vpbroadcastw    m6, xm6
 %endif
-    neg           offq                          ; -off1
-%if %5 == 4
-    movq           xm6, [stkq+offq*2+%6*0]      ; p1
-    movq           xm9, [stkq+offq*2+%6*2]
-    movhps         xm6, [stkq+offq*2+%6*1]
-    movhps         xm9, [stkq+offq*2+%6*3]
-    vinserti128     m6, xm9, 1
+    lzcnt      pridmpd, prid
+    rorx          tmpd, prid, 2
+    cmp      dword r9m, 0xfff ; if (bpc == 12)
+    cmove         prid, tmpd  ;     pri >>= 2
+    mov           tmpd, r7m   ; damping
+    and           prid, 4
+    sub           tmpd, 31
+    vpbroadcastd    m9, [base+pri_taps+priq+8*0]
+    vpbroadcastd   m10, [base+pri_taps+priq+8*1]
+    test          secd, secd
+    jz .pri_only
+%if WIN64
+    movaps         r8m, xmm13
+    vpbroadcastw   m13, secm
+    movaps         r4m, xmm11
+    movaps         r6m, xmm12
 %else
-    movu           xm6, [stkq+offq*2+%6*0]      ; p1
-    vinserti128     m6, [stkq+offq*2+%6*1], 1
+    movd           xm0, secd
+    vpbroadcastw   m13, xm0
 %endif
-    ; out of bounds values are set to a value that is a both a large unsigned
-    ; value and a negative signed value.
-    ; use signed max and unsigned min to remove them
-    pmaxsw          m7, m5                      ; max after p0
-    pminuw          m8, m5                      ; min after p0
-    pmaxsw          m7, m6                      ; max after p1
-    pminuw          m8, m6                      ; min after p1
-
-    ; accumulate sum[m15] over p0/p1
-    psubw           m5, m4                      ; diff_p0(p0 - px)
-    psubw           m6, m4                      ; diff_p1(p1 - px)
-    pabsw           m9, m5
-    pabsw          m10, m6
-    psignw         m11, %4, m5
-    psignw         m12, %4, m6
-    psrlw           m5, m9, %2
-    psrlw           m6, m10, %2
-    psubusw         m5, %3, m5
-    psubusw         m6, %3, m6
-    pminuw          m5, m9                      ; constrain(diff_p0)
-    pminuw          m6, m10                     ; constrain(diff_p1)
-    pmullw          m5, m11                     ; constrain(diff_p0) * taps
-    pmullw          m6, m12                     ; constrain(diff_p1) * taps
-    paddw          m15, m5
-    paddw          m15, m6
-%endmacro
-
-%macro cdef_filter_fn 3 ; w, h, stride
-INIT_YMM avx2
-%if %1 != 4 || %2 != 8
-cglobal cdef_filter_%1x%2_16bpc, 4, 9, 16, 2 * 16 + (%2+4)*%3, \
-                                 dst, stride, left, top, pri, sec, \
-                                 stride3, dst4, edge
+    lzcnt         secd, secd
+    xor           prid, prid
+    add        pridmpd, tmpd
+    cmovs      pridmpd, prid
+    add           secd, tmpd
+    lea           tmpq, [px]
+    mov    [pri_shift], pridmpq
+    mov    [sec_shift], secq
+%rep %1*%2/16
+    call mangle(private_prefix %+ _cdef_filter_%1x%1_16bpc %+ SUFFIX).pri_sec
+%endrep
+%if WIN64
+    movaps       xmm11, r4m
+    movaps       xmm12, r6m
+    movaps       xmm13, r8m
+%endif
+    jmp .pri_end
+.pri_only:
+    add        pridmpd, tmpd
+    cmovs      pridmpd, secd
+    lea           tmpq, [px]
+    mov    [pri_shift], pridmpq
+%rep %1*%2/16
+    call mangle(private_prefix %+ _cdef_filter_%1x%1_16bpc %+ SUFFIX).pri
+%endrep
+.pri_end:
+%if WIN64
+    movaps        xmm9, [rsp+16*0]
+    movaps       xmm10, [rsp+16*1]
+%endif
+.end:
+    RET
+.sec_only:
+    mov           tmpd, r7m ; damping
+%if WIN64
+    vpbroadcastw    m6, secm
 %else
-cglobal cdef_filter_%1x%2_16bpc, 4, 10, 16, 2 * 16 + (%2+4)*%3, \
-                                 dst, stride, left, top, pri, sec, \
-                                 stride3, dst4, edge
+    movd           xm6, secd
+    vpbroadcastw    m6, xm6
 %endif
-%define px rsp+2*16+2*%3
-    pcmpeqw        m14, m14
-    psllw          m14, 15                  ; 0x8000
-    mov          edged, r8m
-
-    ; prepare pixel buffers - body/right
+    tzcnt         secd, secd
+    sub           tmpd, secd
+    mov    [sec_shift], tmpq
+    lea           tmpq, [px]
+%rep %1*%2/16
+    call mangle(private_prefix %+ _cdef_filter_%1x%1_16bpc %+ SUFFIX).sec
+%endrep
+    jmp .end
+%if %1 == %2
+ALIGN function_align
+.pri:
+    movsx         offq, byte [dirq+4]    ; off_k0
 %if %1 == 4
-    INIT_XMM avx2
+    mova            m1, [tmpq+32*0]
+    punpcklqdq      m1, [tmpq+32*1]      ; 0 2 1 3
+    movu            m2, [tmpq+offq+32*0]
+    punpcklqdq      m2, [tmpq+offq+32*1] ; k0p0
+    neg           offq
+    movu            m3, [tmpq+offq+32*0]
+    punpcklqdq      m3, [tmpq+offq+32*1] ; k0p1
+%else
+    mova           xm1, [tmpq+32*0]
+    vinserti128     m1, [tmpq+32*1], 1
+    movu           xm2, [tmpq+offq+32*0]
+    vinserti128     m2, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm3, [tmpq+offq+32*0]
+    vinserti128     m3, [tmpq+offq+32*1], 1
 %endif
-%if %2 == 8
-    lea          dst4q, [dstq+strideq*4]
-%endif
-    lea       stride3q, [strideq*3]
-    test         edgeb, 2                   ; have_right
-    jz .no_right
-    movu            m1, [dstq+strideq*0]
-    movu            m2, [dstq+strideq*1]
-    movu            m3, [dstq+strideq*2]
-    movu            m4, [dstq+stride3q]
-    mova     [px+0*%3], m1
-    mova     [px+1*%3], m2
-    mova     [px+2*%3], m3
-    mova     [px+3*%3], m4
-%if %2 == 8
-    movu            m1, [dst4q+strideq*0]
-    movu            m2, [dst4q+strideq*1]
-    movu            m3, [dst4q+strideq*2]
-    movu            m4, [dst4q+stride3q]
-    mova     [px+4*%3], m1
-    mova     [px+5*%3], m2
-    mova     [px+6*%3], m3
-    mova     [px+7*%3], m4
-%endif
-    jmp .body_done
-.no_right:
+    movsx         offq, byte [dirq+5]    ; off_k1
+    psubw           m2, m1               ; diff_k0p0
+    psubw           m3, m1               ; diff_k0p1
+    pabsw           m4, m2               ; adiff_k0p0
+    psrlw           m5, m4, [pri_shift+gprsize]
+    psubusw         m0, m6, m5
+    pabsw           m5, m3               ; adiff_k0p1
+    pminsw          m0, m4
+    psrlw           m4, m5, [pri_shift+gprsize]
+    psignw          m0, m2               ; constrain(diff_k0p0)
+    psubusw         m2, m6, m4
+    pminsw          m2, m5
 %if %1 == 4
-    movq           xm1, [dstq+strideq*0]
-    movq           xm2, [dstq+strideq*1]
-    movq           xm3, [dstq+strideq*2]
-    movq           xm4, [dstq+stride3q]
-    movq     [px+0*%3], xm1
-    movq     [px+1*%3], xm2
-    movq     [px+2*%3], xm3
-    movq     [px+3*%3], xm4
+    movu            m4, [tmpq+offq+32*0]
+    punpcklqdq      m4, [tmpq+offq+32*1] ; k1p0
+    neg           offq
+    movu            m5, [tmpq+offq+32*0]
+    punpcklqdq      m5, [tmpq+offq+32*1] ; k1p1
+%else
+    movu           xm4, [tmpq+offq+32*0]
+    vinserti128     m4, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm5, [tmpq+offq+32*0]
+    vinserti128     m5, [tmpq+offq+32*1], 1
+%endif
+    psubw           m4, m1               ; diff_k1p0
+    psubw           m5, m1               ; diff_k1p1
+    psignw          m2, m3               ; constrain(diff_k0p1)
+    pabsw           m3, m4               ; adiff_k1p0
+    paddw           m0, m2               ; constrain(diff_k0)
+    psrlw           m2, m3, [pri_shift+gprsize]
+    psubusw         m7, m6, m2
+    pabsw           m2, m5               ; adiff_k1p1
+    pminsw          m7, m3
+    psrlw           m3, m2, [pri_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k1p0)
+    psubusw         m4, m6, m3
+    pminsw          m4, m2
+    psignw          m4, m5               ; constrain(diff_k1p1)
+    paddw           m7, m4               ; constrain(diff_k1)
+    pmullw          m0, m9               ; pri_tap_k0
+    pmullw          m7, m10              ; pri_tap_k1
+    paddw           m0, m7               ; sum
+    psraw           m2, m0, 15
+    paddw           m0, m2
+    pmulhrsw        m0, m8
+    add           tmpq, 32*2
+    paddw           m0, m1
+%if %1 == 4
+    vextracti128   xm1, m0, 1
+    movq   [dstq+strideq*0], xm0
+    movq   [dstq+strideq*1], xm1
+    movhps [dstq+strideq*2], xm0
+    movhps [dstq+r8       ], xm1
+    lea           dstq, [dstq+strideq*4]
+%else
+    mova         [dstq+strideq*0], xm0
+    vextracti128 [dstq+strideq*1], m0, 1
+    lea           dstq, [dstq+strideq*2]
+%endif
+    ret
+ALIGN function_align
+.sec:
+    movsx         offq, byte [dirq+8]    ; off1_k0
+%if %1 == 4
+    mova            m1, [tmpq+32*0]
+    punpcklqdq      m1, [tmpq+32*1]
+    movu            m2, [tmpq+offq+32*0]
+    punpcklqdq      m2, [tmpq+offq+32*1] ; k0s0
+    neg           offq
+    movu            m3, [tmpq+offq+32*0]
+    punpcklqdq      m3, [tmpq+offq+32*1] ; k0s1
+%else
+    mova           xm1, [tmpq+32*0]
+    vinserti128     m1, [tmpq+32*1], 1
+    movu           xm2, [tmpq+offq+32*0]
+    vinserti128     m2, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm3, [tmpq+offq+32*0]
+    vinserti128     m3, [tmpq+offq+32*1], 1
+%endif
+    movsx         offq, byte [dirq+0]    ; off2_k0
+    psubw           m2, m1               ; diff_k0s0
+    psubw           m3, m1               ; diff_k0s1
+    pabsw           m4, m2               ; adiff_k0s0
+    psrlw           m5, m4, [sec_shift+gprsize]
+    psubusw         m0, m6, m5
+    pabsw           m5, m3               ; adiff_k0s1
+    pminsw          m0, m4
+    psrlw           m4, m5, [sec_shift+gprsize]
+    psignw          m0, m2               ; constrain(diff_k0s0)
+    psubusw         m2, m6, m4
+    pminsw          m2, m5
+%if %1 == 4
+    movu            m4, [tmpq+offq+32*0]
+    punpcklqdq      m4, [tmpq+offq+32*1] ; k0s2
+    neg           offq
+    movu            m5, [tmpq+offq+32*0]
+    punpcklqdq      m5, [tmpq+offq+32*1] ; k0s3
+%else
+    movu           xm4, [tmpq+offq+32*0]
+    vinserti128     m4, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm5, [tmpq+offq+32*0]
+    vinserti128     m5, [tmpq+offq+32*1], 1
+%endif
+    movsx         offq, byte [dirq+9]    ; off1_k1
+    psubw           m4, m1               ; diff_k0s2
+    psubw           m5, m1               ; diff_k0s3
+    psignw          m2, m3               ; constrain(diff_k0s1)
+    pabsw           m3, m4               ; adiff_k0s2
+    paddw           m0, m2
+    psrlw           m2, m3, [sec_shift+gprsize]
+    psubusw         m7, m6, m2
+    pabsw           m2, m5               ; adiff_k0s3
+    pminsw          m7, m3
+    psrlw           m3, m2, [sec_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k0s2)
+    psubusw         m4, m6, m3
+    pminsw          m4, m2
+%if %1 == 4
+    movu            m2, [tmpq+offq+32*0]
+    punpcklqdq      m2, [tmpq+offq+32*1] ; k1s0
+    neg           offq
+    movu            m3, [tmpq+offq+32*0]
+    punpcklqdq      m3, [tmpq+offq+32*1] ; k1s1
+%else
+    movu           xm2, [tmpq+offq+32*0]
+    vinserti128     m2, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm3, [tmpq+offq+32*0]
+    vinserti128     m3, [tmpq+offq+32*1], 1
+%endif
+    movsx         offq, byte [dirq+1]    ; off2_k1
+    paddw           m0, m7
+    psignw          m4, m5               ; constrain(diff_k0s3)
+    paddw           m0, m4               ; constrain(diff_k0)
+    psubw           m2, m1               ; diff_k1s0
+    psubw           m3, m1               ; diff_k1s1
+    paddw           m0, m0               ; sec_tap_k0
+    pabsw           m4, m2               ; adiff_k1s0
+    psrlw           m5, m4, [sec_shift+gprsize]
+    psubusw         m7, m6, m5
+    pabsw           m5, m3               ; adiff_k1s1
+    pminsw          m7, m4
+    psrlw           m4, m5, [sec_shift+gprsize]
+    psignw          m7, m2               ; constrain(diff_k1s0)
+    psubusw         m2, m6, m4
+    pminsw          m2, m5
+%if %1 == 4
+    movu            m4, [tmpq+offq+32*0]
+    punpcklqdq      m4, [tmpq+offq+32*1] ; k1s2
+    neg           offq
+    movu            m5, [tmpq+offq+32*0]
+    punpcklqdq      m5, [tmpq+offq+32*1] ; k1s3
+%else
+    movu           xm4, [tmpq+offq+32*0]
+    vinserti128     m4, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm5, [tmpq+offq+32*0]
+    vinserti128     m5, [tmpq+offq+32*1], 1
+%endif
+    paddw           m0, m7
+    psubw           m4, m1               ; diff_k1s2
+    psubw           m5, m1               ; diff_k1s3
+    psignw          m2, m3               ; constrain(diff_k1s1)
+    pabsw           m3, m4               ; adiff_k1s2
+    paddw           m0, m2
+    psrlw           m2, m3, [sec_shift+gprsize]
+    psubusw         m7, m6, m2
+    pabsw           m2, m5               ; adiff_k1s3
+    pminsw          m7, m3
+    psrlw           m3, m2, [sec_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k1s2)
+    psubusw         m4, m6, m3
+    pminsw          m4, m2
+    paddw           m0, m7
+    psignw          m4, m5               ; constrain(diff_k1s3)
+    paddw           m0, m4               ; sum
+    psraw           m2, m0, 15
+    paddw           m0, m2
+    pmulhrsw        m0, m8
+    add           tmpq, 32*2
+    paddw           m0, m1
+%if %1 == 4
+    vextracti128   xm1, m0, 1
+    movq   [dstq+strideq*0], xm0
+    movq   [dstq+strideq*1], xm1
+    movhps [dstq+strideq*2], xm0
+    movhps [dstq+r8       ], xm1
+    lea           dstq, [dstq+strideq*4]
+%else
+    mova         [dstq+strideq*0], xm0
+    vextracti128 [dstq+strideq*1], m0, 1
+    lea           dstq, [dstq+strideq*2]
+%endif
+    ret
+ALIGN function_align
+.pri_sec:
+    movsx         offq, byte [dirq+8]    ; off2_k0
+%if %1 == 4
+    mova            m1, [tmpq+32*0]
+    punpcklqdq      m1, [tmpq+32*1]
+    movu            m2, [tmpq+offq+32*0]
+    punpcklqdq      m2, [tmpq+offq+32*1] ; k0s0
+    neg           offq
+    movu            m3, [tmpq+offq+32*0]
+    punpcklqdq      m3, [tmpq+offq+32*1] ; k0s1
 %else
     mova           xm1, [dstq+strideq*0]
-    mova           xm2, [dstq+strideq*1]
-    mova           xm3, [dstq+strideq*2]
-    mova           xm4, [dstq+stride3q]
-    mova     [px+0*%3], xm1
-    mova     [px+1*%3], xm2
-    mova     [px+2*%3], xm3
-    mova     [px+3*%3], xm4
+    vinserti128     m1, [dstq+strideq*1], 1
+    movu           xm2, [tmpq+offq+32*0]
+    vinserti128     m2, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm3, [tmpq+offq+32*0]
+    vinserti128     m3, [tmpq+offq+32*1], 1
 %endif
-    movd [px+0*%3+%1*2], xm14
-    movd [px+1*%3+%1*2], xm14
-    movd [px+2*%3+%1*2], xm14
-    movd [px+3*%3+%1*2], xm14
-%if %2 == 8
- %if %1 == 4
-    movq           xm1, [dst4q+strideq*0]
-    movq           xm2, [dst4q+strideq*1]
-    movq           xm3, [dst4q+strideq*2]
-    movq           xm4, [dst4q+stride3q]
-    movq     [px+4*%3], xm1
-    movq     [px+5*%3], xm2
-    movq     [px+6*%3], xm3
-    movq     [px+7*%3], xm4
- %else
-    mova           xm1, [dst4q+strideq*0]
-    mova           xm2, [dst4q+strideq*1]
-    mova           xm3, [dst4q+strideq*2]
-    mova           xm4, [dst4q+stride3q]
-    mova     [px+4*%3], xm1
-    mova     [px+5*%3], xm2
-    mova     [px+6*%3], xm3
-    mova     [px+7*%3], xm4
- %endif
-    movd [px+4*%3+%1*2], xm14
-    movd [px+5*%3+%1*2], xm14
-    movd [px+6*%3+%1*2], xm14
-    movd [px+7*%3+%1*2], xm14
-%endif
-.body_done:
-
-    ; top
-    test         edgeb, 4                    ; have_top
-    jz .no_top
-    test         edgeb, 1                    ; have_left
-    jz .top_no_left
-    test         edgeb, 2                    ; have_right
-    jz .top_no_right
-    movu            m1, [topq+strideq*0-%1]
-    movu            m2, [topq+strideq*1-%1]
-    movu  [px-2*%3-%1], m1
-    movu  [px-1*%3-%1], m2
-    jmp .top_done
-.top_no_right:
-    movu            m1, [topq+strideq*0-%1*2]
-    movu            m2, [topq+strideq*1-%1*2]
-    movu [px-2*%3-%1*2], m1
-    movu [px-1*%3-%1*2], m2
-    movd [px-2*%3+%1*2], xm14
-    movd [px-1*%3+%1*2], xm14
-    jmp .top_done
-.top_no_left:
-    test         edgeb, 2                   ; have_right
-    jz .top_no_left_right
-    movu            m1, [topq+strideq*0]
-    movu            m2, [topq+strideq*1]
-    mova   [px-2*%3+0], m1
-    mova   [px-1*%3+0], m2
-    movd   [px-2*%3-4], xm14
-    movd   [px-1*%3-4], xm14
-    jmp .top_done
-.top_no_left_right:
+    movsx         offq, byte [dirq+0]    ; off3_k0
+    pmaxsw         m11, m2, m3
+    pminuw         m12, m2, m3
+    psubw           m2, m1               ; diff_k0s0
+    psubw           m3, m1               ; diff_k0s1
+    pabsw           m4, m2               ; adiff_k0s0
+    psrlw           m5, m4, [sec_shift+gprsize]
+    psubusw         m0, m13, m5
+    pabsw           m5, m3               ; adiff_k0s1
+    pminsw          m0, m4
+    psrlw           m4, m5, [sec_shift+gprsize]
+    psignw          m0, m2               ; constrain(diff_k0s0)
+    psubusw         m2, m13, m4
+    pminsw          m2, m5
 %if %1 == 4
-    movq           xm1, [topq+strideq*0]
-    movq           xm2, [topq+strideq*1]
-    movq   [px-2*%3+0], xm1
-    movq   [px-1*%3+0], xm2
+    movu            m4, [tmpq+offq+32*0]
+    punpcklqdq      m4, [tmpq+offq+32*1] ; k0s2
+    neg           offq
+    movu            m5, [tmpq+offq+32*0]
+    punpcklqdq      m5, [tmpq+offq+32*1] ; k0s3
 %else
-    mova           xm1, [topq+strideq*0]
-    mova           xm2, [topq+strideq*1]
-    mova   [px-2*%3+0], xm1
-    mova   [px-1*%3+0], xm2
+    movu           xm4, [tmpq+offq+32*0]
+    vinserti128     m4, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm5, [tmpq+offq+32*0]
+    vinserti128     m5, [tmpq+offq+32*1], 1
 %endif
-    movd   [px-2*%3-4], xm14
-    movd   [px-1*%3-4], xm14
-    movd [px-2*%3+%1*2], xm14
-    movd [px-1*%3+%1*2], xm14
-    jmp .top_done
-.no_top:
-    movu   [px-2*%3-%1], m14
-    movu   [px-1*%3-%1], m14
-.top_done:
-
-    ; left
-    test         edgeb, 1                   ; have_left
-    jz .no_left
-    mova           xm1, [leftq+ 0]
-%if %2 == 8
-    mova           xm2, [leftq+16]
-%endif
-    movd   [px+0*%3-4], xm1
-    pextrd [px+1*%3-4], xm1, 1
-    pextrd [px+2*%3-4], xm1, 2
-    pextrd [px+3*%3-4], xm1, 3
-%if %2 == 8
-    movd   [px+4*%3-4], xm2
-    pextrd [px+5*%3-4], xm2, 1
-    pextrd [px+6*%3-4], xm2, 2
-    pextrd [px+7*%3-4], xm2, 3
-%endif
-    jmp .left_done
-.no_left:
-    movd   [px+0*%3-4], xm14
-    movd   [px+1*%3-4], xm14
-    movd   [px+2*%3-4], xm14
-    movd   [px+3*%3-4], xm14
-%if %2 == 8
-    movd   [px+4*%3-4], xm14
-    movd   [px+5*%3-4], xm14
-    movd   [px+6*%3-4], xm14
-    movd   [px+7*%3-4], xm14
-%endif
-.left_done:
-
-    ; bottom
-    DEFINE_ARGS dst, stride, dst8, dummy1, pri, sec, stride3, dummy3, edge
-    test         edgeb, 8                   ; have_bottom
-    jz .no_bottom
-    lea          dst8q, [dstq+%2*strideq]
-    test         edgeb, 1                   ; have_left
-    jz .bottom_no_left
-    test         edgeb, 2                   ; have_right
-    jz .bottom_no_right
-    movu            m1, [dst8q-%1]
-    movu            m2, [dst8q+strideq-%1]
-    movu   [px+(%2+0)*%3-%1], m1
-    movu   [px+(%2+1)*%3-%1], m2
-    jmp .bottom_done
-.bottom_no_right:
-    movu            m1, [dst8q-%1*2]
-    movu            m2, [dst8q+strideq-%1*2]
-    movu  [px+(%2+0)*%3-%1*2], m1
-    movu  [px+(%2+1)*%3-%1*2], m2
-%if %1 == 8
-    movd  [px+(%2-1)*%3+%1*2], xm14                ; overwritten by previous movu
-%endif
-    movd  [px+(%2+0)*%3+%1*2], xm14
-    movd  [px+(%2+1)*%3+%1*2], xm14
-    jmp .bottom_done
-.bottom_no_left:
-    test         edgeb, 2                  ; have_right
-    jz .bottom_no_left_right
-    movu            m1, [dst8q]
-    movu            m2, [dst8q+strideq]
-    mova   [px+(%2+0)*%3+0], m1
-    mova   [px+(%2+1)*%3+0], m2
-    movd   [px+(%2+0)*%3-4], xm14
-    movd   [px+(%2+1)*%3-4], xm14
-    jmp .bottom_done
-.bottom_no_left_right:
+    movsx         offq, byte [dirq+9]    ; off2_k1
+    psignw          m2, m3               ; constrain(diff_k0s1)
+    pmaxsw         m11, m4
+    pminuw         m12, m4
+    pmaxsw         m11, m5
+    pminuw         m12, m5
+    psubw           m4, m1               ; diff_k0s2
+    psubw           m5, m1               ; diff_k0s3
+    paddw           m0, m2
+    pabsw           m3, m4               ; adiff_k0s2
+    psrlw           m2, m3, [sec_shift+gprsize]
+    psubusw         m7, m13, m2
+    pabsw           m2, m5               ; adiff_k0s3
+    pminsw          m7, m3
+    psrlw           m3, m2, [sec_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k0s2)
+    psubusw         m4, m13, m3
+    pminsw          m4, m2
 %if %1 == 4
-    movq           xm1, [dst8q]
-    movq           xm2, [dst8q+strideq]
-    movq   [px+(%2+0)*%3+0], xm1
-    movq   [px+(%2+1)*%3+0], xm2
+    movu            m2, [tmpq+offq+32*0]
+    punpcklqdq      m2, [tmpq+offq+32*1] ; k1s0
+    neg           offq
+    movu            m3, [tmpq+offq+32*0]
+    punpcklqdq      m3, [tmpq+offq+32*1] ; k1s1
 %else
-    mova           xm1, [dst8q]
-    mova           xm2, [dst8q+strideq]
-    mova   [px+(%2+0)*%3+0], xm1
-    mova   [px+(%2+1)*%3+0], xm2
+    movu           xm2, [tmpq+offq+32*0]
+    vinserti128     m2, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm3, [tmpq+offq+32*0]
+    vinserti128     m3, [tmpq+offq+32*1], 1
 %endif
-    movd   [px+(%2+0)*%3-4], xm14
-    movd   [px+(%2+1)*%3-4], xm14
-    movd  [px+(%2+0)*%3+%1*2], xm14
-    movd  [px+(%2+1)*%3+%1*2], xm14
-    jmp .bottom_done
-.no_bottom:
-    movu   [px+(%2+0)*%3-%1], m14
-    movu   [px+(%2+1)*%3-%1], m14
-.bottom_done:
-
-    ; actual filter
-    INIT_YMM avx2
-    DEFINE_ARGS dst, stride, pridmp, damping, pri, secdmp, stride3, zero
- %undef edged
-    movifnidn     prid, prim
-    mov       dampingd, r7m
-    lzcnt      pridmpd, prid
-%if UNIX64
-    movd           xm0, prid
-    movd           xm1, secdmpd
-%endif
-    lzcnt      secdmpd, secdmpm
-    sub       dampingd, 31
-    xor          zerod, zerod
-    add        pridmpd, dampingd
-    cmovs      pridmpd, zerod
-    add        secdmpd, dampingd
-    mov        [rsp+0], pridmpq                 ; pri_shift
-    mov        [rsp+8], secdmpq                 ; sec_shift
-
-    ; pri/sec_taps[k] [4 total]
-    DEFINE_ARGS dst, stride, table, dir, pri, sec, stride3
-%if UNIX64
-    vpbroadcastw    m0, xm0                     ; pri_strength
-    vpbroadcastw    m1, xm1                     ; sec_strength
-%else
-    vpbroadcastw    m0, prim                    ; pri_strength
-    vpbroadcastw    m1, secm                    ; sec_strength
-%endif
-    rorx           r2d, prid, 2
-    cmp      dword r9m, 0xfff
-    cmove         prid, r2d
-    and           prid, 4
-    lea         tableq, [tap_table]
-    lea           priq, [tableq+priq]           ; pri_taps
-    lea           secq, [tableq+8]              ; sec_taps
-
-    ; off1/2/3[k] [6 total] from [tableq+12+(dir+0/2/6)*2+k]
-    mov           dird, r6m
-    lea         tableq, [tableq+dirq*2+12]
-%if %1*%2*2/mmsize > 1
- %if %1 == 4
-    DEFINE_ARGS dst, stride, dir, stk, pri, sec, stride3, h, off, k
- %else
-    DEFINE_ARGS dst, stride, dir, stk, pri, sec, h, off, k
- %endif
-    mov             hd, %1*%2*2/mmsize
-%else
-    DEFINE_ARGS dst, stride, dir, stk, pri, sec, stride3, off, k
-%endif
-    lea           stkq, [px]
-    pxor           m13, m13
-%if %1*%2*2/mmsize > 1
-.v_loop:
-%endif
-    mov             kd, 1
+    movsx         offq, byte [dirq+1]    ; off3_k1
+    paddw           m0, m7
+    psignw          m4, m5               ; constrain(diff_k0s3)
+    pmaxsw         m11, m2
+    pminuw         m12, m2
+    pmaxsw         m11, m3
+    pminuw         m12, m3
+    paddw           m0, m4               ; constrain(diff_k0)
+    psubw           m2, m1               ; diff_k1s0
+    psubw           m3, m1               ; diff_k1s1
+    paddw           m0, m0               ; sec_tap_k0
+    pabsw           m4, m2               ; adiff_k1s0
+    psrlw           m5, m4, [sec_shift+gprsize]
+    psubusw         m7, m13, m5
+    pabsw           m5, m3               ; adiff_k1s1
+    pminsw          m7, m4
+    psrlw           m4, m5, [sec_shift+gprsize]
+    psignw          m7, m2               ; constrain(diff_k1s0)
+    psubusw         m2, m13, m4
+    pminsw          m2, m5
 %if %1 == 4
-    movq           xm4, [stkq+%3*0]
-    movhps         xm4, [stkq+%3*1]
-    movq           xm5, [stkq+%3*2]
-    movhps         xm5, [stkq+%3*3]
-    vinserti128     m4, xm5, 1
+    movu            m4, [tmpq+offq+32*0]
+    punpcklqdq      m4, [tmpq+offq+32*1] ; k1s2
+    neg           offq
+    movu            m5, [tmpq+offq+32*0]
+    punpcklqdq      m5, [tmpq+offq+32*1] ; k1s3
 %else
-    mova           xm4, [stkq+%3*0]             ; px
-    vinserti128     m4, [stkq+%3*1], 1
+    movu           xm4, [tmpq+offq+32*0]
+    vinserti128     m4, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm5, [tmpq+offq+32*0]
+    vinserti128     m5, [tmpq+offq+32*1], 1
 %endif
-    pxor           m15, m15                     ; sum
-    mova            m7, m4                      ; max
-    mova            m8, m4                      ; min
-.k_loop:
-    vpbroadcastw    m2, [priq+kq*2]             ; pri_taps
-    vpbroadcastw    m3, [secq+kq*2]             ; sec_taps
-
-    ACCUMULATE_TAP 0*2, [rsp+0], m0, m2, %1, %3
-    ACCUMULATE_TAP 2*2, [rsp+8], m1, m3, %1, %3
-    ACCUMULATE_TAP 6*2, [rsp+8], m1, m3, %1, %3
-
-    dec             kq
-    jge .k_loop
-
-    vpbroadcastd   m12, [pw_2048]
-    pcmpgtw        m11, m13, m15
-    paddw          m15, m11
-    pmulhrsw       m15, m12
-    paddw           m4, m15
-    pminsw          m4, m7
-    pmaxsw          m4, m8
+    movsx         offq, byte [dirq+4]    ; off1_k0
+    paddw           m0, m7
+    psignw          m2, m3               ; constrain(diff_k1s1)
+    pmaxsw         m11, m4
+    pminuw         m12, m4
+    pmaxsw         m11, m5
+    pminuw         m12, m5
+    psubw           m4, m1               ; diff_k1s2
+    psubw           m5, m1               ; diff_k1s3
+    pabsw           m3, m4               ; adiff_k1s2
+    paddw           m0, m2
+    psrlw           m2, m3, [sec_shift+gprsize]
+    psubusw         m7, m13, m2
+    pabsw           m2, m5               ; adiff_k1s3
+    pminsw          m7, m3
+    psrlw           m3, m2, [sec_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k1s2)
+    psubusw         m4, m13, m3
+    pminsw          m4, m2
+    paddw           m0, m7
 %if %1 == 4
-    vextracti128   xm5, m4, 1
-    movq [dstq+strideq*0], xm4
-    movhps [dstq+strideq*1], xm4
-    movq [dstq+strideq*2], xm5
-    movhps [dstq+stride3q], xm5
+    movu            m2, [tmpq+offq+32*0]
+    punpcklqdq      m2, [tmpq+offq+32*1] ; k0p0
+    neg           offq
+    movu            m3, [tmpq+offq+32*0]
+    punpcklqdq      m3, [tmpq+offq+32*1] ; k0p1
 %else
-    mova [dstq+strideq*0], xm4
-    vextracti128 [dstq+strideq*1], m4, 1
+    movu           xm2, [tmpq+offq+32*0]
+    vinserti128     m2, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm3, [tmpq+offq+32*0]
+    vinserti128     m3, [tmpq+offq+32*1], 1
 %endif
-
-%if %1*%2*2/mmsize > 1
- %define vloop_lines (mmsize/(%1*2))
-    lea           dstq, [dstq+strideq*vloop_lines]
-    add           stkq, %3*vloop_lines
-    dec             hd
-    jg .v_loop
+    movsx         offq, byte [dirq+5]    ; off1_k1
+    psignw          m4, m5               ; constrain(diff_k1s3)
+    pmaxsw         m11, m2
+    pminuw         m12, m2
+    pmaxsw         m11, m3
+    pminuw         m12, m3
+    psubw           m2, m1               ; diff_k0p0
+    psubw           m3, m1               ; diff_k0p1
+    paddw           m0, m4
+    pabsw           m4, m2               ; adiff_k0p0
+    psrlw           m5, m4, [pri_shift+gprsize]
+    psubusw         m7, m6, m5
+    pabsw           m5, m3               ; adiff_k0p1
+    pminsw          m7, m4
+    psrlw           m4, m5, [pri_shift+gprsize]
+    psignw          m7, m2               ; constrain(diff_k0p0)
+    psubusw         m2, m6, m4
+    pminsw          m2, m5
+%if %1 == 4
+    movu            m4, [tmpq+offq+32*0]
+    punpcklqdq      m4, [tmpq+offq+32*1] ; k1p0
+    neg           offq
+    movu            m5, [tmpq+offq+32*0]
+    punpcklqdq      m5, [tmpq+offq+32*1] ; k1p1
+%else
+    movu           xm4, [tmpq+offq+32*0]
+    vinserti128     m4, [tmpq+offq+32*1], 1
+    neg           offq
+    movu           xm5, [tmpq+offq+32*0]
+    vinserti128     m5, [tmpq+offq+32*1], 1
 %endif
-
-    RET
+    psignw          m2, m3               ; constrain(diff_k0p1)
+    paddw           m7, m2               ; constrain(diff_k0)
+    pmaxsw         m11, m4
+    pminuw         m12, m4
+    pmaxsw         m11, m5
+    pminuw         m12, m5
+    psubw           m4, m1               ; diff_k1p0
+    psubw           m5, m1               ; diff_k1p1
+    pabsw           m3, m4               ; adiff_k1p0
+    pmullw          m7, m9               ; pri_tap_k0
+    paddw           m0, m7
+    psrlw           m2, m3, [pri_shift+gprsize]
+    psubusw         m7, m6, m2
+    pabsw           m2, m5               ; adiff_k1p1
+    pminsw          m7, m3
+    psrlw           m3, m2, [pri_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k1p0)
+    psubusw         m4, m6, m3
+    pminsw          m4, m2
+    psignw          m4, m5               ; constrain(diff_k1p1)
+    paddw           m7, m4               ; constrain(diff_k1)
+    pmullw          m7, m10              ; pri_tap_k1
+    paddw           m0, m7               ; sum
+    psraw           m2, m0, 15
+    paddw           m0, m2
+    pmulhrsw        m0, m8
+    add           tmpq, 32*2
+    pmaxsw         m11, m1
+    pminuw         m12, m1
+    paddw           m0, m1
+    pminsw          m0, m11
+    pmaxsw          m0, m12
+%if %1 == 4
+    vextracti128   xm1, m0, 1
+    movq   [dstq+strideq*0], xm0
+    movq   [dstq+strideq*1], xm1
+    movhps [dstq+strideq*2], xm0
+    movhps [dstq+r8       ], xm1
+    lea           dstq, [dstq+strideq*4]
+%else
+    mova         [dstq+strideq*0], xm0
+    vextracti128 [dstq+strideq*1], m0, 1
+    lea           dstq, [dstq+strideq*2]
+%endif
+    ret
+%endif
 %endmacro
 
-cdef_filter_fn 8, 8, 32
-cdef_filter_fn 4, 4, 32
-
 INIT_YMM avx2
+cglobal cdef_filter_4x4_16bpc, 4, 9, 9, 16*10, dst, stride, left, top, pri, sec, edge
+%if WIN64
+    %define         px  rsp+16*6
+    %define       offq  r7
+    %define  pri_shift  rsp+16*2
+    %define  sec_shift  rsp+16*3
+%else
+    %define         px  rsp+16*4
+    %define       offq  r3
+    %define  pri_shift  rsp+16*0
+    %define  sec_shift  rsp+16*1
+%endif
+    %define       base  r7-dir_table4
+    mov          edged, r8m
+    lea             r7, [dir_table4]
+    movu           xm0, [dstq+strideq*0]
+    movu           xm1, [dstq+strideq*1]
+    lea             r8, [strideq*3]
+    movu           xm2, [dstq+strideq*2]
+    movu           xm3, [dstq+r8       ]
+    vpbroadcastd    m7, [base+pw_m16384]
+    mova   [px+16*0+0], xm0
+    mova   [px+16*1+0], xm1
+    mova   [px+16*2+0], xm2
+    mova   [px+16*3+0], xm3
+    test         edgeb, 4 ; HAVE_TOP
+    jz .no_top
+    movu           xm0, [topq+strideq*0]
+    movu           xm1, [topq+strideq*1]
+    mova   [px-16*2+0], xm0
+    mova   [px-16*1+0], xm1
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .top_no_left
+    movd           xm0, [topq+strideq*0-4]
+    movd           xm1, [topq+strideq*1-4]
+    movd   [px-16*2-4], xm0
+    movd   [px-16*1-4], xm1
+    jmp .top_done
+.no_top:
+    mova   [px-16*2+0], m7
+.top_no_left:
+    movd   [px-16*2-4], xm7
+    movd   [px-16*1-4], xm7
+.top_done:
+    test         edgeb, 8 ; HAVE_BOTTOM
+    jz .no_bottom
+    lea             r3, [dstq+strideq*4]
+    movu           xm0, [r3+strideq*0]
+    movu           xm1, [r3+strideq*1]
+    mova   [px+16*4+0], xm0
+    mova   [px+16*5+0], xm1
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .bottom_no_left
+    movd           xm0, [r3+strideq*0-4]
+    movd           xm1, [r3+strideq*1-4]
+    movd   [px+16*4-4], xm0
+    movd   [px+16*5-4], xm1
+    jmp .bottom_done
+.no_bottom:
+    mova   [px+16*4+0], m7
+.bottom_no_left:
+    movd   [px+16*4-4], xm7
+    movd   [px+16*5-4], xm7
+.bottom_done:
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .no_left
+    movd           xm0, [leftq+4*0]
+    movd           xm1, [leftq+4*1]
+    movd           xm2, [leftq+4*2]
+    movd           xm3, [leftq+4*3]
+    movd   [px+16*0-4], xm0
+    movd   [px+16*1-4], xm1
+    movd   [px+16*2-4], xm2
+    movd   [px+16*3-4], xm3
+    jmp .left_done
+.no_left:
+    REPX {movd [px+16*x-4], xm7}, 0, 1, 2, 3
+.left_done:
+    test         edgeb, 2 ; HAVE_RIGHT
+    jnz .padding_done
+    REPX {movd [px+16*x+8], xm7}, -2, -1, 0, 1, 2, 3, 4, 5
+.padding_done:
+    CDEF_FILTER      4, 4
+
+cglobal cdef_filter_4x8_16bpc, 4, 9, 9, 16*14, dst, stride, left, top, pri, sec, edge
+    mov          edged, r8m
+    movu           xm0, [dstq+strideq*0]
+    movu           xm1, [dstq+strideq*1]
+    lea             r8, [strideq*3]
+    movu           xm2, [dstq+strideq*2]
+    movu           xm3, [dstq+r8       ]
+    lea             r7, [dstq+strideq*4]
+    movu           xm4, [r7  +strideq*0]
+    movu           xm5, [r7  +strideq*1]
+    movu           xm6, [r7  +strideq*2]
+    movu           xm7, [r7  +r8       ]
+    lea             r7, [dir_table4]
+    mova   [px+16*0+0], xm0
+    mova   [px+16*1+0], xm1
+    mova   [px+16*2+0], xm2
+    mova   [px+16*3+0], xm3
+    mova   [px+16*4+0], xm4
+    mova   [px+16*5+0], xm5
+    mova   [px+16*6+0], xm6
+    mova   [px+16*7+0], xm7
+    vpbroadcastd    m7, [base+pw_m16384]
+    test         edgeb, 4 ; HAVE_TOP
+    jz .no_top
+    movu           xm0, [topq+strideq*0]
+    movu           xm1, [topq+strideq*1]
+    mova   [px-16*2+0], xm0
+    mova   [px-16*1+0], xm1
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .top_no_left
+    movd           xm0, [topq+strideq*0-4]
+    movd           xm1, [topq+strideq*1-4]
+    movd   [px-16*2-4], xm0
+    movd   [px-16*1-4], xm1
+    jmp .top_done
+.no_top:
+    mova   [px-16*2+0], m7
+.top_no_left:
+    movd   [px-16*2-4], xm7
+    movd   [px-16*1-4], xm7
+.top_done:
+    test         edgeb, 8 ; HAVE_BOTTOM
+    jz .no_bottom
+    lea             r3, [dstq+strideq*8]
+    movu           xm0, [r3+strideq*0]
+    movu           xm1, [r3+strideq*1]
+    mova   [px+16*8+0], xm0
+    mova   [px+16*9+0], xm1
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .bottom_no_left
+    movd           xm0, [r3+strideq*0-4]
+    movd           xm1, [r3+strideq*1-4]
+    movd   [px+16*8-4], xm0
+    movd   [px+16*9-4], xm1
+    jmp .bottom_done
+.no_bottom:
+    mova   [px+16*8+0], m7
+.bottom_no_left:
+    movd   [px+16*8-4], xm7
+    movd   [px+16*9-4], xm7
+.bottom_done:
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .no_left
+    movd           xm0, [leftq+4*0]
+    movd           xm1, [leftq+4*1]
+    movd           xm2, [leftq+4*2]
+    movd           xm3, [leftq+4*3]
+    movd   [px+16*0-4], xm0
+    movd   [px+16*1-4], xm1
+    movd   [px+16*2-4], xm2
+    movd   [px+16*3-4], xm3
+    movd           xm0, [leftq+4*4]
+    movd           xm1, [leftq+4*5]
+    movd           xm2, [leftq+4*6]
+    movd           xm3, [leftq+4*7]
+    movd   [px+16*4-4], xm0
+    movd   [px+16*5-4], xm1
+    movd   [px+16*6-4], xm2
+    movd   [px+16*7-4], xm3
+    jmp .left_done
+.no_left:
+    REPX {movd [px+16*x-4], xm7}, 0, 1, 2, 3, 4, 5, 6, 7
+.left_done:
+    test         edgeb, 2 ; HAVE_RIGHT
+    jnz .padding_done
+    REPX {movd [px+16*x+8], xm7}, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+.padding_done:
+    CDEF_FILTER      4, 8
+
+cglobal cdef_filter_8x8_16bpc, 4, 8, 9, 32*13, dst, stride, left, top, pri, sec, edge
+%if WIN64
+    %define         px  rsp+32*4
+%else
+    %define         px  rsp+32*3
+%endif
+    %define       base  r7-dir_table8
+    mov          edged, r8m
+    movu            m0, [dstq+strideq*0]
+    movu            m1, [dstq+strideq*1]
+    lea             r7, [dstq+strideq*2]
+    movu            m2, [r7  +strideq*0]
+    movu            m3, [r7  +strideq*1]
+    lea             r7, [r7  +strideq*2]
+    movu            m4, [r7  +strideq*0]
+    movu            m5, [r7  +strideq*1]
+    lea             r7, [r7  +strideq*2]
+    movu            m6, [r7  +strideq*0]
+    movu            m7, [r7  +strideq*1]
+    lea             r7, [dir_table8]
+    mova   [px+32*0+0], m0
+    mova   [px+32*1+0], m1
+    mova   [px+32*2+0], m2
+    mova   [px+32*3+0], m3
+    mova   [px+32*4+0], m4
+    mova   [px+32*5+0], m5
+    mova   [px+32*6+0], m6
+    mova   [px+32*7+0], m7
+    vpbroadcastd    m7, [base+pw_m16384]
+    test         edgeb, 4 ; HAVE_TOP
+    jz .no_top
+    movu            m0, [topq+strideq*0]
+    movu            m1, [topq+strideq*1]
+    mova   [px-32*2+0], m0
+    mova   [px-32*1+0], m1
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .top_no_left
+    movd           xm0, [topq+strideq*0-4]
+    movd           xm1, [topq+strideq*1-4]
+    movd   [px-32*2-4], xm0
+    movd   [px-32*1-4], xm1
+    jmp .top_done
+.no_top:
+    mova   [px-32*2+0], m7
+    mova   [px-32*1+0], m7
+.top_no_left:
+    movd   [px-32*2-4], xm7
+    movd   [px-32*1-4], xm7
+.top_done:
+    test         edgeb, 8 ; HAVE_BOTTOM
+    jz .no_bottom
+    lea             r3, [dstq+strideq*8]
+    movu            m0, [r3+strideq*0]
+    movu            m1, [r3+strideq*1]
+    mova   [px+32*8+0], m0
+    mova   [px+32*9+0], m1
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .bottom_no_left
+    movd           xm0, [r3+strideq*0-4]
+    movd           xm1, [r3+strideq*1-4]
+    movd   [px+32*8-4], xm0
+    movd   [px+32*9-4], xm1
+    jmp .bottom_done
+.no_bottom:
+    mova   [px+32*8+0], m7
+    mova   [px+32*9+0], m7
+.bottom_no_left:
+    movd   [px+32*8-4], xm7
+    movd   [px+32*9-4], xm7
+.bottom_done:
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .no_left
+    movd           xm0, [leftq+4*0]
+    movd           xm1, [leftq+4*1]
+    movd           xm2, [leftq+4*2]
+    movd           xm3, [leftq+4*3]
+    movd   [px+32*0-4], xm0
+    movd   [px+32*1-4], xm1
+    movd   [px+32*2-4], xm2
+    movd   [px+32*3-4], xm3
+    movd           xm0, [leftq+4*4]
+    movd           xm1, [leftq+4*5]
+    movd           xm2, [leftq+4*6]
+    movd           xm3, [leftq+4*7]
+    movd   [px+32*4-4], xm0
+    movd   [px+32*5-4], xm1
+    movd   [px+32*6-4], xm2
+    movd   [px+32*7-4], xm3
+    jmp .left_done
+.no_left:
+    REPX {movd [px+32*x-4], xm7}, 0, 1, 2, 3, 4, 5, 6, 7
+.left_done:
+    test         edgeb, 2 ; HAVE_RIGHT
+    jnz .padding_done
+    REPX {movd [px+32*x+16], xm7}, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+.padding_done:
+    CDEF_FILTER      8, 8
+
 cglobal cdef_dir_16bpc, 4, 7, 6, src, stride, var, bdmax
     lea             r6, [dir_shift]
     shr         bdmaxd, 11 ; 0 for 10bpc, 1 for 12bpc

--- a/src/x86/cdef16_avx2.asm
+++ b/src/x86/cdef16_avx2.asm
@@ -368,7 +368,6 @@ cglobal cdef_filter_%1x%2_16bpc, 4, 10, 16, 2 * 16 + (%2+4)*%3, \
     add        pridmpd, dampingd
     cmovs      pridmpd, zerod
     add        secdmpd, dampingd
-    cmovs      secdmpd, zerod
     mov        [rsp+0], pridmpq                 ; pri_shift
     mov        [rsp+8], secdmpq                 ; sec_shift
 

--- a/src/x86/cdef16_sse.asm
+++ b/src/x86/cdef16_sse.asm
@@ -1,3 +1,5 @@
+; Copyright © 2021, VideoLAN and dav1d authors
+; Copyright © 2021, Two Orioles, LLC
 ; Copyright (c) 2017-2021, The rav1e contributors
 ; Copyright (c) 2021, Nathan Egge
 ; All rights reserved.
@@ -28,10 +30,33 @@
 
 SECTION_RODATA
 
+%macro DUP8 1-*
+    %rep %0
+        times 8 dw %1
+        %rotate 1
+    %endrep
+%endmacro
+
+pri_taps:  DUP8 4, 2, 3, 3
+dir_table: db  1 * 32 + 0,  2 * 32 + 0
+           db  1 * 32 + 0,  2 * 32 - 2
+           db -1 * 32 + 2, -2 * 32 + 4
+           db  0 * 32 + 2, -1 * 32 + 4
+           db  0 * 32 + 2,  0 * 32 + 4
+           db  0 * 32 + 2,  1 * 32 + 4
+           db  1 * 32 + 2,  2 * 32 + 4
+           db  1 * 32 + 0,  2 * 32 + 2
+           db  1 * 32 + 0,  2 * 32 + 0
+           db  1 * 32 + 0,  2 * 32 - 2
+           db -1 * 32 + 2, -2 * 32 + 4
+           db  0 * 32 + 2, -1 * 32 + 4
+
 dir_shift: times 4 dw 0x4000
            times 4 dw 0x1000
 
 pw_128:    times 4 dw 128
+pw_2048:   times 8 dw 2048
+pw_m16384: times 8 dw -16384
 
 cextern cdef_dir_8bpc_ssse3.main
 cextern cdef_dir_8bpc_sse4.main
@@ -46,6 +71,891 @@ SECTION .text
     %%f(%1)
 %endrep
 %endmacro
+
+%if ARCH_X86_32
+DECLARE_REG_TMP 5, 3
+%elif WIN64
+DECLARE_REG_TMP 7, 4
+%else
+DECLARE_REG_TMP 7, 8
+%endif
+
+%macro CDEF_FILTER 2 ; w, h
+%if ARCH_X86_64
+    DEFINE_ARGS dst, stride, tmp, pridmp, pri, sec, dir
+    mova            m8, [base+pw_2048]
+%else
+    DEFINE_ARGS dst, pridmp, tmp, sec, pri, _, dir
+    %define         m8  [base+pw_2048]
+    %define         m9  [rsp+16*1+gprsize]
+    %define        m10  [rsp+16*2+gprsize]
+%endif
+    movifnidn     prid, r4m
+    movifnidn     secd, r5m
+    test          prid, prid
+    jz .sec_only
+    movd            m6, r4m
+%if ARCH_X86_32
+    mov       [rsp+24], pridmpd
+%endif
+    bsr        pridmpd, prid
+    lea           tmpd, [priq*4]
+    cmp      dword r9m, 0x3ff ; if (bpc == 10)
+    cmove         prid, tmpd  ;     pri <<= 2
+    mov           tmpd, r7m   ; damping
+    mov           dird, r6m
+    and           prid, 16
+    pshufb          m6, m7    ; splat
+    lea           dirq, [base+dir_table+dirq*2]
+    lea           priq, [base+pri_taps+priq*2]
+    test          secd, secd
+    jz .pri_only
+    mova         [rsp], m6
+    movd            m6, secd
+    bsr           secd, secd
+    sub        pridmpd, tmpd
+    sub           tmpd, secd
+    pshufb          m6, m7
+    xor           secd, secd
+    neg        pridmpd
+    cmovs      pridmpd, secd
+%if ARCH_X86_32
+    mov  [pri_shift+4], secd
+    mov  [sec_shift+4], secd
+%endif
+    mov  [pri_shift+0], pridmpq
+    mov  [sec_shift+0], tmpq
+    lea           tmpq, [px]
+%if WIN64
+    movaps         r4m, m9
+    movaps         r6m, m10
+%elif ARCH_X86_32
+    mov        pridmpd, [rsp+24]
+%endif
+%rep %1*%2/8
+    call mangle(private_prefix %+ _cdef_filter_%1x%1_16bpc %+ SUFFIX).pri_sec
+%endrep
+%if WIN64
+    movaps          m9, r4m
+    movaps         m10, r6m
+%endif
+    jmp .end
+.pri_only:
+    sub           tmpd, pridmpd
+    cmovs         tmpd, secd
+%if ARCH_X86_32
+    mov        pridmpd, [rsp+24]
+    mov  [pri_shift+4], secd
+%endif
+    mov  [pri_shift+0], tmpq
+    lea           tmpq, [px]
+%rep %1*%2/8
+    call mangle(private_prefix %+ _cdef_filter_%1x%1_16bpc %+ SUFFIX).pri
+%endrep
+.end:
+    RET
+.sec_only:
+    mov           tmpd, r7m ; damping
+    movd            m6, r5m
+    bsr           secd, secd
+    mov           dird, r6m
+    pshufb          m6, m7
+    sub           tmpd, secd
+    lea           dirq, [base+dir_table+dirq*2]
+%if ARCH_X86_32
+    mov  [sec_shift+4], prid
+%endif
+    mov  [sec_shift+0], tmpq
+    lea           tmpq, [px]
+%rep %1*%2/8
+    call mangle(private_prefix %+ _cdef_filter_%1x%1_16bpc %+ SUFFIX).sec
+%endrep
+    jmp .end
+%if %1 == %2
+DEFINE_ARGS dst, stride, tmp, off, pri, _, dir
+ALIGN function_align
+.pri:
+    movsx         offq, byte [dirq+4]    ; off_k0
+%if %1 == 4
+    movq            m1, [dstq+strideq*0]
+    movhps          m1, [dstq+strideq*1]
+    movq            m2, [tmpq+offq+32*0] ; k0p0
+    movhps          m2, [tmpq+offq+32*1]
+    neg           offq
+    movq            m3, [tmpq+offq+32*0] ; k0p1
+    movhps          m3, [tmpq+offq+32*1]
+%else
+    mova            m1, [dstq]
+    movu            m2, [tmpq+offq]
+    neg           offq
+    movu            m3, [tmpq+offq]
+%endif
+    movsx         offq, byte [dirq+5]    ; off_k1
+    psubw           m2, m1               ; diff_k0p0
+    psubw           m3, m1               ; diff_k0p1
+    pabsw           m4, m2               ; adiff_k0p0
+    psrlw           m5, m4, [pri_shift+gprsize]
+    psubusw         m0, m6, m5
+    pabsw           m5, m3               ; adiff_k0p1
+    pminsw          m0, m4
+    psrlw           m4, m5, [pri_shift+gprsize]
+    psignw          m0, m2               ; constrain(diff_k0p0)
+    psubusw         m2, m6, m4
+    pminsw          m2, m5
+%if %1 == 4
+    movq            m4, [tmpq+offq+32*0] ; k1p0
+    movhps          m4, [tmpq+offq+32*1]
+    neg           offq
+    movq            m5, [tmpq+offq+32*0] ; k1p1
+    movhps          m5, [tmpq+offq+32*1]
+%else
+    movu            m4, [tmpq+offq]
+    neg           offq
+    movu            m5, [tmpq+offq]
+%endif
+    psubw           m4, m1               ; diff_k1p0
+    psubw           m5, m1               ; diff_k1p1
+    psignw          m2, m3               ; constrain(diff_k0p1)
+    pabsw           m3, m4               ; adiff_k1p0
+    paddw           m0, m2               ; constrain(diff_k0)
+    psrlw           m2, m3, [pri_shift+gprsize]
+    psubusw         m7, m6, m2
+    pabsw           m2, m5               ; adiff_k1p1
+    pminsw          m7, m3
+    psrlw           m3, m2, [pri_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k1p0)
+    psubusw         m4, m6, m3
+    pminsw          m4, m2
+    psignw          m4, m5               ; constrain(diff_k1p1)
+    paddw           m7, m4               ; constrain(diff_k1)
+    pmullw          m0, [priq+16*0]      ; pri_tap_k0
+    pmullw          m7, [priq+16*1]      ; pri_tap_k1
+    paddw           m0, m7               ; sum
+    psraw           m2, m0, 15
+    paddw           m0, m2
+    pmulhrsw        m0, m8
+    paddw           m0, m1
+%if %1 == 4
+    add           tmpq, 32*2
+    movq   [dstq+strideq*0], m0
+    movhps [dstq+strideq*1], m0
+    lea           dstq, [dstq+strideq*2]
+%else
+    add           tmpq, 32
+    mova        [dstq], m0
+    add           dstq, strideq
+%endif
+    ret
+ALIGN function_align
+.sec:
+    movsx         offq, byte [dirq+8]    ; off1_k0
+%if %1 == 4
+    movq            m1, [dstq+strideq*0]
+    movhps          m1, [dstq+strideq*1]
+    movq            m2, [tmpq+offq+32*0] ; k0s0
+    movhps          m2, [tmpq+offq+32*1]
+    neg           offq
+    movq            m3, [tmpq+offq+32*0] ; k0s1
+    movhps          m3, [tmpq+offq+32*1]
+%else
+    mova            m1, [dstq]
+    movu            m2, [tmpq+offq]
+    neg           offq
+    movu            m3, [tmpq+offq]
+%endif
+    movsx         offq, byte [dirq+0]    ; off2_k0
+    psubw           m2, m1               ; diff_k0s0
+    psubw           m3, m1               ; diff_k0s1
+    pabsw           m4, m2               ; adiff_k0s0
+    psrlw           m5, m4, [sec_shift+gprsize]
+    psubusw         m0, m6, m5
+    pabsw           m5, m3               ; adiff_k0s1
+    pminsw          m0, m4
+    psrlw           m4, m5, [sec_shift+gprsize]
+    psignw          m0, m2               ; constrain(diff_k0s0)
+    psubusw         m2, m6, m4
+    pminsw          m2, m5
+%if %1 == 4
+    movq            m4, [tmpq+offq+32*0] ; k0s2
+    movhps          m4, [tmpq+offq+32*1]
+    neg           offq
+    movq            m5, [tmpq+offq+32*0] ; k0s3
+    movhps          m5, [tmpq+offq+32*1]
+%else
+    movu            m4, [tmpq+offq]
+    neg           offq
+    movu            m5, [tmpq+offq]
+%endif
+    movsx         offq, byte [dirq+9]    ; off1_k1
+    psubw           m4, m1               ; diff_k0s2
+    psubw           m5, m1               ; diff_k0s3
+    psignw          m2, m3               ; constrain(diff_k0s1)
+    pabsw           m3, m4               ; adiff_k0s2
+    paddw           m0, m2
+    psrlw           m2, m3, [sec_shift+gprsize]
+    psubusw         m7, m6, m2
+    pabsw           m2, m5               ; adiff_k0s3
+    pminsw          m7, m3
+    psrlw           m3, m2, [sec_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k0s2)
+    psubusw         m4, m6, m3
+    pminsw          m4, m2
+%if %1 == 4
+    movq            m2, [tmpq+offq+32*0] ; k1s0
+    movhps          m2, [tmpq+offq+32*1]
+    neg           offq
+    movq            m3, [tmpq+offq+32*0] ; k1s1
+    movhps          m3, [tmpq+offq+32*1]
+%else
+    movu            m2, [tmpq+offq]
+    neg           offq
+    movu            m3, [tmpq+offq]
+%endif
+    movsx         offq, byte [dirq+1]    ; off2_k1
+    paddw           m0, m7
+    psignw          m4, m5               ; constrain(diff_k0s3)
+    paddw           m0, m4               ; constrain(diff_k0)
+    psubw           m2, m1               ; diff_k1s0
+    psubw           m3, m1               ; diff_k1s1
+    paddw           m0, m0               ; sec_tap_k0
+    pabsw           m4, m2               ; adiff_k1s0
+    psrlw           m5, m4, [sec_shift+gprsize]
+    psubusw         m7, m6, m5
+    pabsw           m5, m3               ; adiff_k1s1
+    pminsw          m7, m4
+    psrlw           m4, m5, [sec_shift+gprsize]
+    psignw          m7, m2               ; constrain(diff_k1s0)
+    psubusw         m2, m6, m4
+    pminsw          m2, m5
+%if %1 == 4
+    movq            m4, [tmpq+offq+32*0] ; k1s2
+    movhps          m4, [tmpq+offq+32*1]
+    neg           offq
+    movq            m5, [tmpq+offq+32*0] ; k1s3
+    movhps          m5, [tmpq+offq+32*1]
+%else
+    movu            m4, [tmpq+offq]
+    neg           offq
+    movu            m5, [tmpq+offq]
+%endif
+    paddw           m0, m7
+    psubw           m4, m1               ; diff_k1s2
+    psubw           m5, m1               ; diff_k1s3
+    psignw          m2, m3               ; constrain(diff_k1s1)
+    pabsw           m3, m4               ; adiff_k1s2
+    paddw           m0, m2
+    psrlw           m2, m3, [sec_shift+gprsize]
+    psubusw         m7, m6, m2
+    pabsw           m2, m5               ; adiff_k1s3
+    pminsw          m7, m3
+    psrlw           m3, m2, [sec_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k1s2)
+    psubusw         m4, m6, m3
+    pminsw          m4, m2
+    paddw           m0, m7
+    psignw          m4, m5               ; constrain(diff_k1s3)
+    paddw           m0, m4               ; sum
+    psraw           m2, m0, 15
+    paddw           m0, m2
+    pmulhrsw        m0, m8
+    paddw           m0, m1
+%if %1 == 4
+    add           tmpq, 32*2
+    movq   [dstq+strideq*0], m0
+    movhps [dstq+strideq*1], m0
+    lea           dstq, [dstq+strideq*2]
+%else
+    add           tmpq, 32
+    mova        [dstq], m0
+    add           dstq, strideq
+%endif
+    ret
+ALIGN function_align
+.pri_sec:
+    movsx         offq, byte [dirq+8]    ; off2_k0
+%if %1 == 4
+    movq            m1, [dstq+strideq*0]
+    movhps          m1, [dstq+strideq*1]
+    movq            m2, [tmpq+offq+32*0] ; k0s0
+    movhps          m2, [tmpq+offq+32*1]
+    neg           offq
+    movq            m3, [tmpq+offq+32*0] ; k0s1
+    movhps          m3, [tmpq+offq+32*1]
+%else
+    mova            m1, [dstq]
+    movu            m2, [tmpq+offq]
+    neg           offq
+    movu            m3, [tmpq+offq]
+%endif
+    movsx         offq, byte [dirq+0]    ; off3_k0
+    pabsw           m4, m2
+%if ARCH_X86_64
+    pabsw          m10, m3
+    pmaxsw          m9, m2, m3
+    pminsw         m10, m4
+%else
+    pabsw           m7, m3
+    pmaxsw          m5, m2, m3
+    pminsw          m4, m7
+    mova            m9, m5
+    mova           m10, m4
+%endif
+    psubw           m2, m1               ; diff_k0s0
+    psubw           m3, m1               ; diff_k0s1
+    pabsw           m4, m2               ; adiff_k0s0
+    psrlw           m5, m4, [sec_shift+gprsize]
+    psubusw         m0, m6, m5
+    pabsw           m5, m3               ; adiff_k0s1
+    pminsw          m0, m4
+    psrlw           m4, m5, [sec_shift+gprsize]
+    psignw          m0, m2               ; constrain(diff_k0s0)
+    psubusw         m2, m6, m4
+    pminsw          m2, m5
+%if %1 == 4
+    movq            m4, [tmpq+offq+32*0] ; k0s2
+    movhps          m4, [tmpq+offq+32*1]
+    neg           offq
+    movq            m5, [tmpq+offq+32*0] ; k0s3
+    movhps          m5, [tmpq+offq+32*1]
+%else
+    movu            m4, [tmpq+offq]
+    neg           offq
+    movu            m5, [tmpq+offq]
+%endif
+    movsx         offq, byte [dirq+9]    ; off2_k1
+    pabsw           m7, m4
+    psignw          m2, m3
+    pabsw           m3, m5               ; constrain(diff_k0s1)
+%if ARCH_X86_64
+    pmaxsw          m9, m4
+    pminsw         m10, m7
+    pmaxsw          m9, m5
+    pminsw         m10, m3
+%else
+    pminsw          m7, m10
+    pminsw          m7, m3
+    pmaxsw          m3, m9, m4
+    pmaxsw          m3, m5
+    mova           m10, m7
+    mova            m9, m3
+%endif
+    psubw           m4, m1               ; diff_k0s2
+    psubw           m5, m1               ; diff_k0s3
+    paddw           m0, m2
+    pabsw           m3, m4               ; adiff_k0s2
+    psrlw           m2, m3, [sec_shift+gprsize]
+    psubusw         m7, m6, m2
+    pabsw           m2, m5               ; adiff_k0s3
+    pminsw          m7, m3
+    psrlw           m3, m2, [sec_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k0s2)
+    psubusw         m4, m6, m3
+    pminsw          m4, m2
+%if %1 == 4
+    movq            m2, [tmpq+offq+32*0] ; k1s0
+    movhps          m2, [tmpq+offq+32*1]
+    neg           offq
+    movq            m3, [tmpq+offq+32*0] ; k1s1
+    movhps          m3, [tmpq+offq+32*1]
+%else
+    movu            m2, [tmpq+offq]
+    neg           offq
+    movu            m3, [tmpq+offq]
+%endif
+    movsx         offq, byte [dirq+1]    ; off3_k1
+    paddw           m0, m7
+    pabsw           m7, m2
+    psignw          m4, m5               ; constrain(diff_k0s3)
+    pabsw           m5, m3
+%if ARCH_X86_64
+    pmaxsw          m9, m2
+    pminsw         m10, m7
+    pmaxsw          m9, m3
+    pminsw         m10, m5
+%else
+    pminsw          m7, m10
+    pminsw          m7, m5
+    pmaxsw          m5, m9, m2
+    pmaxsw          m5, m3
+    mova           m10, m7
+    mova            m9, m5
+%endif
+    paddw           m0, m4               ; constrain(diff_k0)
+    psubw           m2, m1               ; diff_k1s0
+    psubw           m3, m1               ; diff_k1s1
+    paddw           m0, m0               ; sec_tap_k0
+    pabsw           m4, m2               ; adiff_k1s0
+    psrlw           m5, m4, [sec_shift+gprsize]
+    psubusw         m7, m6, m5
+    pabsw           m5, m3               ; adiff_k1s1
+    pminsw          m7, m4
+    psrlw           m4, m5, [sec_shift+gprsize]
+    psignw          m7, m2               ; constrain(diff_k1s0)
+    psubusw         m2, m6, m4
+    pminsw          m2, m5
+%if %1 == 4
+    movq            m4, [tmpq+offq+32*0] ; k1s2
+    movhps          m4, [tmpq+offq+32*1]
+    neg           offq
+    movq            m5, [tmpq+offq+32*0] ; k1s3
+    movhps          m5, [tmpq+offq+32*1]
+%else
+    movu            m4, [tmpq+offq]
+    neg           offq
+    movu            m5, [tmpq+offq]
+%endif
+    movsx         offq, byte [dirq+4]    ; off1_k0
+    paddw           m0, m7
+    pabsw           m7, m4
+    psignw          m2, m3               ; constrain(diff_k1s1)
+    pabsw           m3, m5
+%if ARCH_X86_64
+    pmaxsw          m9, m4
+    pminsw         m10, m7
+    pmaxsw          m9, m5
+    pminsw         m10, m3
+%else
+    pminsw          m7, m10
+    pminsw          m7, m3
+    pmaxsw          m3, m9, m4
+    pmaxsw          m3, m5
+    mova           m10, m7
+    mova            m9, m3
+%endif
+    psubw           m4, m1               ; diff_k1s2
+    psubw           m5, m1               ; diff_k1s3
+    pabsw           m3, m4               ; adiff_k1s2
+    paddw           m0, m2
+    psrlw           m2, m3, [sec_shift+gprsize]
+    psubusw         m7, m6, m2
+    pabsw           m2, m5               ; adiff_k1s3
+    pminsw          m7, m3
+    psrlw           m3, m2, [sec_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k1s2)
+    psubusw         m4, m6, m3
+    pminsw          m4, m2
+    paddw           m0, m7
+%if %1 == 4
+    movq            m2, [tmpq+offq+32*0] ; k0p0
+    movhps          m2, [tmpq+offq+32*1]
+    neg           offq
+    movq            m3, [tmpq+offq+32*0] ; k0p1
+    movhps          m3, [tmpq+offq+32*1]
+%else
+    movu            m2, [tmpq+offq]
+    neg           offq
+    movu            m3, [tmpq+offq]
+%endif
+    movsx         offq, byte [dirq+5]    ; off1_k1
+    pabsw           m7, m2
+    psignw          m4, m5               ; constrain(diff_k1s3)
+    pabsw           m5, m3
+%if ARCH_X86_64
+    pmaxsw          m9, m2
+    pminsw         m10, m7
+    pmaxsw          m9, m3
+    pminsw         m10, m5
+%else
+    pminsw          m7, m10
+    pminsw          m7, m5
+    pmaxsw          m5, m9, m2
+    pmaxsw          m5, m3
+    mova           m10, m7
+    mova            m9, m5
+%endif
+    psubw           m2, m1               ; diff_k0p0
+    psubw           m3, m1               ; diff_k0p1
+    paddw           m0, m4
+    pabsw           m4, m2               ; adiff_k0p0
+    psrlw           m5, m4, [pri_shift+gprsize]
+    psubusw         m7, [rsp+gprsize], m5
+    pabsw           m5, m3               ; adiff_k0p1
+    pminsw          m7, m4
+    psrlw           m4, m5, [pri_shift+gprsize]
+    psignw          m7, m2               ; constrain(diff_k0p0)
+    psubusw         m2, [rsp+gprsize], m4
+    pminsw          m2, m5
+%if %1 == 4
+    movq            m4, [tmpq+offq+32*0] ; k1p0
+    movhps          m4, [tmpq+offq+32*1]
+    neg           offq
+    movq            m5, [tmpq+offq+32*0] ; k1p1
+    movhps          m5, [tmpq+offq+32*1]
+%else
+    movu            m4, [tmpq+offq]
+    neg           offq
+    movu            m5, [tmpq+offq]
+%endif
+    psignw          m2, m3               ; constrain(diff_k0p1)
+    pabsw           m3, m4
+    paddw           m7, m2               ; constrain(diff_k0)
+    pabsw           m2, m5
+%if ARCH_X86_64
+    pmaxsw          m9, m4
+    pminsw         m10, m3
+    pmaxsw          m9, m5
+    pminsw         m10, m2
+%else
+    pminsw          m3, m10
+    pminsw          m3, m2
+    pmaxsw          m2, m9, m4
+    pmaxsw          m2, m5
+    mova           m10, m3
+    mova            m9, m2
+%endif
+    psubw           m4, m1               ; diff_k1p0
+    psubw           m5, m1               ; diff_k1p1
+    pabsw           m3, m4               ; adiff_k1p0
+    pmullw          m7, [priq+16*0]      ; pri_tap_k0
+    paddw           m0, m7
+    psrlw           m2, m3, [pri_shift+gprsize]
+    psubusw         m7, [rsp+16*0+gprsize], m2
+    pabsw           m2, m5               ; adiff_k1p1
+    pminsw          m7, m3
+    psrlw           m3, m2, [pri_shift+gprsize]
+    psignw          m7, m4               ; constrain(diff_k1p0)
+    psubusw         m4, [rsp+16*0+gprsize], m3
+    pminsw          m4, m2
+    psignw          m4, m5               ; constrain(diff_k1p1)
+    paddw           m7, m4               ; constrain(diff_k1)
+    pmullw          m7, [priq+16*1]      ; pri_tap_k1
+    paddw           m0, m7               ; sum
+    psraw           m2, m0, 15
+    paddw           m0, m2
+    pmulhrsw        m0, m8
+    paddw           m0, m1
+%if ARCH_X86_64
+    pmaxsw          m9, m1
+    pminsw          m0, m9
+%else
+    pmaxsw          m2, m9, m1
+    pminsw          m0, m2
+%endif
+    pminsw          m1, m10
+    pmaxsw          m0, m1
+%if %1 == 4
+    add           tmpq, 32*2
+    movq   [dstq+strideq*0], m0
+    movhps [dstq+strideq*1], m0
+    lea           dstq, [dstq+strideq*2]
+%else
+    add           tmpq, 32
+    mova        [dstq], m0
+    add           dstq, strideq
+%endif
+    ret
+%endif
+%endmacro
+
+INIT_XMM ssse3
+%if ARCH_X86_64
+cglobal cdef_filter_4x4_16bpc, 4, 8, 9, 32*10, dst, stride, left, top, pri, sec, edge
+    %define         px  rsp+32*4
+%else
+cglobal cdef_filter_4x4_16bpc, 2, 7, 8, -32*11, dst, stride, edge, top, left
+    %define         px  rsp+32*5
+%endif
+    %define       base  t0-dir_table
+    %define  pri_shift  px-16*6
+    %define  sec_shift  px-16*5
+    mov          edged, r8m
+    LEA             t0, dir_table
+    movu            m0, [dstq+strideq*0]
+    movu            m1, [dstq+strideq*1]
+    lea             t1, [dstq+strideq*2]
+    movu            m2, [t1  +strideq*0]
+    movu            m3, [t1  +strideq*1]
+    movddup         m7, [base+pw_m16384]
+    mova   [px+32*0+0], m0
+    mova   [px+32*1+0], m1
+    mova   [px+32*2+0], m2
+    mova   [px+32*3+0], m3
+    test         edgeb, 4 ; HAVE_TOP
+    jz .no_top
+    movifnidn     topq, topmp
+    movu            m0, [topq+strideq*0]
+    movu            m1, [topq+strideq*1]
+    mova   [px-32*2+0], m0
+    mova   [px-32*1+0], m1
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .top_no_left
+    movd            m0, [topq+strideq*0-4]
+    movd            m1, [topq+strideq*1-4]
+    movd   [px-32*2-4], m0
+    movd   [px-32*1-4], m1
+    jmp .top_done
+.no_top:
+    mova   [px-32*2+0], m7
+    mova   [px-32*1+0], m7
+.top_no_left:
+    movd   [px-32*2-4], m7
+    movd   [px-32*1-4], m7
+.top_done:
+    test         edgeb, 8 ; HAVE_BOTTOM
+    jz .no_bottom
+    lea             r3, [dstq+strideq*4]
+    movu            m0, [r3+strideq*0]
+    movu            m1, [r3+strideq*1]
+    mova   [px+32*4+0], m0
+    mova   [px+32*5+0], m1
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .bottom_no_left
+    movd            m0, [r3+strideq*0-4]
+    movd            m1, [r3+strideq*1-4]
+    movd   [px+32*4-4], m0
+    movd   [px+32*5-4], m1
+    jmp .bottom_done
+.no_bottom:
+    mova   [px+32*4+0], m7
+    mova   [px+32*5+0], m7
+.bottom_no_left:
+    movd   [px+32*4-4], m7
+    movd   [px+32*5-4], m7
+.bottom_done:
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .no_left
+    movifnidn    leftq, r2mp
+    movd            m0, [leftq+4*0]
+    movd            m1, [leftq+4*1]
+    movd            m2, [leftq+4*2]
+    movd            m3, [leftq+4*3]
+    movd   [px+32*0-4], m0
+    movd   [px+32*1-4], m1
+    movd   [px+32*2-4], m2
+    movd   [px+32*3-4], m3
+    jmp .left_done
+.no_left:
+    REPX {movd [px+32*x-4], m7}, 0, 1, 2, 3
+.left_done:
+    test         edgeb, 2 ; HAVE_RIGHT
+    jnz .padding_done
+    REPX {movd [px+32*x+8], m7}, -2, -1, 0, 1, 2, 3, 4, 5
+.padding_done:
+    CDEF_FILTER      4, 4
+
+%if ARCH_X86_64
+cglobal cdef_filter_4x8_16bpc, 4, 8, 9, 32*14, dst, stride, left, top, pri, sec, edge
+%else
+cglobal cdef_filter_4x8_16bpc, 2, 7, 8, -32*15, dst, stride, edge, top, left
+%endif
+    mov          edged, r8m
+    LEA             t0, dir_table
+    movu            m0, [dstq+strideq*0]
+    movu            m1, [dstq+strideq*1]
+    lea             t1, [dstq+strideq*2]
+    movu            m2, [t1  +strideq*0]
+    movu            m3, [t1  +strideq*1]
+    lea             t1, [t1  +strideq*2]
+    movu            m4, [t1  +strideq*0]
+    movu            m5, [t1  +strideq*1]
+    lea             t1, [t1  +strideq*2]
+    movu            m6, [t1  +strideq*0]
+    movu            m7, [t1  +strideq*1]
+    mova   [px+32*0+0], m0
+    mova   [px+32*1+0], m1
+    mova   [px+32*2+0], m2
+    mova   [px+32*3+0], m3
+    mova   [px+32*4+0], m4
+    mova   [px+32*5+0], m5
+    mova   [px+32*6+0], m6
+    mova   [px+32*7+0], m7
+    movddup         m7, [base+pw_m16384]
+    test         edgeb, 4 ; HAVE_TOP
+    jz .no_top
+    movifnidn     topq, topmp
+    movu            m0, [topq+strideq*0]
+    movu            m1, [topq+strideq*1]
+    mova   [px-32*2+0], m0
+    mova   [px-32*1+0], m1
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .top_no_left
+    movd            m0, [topq+strideq*0-4]
+    movd            m1, [topq+strideq*1-4]
+    movd   [px-32*2-4], m0
+    movd   [px-32*1-4], m1
+    jmp .top_done
+.no_top:
+    mova   [px-32*2+0], m7
+    mova   [px-32*1+0], m7
+.top_no_left:
+    movd   [px-32*2-4], m7
+    movd   [px-32*1-4], m7
+.top_done:
+    test         edgeb, 8 ; HAVE_BOTTOM
+    jz .no_bottom
+    lea             r3, [dstq+strideq*8]
+    movu            m0, [r3+strideq*0]
+    movu            m1, [r3+strideq*1]
+    mova   [px+32*8+0], m0
+    mova   [px+32*9+0], m1
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .bottom_no_left
+    movd            m0, [r3+strideq*0-4]
+    movd            m1, [r3+strideq*1-4]
+    movd   [px+32*8-4], m0
+    movd   [px+32*9-4], m1
+    jmp .bottom_done
+.no_bottom:
+    mova   [px+32*8+0], m7
+    mova   [px+32*9+0], m7
+.bottom_no_left:
+    movd   [px+32*8-4], m7
+    movd   [px+32*9-4], m7
+.bottom_done:
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .no_left
+    movifnidn    leftq, r2mp
+    movd            m0, [leftq+4*0]
+    movd            m1, [leftq+4*1]
+    movd            m2, [leftq+4*2]
+    movd            m3, [leftq+4*3]
+    movd   [px+32*0-4], m0
+    movd   [px+32*1-4], m1
+    movd   [px+32*2-4], m2
+    movd   [px+32*3-4], m3
+    movd            m0, [leftq+4*4]
+    movd            m1, [leftq+4*5]
+    movd            m2, [leftq+4*6]
+    movd            m3, [leftq+4*7]
+    movd   [px+32*4-4], m0
+    movd   [px+32*5-4], m1
+    movd   [px+32*6-4], m2
+    movd   [px+32*7-4], m3
+    jmp .left_done
+.no_left:
+    REPX {movd [px+32*x-4], m7}, 0, 1, 2, 3, 4, 5, 6, 7
+.left_done:
+    test         edgeb, 2 ; HAVE_RIGHT
+    jnz .padding_done
+    REPX {movd [px+32*x+8], m7}, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+.padding_done:
+    CDEF_FILTER      4, 8
+
+%if ARCH_X86_64
+cglobal cdef_filter_8x8_16bpc, 4, 8, 9, 32*14, dst, stride, left, top, pri, sec, edge
+%else
+cglobal cdef_filter_8x8_16bpc, 2, 7, 8, -32*15, dst, stride, edge, top, left
+%endif
+    mov          edged, r8m
+    LEA             t0, dir_table
+    mova            m0, [dstq+strideq*0+ 0]
+    movd            m1, [dstq+strideq*0+16]
+    mova            m2, [dstq+strideq*1+ 0]
+    movd            m3, [dstq+strideq*1+16]
+    lea             t1, [dstq+strideq*2]
+    mova            m4, [t1  +strideq*0+ 0]
+    movd            m5, [t1  +strideq*0+16]
+    mova            m6, [t1  +strideq*1+ 0]
+    movd            m7, [t1  +strideq*1+16]
+    lea             t1, [t1  +strideq*2]
+    mova  [px+32*0+ 0], m0
+    movd  [px+32*0+16], m1
+    mova  [px+32*1+ 0], m2
+    movd  [px+32*1+16], m3
+    mova  [px+32*2+ 0], m4
+    movd  [px+32*2+16], m5
+    mova  [px+32*3+ 0], m6
+    movd  [px+32*3+16], m7
+    mova            m0, [t1  +strideq*0+ 0]
+    movd            m1, [t1  +strideq*0+16]
+    mova            m2, [t1  +strideq*1+ 0]
+    movd            m3, [t1  +strideq*1+16]
+    lea             t1, [t1  +strideq*2]
+    mova            m4, [t1  +strideq*0+ 0]
+    movd            m5, [t1  +strideq*0+16]
+    mova            m6, [t1  +strideq*1+ 0]
+    movd            m7, [t1  +strideq*1+16]
+    mova  [px+32*4+ 0], m0
+    movd  [px+32*4+16], m1
+    mova  [px+32*5+ 0], m2
+    movd  [px+32*5+16], m3
+    mova  [px+32*6+ 0], m4
+    movd  [px+32*6+16], m5
+    mova  [px+32*7+ 0], m6
+    movd  [px+32*7+16], m7
+    movddup         m7, [base+pw_m16384]
+    test         edgeb, 4 ; HAVE_TOP
+    jz .no_top
+    movifnidn     topq, topmp
+    mova            m0, [topq+strideq*0+ 0]
+    mova            m1, [topq+strideq*0+16]
+    mova            m2, [topq+strideq*1+ 0]
+    mova            m3, [topq+strideq*1+16]
+    mova  [px-32*2+ 0], m0
+    movd  [px-32*2+16], m1
+    mova  [px-32*1+ 0], m2
+    movd  [px-32*1+16], m3
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .top_no_left
+    movd            m0, [topq+strideq*0-4]
+    movd            m1, [topq+strideq*1-4]
+    movd   [px-32*2-4], m0
+    movd   [px-32*1-4], m1
+    jmp .top_done
+.no_top:
+    mova  [px-32*2+ 0], m7
+    movd  [px-32*2+16], m7
+    mova  [px-32*1+ 0], m7
+    movd  [px-32*1+16], m7
+.top_no_left:
+    movd  [px-32*2- 4], m7
+    movd  [px-32*1- 4], m7
+.top_done:
+    test         edgeb, 8 ; HAVE_BOTTOM
+    jz .no_bottom
+    lea             r3, [dstq+strideq*8]
+    mova            m0, [r3+strideq*0+ 0]
+    movd            m1, [r3+strideq*0+16]
+    mova            m2, [r3+strideq*1+ 0]
+    movd            m3, [r3+strideq*1+16]
+    mova  [px+32*8+ 0], m0
+    movd  [px+32*8+16], m1
+    mova  [px+32*9+ 0], m2
+    movd  [px+32*9+16], m3
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .bottom_no_left
+    movd            m0, [r3+strideq*0-4]
+    movd            m1, [r3+strideq*1-4]
+    movd  [px+32*8- 4], m0
+    movd  [px+32*9- 4], m1
+    jmp .bottom_done
+.no_bottom:
+    mova  [px+32*8+ 0], m7
+    movd  [px+32*8+16], m7
+    mova  [px+32*9+ 0], m7
+    movd  [px+32*9+16], m7
+.bottom_no_left:
+    movd  [px+32*8- 4], m7
+    movd  [px+32*9- 4], m7
+.bottom_done:
+    test         edgeb, 1 ; HAVE_LEFT
+    jz .no_left
+    movifnidn    leftq, r2mp
+    movd            m0, [leftq+4*0]
+    movd            m1, [leftq+4*1]
+    movd            m2, [leftq+4*2]
+    movd            m3, [leftq+4*3]
+    movd  [px+32*0- 4], m0
+    movd  [px+32*1- 4], m1
+    movd  [px+32*2- 4], m2
+    movd  [px+32*3- 4], m3
+    movd            m0, [leftq+4*4]
+    movd            m1, [leftq+4*5]
+    movd            m2, [leftq+4*6]
+    movd            m3, [leftq+4*7]
+    movd  [px+32*4- 4], m0
+    movd  [px+32*5- 4], m1
+    movd  [px+32*6- 4], m2
+    movd  [px+32*7- 4], m3
+    jmp .left_done
+.no_left:
+    REPX {movd [px+32*x- 4], m7}, 0, 1, 2, 3, 4, 5, 6, 7
+.left_done:
+    test         edgeb, 2 ; HAVE_RIGHT
+    jnz .padding_done
+    REPX {movd [px+32*x+16], m7}, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+.padding_done:
+    CDEF_FILTER      8, 8
 
 %macro CDEF_DIR 0
 %if ARCH_X86_64

--- a/src/x86/cdef16_sse.asm
+++ b/src/x86/cdef16_sse.asm
@@ -112,7 +112,7 @@ DECLARE_REG_TMP 7, 8
     jz .pri_only
     mova         [rsp], m6
     movd            m6, secd
-    bsr           secd, secd
+    tzcnt         secd, secd
     sub        pridmpd, tmpd
     sub           tmpd, secd
     pshufb          m6, m7
@@ -157,7 +157,7 @@ DECLARE_REG_TMP 7, 8
 .sec_only:
     mov           tmpd, r7m ; damping
     movd            m6, r5m
-    bsr           secd, secd
+    tzcnt         secd, secd
     mov           dird, r6m
     pshufb          m6, m7
     sub           tmpd, secd

--- a/src/x86/cdef_avx2.asm
+++ b/src/x86/cdef_avx2.asm
@@ -472,7 +472,6 @@ cglobal cdef_filter_%1x%2_8bpc, 4, 9, 0, dst, stride, left, top, \
     movd           xm1, secdmpd
     lzcnt      secdmpd, secdmpd
     add        secdmpd, dampingd
-    cmovs      secdmpd, zerod
     mov        [rsp+8], secdmpq                 ; sec_shift
 
  DEFINE_ARGS dst, stride, left, top, pri, secdmp, table, pridmp
@@ -552,7 +551,6 @@ cglobal cdef_filter_%1x%2_8bpc, 4, 9, 0, dst, stride, left, top, \
     movd           xm1, secdmpd
     lzcnt      secdmpd, secdmpd
     add        secdmpd, dampingd
-    cmovs      secdmpd, zerod
     mov        [rsp+8], secdmpq                 ; sec_shift
  DEFINE_ARGS dst, stride, left, top, _, secdmp, table
     lea         tableq, [tap_table]
@@ -1481,7 +1479,6 @@ cglobal cdef_filter_%1x%2_8bpc, 4, 9, 0, dst, stride, left, top, \
     movd           xm1, secdmpd
     lzcnt      secdmpd, secdmpd
     add        secdmpd, dampingd
-    cmovs      secdmpd, zerod
     mov        [rsp+8], secdmpq                 ; sec_shift
 
     DEFINE_ARGS dst, stride, pridmp, table, pri, secdmp, stride3
@@ -1556,7 +1553,6 @@ cglobal cdef_filter_%1x%2_8bpc, 4, 9, 0, dst, stride, left, top, \
     movd           xm1, secdmpd
     lzcnt      secdmpd, secdmpd
     add        secdmpd, dampingd
-    cmovs      secdmpd, zerod
     mov        [rsp+8], secdmpq                 ; sec_shift
  DEFINE_ARGS dst, stride, _, table, _, secdmp, stride3
     lea         tableq, [tap_table]

--- a/src/x86/cdef_sse.asm
+++ b/src/x86/cdef_sse.asm
@@ -566,7 +566,7 @@ cglobal cdef_filter_%1x%2_8bpc, 2, 7, 8, - 7 * 16 - (%2+4)*32, \
     test          secd, secd
     jz .pri_only
     movd           m10, r5m
-    bsr           secd, secd
+    tzcnt         secd, secd
     and           prid, 1
     sub        pridmpd, dampingd
     sub           secd, dampingd
@@ -696,7 +696,7 @@ cglobal cdef_filter_%1x%2_8bpc, 2, 7, 8, - 7 * 16 - (%2+4)*32, \
     DEFINE_ARGS dst, stride, sec, damping, dir, tap, zero
 %endif
     movd            m1, r5m
-    bsr           secd, secd
+    tzcnt         secd, secd
     mov           dird, r6m
     xor          zerod, zerod
     sub       dampingd, secd

--- a/src/x86/cdef_sse.asm
+++ b/src/x86/cdef_sse.asm
@@ -575,7 +575,6 @@ cglobal cdef_filter_%1x%2_8bpc, 2, 7, 8, - 7 * 16 - (%2+4)*32, \
     neg        pridmpd
     cmovs      pridmpd, dampingd
     neg           secd
-    cmovs         secd, dampingd
     PSHUFB_0        m1, m7
     PSHUFB_0       m10, m7
  %if ARCH_X86_64

--- a/src/x86/itx16_sse.asm
+++ b/src/x86/itx16_sse.asm
@@ -626,7 +626,7 @@ cglobal iidentity_4x4_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     movhps [r5  +strideq*1], m1
     RET
 
-%macro INV_TXFM_4X8_FN 2-3 0 ; type1, type2
+%macro INV_TXFM_4X8_FN 2-3 0 ; type1, type2, eob_offset
     INV_TXFM_FN          %1, %2, %3, 4x8
 %ifidn %1_%2, dct_dct
     imul                r5d, [cq], 2896
@@ -908,7 +908,7 @@ cglobal iidentity_4x8_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     mova                 m4, [o(pw_4096)]
     jmp m(idct_4x8_internal_16bpc).end
 
-%macro INV_TXFM_4X16_FN 2-3 2d ; type1, type2
+%macro INV_TXFM_4X16_FN 2-3 2d ; type1, type2, eob_tbl_suffix
     INV_TXFM_FN          %1, %2, tbl_4x16_%3, 4x16
 %ifidn %1_%2, dct_dct
     imul                r5d, [cq], 2896
@@ -1683,7 +1683,7 @@ cglobal iidentity_8x4_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     paddsw               m3, m7
     jmp m(idct_8x4_internal_16bpc).end
 
-%macro INV_TXFM_8X8_FN 2-3 0 ; type1, type2
+%macro INV_TXFM_8X8_FN 2-3 0 ; type1, type2, eob_offset
 %if ARCH_X86_64
     INV_TXFM_FN          %1, %2, %3, 8x8, 14, 0-3*16
 %else
@@ -1994,7 +1994,7 @@ cglobal iidentity_8x8_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
 %endif
     jmp m(idct_8x8_internal_16bpc).end
 
-%macro INV_TXFM_8X16_FN 2-3 2d ; type1, type2
+%macro INV_TXFM_8X16_FN 2-3 2d ; type1, type2, eob_tbl_suffix
 %if ARCH_X86_64
     INV_TXFM_FN          %1, %2, tbl_8x16_%3, 8x16, 14, 0-16*16
 %else
@@ -3387,7 +3387,7 @@ cglobal iidentity_16x4_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     paddsw               m3, m7
     ret
 
-%macro INV_TXFM_16X8_FN 2-3 0 ; type1, type2
+%macro INV_TXFM_16X8_FN 2-3 0 ; type1, type2, eob_offset
 %if ARCH_X86_64
     INV_TXFM_FN          %1, %2, %3, 16x8, 16, 0-8*16
 %else
@@ -4105,7 +4105,7 @@ cglobal iidentity_16x8_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     ret
 %endif
 
-%macro INV_TXFM_16X16_FN 2-3 2d ; type1, type2
+%macro INV_TXFM_16X16_FN 2-3 2d ; type1, type2, eob_tbl_suffix
 %if ARCH_X86_64
     INV_TXFM_FN          %1, %2, tbl_16x16_%3, 16x16, 16, 0-(16+WIN64)*16
 %else

--- a/src/x86/itx16_sse.asm
+++ b/src/x86/itx16_sse.asm
@@ -1344,20 +1344,20 @@ cglobal idct_8x4_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     jmp                tx2q
 .transpose4x8packed:
     ; transpose
-    punpckhwd            m5, m0, m4
+    punpcklwd            m1, m2, m6
+    punpckhwd            m2, m6
+    punpckhwd            m6, m0, m4
     punpcklwd            m0, m4
-    punpckhwd            m4, m2, m6
-    punpcklwd            m2, m6
 
-    punpckhwd            m3, m0, m2
-    punpcklwd            m0, m2
-    punpckhwd            m7, m5, m4
-    punpcklwd            m5, m4
+    punpckhwd            m3, m0, m1
+    punpcklwd            m0, m1
+    punpckhwd            m4, m6, m2
+    punpcklwd            m6, m2
 
-    punpckhwd            m1, m0, m5
-    punpcklwd            m0, m5
-    punpcklwd            m2, m3, m7
-    punpckhwd            m3, m7
+    punpcklwd            m2, m3, m4
+    punpckhwd            m3, m4
+    punpckhwd            m1, m0, m6
+    punpcklwd            m0, m6
     ret
 .main:
     call .main_pass1
@@ -2513,20 +2513,20 @@ cglobal idct_16x4_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     jmp                tx2q
 %if ARCH_X86_64
 .transpose4x8packed_hi:
-    punpckhwd           m11, m8, m10
-    punpcklwd            m8, m10
-    punpckhwd           m13, m12, m14
-    punpcklwd           m12, m14
+    punpcklwd            m9, m10, m14
+    punpckhwd           m10, m14
+    punpckhwd           m14, m8, m12
+    punpcklwd            m8, m12
 
-    punpckhwd           m10, m8, m11
-    punpcklwd            m8, m11
-    punpckhwd           m14, m12, m13
-    punpcklwd           m12, m13
+    punpckhwd           m11, m8, m9
+    punpcklwd            m8, m9
+    punpckhwd           m12, m14, m10
+    punpcklwd           m14, m10
 
-    punpckhqdq           m9, m8, m12
-    punpcklqdq           m8, m12
-    punpckhqdq          m11, m10, m14
-    punpcklqdq          m10, m14
+    punpcklwd           m10, m11, m12
+    punpckhwd           m11, m12
+    punpckhwd            m9, m8, m14
+    punpcklwd            m8, m14
     ret
 %endif
 .main_oddhalf:

--- a/src/x86/itx16_sse.asm
+++ b/src/x86/itx16_sse.asm
@@ -1833,23 +1833,7 @@ cglobal idct_8x8_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     packssdw             m6, m7
     packssdw             m0, m1
     packssdw             m4, m5
-.transpose:
-    punpcklwd            m7, m2, m6
-    punpckhwd            m2, m6
-    punpckhwd            m5, m0, m4
-    punpcklwd            m0, m4
-
-    punpckhwd            m4, m5, m2
-    punpcklwd            m5, m2
-    punpckhwd            m2, m0, m7
-    punpcklwd            m0, m7
-
-    punpckhwd            m3, m2, m4
-    punpcklwd            m2, m4
-    punpckhwd            m1, m0, m5
-    punpcklwd            m0, m5
-
-    ret
+    jmp m(idct_8x4_internal_16bpc).transpose4x8packed
 
 .pass2:
 %if ARCH_X86_32
@@ -2045,7 +2029,7 @@ cglobal iflipadst_8x8_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     mova                 m2, m5
     mova                 m4, m3
     mova                 m6, m1
-    jmp m(idct_8x8_internal_16bpc).transpose
+    jmp m(idct_8x4_internal_16bpc).transpose4x8packed
 
 .pass2:
     lea                dstq, [dstq+strideq*8]

--- a/src/x86/itx16_sse.asm
+++ b/src/x86/itx16_sse.asm
@@ -1478,19 +1478,16 @@ cglobal idct_8x4_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
 %endif
     call m_suffix(idct_8x4_internal_8bpc, _ssse3).main
 .end:
-    call .round2
     lea                  r3, [strideq*3]
-    call .write_8x4_load
+    call .round2_and_write_8x4
     REPX {mova [cq+16*x], m6}, 0, 1, 2, 3, 4, 5, 6, 7
     RET
-.round2:
-    mova                 m4, [o(pw_2048)]
-.round1:
-    REPX   {pmulhrsw x, m4}, m0, m1, m2, m3
-    ret
-.write_8x4_load:
+.round2_and_write_8x4:
     pxor                 m6, m6
     mova                 m5, [o(pixel_10bpc_max)]
+    mova                 m4, [o(pw_2048)]
+.round1_and_write_8x4:
+    REPX   {pmulhrsw x, m4}, m0, m1, m2, m3
 .write_8x4:
     paddw                m0, [dstq+strideq*0]
     paddw                m1, [dstq+strideq*1]
@@ -2351,11 +2348,9 @@ cglobal iidentity_8x16_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
 .pass2_loop:
     call .main
 %if ARCH_X86_64
-    call m(idct_8x4_internal_16bpc).round1
-    call m(idct_8x4_internal_16bpc).write_8x4
+    call m(idct_8x4_internal_16bpc).round1_and_write_8x4
 %else
-    call m(idct_8x4_internal_16bpc).round2
-    call m(idct_8x4_internal_16bpc).write_8x4_load
+    call m(idct_8x4_internal_16bpc).round2_and_write_8x4
 %endif
     REPX {mova [cq+x*16], m6}, 0, 4, 8, 12, 16, 20, 24, 28
     dec                 r5d
@@ -2747,8 +2742,7 @@ cglobal idct_16x4_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     lea                  r5, [o(itx8_start)]
 %endif
     call                 r4
-    call m(idct_8x4_internal_16bpc).round2
-    call m(idct_8x4_internal_16bpc).write_8x4_load
+    call m(idct_8x4_internal_16bpc).round2_and_write_8x4
     REPX {mova [cq+x*16], m6}, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
 %if ARCH_X86_64
     mova                 m0, m8
@@ -2766,8 +2760,7 @@ cglobal idct_16x4_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     lea                  r5, [o(itx8_start)]
 %endif
     call                 r4
-    call m(idct_8x4_internal_16bpc).round2
-    call m(idct_8x4_internal_16bpc).write_8x4_load
+    call m(idct_8x4_internal_16bpc).round2_and_write_8x4
     RET
 
 INV_TXFM_16X4_FN adst, dct
@@ -4564,11 +4557,9 @@ cglobal iidentity_16x16_internal_16bpc, 0, 0, 0, dst, stride, c, eob, tx2
     mova                 m3, [cq+3*64+0]
     call m(iidentity_8x16_internal_16bpc).main
 %if ARCH_X86_64
-    call m(idct_8x4_internal_16bpc).round1
-    call m(idct_8x4_internal_16bpc).write_8x4
+    call m(idct_8x4_internal_16bpc).round1_and_write_8x4
 %else
-    call m(idct_8x4_internal_16bpc).round2
-    call m(idct_8x4_internal_16bpc).write_8x4_load
+    call m(idct_8x4_internal_16bpc).round2_and_write_8x4
 %endif
     REPX {mova [cq+x*16], m6}, 0, 4, 8, 12
     add                  cq, 16

--- a/src/x86/itx_sse.asm
+++ b/src/x86/itx_sse.asm
@@ -5105,7 +5105,7 @@ cglobal idct_16x64_internal_8bpc, 0, 0, 0, dst, stride, coeff, eob, tx2
 
 
 ALIGN function_align
-.main_fast:
+cglobal_label .main_fast
     mova                    m0, [rsp+gprsize*2+16*35]     ;in1
     pmulhrsw                m3, m0, [o(pw_4095x8)]        ;t62,t63
     pmulhrsw                m0, [o(pw_101x8)]             ;t32,t33
@@ -5179,7 +5179,7 @@ ALIGN function_align
     jmp .main2
 
 ALIGN function_align
-.main:
+cglobal_label .main
     mova                    m0, [rsp+gprsize*2+16*35]     ;in1
     mova                    m1, [rsp+gprsize*2+16*65]     ;in31
     pmulhrsw                m3, m0, [o(pw_4095x8)]        ;t63a

--- a/src/x86/itx_sse.asm
+++ b/src/x86/itx_sse.asm
@@ -3561,7 +3561,7 @@ cglobal idct_8x32_internal_8bpc, 0, 0, 0, dst, stride, coeff, eob, tx2
     ret
 
 ALIGN function_align
-.main_veryfast:
+cglobal_label .main_veryfast
     mova                    m0, [rsp+gprsize*2+16*19]     ;in1
     pmulhrsw                m3, m0, [o(pw_4091x8)]        ;t30,t31
     pmulhrsw                m0, [o(pw_201x8)]             ;t16,t17
@@ -3595,7 +3595,7 @@ ALIGN function_align
     jmp .main2
 
 ALIGN function_align
-.main_fast: ;bottom half is zero
+cglobal_label .main_fast ;bottom half is zero
     mova                    m0, [rsp+gprsize*2+16*19]     ;in1
     mova                    m1, [rsp+gprsize*2+16*20]     ;in15
     pmulhrsw                m3, m0, [o(pw_4091x8)]        ;t31a
@@ -3651,7 +3651,7 @@ ALIGN function_align
     jmp .main2
 
 ALIGN function_align
-.main:
+cglobal_label .main
     mova                    m7, [o(pd_2048)]
     mova                    m0, [rsp+gprsize*2+16*19]     ;in1
     mova                    m1, [rsp+gprsize*2+16*20]     ;in15

--- a/src/x86/looprestoration_sse.asm
+++ b/src/x86/looprestoration_sse.asm
@@ -35,34 +35,38 @@ wiener_shufB:  db  2,  3,  3,  4,  4,  5,  5,  6,  6,  7,  7,  8,  8,  9,  9, 10
 wiener_shufC:  db  6,  5,  7,  6,  8,  7,  9,  8, 10,  9, 11, 10, 12, 11, 13, 12
 wiener_shufD:  db  4, -1,  5, -1,  6, -1,  7, -1,  8, -1,  9, -1, 10, -1, 11, -1
 wiener_l_shuf: db  0,  0,  0,  0,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11
-pb_unpcklwdw:  db  0,  1,  0,  1,  4,  5,  4,  5,  8,  9,  8,  9, 12, 13, 12, 13
+sgr_lshuf3:    db  0,  0,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13
+sgr_lshuf5:    db  0,  0,  0,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12
+pb_0to15:      db  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15
 
 pb_right_ext_mask: times 24 db 0xff
                    times 8 db 0
-pb_0:          times 16 db 0
+pb_1:          times 16 db 1
 pb_3:          times 16 db 3
-pb_15:         times 16 db 15
-pb_0_1:        times 8 db 0, 1
-pb_14_15:      times 8 db 14, 15
-pw_1:          times 8 dw 1
-pw_16:         times 8 dw 16
-pw_128:        times 8 dw 128
 pw_256:        times 8 dw 256
-pw_2048:       times 8 dw 2048
 pw_2056:       times 8 dw 2056
 pw_m16380:     times 8 dw -16380
-pw_5_6:        times 4 dw 5, 6
-pd_1024:       times 4 dd 1024
-%if ARCH_X86_32
-pd_512:        times 4 dd 512
-pd_2048:       times 4 dd 2048
-%endif
-pd_0xF0080029: times 4 dd 0xF0080029
-pd_0xF00801C7: times 4 dd 0XF00801C7
+pd_4096:       times 4 dd 4096
+pd_34816:      times 4 dd 34816
+pd_0xffff:     times 4 dd 0xffff
+pd_0xf00800a4: times 4 dd 0xf00800a4
+pd_0xf00801c7: times 4 dd 0xf00801c7
 
 cextern sgr_x_by_x
 
 SECTION .text
+
+%macro movif64 2 ; dst, src
+ %if ARCH_X86_64
+    mov             %1, %2
+ %endif
+%endmacro
+
+%macro movif32 2 ; dst, src
+ %if ARCH_X86_32
+    mov             %1, %2
+ %endif
+%endmacro
 
 %if ARCH_X86_32
  %define PIC_base_offset $$
@@ -1130,1319 +1134,2611 @@ WIENER
 ;;      self-guided     ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-%macro MULLD 2
-    pmulhuw       m5, %1, %2
-    pmullw        %1, %2
-    pslld         m5, 16
-    paddd         %1, m5
-%endmacro
-
-%macro GATHERDD 2
-    mova          m5, m7
-    movd         r6d, %2
+%macro GATHERDD 3 ; dst, src, tmp
+    movd           %3d, %2
  %if ARCH_X86_64
-    movd          %1, [r5+r6]
-    pextrw       r6d, %2, 2
-    pinsrw        m5, [r5+r6+2], 3
-    pextrw       r6d, %2, 4
-    pinsrw        %1, [r5+r6+2], 5
-    pextrw       r6d, %2, 6
-    pinsrw        m5, [r5+r6+2], 7
+    movd            %1, [r13+%3]
+    pextrw         %3d, %2, 2
+    pinsrw          %1, [r13+%3+2], 3
+    pextrw         %3d, %2, 4
+    pinsrw          %1, [r13+%3+2], 5
+    pextrw         %3d, %2, 6
+    pinsrw          %1, [r13+%3+2], 7
  %else
-    movd          %1, [PIC_sym(sgr_x_by_x-0xF03)+r6]
-    pextrw       r6d, %2, 2
-    pinsrw        m5, [PIC_sym(sgr_x_by_x-0xF03)+r6+2], 3
-    pextrw       r6d, %2, 4
-    pinsrw        %1, [PIC_sym(sgr_x_by_x-0xF03)+r6+2], 5
-    pextrw       r6d, %2, 6
-    pinsrw        m5, [PIC_sym(sgr_x_by_x-0xF03)+r6+2], 7
+    movd            %1, [base+sgr_x_by_x-0xf03+%3]
+    pextrw          %3, %2, 2
+    pinsrw          %1, [base+sgr_x_by_x-0xf03+%3+2], 3
+    pextrw          %3, %2, 4
+    pinsrw          %1, [base+sgr_x_by_x-0xf03+%3+2], 5
+    pextrw          %3, %2, 6
+    pinsrw          %1, [base+sgr_x_by_x-0xf03+%3+2], 7
  %endif
-    por           %1, m5
 %endmacro
 
-%if ARCH_X86_64
-cglobal sgr_box3_h_8bpc, 5, 11, 8, sumsq, sum, left, src, stride, x, h, edge, w, xlim
-    mov        xlimd, edgem
-    movifnidn     xd, xm
-    mov           hd, hm
-    mov        edged, xlimd
-    and        xlimd, 2                             ; have_right
-    add           xd, xlimd
-    xor        xlimd, 2                             ; 2*!have_right
-%else
-cglobal sgr_box3_h_8bpc, 6, 7, 8, sumsq, sum, left, src, stride, x, h, edge, w, xlim
- %define wq     r0m
- %define xlimd  r1m
- %define hd     hmp
- %define edgeb  byte edgem
+%macro GATHER_X_BY_X 5 ; dst, src0, src1, tmp32, tmp32_restore
+ %if ARCH_X86_64
+  %define tmp r14
+ %else
+  %define tmp %4
+ %endif
+    GATHERDD        %1, %2, tmp
+    GATHERDD        %2, %3, tmp
+    movif32         %4, %5
+    psrld           %1, 24
+    psrld           %2, 24
+    packssdw        %1, %2
+%endmacro
 
-    mov           r6, edgem
-    and           r6, 2                             ; have_right
-    add           xd, r6
-    xor           r6, 2                             ; 2*!have_right
-    mov        xlimd, r6
-    SETUP_PIC     r6, 0
-%endif
-
-    jnz .no_right
-    add           xd, 7
-    and           xd, ~7
-.no_right:
-    pxor          m1, m1
-    lea         srcq, [srcq+xq]
-    lea         sumq, [sumq+xq*2-2]
-    lea       sumsqq, [sumsqq+xq*4-4]
-    neg           xq
-    mov           wq, xq
-%if ARCH_X86_64
-    lea          r10, [pb_right_ext_mask+24]
-%endif
-.loop_y:
-    mov           xq, wq
-
-    ; load left
-    test       edgeb, 1                             ; have_left
-    jz .no_left
-    test       leftq, leftq
-    jz .load_left_from_main
-    movd          m0, [leftq]
-    pslldq        m0, 12
-    add        leftq, 4
-    jmp .expand_x
-.no_left:
-    movd          m0, [srcq+xq]
-    pshufb        m0, [PIC_sym(pb_0)]
-    jmp .expand_x
-.load_left_from_main:
-    movd          m0, [srcq+xq-2]
-    pslldq        m0, 14
-.expand_x:
-    punpckhbw    xm0, xm1
-
-    ; when we reach this, m0 contains left two px in highest words
-    cmp           xd, -8
-    jle .loop_x
-.partial_load_and_extend:
-    movd          m3, [srcq-4]
-    pshufb        m3, [PIC_sym(pb_3)]
-    movq          m2, [srcq+xq]
-    punpcklbw     m2, m1
-    punpcklbw     m3, m1
-%if ARCH_X86_64
-    movu          m4, [r10+xq*2]
-%else
-    movu          m4, [PIC_sym(pb_right_ext_mask)+xd*2+24]
-%endif
-    pand          m2, m4
-    pandn         m4, m3
-    por           m2, m4
-    jmp .loop_x_noload
-.right_extend:
-    pshufb        m2, m0, [PIC_sym(pb_14_15)]
-    jmp .loop_x_noload
-
-.loop_x:
-    movq          m2, [srcq+xq]
-    punpcklbw     m2, m1
-.loop_x_noload:
-    palignr       m3, m2, m0, 12
-    palignr       m4, m2, m0, 14
-
-    punpcklwd     m5, m3, m2
-    punpckhwd     m6, m3, m2
-    paddw         m3, m4
-    punpcklwd     m7, m4, m1
-    punpckhwd     m4, m1
-    pmaddwd       m5, m5
-    pmaddwd       m6, m6
-    pmaddwd       m7, m7
-    pmaddwd       m4, m4
-    paddd         m5, m7
-    paddd         m6, m4
-    paddw         m3, m2
-    movu [sumq+xq*2], m3
-    movu [sumsqq+xq*4+ 0], m5
-    movu [sumsqq+xq*4+16], m6
-
-    mova          m0, m2
-    add           xq, 8
-
-    ; if x <= -8 we can reload more pixels
-    ; else if x < 0 we reload and extend (this implies have_right=0)
-    ; else if x < xlimd we extend from previous load (this implies have_right=0)
-    ; else we are done
-
-    cmp           xd, -8
-    jle .loop_x
-    test          xd, xd
-    jl .partial_load_and_extend
-    cmp           xd, xlimd
-    jl .right_extend
-
-    add       sumsqq, (384+16)*4
-    add         sumq, (384+16)*2
-    add         srcq, strideq
-    dec           hd
-    jg .loop_y
-    RET
-
-%if ARCH_X86_64
-cglobal sgr_box3_v_8bpc, 4, 10, 9, sumsq, sum, w, h, edge, x, y, sumsq_base, sum_base, ylim
-    movifnidn  edged, edgem
-%else
-cglobal sgr_box3_v_8bpc, 3, 7, 8, -28, sumsq, sum, w, edge, h, x, y
- %define sumsq_baseq dword [esp+0]
- %define sum_baseq   dword [esp+4]
- %define ylimd       dword [esp+8]
- %define m8          [esp+12]
-    mov        edged, r4m
-    mov           hd, r3m
-%endif
-    mov           xq, -2
-%if ARCH_X86_64
-    mov        ylimd, edged
-    and        ylimd, 8                             ; have_bottom
-    shr        ylimd, 2
-    sub        ylimd, 2                             ; -2 if have_bottom=0, else 0
-    mov  sumsq_baseq, sumsqq
-    mov    sum_baseq, sumq
-.loop_x:
-    mov       sumsqq, sumsq_baseq
-    mov         sumq, sum_baseq
-    lea           yd, [hq+ylimq+2]
-%else
-    mov           yd, edged
-    and           yd, 8                             ; have_bottom
-    shr           yd, 2
-    sub           yd, 2                             ; -2 if have_bottom=0, else 0
-    mov  sumsq_baseq, sumsqq
-    mov    sum_baseq, sumq
-    mov        ylimd, yd
-.loop_x:
-    mov       sumsqd, sumsq_baseq
-    mov         sumd, sum_baseq
-    lea           yd, [hq+2]
-    add           yd, ylimd
-%endif
-    lea       sumsqq, [sumsqq+xq*4+4-(384+16)*4]
-    lea         sumq, [sumq+xq*2+2-(384+16)*2]
-    test       edgeb, 4                             ; have_top
-    jnz .load_top
-    movu          m0, [sumsqq+(384+16)*4*1]
-    movu          m1, [sumsqq+(384+16)*4*1+16]
-    mova          m2, m0
-    mova          m3, m1
-    mova          m4, m0
-    mova          m5, m1
-    movu          m6, [sumq+(384+16)*2*1]
-    mova          m7, m6
-    mova          m8, m6
-    jmp .loop_y_noload
-.load_top:
-    movu          m0, [sumsqq-(384+16)*4*1]      ; l2sq [left]
-    movu          m1, [sumsqq-(384+16)*4*1+16]   ; l2sq [right]
-    movu          m2, [sumsqq-(384+16)*4*0]      ; l1sq [left]
-    movu          m3, [sumsqq-(384+16)*4*0+16]   ; l1sq [right]
-    movu          m6, [sumq-(384+16)*2*1]        ; l2
-    movu          m7, [sumq-(384+16)*2*0]        ; l1
-.loop_y:
-%if ARCH_X86_64
-    movu          m8, [sumq+(384+16)*2*1]        ; l0
-%else
-    movu          m4, [sumq+(384+16)*2*1]        ; l0
-    mova          m8, m4
-%endif
-    movu          m4, [sumsqq+(384+16)*4*1]      ; l0sq [left]
-    movu          m5, [sumsqq+(384+16)*4*1+16]   ; l0sq [right]
-.loop_y_noload:
-    paddd         m0, m2
-    paddd         m1, m3
-    paddw         m6, m7
-    paddd         m0, m4
-    paddd         m1, m5
-    paddw         m6, m8
-    movu [sumsqq+ 0], m0
-    movu [sumsqq+16], m1
-    movu      [sumq], m6
-
-    ; shift position down by one
-    mova          m0, m2
-    mova          m1, m3
-    mova          m2, m4
-    mova          m3, m5
-    mova          m6, m7
-    mova          m7, m8
-    add       sumsqq, (384+16)*4
-    add         sumq, (384+16)*2
-    dec           yd
-    jg .loop_y
-    cmp           yd, ylimd
-    jg .loop_y_noload
-    add           xd, 8
-    cmp           xd, wd
-    jl .loop_x
-    RET
-
-cglobal sgr_calc_ab1_8bpc, 4, 7, 12, a, b, w, h, s
-    movifnidn     sd, sm
-    sub           aq, (384+16-1)*4
-    sub           bq, (384+16-1)*2
-    add           hd, 2
-%if ARCH_X86_64
-    LEA           r5, sgr_x_by_x-0xF03
-%else
-    SETUP_PIC r5, 0
-%endif
-    movd          m6, sd
-    pshuflw       m6, m6, q0000
-    punpcklqdq    m6, m6
-    pxor          m7, m7
-    DEFINE_ARGS a, b, w, h, x
-%if ARCH_X86_64
-    mova          m8, [pd_0xF00801C7]
-    mova          m9, [pw_256]
-    psrld        m10, m9, 13                        ; pd_2048
-    mova         m11, [pb_unpcklwdw]
-%else
- %define m8     [PIC_sym(pd_0xF00801C7)]
- %define m9     [PIC_sym(pw_256)]
- %define m10    [PIC_sym(pd_2048)]
- %define m11    [PIC_sym(pb_unpcklwdw)]
-%endif
-.loop_y:
-    mov           xq, -2
-.loop_x:
-    movq          m0, [bq+xq*2]
-    movq          m1, [bq+xq*2+(384+16)*2]
-    punpcklwd     m0, m7
-    punpcklwd     m1, m7
-    movu          m2, [aq+xq*4]
-    movu          m3, [aq+xq*4+(384+16)*4]
-    pslld         m4, m2, 3
-    pslld         m5, m3, 3
-    paddd         m2, m4                            ; aa * 9
-    paddd         m3, m5
-    pmaddwd       m4, m0, m0
-    pmaddwd       m5, m1, m1
-    pmaddwd       m0, m8
-    pmaddwd       m1, m8
-    psubd         m2, m4                            ; p = aa * 9 - bb * bb
-    psubd         m3, m5
-    MULLD         m2, m6
-    MULLD         m3, m6
-    paddusw       m2, m8
-    paddusw       m3, m8
-    psrld         m2, 20                            ; z
-    psrld         m3, 20
-    GATHERDD      m4, m2                            ; xx
-    GATHERDD      m2, m3
-    psrld         m4, 24
-    psrld         m2, 24
-    packssdw      m3, m4, m2
-    pshufb        m4, m11
-    MULLD         m0, m4
-    pshufb        m2, m11
-    MULLD         m1, m2
-    psubw         m5, m9, m3
-    paddd         m0, m10
-    paddd         m1, m10
-    psrld         m0, 12
-    psrld         m1, 12
-    movq   [bq+xq*2], m5
-    psrldq        m5, 8
-    movq [bq+xq*2+(384+16)*2], m5
-    movu   [aq+xq*4], m0
-    movu [aq+xq*4+(384+16)*4], m1
-    add           xd, 4
-    cmp           xd, wd
-    jl .loop_x
-    add           aq, (384+16)*4*2
-    add           bq, (384+16)*2*2
-    sub           hd, 2
-    jg .loop_y
-    RET
-
-%if ARCH_X86_64
-cglobal sgr_finish_filter1_8bpc, 5, 13, 16, t, src, stride, a, b, w, h, \
-                                            tmp_base, src_base, a_base, b_base, x, y
-    movifnidn     wd, wm
-    mov           hd, hm
-    mova         m15, [pw_16]
-    mov    tmp_baseq, tq
-    mov    src_baseq, srcq
-    mov      a_baseq, aq
-    mov      b_baseq, bq
-    xor           xd, xd
-%else
-cglobal sgr_finish_filter1_8bpc, 7, 7, 8, -144, t, src, stride, a, b, x, y
- %define tmp_baseq  [esp+8]
- %define src_baseq  [esp+12]
- %define a_baseq    [esp+16]
- %define b_baseq    [esp+20]
- %define wd         [esp+24]
- %define hd         [esp+28]
-    mov    tmp_baseq, tq
-    mov    src_baseq, srcq
-    mov      a_baseq, aq
-    mov      b_baseq, bq
-    mov           wd, xd
-    mov           hd, yd
-    xor           xd, xd
-    SETUP_PIC yd, 1, 1
-    jmp .loop_start
-%endif
-
-.loop_x:
-    mov           tq, tmp_baseq
-    mov         srcq, src_baseq
-    mov           aq, a_baseq
-    mov           bq, b_baseq
-%if ARCH_X86_32
-.loop_start:
-    movu          m0, [bq+xq*2-(384+16)*2-2]
-    movu          m2, [bq+xq*2-(384+16)*2+2]
-    mova          m1, [bq+xq*2-(384+16)*2]          ; b:top
-    paddw         m0, m2                            ; b:tl+tr
-    movu          m2, [bq+xq*2-2]
-    movu          m3, [bq+xq*2+2]
-    paddw         m1, [bq+xq*2]                     ; b:top+ctr
-    paddw         m2, m3                            ; b:l+r
-    mova  [esp+0x80], m0
-    mova  [esp+0x70], m1
-    mova  [esp+0x60], m2
-%endif
-    movu          m0, [aq+xq*4-(384+16)*4-4]
-    movu          m2, [aq+xq*4-(384+16)*4+4]
-    mova          m1, [aq+xq*4-(384+16)*4]          ; a:top [first half]
-    paddd         m0, m2                            ; a:tl+tr [first half]
-    movu          m2, [aq+xq*4-(384+16)*4-4+16]
-    movu          m4, [aq+xq*4-(384+16)*4+4+16]
-    mova          m3, [aq+xq*4-(384+16)*4+16]       ; a:top [second half]
-    paddd         m2, m4                            ; a:tl+tr [second half]
-    movu          m4, [aq+xq*4-4]
-    movu          m5, [aq+xq*4+4]
-    paddd         m1, [aq+xq*4]                     ; a:top+ctr [first half]
-    paddd         m4, m5                            ; a:l+r [first half]
-    movu          m5, [aq+xq*4+16-4]
-    movu          m6, [aq+xq*4+16+4]
-    paddd         m3, [aq+xq*4+16]                  ; a:top+ctr [second half]
-    paddd         m5, m6                            ; a:l+r [second half]
-%if ARCH_X86_64
-    movu          m6, [bq+xq*2-(384+16)*2-2]
-    movu          m8, [bq+xq*2-(384+16)*2+2]
-    mova          m7, [bq+xq*2-(384+16)*2]          ; b:top
-    paddw         m6, m8                            ; b:tl+tr
-    movu          m8, [bq+xq*2-2]
-    movu          m9, [bq+xq*2+2]
-    paddw         m7, [bq+xq*2]                     ; b:top+ctr
-    paddw         m8, m9                            ; b:l+r
-%endif
-
-    lea           tq, [tq+xq*2]
-    lea         srcq, [srcq+xq*1]
-    lea           aq, [aq+xq*4+(384+16)*4]
-    lea           bq, [bq+xq*2+(384+16)*2]
-    mov           yd, hd
-.loop_y:
-%if ARCH_X86_64
-    movu          m9, [bq-2]
-    movu         m10, [bq+2]
-    paddw         m7, [bq]                          ; b:top+ctr+bottom
-    paddw         m9, m10                           ; b:bl+br
-    paddw        m10, m7, m8                        ; b:top+ctr+bottom+l+r
-    paddw         m6, m9                            ; b:tl+tr+bl+br
-    psubw         m7, [bq-(384+16)*2*2]             ; b:ctr+bottom
-    paddw        m10, m6
-    psllw        m10, 2
-    psubw        m10, m6                            ; aa
-    pxor         m14, m14
-    movq         m12, [srcq]
-    punpcklbw    m12, m14
-    punpcklwd     m6, m10, m15
-    punpckhwd    m10, m15
-    punpcklwd    m13, m12, m15
-    punpckhwd    m12, m15
-    pmaddwd       m6, m13                           ; aa*src[x]+256 [first half]
-    pmaddwd      m10, m12                           ; aa*src[x]+256 [second half]
-%else
-    paddd         m1, [aq]                          ; a:top+ctr+bottom [first half]
-    paddd         m3, [aq+16]                       ; a:top+ctr+bottom [second half]
-    mova  [esp+0x50], m1
-    mova  [esp+0x40], m3
-    mova  [esp+0x30], m4
-    movu          m6, [aq-4]
-    movu          m7, [aq+4]
-    paddd         m1, m4                            ; a:top+ctr+bottom+l+r [first half]
-    paddd         m3, m5                            ; a:top+ctr+bottom+l+r [second half]
-    paddd         m6, m7                            ; a:bl+br [first half]
-    movu          m7, [aq+16-4]
-    movu          m4, [aq+16+4]
-    paddd         m7, m4                            ; a:bl+br [second half]
-    paddd         m0, m6                            ; a:tl+tr+bl+br [first half]
-    paddd         m2, m7                            ; a:tl+tr+bl+br [second half]
-    paddd         m1, m0
-    paddd         m3, m2
-    pslld         m1, 2
-    pslld         m3, 2
-    psubd         m1, m0                            ; bb [first half]
-    psubd         m3, m2                            ; bb [second half]
-%endif
-
-%if ARCH_X86_64
-    movu         m11, [aq-4]
-    movu         m12, [aq+4]
-    paddd         m1, [aq]                          ; a:top+ctr+bottom [first half]
-    paddd        m11, m12                           ; a:bl+br [first half]
-    movu         m12, [aq+16-4]
-    movu         m13, [aq+16+4]
-    paddd         m3, [aq+16]                       ; a:top+ctr+bottom [second half]
-    paddd        m12, m13                           ; a:bl+br [second half]
-    paddd        m13, m1, m4                        ; a:top+ctr+bottom+l+r [first half]
-    paddd        m14, m3, m5                        ; a:top+ctr+bottom+l+r [second half]
-    paddd         m0, m11                           ; a:tl+tr+bl+br [first half]
-    paddd         m2, m12                           ; a:tl+tr+bl+br [second half]
-    paddd        m13, m0
-    paddd        m14, m2
-    pslld        m13, 2
-    pslld        m14, 2
-    psubd        m13, m0                            ; bb [first half]
-    psubd        m14, m2                            ; bb [second half]
-    psubd         m1, [aq-(384+16)*4*2]             ; a:ctr+bottom [first half]
-    psubd         m3, [aq-(384+16)*4*2+16]          ; a:ctr+bottom [second half]
-%else
-    mova          m4, [esp+0x80]
-    mova  [esp+0x80], m5
-    mova          m5, [esp+0x70]
-    mova  [esp+0x70], m6
-    mova          m6, [esp+0x60]
-    mova  [esp+0x60], m7
-    mova  [esp+0x20], m1
-    movu          m7, [bq-2]
-    movu          m1, [bq+2]
-    paddw         m5, [bq]                          ; b:top+ctr+bottom
-    paddw         m7, m1
-    paddw         m1, m5, m6                        ; b:top+ctr+bottom+l+r
-    paddw         m4, m7                            ; b:tl+tr+bl+br
-    psubw         m5, [bq-(384+16)*2*2]             ; b:ctr+bottom
-    paddw         m1, m4
-    psllw         m1, 2
-    psubw         m1, m4                            ; aa
-    movq          m0, [srcq]
-    XCHG_PIC_REG
-    punpcklbw     m0, [PIC_sym(pb_0)]
-    punpcklwd     m4, m1, [PIC_sym(pw_16)]
-    punpckhwd     m1, [PIC_sym(pw_16)]
-    punpcklwd     m2, m0, [PIC_sym(pw_16)]
-    punpckhwd     m0, [PIC_sym(pw_16)]
-    XCHG_PIC_REG
-    pmaddwd       m4, m2                            ; aa*src[x]+256 [first half]
-    pmaddwd       m1, m0                            ; aa*src[x]+256 [second half]
-%endif
-
-%if ARCH_X86_64
-    paddd         m6, m13
-    paddd        m10, m14
-    psrad         m6, 9
-    psrad        m10, 9
-    packssdw      m6, m10
-    mova        [tq], m6
-%else
-    paddd         m4, [esp+0x20]
-    paddd         m1, m3
-    psrad         m4, 9
-    psrad         m1, 9
-    packssdw      m4, m1
-    mova        [tq], m4
-%endif
-
-    ; shift to next row
-%if ARCH_X86_64
-    mova          m0, m4
-    mova          m2, m5
-    mova          m4, m11
-    mova          m5, m12
-    mova          m6, m8
-    mova          m8, m9
-%else
-    mova          m1, [esp+0x50]
-    mova          m3, [esp+0x40]
-    mova          m0, [esp+0x30]
-    mova          m2, [esp+0x80]
-    mova          m4, [esp+0x70]
-    mova  [esp+0x70], m5
-    mova          m5, [esp+0x60]
-    mova  [esp+0x80], m6
-    mova  [esp+0x60], m7
-    psubd         m1, [aq-(384+16)*4*2]             ; a:ctr+bottom [first half]
-    psubd         m3, [aq-(384+16)*4*2+16]          ; a:ctr+bottom [second half]
-%endif
-
-    add         srcq, strideq
-    add           aq, (384+16)*4
-    add           bq, (384+16)*2
-    add           tq, 384*2
-    dec           yd
-    jg .loop_y
-    add           xd, 8
-    cmp           xd, wd
-    jl .loop_x
-    RET
-
-cglobal sgr_weighted1_8bpc, 4, 7, 8, dst, stride, t, w, h, wt
-    movifnidn     hd, hm
-%if ARCH_X86_32
-    SETUP_PIC r6, 0
-%endif
-    movd          m0, wtm
-    pshufb        m0, [PIC_sym(pb_0_1)]
-    psllw         m0, 4
-    pxor          m7, m7
-    DEFINE_ARGS dst, stride, t, w, h, idx
-.loop_y:
-    xor         idxd, idxd
-.loop_x:
-    mova          m1, [tq+idxq*2+ 0]
-    mova          m4, [tq+idxq*2+16]
-    mova          m5, [dstq+idxq]
-    punpcklbw     m2, m5, m7
-    punpckhbw     m5, m7
-    psllw         m3, m2, 4
-    psllw         m6, m5, 4
-    psubw         m1, m3
-    psubw         m4, m6
-    pmulhrsw      m1, m0
-    pmulhrsw      m4, m0
-    paddw         m1, m2
-    paddw         m4, m5
-    packuswb      m1, m4
-    mova [dstq+idxq], m1
-    add         idxd, 16
-    cmp         idxd, wd
-    jl .loop_x
-    add         dstq, strideq
-    add           tq, 384 * 2
-    dec           hd
-    jg .loop_y
-    RET
-
-%if ARCH_X86_64
-cglobal sgr_box5_h_8bpc, 5, 11, 12, sumsq, sum, left, src, stride, w, h, edge, x, xlim
-    mov        edged, edgem
-    movifnidn     wd, wm
-    mov           hd, hm
-    mova         m10, [pb_0]
-    mova         m11, [pb_0_1]
-%else
-cglobal sgr_box5_h_8bpc, 7, 7, 8, sumsq, sum, left, src, xlim, x, h, edge
- %define edgeb      byte edgem
- %define wd         xd
- %define wq         wd
- %define wm         r5m
- %define strideq    r4m
-    SUB          esp, 8
-    SETUP_PIC sumsqd, 1, 1
-
- %define m10    [PIC_sym(pb_0)]
- %define m11    [PIC_sym(pb_0_1)]
-%endif
-
-    test       edgeb, 2                             ; have_right
-    jz .no_right
-    xor        xlimd, xlimd
-    add           wd, 2
-    add           wd, 15
-    and           wd, ~15
-    jmp .right_done
-.no_right:
-    mov        xlimd, 3
-    dec           wd
-.right_done:
-    pxor          m1, m1
-    lea         srcq, [srcq+wq+1]
-    lea         sumq, [sumq+wq*2-2]
-    lea       sumsqq, [sumsqq+wq*4-4]
-    neg           wq
-%if ARCH_X86_64
-    lea          r10, [pb_right_ext_mask+24]
-%else
-    mov           wm, xd
- %define wq wm
-%endif
-
-.loop_y:
-    mov           xq, wq
-    ; load left
-    test       edgeb, 1                             ; have_left
-    jz .no_left
-    test       leftq, leftq
-    jz .load_left_from_main
-    movd          m0, [leftq]
-    movd          m2, [srcq+xq-1]
-    pslldq        m2, 4
-    por           m0, m2
-    pslldq        m0, 11
-    add        leftq, 4
-    jmp .expand_x
-.no_left:
-    movd          m0, [srcq+xq-1]
-    XCHG_PIC_REG
-    pshufb        m0, m10
-    XCHG_PIC_REG
-    jmp .expand_x
-.load_left_from_main:
-    movd          m0, [srcq+xq-4]
-    pslldq        m0, 12
-.expand_x:
-    punpckhbw     m0, m1
-
-    ; when we reach this, m0 contains left two px in highest words
-    cmp           xd, -8
-    jle .loop_x
-    test          xd, xd
-    jge .right_extend
-.partial_load_and_extend:
-    XCHG_PIC_REG
-    movd          m3, [srcq-1]
-    movq          m2, [srcq+xq]
-    pshufb        m3, m10
-    punpcklbw     m3, m1
-    punpcklbw     m2, m1
-%if ARCH_X86_64
-    movu          m4, [r10+xq*2]
-%else
-    movu          m4, [PIC_sym(pb_right_ext_mask)+xd*2+24]
-    XCHG_PIC_REG
-%endif
-    pand          m2, m4
-    pandn         m4, m3
-    por           m2, m4
-    jmp .loop_x_noload
-.right_extend:
-    psrldq        m2, m0, 14
-    XCHG_PIC_REG
-    pshufb        m2, m11
-    XCHG_PIC_REG
-    jmp .loop_x_noload
-
-.loop_x:
-    movq          m2, [srcq+xq]
-    punpcklbw     m2, m1
-.loop_x_noload:
-    palignr       m3, m2, m0, 8
-    palignr       m4, m2, m0, 10
-    palignr       m5, m2, m0, 12
-    palignr       m6, m2, m0, 14
-
-%if ARCH_X86_64
-    paddw         m0, m3, m2
-    punpcklwd     m7, m3, m2
-    punpckhwd     m3, m2
-    paddw         m0, m4
-    punpcklwd     m8, m4, m5
-    punpckhwd     m4, m5
-    paddw         m0, m5
-    punpcklwd     m9, m6, m1
-    punpckhwd     m5, m6, m1
-    paddw         m0, m6
-    pmaddwd       m7, m7
-    pmaddwd       m3, m3
-    pmaddwd       m8, m8
-    pmaddwd       m4, m4
-    pmaddwd       m9, m9
-    pmaddwd       m5, m5
-    paddd         m7, m8
-    paddd         m3, m4
-    paddd         m7, m9
-    paddd         m3, m5
-    movu [sumq+xq*2], m0
-    movu [sumsqq+xq*4+ 0], m7
-    movu [sumsqq+xq*4+16], m3
-%else
-    paddw         m0, m3, m2
-    paddw         m0, m4
-    paddw         m0, m5
-    paddw         m0, m6
-    movu [sumq+xq*2], m0
-    punpcklwd     m7, m3, m2
-    punpckhwd     m3, m2
-    punpcklwd     m0, m4, m5
-    punpckhwd     m4, m5
-    punpckhwd     m5, m6, m1
-    pmaddwd       m7, m7
-    pmaddwd       m3, m3
-    pmaddwd       m0, m0
-    pmaddwd       m4, m4
-    pmaddwd       m5, m5
-    paddd         m7, m0
-    paddd         m3, m4
-    paddd         m3, m5
-    punpcklwd     m0, m6, m1
-    pmaddwd       m0, m0
-    paddd         m7, m0
-    movu [sumsqq+xq*4+ 0], m7
-    movu [sumsqq+xq*4+16], m3
-%endif
-
-    mova          m0, m2
-    add           xq, 8
-
-    ; if x <= -8 we can reload more pixels
-    ; else if x < 0 we reload and extend (this implies have_right=0)
-    ; else if x < xlimd we extend from previous load (this implies have_right=0)
-    ; else we are done
-
-    cmp           xd, -8
-    jle .loop_x
-    test          xd, xd
-    jl .partial_load_and_extend
-    cmp           xd, xlimd
-    jl .right_extend
-
-    add         srcq, strideq
-    add       sumsqq, (384+16)*4
-    add         sumq, (384+16)*2
-    dec           hd
-    jg .loop_y
-%if ARCH_X86_32
-    ADD          esp, 8
-%endif
-    RET
-
-%if ARCH_X86_64
-cglobal sgr_box5_v_8bpc, 4, 10, 15, sumsq, sum, w, h, edge, x, y, sumsq_ptr, sum_ptr, ylim
-    movifnidn  edged, edgem
-    mov        ylimd, edged
-%else
-cglobal sgr_box5_v_8bpc, 5, 7, 8, -44, sumsq, sum, x, y, ylim, sumsq_ptr, sum_ptr
- %define wm     [esp+0]
- %define hm     [esp+4]
- %define edgem  [esp+8]
-    mov           wm, xd
-    mov           hm, yd
-    mov        edgem, ylimd
-%endif
-
-    and        ylimd, 8                             ; have_bottom
-    shr        ylimd, 2
-    sub        ylimd, 3                             ; -3 if have_bottom=0, else -1
-    mov           xq, -2
-%if ARCH_X86_64
-.loop_x:
-    lea           yd, [hd+ylimd+2]
-    lea   sumsq_ptrq, [sumsqq+xq*4+4-(384+16)*4]
-    lea     sum_ptrq, [  sumq+xq*2+2-(384+16)*2]
-    test       edgeb, 4                             ; have_top
-    jnz .load_top
-    movu          m0, [sumsq_ptrq+(384+16)*4*1]
-    movu          m1, [sumsq_ptrq+(384+16)*4*1+16]
-    mova          m2, m0
-    mova          m3, m1
-    mova          m4, m0
-    mova          m5, m1
-    mova          m6, m0
-    mova          m7, m1
-    movu         m10, [sum_ptrq+(384+16)*2*1]
-    mova         m11, m10
-    mova         m12, m10
-    mova         m13, m10
-    jmp .loop_y_second_load
-.load_top:
-    movu          m0, [sumsq_ptrq-(384+16)*4*1]      ; l3/4sq [left]
-    movu          m1, [sumsq_ptrq-(384+16)*4*1+16]   ; l3/4sq [right]
-    movu          m4, [sumsq_ptrq-(384+16)*4*0]      ; l2sq [left]
-    movu          m5, [sumsq_ptrq-(384+16)*4*0+16]   ; l2sq [right]
-    mova          m2, m0
-    mova          m3, m1
-    movu         m10, [sum_ptrq-(384+16)*2*1]        ; l3/4
-    movu         m12, [sum_ptrq-(384+16)*2*0]        ; l2
-    mova         m11, m10
-.loop_y:
-    movu          m6, [sumsq_ptrq+(384+16)*4*1]      ; l1sq [left]
-    movu          m7, [sumsq_ptrq+(384+16)*4*1+16]   ; l1sq [right]
-    movu         m13, [sum_ptrq+(384+16)*2*1]        ; l1
-.loop_y_second_load:
-    test          yd, yd
-    jle .emulate_second_load
-    movu          m8, [sumsq_ptrq+(384+16)*4*2]      ; l0sq [left]
-    movu          m9, [sumsq_ptrq+(384+16)*4*2+16]   ; l0sq [right]
-    movu         m14, [sum_ptrq+(384+16)*2*2]        ; l0
-.loop_y_noload:
-    paddd         m0, m2
-    paddd         m1, m3
-    paddw        m10, m11
-    paddd         m0, m4
-    paddd         m1, m5
-    paddw        m10, m12
-    paddd         m0, m6
-    paddd         m1, m7
-    paddw        m10, m13
-    paddd         m0, m8
-    paddd         m1, m9
-    paddw        m10, m14
-    movu [sumsq_ptrq+ 0], m0
-    movu [sumsq_ptrq+16], m1
-    movu  [sum_ptrq], m10
-
-    ; shift position down by one
-    mova          m0, m4
-    mova          m1, m5
-    mova          m2, m6
-    mova          m3, m7
-    mova          m4, m8
-    mova          m5, m9
-    mova         m10, m12
-    mova         m11, m13
-    mova         m12, m14
-    add   sumsq_ptrq, (384+16)*4*2
-    add     sum_ptrq, (384+16)*2*2
-    sub           yd, 2
-    jge .loop_y
-    ; l1 = l0
-    mova          m6, m8
-    mova          m7, m9
-    mova         m13, m14
-    cmp           yd, ylimd
-    jg .loop_y_noload
-    add           xd, 8
-    cmp           xd, wd
-    jl .loop_x
-    RET
-.emulate_second_load:
-    mova          m8, m6
-    mova          m9, m7
-    mova         m14, m13
-    jmp .loop_y_noload
-%else
-.sumsq_loop_x:
-    lea           yd, [ylimd+2]
-    add           yd, hm
-    lea   sumsq_ptrq, [sumsqq+xq*4+4-(384+16)*4]
-    test  byte edgem, 4                             ; have_top
-    jnz .sumsq_load_top
-    movu          m0, [sumsq_ptrq+(384+16)*4*1]
-    movu          m1, [sumsq_ptrq+(384+16)*4*1+16]
-    mova          m4, m0
-    mova          m5, m1
-    mova          m6, m0
-    mova          m7, m1
-    mova  [esp+0x1c], m0
-    mova  [esp+0x0c], m1
-    jmp .sumsq_loop_y_second_load
-.sumsq_load_top:
-    movu          m0, [sumsq_ptrq-(384+16)*4*1]      ; l3/4sq [left]
-    movu          m1, [sumsq_ptrq-(384+16)*4*1+16]   ; l3/4sq [right]
-    movu          m4, [sumsq_ptrq-(384+16)*4*0]      ; l2sq [left]
-    movu          m5, [sumsq_ptrq-(384+16)*4*0+16]   ; l2sq [right]
-    mova  [esp+0x1c], m0
-    mova  [esp+0x0c], m1
-.sumsq_loop_y:
-    movu          m6, [sumsq_ptrq+(384+16)*4*1]      ; l1sq [left]
-    movu          m7, [sumsq_ptrq+(384+16)*4*1+16]   ; l1sq [right]
-.sumsq_loop_y_second_load:
-    test          yd, yd
-    jle .sumsq_emulate_second_load
-    movu          m2, [sumsq_ptrq+(384+16)*4*2]      ; l0sq [left]
-    movu          m3, [sumsq_ptrq+(384+16)*4*2+16]   ; l0sq [right]
-.sumsq_loop_y_noload:
-    paddd         m0, [esp+0x1c]
-    paddd         m1, [esp+0x0c]
-    paddd         m0, m4
-    paddd         m1, m5
-    paddd         m0, m6
-    paddd         m1, m7
-    paddd         m0, m2
-    paddd         m1, m3
-    movu [sumsq_ptrq+ 0], m0
-    movu [sumsq_ptrq+16], m1
-
-    ; shift position down by one
-    mova          m0, m4
-    mova          m1, m5
-    mova          m4, m2
-    mova          m5, m3
-    mova  [esp+0x1c], m6
-    mova  [esp+0x0c], m7
-    add   sumsq_ptrq, (384+16)*4*2
-    sub           yd, 2
-    jge .sumsq_loop_y
-    ; l1 = l0
-    mova          m6, m2
-    mova          m7, m3
-    cmp           yd, ylimd
-    jg .sumsq_loop_y_noload
-    add           xd, 8
-    cmp           xd, wm
-    jl .sumsq_loop_x
-
-    mov           xd, -2
-.sum_loop_x:
-    lea           yd, [ylimd+2]
-    add           yd, hm
-    lea     sum_ptrq, [sumq+xq*2+2-(384+16)*2]
-    test  byte edgem, 4                             ; have_top
-    jnz .sum_load_top
-    movu          m0, [sum_ptrq+(384+16)*2*1]
-    mova          m1, m0
-    mova          m2, m0
-    mova          m3, m0
-    jmp .sum_loop_y_second_load
-.sum_load_top:
-    movu          m0, [sum_ptrq-(384+16)*2*1]        ; l3/4
-    movu          m2, [sum_ptrq-(384+16)*2*0]        ; l2
-    mova          m1, m0
-.sum_loop_y:
-    movu          m3, [sum_ptrq+(384+16)*2*1]        ; l1
-.sum_loop_y_second_load:
-    test          yd, yd
-    jle .sum_emulate_second_load
-    movu          m4, [sum_ptrq+(384+16)*2*2]        ; l0
-.sum_loop_y_noload:
-    paddw         m0, m1
-    paddw         m0, m2
-    paddw         m0, m3
-    paddw         m0, m4
-    movu  [sum_ptrq], m0
-
-    ; shift position down by one
-    mova          m0, m2
-    mova          m1, m3
-    mova          m2, m4
-    add     sum_ptrq, (384+16)*2*2
-    sub           yd, 2
-    jge .sum_loop_y
-    ; l1 = l0
-    mova          m3, m4
-    cmp           yd, ylimd
-    jg .sum_loop_y_noload
-    add           xd, 8
-    cmp           xd, wm
-    jl .sum_loop_x
-    RET
-.sumsq_emulate_second_load:
-    mova          m2, m6
-    mova          m3, m7
-    jmp .sumsq_loop_y_noload
-.sum_emulate_second_load:
-    mova          m4, m3
-    jmp .sum_loop_y_noload
-%endif
-
-cglobal sgr_calc_ab2_8bpc, 4, 7, 11, a, b, w, h, s
-    movifnidn     sd, sm
-    sub           aq, (384+16-1)*4
-    sub           bq, (384+16-1)*2
-    add           hd, 2
-%if ARCH_X86_64
-    LEA           r5, sgr_x_by_x-0xF03
-%else
-    SETUP_PIC r5, 0
-%endif
-    movd          m6, sd
-    pshuflw       m6, m6, q0000
-    punpcklqdq    m6, m6
-    pxor          m7, m7
-    DEFINE_ARGS a, b, w, h, x
-%if ARCH_X86_64
-    mova          m8, [pd_0xF0080029]
-    mova          m9, [pw_256]
-    psrld        m10, m9, 15                        ; pd_512
-%else
- %define m8     [PIC_sym(pd_0xF0080029)]
- %define m9     [PIC_sym(pw_256)]
- %define m10    [PIC_sym(pd_512)]
-%endif
-.loop_y:
-    mov           xq, -2
-.loop_x:
-    movq          m0, [bq+xq*2+0]
-    movq          m1, [bq+xq*2+8]
-    punpcklwd     m0, m7
-    punpcklwd     m1, m7
-    movu          m2, [aq+xq*4+ 0]
-    movu          m3, [aq+xq*4+16]
-    pslld         m4, m2, 3                         ; aa * 8
-    pslld         m5, m3, 3
-    paddd         m2, m4                            ; aa * 9
-    paddd         m3, m5
-    paddd         m4, m4                            ; aa * 16
-    paddd         m5, m5
-    paddd         m2, m4                            ; aa * 25
-    paddd         m3, m5
-    pmaddwd       m4, m0, m0
-    pmaddwd       m5, m1, m1
-    psubd         m2, m4                            ; p = aa * 25 - bb * bb
-    psubd         m3, m5
-    MULLD         m2, m6
-    MULLD         m3, m6
-    paddusw       m2, m8
-    paddusw       m3, m8
-    psrld         m2, 20                            ; z
-    psrld         m3, 20
-    GATHERDD      m4, m2                            ; xx
-    GATHERDD      m2, m3
-    psrld         m4, 24
-    psrld         m2, 24
-    packssdw      m3, m4, m2
-    pmullw        m4, m8
-    pmullw        m2, m8
-    psubw         m5, m9, m3
-    pmaddwd       m0, m4
-    pmaddwd       m1, m2
-    paddd         m0, m10
-    paddd         m1, m10
-    psrld         m0, 10
-    psrld         m1, 10
-    movu   [bq+xq*2], m5
-    movu [aq+xq*4+ 0], m0
-    movu [aq+xq*4+16], m1
-    add           xd, 8
-    cmp           xd, wd
-    jl .loop_x
-    add           aq, (384+16)*4*2
-    add           bq, (384+16)*2*2
-    sub           hd, 2
-    jg .loop_y
-    RET
-
-%if ARCH_X86_64
-cglobal sgr_finish_filter2_8bpc, 5, 13, 14, t, src, stride, a, b, w, h, \
-                                       tmp_base, src_base, a_base, b_base, x, y
-    movifnidn     wd, wm
-    mov           hd, hm
-    mov    tmp_baseq, tq
-    mov    src_baseq, srcq
-    mov      a_baseq, aq
-    mov      b_baseq, bq
-    mova          m9, [pw_5_6]
-    mova         m12, [pw_256]
-    psrlw        m10, m12, 8                    ; pw_1
-    psrlw        m11, m12, 1                    ; pw_128
-    pxor         m13, m13
-%else
-cglobal sgr_finish_filter2_8bpc, 6, 7, 8, t, src, stride, a, b, x, y
- %define tmp_baseq  r0m
- %define src_baseq  r1m
- %define a_baseq    r3m
- %define b_baseq    r4m
- %define wd         r5m
- %define hd         r6m
-
-    SUB          esp, 8
-    SETUP_PIC yd
-
- %define m8     m5
- %define m9     [PIC_sym(pw_5_6)]
- %define m10    [PIC_sym(pw_1)]
- %define m11    [PIC_sym(pw_128)]
- %define m12    [PIC_sym(pw_256)]
- %define m13    m0
-%endif
-    xor           xd, xd
-.loop_x:
-    mov           tq, tmp_baseq
-    mov         srcq, src_baseq
-    mov           aq, a_baseq
-    mov           bq, b_baseq
-    movu          m0, [aq+xq*4-(384+16)*4-4]
-    mova          m1, [aq+xq*4-(384+16)*4]
-    movu          m2, [aq+xq*4-(384+16)*4+4]
-    movu          m3, [aq+xq*4-(384+16)*4-4+16]
-    mova          m4, [aq+xq*4-(384+16)*4+16]
-    movu          m5, [aq+xq*4-(384+16)*4+4+16]
-    paddd         m0, m2
-    paddd         m3, m5
-    paddd         m0, m1
-    paddd         m3, m4
-    pslld         m2, m0, 2
-    pslld         m5, m3, 2
-    paddd         m2, m0
-    paddd         m5, m3
-    paddd         m0, m2, m1                    ; prev_odd_b [first half]
-    paddd         m1, m5, m4                    ; prev_odd_b [second half]
-    movu          m3, [bq+xq*2-(384+16)*2-2]
-    mova          m4, [bq+xq*2-(384+16)*2]
-    movu          m5, [bq+xq*2-(384+16)*2+2]
-    paddw         m3, m5
-    punpcklwd     m5, m3, m4
-    punpckhwd     m3, m4
-    pmaddwd       m5, m9
-    pmaddwd       m3, m9
-    mova          m2, m5
-    packssdw      m2, m3                        ; prev_odd_a
-    lea           tq, [tq+xq*2]
-    lea         srcq, [srcq+xq*1]
-    lea           aq, [aq+xq*4+(384+16)*4]
-    lea           bq, [bq+xq*2+(384+16)*2]
-%if ARCH_X86_32
-    mov        [esp], PIC_reg
-%endif
-    mov           yd, hd
-    XCHG_PIC_REG
-.loop_y:
-    movu          m3, [aq-4]
-    mova          m4, [aq]
-    movu          m5, [aq+4]
-    paddd         m3, m5
-    paddd         m3, m4
-    pslld         m5, m3, 2
-    paddd         m5, m3
-    paddd         m5, m4                        ; cur_odd_b [first half]
-    movu          m3, [aq+16-4]
-    mova          m6, [aq+16]
-    movu          m7, [aq+16+4]
-    paddd         m3, m7
-    paddd         m3, m6
-    pslld         m7, m3, 2
-    paddd         m7, m3
-    paddd         m4, m7, m6                    ; cur_odd_b [second half]
-    movu          m3, [bq-2]
-    mova          m6, [bq]
-    movu          m7, [bq+2]
-    paddw         m3, m7
-    punpcklwd     m7, m3, m6
-    punpckhwd     m3, m6
-    pmaddwd       m7, m9
-    pmaddwd       m3, m9
-    packssdw      m6, m7, m3                    ; cur_odd_a
-
-    paddd         m0, m5                        ; cur_even_b [first half]
-    paddd         m1, m4                        ; cur_even_b [second half]
-    paddw         m2, m6                        ; cur_even_a
-
-    movq          m3, [srcq]
-%if ARCH_X86_64
-    punpcklbw     m3, m13
-%else
-    mova        [td], m5
-    pxor          m7, m7
-    punpcklbw     m3, m7
-%endif
-    punpcklwd     m7, m3, m10
-    punpckhwd     m3, m10
-    punpcklwd     m8, m2, m12
-    punpckhwd     m2, m12
-    pmaddwd       m7, m8
-    pmaddwd       m3, m2
-    paddd         m7, m0
-    paddd         m3, m1
-    psrad         m7, 9
-    psrad         m3, 9
+%macro MULLD 3 ; dst, src, tmp
+    pmulhuw         %3, %1, %2
+    pmullw          %1, %2
+    pslld           %3, 16
+    paddd           %1, %3
+%endmacro
 
 %if ARCH_X86_32
-    pxor         m13, m13
-%endif
-    movq          m8, [srcq+strideq]
-    punpcklbw     m8, m13
-    punpcklwd     m0, m8, m10
-    punpckhwd     m8, m10
-    punpcklwd     m1, m6, m11
-    punpckhwd     m2, m6, m11
-    pmaddwd       m0, m1
-    pmaddwd       m8, m2
-%if ARCH_X86_64
-    paddd         m0, m5
+DECLARE_REG_TMP 0, 1, 2, 3, 4
+ %if STACK_ALIGNMENT < 16
+  %assign extra_stack 5*16
+ %else
+  %assign extra_stack 3*16
+ %endif
+cglobal sgr_filter_5x5_8bpc, 1, 7, 8, -400*24-16-extra_stack, \
+                             dst, dst_stride, left, lpf, lpf_stride, w, params, h
+ %if STACK_ALIGNMENT < 16
+  %define dstm         dword [esp+calloff+16*0+4*6]
+  %define dst_stridemp dword [esp+calloff+16*0+4*7]
+  %define leftm        dword [esp+calloff+16*3+4*0]
+  %define lpfm         dword [esp+calloff+16*3+4*1]
+  %define lpf_stridem  dword [esp+calloff+16*3+4*2]
+  %define w0m          dword [esp+calloff+16*3+4*3]
+  %define hd           dword [esp+calloff+16*3+4*4]
+  %define edgeb         byte [esp+calloff+16*3+4*5]
+  %define edged        dword [esp+calloff+16*3+4*5]
+  %define leftmp leftm
+ %else
+  %define w0m wm
+  %define hd dword r6m
+  %define edgeb  byte r8m
+  %define edged dword r8m
+ %endif
+ %define hvsrcm dword [esp+calloff+4*0]
+ %define w1m    dword [esp+calloff+4*1]
+ %define t0m    dword [esp+calloff+4*2]
+ %define t2m    dword [esp+calloff+4*3]
+ %define t3m    dword [esp+calloff+4*4]
+ %define t4m    dword [esp+calloff+4*5]
+ %define  m8 [base+pb_1]
+ %define  m9 [esp+calloff+16*2]
+ %define m10 [base+pd_0xf00800a4]
+ %define m11 [base+pw_256]
+ %define m12 [base+pd_34816]
+ %define m13 [base+pb_0to15]
+ %define m14 [base+sgr_lshuf5]
+ %define r10 r5
+ %define base r6-$$
+ %assign calloff 0
+ %if STACK_ALIGNMENT < 16
+    mov    dst_strideq, [rstk+stack_offset+ 8]
+    mov          leftq, [rstk+stack_offset+12]
+    mov           lpfq, [rstk+stack_offset+16]
+    mov    lpf_strideq, [rstk+stack_offset+20]
+    mov             wd, [rstk+stack_offset+24]
+    mov           dstm, dstq
+    mov   dst_stridemp, dst_strideq
+    mov          leftm, leftq
+    mov             r1, [rstk+stack_offset+28]
+    mov             r2, [rstk+stack_offset+36]
+    mov           lpfm, lpfq
+    mov    lpf_stridem, lpf_strideq
+    mov             hd, r1
+    mov          edged, r2
+ %endif
 %else
-    paddd         m0, [td]
+DECLARE_REG_TMP 4, 9, 7, 11, 12
+cglobal sgr_filter_5x5_8bpc, 5, 15, 15, -400*24-16, dst, dst_stride, left, lpf, \
+                                                    lpf_stride, w, edge, params, h
 %endif
-    paddd         m8, m4
-    psrad         m0, 8
-    psrad         m8, 8
-
-    packssdw      m7, m3
-    packssdw      m0, m8
-%if ARCH_X86_32
-    mova          m5, [td]
+%if ARCH_X86_64 || STACK_ALIGNMENT >= 16
+    mov             wd, wm
 %endif
-    mova [tq+384*2*0], m7
-    mova [tq+384*2*1], m0
-
-    mova          m0, m5
-    mova          m1, m4
-    mova          m2, m6
-    add           aq, (384+16)*4*2
-    add           bq, (384+16)*2*2
-    add           tq, 384*2*2
-    lea         srcq, [srcq+strideq*2]
 %if ARCH_X86_64
-    sub           yd, 2
+    mov        paramsq, paramsmp
+    lea            r13, [sgr_x_by_x-0xf03]
+    mov          edged, r8m
+    mov             hd, r6m
+    movu            m9, [paramsq]
+    mova           m11, [pw_256]
+    add           lpfq, wq
+    mova            m8, [pb_1]
+    lea             t1, [rsp+wq*2+20]
+    mova           m10, [pd_0xf00800a4]
+    add           dstq, wq
+    lea             t3, [rsp+wq*4+400*12+16]
+    mova           m12, [pd_34816]  ; (1 << 11) + (1 << 15)
+    lea             t4, [rsp+wq*2+400*20+16]
+    pshufhw         m7, m9, q0000
+    pshufb          m9, m11       ; s0
+    punpckhqdq      m7, m7        ; w0
+    neg             wq
+    mova           m13, [pb_0to15]
+    pxor            m6, m6
+    mova           m14, [sgr_lshuf5]
+    psllw           m7, 4
+ DEFINE_ARGS dst, dst_stride, left, lpf, lpf_stride, _, edge, _, h, _, w
+ %define lpfm        [rsp+0]
+ %define lpf_stridem [rsp+8]
 %else
-    sub dword [esp+4], 2
+    mov             r1, [rstk+stack_offset+32] ; params
+    LEA             r6, $$
+    movu            m1, [r1]
+    add           lpfm, wq
+    lea             t1, [rsp+extra_stack+wq*2+20]
+    add           dstq, wq
+    lea             t3, [rsp+extra_stack+wq*4+400*12+16]
+    mov           dstm, dstq
+    lea             t4, [rsp+extra_stack+wq*2+400*20+16]
+    mov            t3m, t3
+    pshufhw         m7, m1, q0000
+    mov            t4m, t4
+    pshufb          m1, m11       ; s0
+    punpckhqdq      m7, m7        ; w0
+    psllw           m7, 4
+    neg             wq
+    mova            m9, m1
+    pxor            m6, m6
+    mov            w1m, wd
+    sub             wd, 2
+    mov           lpfq, lpfm
+    mov    lpf_strideq, lpf_stridem
+    mov            w0m, wd
 %endif
-    jg .loop_y
-    add           xd, 8
-    cmp           xd, wd
-    jl .loop_x
-%if ARCH_X86_32
-    ADD          esp, 8
+    test         edgeb, 4 ; LR_HAVE_TOP
+    jz .no_top
+    call .h_top
+    add           lpfq, lpf_strideq
+    movif32        t2m, t1
+    mov             t2, t1
+    call .top_fixup
+    add             t1, 400*6
+    call .h_top
+    lea            r10, [lpfq+lpf_strideq*4]
+    mov           lpfq, dstq
+    movif64 lpf_stridem, lpf_strideq
+    add            r10, lpf_strideq
+    mov           lpfm, r10 ; below
+    movif32        t0m, t2
+    mov             t0, t2
+    dec             hd
+    jz .height1
+    or           edged, 16
+    call .h
+.main:
+    add           lpfq, dst_stridemp
+    movif32         t4, t4m
+    call .hv
+    call .prep_n
+    sub             hd, 2
+    jl .extend_bottom
+.main_loop:
+    movif32       lpfq, hvsrcm
+    add           lpfq, dst_stridemp
+%if ARCH_X86_64
+    test            hb, hb
+%else
+    mov             r5, hd
+    test            r5, r5
 %endif
+    jz .odd_height
+    call .h
+    add           lpfq, dst_stridemp
+    call .hv
+    movif32       dstq, dstm
+    call .n0
+    call .n1
+    sub             hd, 2
+    movif32         t0, t0m
+    jge .main_loop
+    test         edgeb, 8 ; LR_HAVE_BOTTOM
+    jz .extend_bottom
+    mov           lpfq, lpfm
+    call .h_top
+    add           lpfq, lpf_stridem
+    call .hv_bottom
+.end:
+    movif32       dstq, dstm
+    call .n0
+    call .n1
+.end2:
     RET
-
-%undef t2
-cglobal sgr_weighted2_8bpc, 4, 7, 12, dst, stride, t1, t2, w, h, wt
-    movifnidn     wd, wm
-    movd          m0, wtm
+.height1:
+    movif32         t4, t4m
+    call .hv
+    call .prep_n
+    jmp .odd_height_end
+.odd_height:
+    call .hv
+    movif32       dstq, dstm
+    call .n0
+    call .n1
+.odd_height_end:
+    call .v
+    movif32       dstq, dstm
+    call .n0
+    jmp .end2
+.extend_bottom:
+    call .v
+    jmp .end
+.no_top:
+    lea            r10, [lpfq+lpf_strideq*4]
+    mov           lpfq, dstq
+    movif64 lpf_stridem, lpf_strideq
+    lea            r10, [r10+lpf_strideq*2]
+    mov           lpfm, r10
+    call .h
+    lea             t2, [t1+400*6]
+    movif32        t2m, t2
+    call .top_fixup
+    dec             hd
+    jz .no_top_height1
+    or           edged, 16
+    mov             t0, t1
+    mov             t1, t2
+    movif32        t0m, t0
+    jmp .main
+.no_top_height1:
+    movif32         t3, t3m
+    movif32         t4, t4m
+    call .v
+    call .prep_n
+    jmp .odd_height_end
+.extend_right:
+%assign stack_offset stack_offset+8
+%assign calloff 8
+    movd            m1, wd
+    movd            m3, [lpfq-1]
+    pshufb          m1, m6
+    pshufb          m3, m6
+    psubb           m2, m8, m1
+    pcmpgtb         m2, m13
+    pand            m5, m2
+    pandn           m2, m3
+    por             m5, m2
+    ret
+%assign stack_offset stack_offset-4
+%assign calloff 4
+.h: ; horizontal boxsum
 %if ARCH_X86_64
-    movifnidn     hd, hm
-    mova         m10, [pd_1024]
-    pxor         m11, m11
+    lea             wq, [r5-2]
 %else
-    SETUP_PIC     hd, 0
- %define m10    [PIC_sym(pd_1024)]
- %define m11    m7
+ %define leftq r5
 %endif
-    pshufd        m0, m0, 0
-    DEFINE_ARGS dst, stride, t1, t2, w, h, idx
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .h_extend_left
+    movif32      leftq, leftm
+    movddup         m4, [leftq-4]
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    add         leftmp, 4
+    palignr         m5, m4, 13
+    jmp .h_main
+.h_extend_left:
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    pshufb          m5, m14
+    jmp .h_main
+.h_top:
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .h_extend_left
+    movif32         wq, w0m
+.h_loop:
+    movu            m5, [lpfq+wq-1]
+.h_main:
+    test         edgeb, 2 ; LR_HAVE_RIGHT
+    jnz .h_have_right
+    cmp             wd, -10
+    jl .h_have_right
+    call .extend_right
+.h_have_right:
+    punpcklbw       m4, m5, m6
+    punpckhbw       m5, m6
+    palignr         m2, m5, m4, 2
+    paddw           m0, m4, m2
+    palignr         m3, m5, m4, 6
+    paddw           m0, m3
+    punpcklwd       m1, m2, m3
+    pmaddwd         m1, m1
+    punpckhwd       m2, m3
+    pmaddwd         m2, m2
+    palignr         m5, m4, 8
+    paddw           m0, m5
+    punpcklwd       m3, m4, m5
+    pmaddwd         m3, m3
+    paddd           m1, m3
+    punpckhwd       m3, m4, m5
+    pmaddwd         m3, m3
+    shufps          m4, m5, q2121
+    paddw           m0, m4             ; sum
+    punpcklwd       m5, m4, m6
+    pmaddwd         m5, m5
+    punpckhwd       m4, m6
+    pmaddwd         m4, m4
+    paddd           m2, m3
+    test         edgeb, 16             ; y > 0
+    jz .h_loop_end
+    paddw           m0, [t1+wq*2+400*0]
+    paddd           m1, [t1+wq*2+400*2]
+    paddd           m2, [t1+wq*2+400*4]
+.h_loop_end:
+    paddd           m1, m5             ; sumsq
+    paddd           m2, m4
+    mova [t1+wq*2+400*0], m0
+    mova [t1+wq*2+400*2], m1
+    mova [t1+wq*2+400*4], m2
+    add             wq, 8
+    jl .h_loop
+    ret
+.top_fixup:
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov             wd, w0m
+%endif
+.top_fixup_loop: ; the sums of the first row needs to be doubled
+    mova            m0, [t1+wq*2+400*0]
+    mova            m1, [t1+wq*2+400*2]
+    mova            m2, [t1+wq*2+400*4]
+    paddw           m0, m0
+    paddd           m1, m1
+    paddd           m2, m2
+    mova [t2+wq*2+400*0], m0
+    mova [t2+wq*2+400*2], m1
+    mova [t2+wq*2+400*4], m2
+    add             wq, 8
+    jl .top_fixup_loop
+    ret
+ALIGN function_align
+.hv: ; horizontal boxsum + vertical boxsum + ab
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov         hvsrcm, lpfq
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .hv_extend_left
+    movif32      leftq, leftm
+    movddup         m4, [leftq-4]
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    add         leftmp, 4
+    palignr         m5, m4, 13
+    jmp .hv_main
+.hv_extend_left:
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    pshufb          m5, m14
+    jmp .hv_main
+.hv_bottom:
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov         hvsrcm, lpfq
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .hv_extend_left
+    movif32         wq, w0m
 %if ARCH_X86_32
- %define hd     hmp
+    jmp .hv_loop_start
 %endif
+.hv_loop:
+    movif32       lpfq, hvsrcm
+.hv_loop_start:
+    movu            m5, [lpfq+wq-1]
+.hv_main:
+    test         edgeb, 2 ; LR_HAVE_RIGHT
+    jnz .hv_have_right
+    cmp             wd, -10
+    jl .hv_have_right
+    call .extend_right
+.hv_have_right:
+    movif32         t3, hd
+    punpcklbw       m4, m5, m6
+    punpckhbw       m5, m6
+    palignr         m3, m5, m4, 2
+    paddw           m0, m4, m3
+    palignr         m1, m5, m4, 6
+    paddw           m0, m1
+    punpcklwd       m2, m3, m1
+    pmaddwd         m2, m2
+    punpckhwd       m3, m1
+    pmaddwd         m3, m3
+    palignr         m5, m4, 8
+    paddw           m0, m5
+    punpcklwd       m1, m4, m5
+    pmaddwd         m1, m1
+    paddd           m2, m1
+    punpckhwd       m1, m4, m5
+    pmaddwd         m1, m1
+    shufps          m4, m5, q2121
+    paddw           m0, m4            ; h sum
+    punpcklwd       m5, m4, m6
+    pmaddwd         m5, m5
+    punpckhwd       m4, m6
+    pmaddwd         m4, m4
+    paddd           m3, m1
+    paddd           m2, m5            ; h sumsq
+    paddd           m3, m4
+    paddw           m1, m0, [t1+wq*2+400*0]
+    paddd           m4, m2, [t1+wq*2+400*2]
+    paddd           m5, m3, [t1+wq*2+400*4]
+%if ARCH_X86_64
+    test            hd, hd
+%else
+    test            t3, t3
+%endif
+    jz .hv_last_row
+.hv_main2:
+    paddw           m1, [t2+wq*2+400*0] ; hv sum
+    paddd           m4, [t2+wq*2+400*2] ; hv sumsq
+    paddd           m5, [t2+wq*2+400*4]
+    mova [t0+wq*2+400*0], m0
+    pslld           m0, m4, 4
+    mova [t0+wq*2+400*2], m2
+    mova [t0+wq*2+400*4], m3
+    pslld           m2, m4, 3
+    paddd           m4, m0
+    pslld           m0, m5, 4
+    paddd           m4, m2             ; a * 25
+    pslld           m2, m5, 3
+    paddd           m5, m0
+    paddd           m5, m2
+    punpcklwd       m0, m1, m6         ; b
+    punpckhwd       m1, m6
+    pmaddwd         m2, m0, m0         ; b * b
+    pmaddwd         m3, m1, m1
+    psubd           m4, m2             ; p
+    psubd           m5, m3
+    MULLD           m4, m9, m2         ; p * s
+    MULLD           m5, m9, m2
+    pmaddwd         m0, m10            ; b * 164
+    pmaddwd         m1, m10
+    paddusw         m4, m10
+    paddusw         m5, m10
+    psrld           m4, 20             ; min(z, 255)
+    movif32         t3, t3m
+    psrld           m5, 20
+    GATHER_X_BY_X   m3, m4, m5, t2, t2m
+    punpcklwd       m4, m3, m3
+    punpckhwd       m5, m3, m3
+    MULLD           m0, m4, m2
+    MULLD           m1, m5, m2
+    psubw           m2, m11, m3        ; a
+    paddd           m0, m12            ; x * b * 164 + (1 << 11) + (1 << 15)
+    paddd           m1, m12
+    mova   [t4+wq*2+4], m2
+    psrld           m0, 12             ; b
+    psrld           m1, 12
+    mova  [t3+wq*4+ 8], m0
+    mova  [t3+wq*4+24], m1
+    add             wq, 8
+    jl .hv_loop
+    mov             t2, t1
+    mov             t1, t0
+    mov             t0, t2
+    movif32        t2m, t2
+    movif32        t0m, t0
+    ret
+.hv_last_row: ; esoteric edge case for odd heights
+    mova [t1+wq*2+400*0], m1
+    paddw             m1, m0
+    mova [t1+wq*2+400*2], m4
+    paddd             m4, m2
+    mova [t1+wq*2+400*4], m5
+    paddd             m5, m3
+    jmp .hv_main2
+.v: ; vertical boxsum + ab
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov             wd, w0m
+%endif
+.v_loop:
+    mova            m0, [t1+wq*2+400*0]
+    mova            m2, [t1+wq*2+400*2]
+    mova            m3, [t1+wq*2+400*4]
+    paddw           m1, m0, [t2+wq*2+400*0]
+    paddd           m4, m2, [t2+wq*2+400*2]
+    paddd           m5, m3, [t2+wq*2+400*4]
+    paddw           m0, m0
+    paddd           m2, m2
+    paddd           m3, m3
+    paddw           m1, m0             ; hv sum
+    paddd           m4, m2             ; hv sumsq
+    pslld           m0, m4, 4
+    paddd           m5, m3
+    pslld           m2, m4, 3
+    paddd           m4, m0
+    pslld           m0, m5, 4
+    paddd           m4, m2             ; a * 25
+    pslld           m2, m5, 3
+    paddd           m5, m0
+    paddd           m5, m2
+    punpcklwd       m0, m1, m6
+    punpckhwd       m1, m6
+    pmaddwd         m2, m0, m0         ; b * b
+    pmaddwd         m3, m1, m1
+    psubd           m4, m2             ; p
+    psubd           m5, m3
+    MULLD           m4, m9, m2         ; p * s
+    MULLD           m5, m9, m2
+    pmaddwd         m0, m10            ; b * 164
+    pmaddwd         m1, m10
+    paddusw         m4, m10
+    paddusw         m5, m10
+    psrld           m4, 20             ; min(z, 255)
+    psrld           m5, 20
+    GATHER_X_BY_X   m3, m4, m5, t2, t2m
+    punpcklwd       m4, m3, m3
+    punpckhwd       m5, m3, m3
+    MULLD           m0, m4, m2
+    MULLD           m1, m5, m2
+    psubw           m2, m11, m3        ; a
+    paddd           m0, m12            ; x * b * 164 + (1 << 11) + (1 << 15)
+    paddd           m1, m12
+    mova   [t4+wq*2+4], m2
+    psrld           m0, 12             ; b
+    psrld           m1, 12
+    mova  [t3+wq*4+ 8], m0
+    mova  [t3+wq*4+24], m1
+    add             wq, 8
+    jl .v_loop
+    ret
+.prep_n: ; initial neighbor setup
+    movif64         wq, r5
+    movif32         wd, w1m
+.prep_n_loop:
+    movu            m0, [t4+wq*2+ 2]
+    movu            m3, [t4+wq*2+ 4]
+    movu            m1, [t3+wq*4+ 4]
+    movu            m4, [t3+wq*4+ 8]
+    movu            m2, [t3+wq*4+20]
+    movu            m5, [t3+wq*4+24]
+    paddw           m3, m0
+    paddd           m4, m1
+    paddd           m5, m2
+    paddw           m3, [t4+wq*2+ 0]
+    paddd           m4, [t3+wq*4+ 0]
+    paddd           m5, [t3+wq*4+16]
+    paddw           m0, m3
+    psllw           m3, 2
+    paddd           m1, m4
+    pslld           m4, 2
+    paddd           m2, m5
+    pslld           m5, 2
+    paddw           m0, m3             ; a 565
+    paddd           m1, m4             ; b 565
+    paddd           m2, m5
+    mova [t4+wq*2+400*2+ 0], m0
+    mova [t3+wq*4+400*4+ 0], m1
+    mova [t3+wq*4+400*4+16], m2
+    add             wq, 8
+    jl .prep_n_loop
+    ret
+ALIGN function_align
+.n0: ; neighbor + output (even rows)
+    movif64         wq, r5
+    movif32         wd, w1m
+.n0_loop:
+    movu            m0, [t4+wq*2+ 2]
+    movu            m3, [t4+wq*2+ 4]
+    movu            m1, [t3+wq*4+ 4]
+    movu            m4, [t3+wq*4+ 8]
+    movu            m2, [t3+wq*4+20]
+    movu            m5, [t3+wq*4+24]
+    paddw           m3, m0
+    paddd           m4, m1
+    paddd           m5, m2
+    paddw           m3, [t4+wq*2+ 0]
+    paddd           m4, [t3+wq*4+ 0]
+    paddd           m5, [t3+wq*4+16]
+    paddw           m0, m3
+    psllw           m3, 2
+    paddd           m1, m4
+    pslld           m4, 2
+    paddd           m2, m5
+    pslld           m5, 2
+    paddw           m0, m3             ; a 565
+    paddd           m1, m4             ; b 565
+    paddd           m2, m5
+    paddw           m3, m0, [t4+wq*2+400*2+ 0]
+    paddd           m4, m1, [t3+wq*4+400*4+ 0]
+    paddd           m5, m2, [t3+wq*4+400*4+16]
+    mova [t4+wq*2+400*2+ 0], m0
+    mova [t3+wq*4+400*4+ 0], m1
+    mova [t3+wq*4+400*4+16], m2
+    movq            m0, [dstq+wq]
+    punpcklbw       m0, m6
+    punpcklwd       m1, m0, m6          ; src
+    punpcklwd       m2, m3, m6          ; a
+    pmaddwd         m2, m1              ; a * src
+    punpckhwd       m1, m0, m6
+    punpckhwd       m3, m6
+    pmaddwd         m3, m1
+    paddd           m2, m4              ; a * src + b + (1 << 8)
+    paddd           m3, m5
+    psrld           m2, 9
+    psrld           m3, 9
+    packssdw        m2, m3
+    psllw           m1, m0, 4
+    psubw           m2, m1
+    pmulhrsw        m2, m7
+    paddw           m0, m2
+    packuswb        m0, m0
+    movq     [dstq+wq], m0
+    add             wq, 8
+    jl .n0_loop
+    add           dstq, dst_stridemp
+    ret
+ALIGN function_align
+.n1: ; neighbor + output (odd rows)
+    movif64         wq, r5
+    movif32         wd, w1m
+.n1_loop:
+    movq            m0, [dstq+wq]
+    mova            m3, [t4+wq*2+400*2+ 0]
+    mova            m4, [t3+wq*4+400*4+ 0]
+    mova            m5, [t3+wq*4+400*4+16]
+    punpcklbw       m0, m6
+    punpcklwd       m1, m0, m6          ; src
+    punpcklwd       m2, m3, m6          ; a
+    pmaddwd         m2, m1
+    punpckhwd       m1, m0, m6
+    punpckhwd       m3, m6
+    pmaddwd         m3, m1
+    paddd           m2, m4              ; a * src + b + (1 << 7)
+    paddd           m3, m5
+    psrld           m2, 8
+    psrld           m3, 8
+    packssdw        m2, m3
+    psllw           m1, m0, 4
+    psubw           m2, m1
+    pmulhrsw        m2, m7
+    paddw           m0, m2
+    packuswb        m0, m0
+    movq     [dstq+wq], m0
+    add             wq, 8
+    jl .n1_loop
+    add           dstq, dst_stridemp
+    movif32       dstm, dstq
+    ret
 
-.loop_y:
-    xor         idxd, idxd
-.loop_x:
-    mova          m1, [t1q+idxq*2+ 0]
-    mova          m2, [t1q+idxq*2+16]
-    mova          m3, [t2q+idxq*2+ 0]
-    mova          m4, [t2q+idxq*2+16]
-    mova          m6, [dstq+idxq]
 %if ARCH_X86_32
-    pxor          m11, m11
+ %if STACK_ALIGNMENT < 16
+  %assign extra_stack 4*16
+ %else
+  %assign extra_stack 2*16
+ %endif
+cglobal sgr_filter_3x3_8bpc, 1, 7, 8, -400*42-16-extra_stack, \
+                             dst, dst_stride, left, lpf, lpf_stride, w, params, h
+ %if STACK_ALIGNMENT < 16
+  %define dstm         dword [esp+calloff+16*2+4*0]
+  %define dst_stridemp dword [esp+calloff+16*2+4*1]
+  %define leftm        dword [esp+calloff+16*2+4*2]
+  %define lpfm         dword [esp+calloff+16*2+4*3]
+  %define lpf_stridem  dword [esp+calloff+16*2+4*4]
+  %define w0m          dword [esp+calloff+16*2+4*5]
+  %define hd           dword [esp+calloff+16*2+4*6]
+  %define edgeb         byte [esp+calloff+16*2+4*7]
+  %define edged        dword [esp+calloff+16*2+4*7]
+  %define leftmp leftm
+ %else
+  %define w0m wm
+  %define hd dword r6m
+  %define edgeb  byte r8m
+  %define edged dword r8m
+ %endif
+ %define hvsrcm dword [esp+calloff+4*0]
+ %define w1m    dword [esp+calloff+4*1]
+ %define t3m    dword [esp+calloff+4*2]
+ %define t4m    dword [esp+calloff+4*3]
+ %define  m8 [base+pb_0to15]
+ %define  m9 [esp+calloff+16*1]
+ %define m10 [base+pd_0xf00801c7]
+ %define m11 [base+pd_34816]
+ %define m12 [base+pw_256]
+ %define m13 [base+sgr_lshuf3]
+ %define m14 m6
+ %define base r6-$$
+ %assign calloff 0
+ %if STACK_ALIGNMENT < 16
+    mov    dst_strideq, [rstk+stack_offset+ 8]
+    mov          leftq, [rstk+stack_offset+12]
+    mov           lpfq, [rstk+stack_offset+16]
+    mov    lpf_strideq, [rstk+stack_offset+20]
+    mov             wd, [rstk+stack_offset+24]
+    mov           dstm, dstq
+    mov   dst_stridemp, dst_strideq
+    mov          leftm, leftq
+    mov             r1, [rstk+stack_offset+28]
+    mov             r2, [rstk+stack_offset+36]
+    mov           lpfm, lpfq
+    mov    lpf_stridem, lpf_strideq
+    mov             hd, r1
+    mov          edged, r2
+ %endif
+%else
+cglobal sgr_filter_3x3_8bpc, 5, 15, 15, -400*42-8, dst, dst_stride, left, lpf, \
+                                                   lpf_stride, w, edge, params, h
 %endif
-    punpcklbw     m5, m6, m11
-    punpckhbw     m6, m11
-    psllw         m7, m5, 4
-    psubw         m1, m7
-    psubw         m3, m7
-    psllw         m7, m6, 4
-    psubw         m2, m7
-    psubw         m4, m7
-    punpcklwd     m7, m1, m3
-    punpckhwd     m1, m3
-    punpcklwd     m3, m2, m4
-    punpckhwd     m2, m4
-    pmaddwd       m7, m0
-    pmaddwd       m1, m0
-    pmaddwd       m3, m0
-    pmaddwd       m2, m0
-    paddd         m7, m10
-    paddd         m1, m10
-    paddd         m3, m10
-    paddd         m2, m10
-    psrad         m7, 11
-    psrad         m1, 11
-    psrad         m3, 11
-    psrad         m2, 11
-    packssdw      m7, m1
-    packssdw      m3, m2
-    paddw         m7, m5
-    paddw         m3, m6
-    packuswb      m7, m3
-    mova [dstq+idxq], m7
-    add         idxd, 16
-    cmp         idxd, wd
-    jl .loop_x
-    add         dstq, strideq
-    add          t1q, 384 * 2
-    add          t2q, 384 * 2
-    dec           hd
-    jg .loop_y
+%if ARCH_X86_64 || STACK_ALIGNMENT >= 16
+    mov             wd, wm
+%endif
+%if ARCH_X86_64
+    mov        paramsq, paramsmp
+    lea            r13, [sgr_x_by_x-0xf03]
+    mov          edged, r8m
+    mov             hd, r6m
+    movq            m9, [paramsq+4]
+    mova           m12, [pw_256]
+    add           lpfq, wq
+    lea             t1, [rsp+wq*2+12]
+    mova            m8, [pb_0to15]
+    add           dstq, wq
+    lea             t3, [rsp+wq*4+400*12+8]
+    mova           m10, [pd_0xf00801c7]
+    lea             t4, [rsp+wq*2+400*32+8]
+    mova           m11, [pd_34816]
+    pshuflw         m7, m9, q3333
+    pshufb          m9, m12       ; s1
+    punpcklqdq      m7, m7        ; w1
+    neg             wq
+    pxor            m6, m6
+    mova           m13, [sgr_lshuf3]
+    psllw           m7, 4
+ DEFINE_ARGS dst, dst_stride, left, lpf, lpf_stride, _, edge, _, h, _, w
+ %define lpfm [rsp]
+%else
+    mov             r1, [rstk+stack_offset+32] ; params
+    LEA             r6, $$
+    movq            m1, [r1+4]
+    add           lpfm, wq
+    lea             t1, [rsp+extra_stack+wq*2+20]
+    add           dstq, wq
+    lea             t3, [rsp+extra_stack+wq*4+400*12+16]
+    mov           dstm, dstq
+    lea             t4, [rsp+extra_stack+wq*2+400*32+16]
+    mov            t3m, t3
+    pshuflw         m7, m1, q3333
+    mov            t4m, t4
+    pshufb          m1, m12       ; s1
+    punpcklqdq      m7, m7        ; w1
+    psllw           m7, 4
+    neg             wq
+    mova            m9, m1
+    pxor            m6, m6
+    mov            w1m, wd
+    sub             wd, 2
+    mov           lpfq, lpfm
+    mov    lpf_strideq, lpf_stridem
+    mov            w0m, wd
+%endif
+    test         edgeb, 4 ; LR_HAVE_TOP
+    jz .no_top
+    call .h_top
+    add           lpfq, lpf_strideq
+    mov             t2, t1
+    add             t1, 400*6
+    call .h_top
+    lea            r10, [lpfq+lpf_strideq*4]
+    mov           lpfq, dstq
+    add            r10, lpf_strideq
+    mov           lpfm, r10 ; below
+    movif32         t4, t4m
+    call .hv0
+.main:
+    dec             hd
+    jz .height1
+    movif32       lpfq, hvsrcm
+    add           lpfq, dst_stridemp
+    call .hv1
+    call .prep_n
+    sub             hd, 2
+    jl .extend_bottom
+.main_loop:
+    movif32       lpfq, hvsrcm
+    add           lpfq, dst_stridemp
+    call .hv0
+%if ARCH_X86_64
+    test            hb, hb
+%else
+    mov             r5, hd
+    test            r5, r5
+%endif
+    jz .odd_height
+    movif32       lpfq, hvsrcm
+    add           lpfq, dst_stridemp
+    call .hv1
+    call .n0
+    call .n1
+    sub             hd, 2
+    jge .main_loop
+    test         edgeb, 8 ; LR_HAVE_BOTTOM
+    jz .extend_bottom
+    mov           lpfq, lpfm
+    call .hv0_bottom
+%if ARCH_X86_64
+    add           lpfq, lpf_strideq
+%else
+    mov           lpfq, hvsrcm
+    add           lpfq, lpf_stridem
+%endif
+    call .hv1_bottom
+.end:
+    call .n0
+    call .n1
+.end2:
     RET
+.height1:
+    call .v1
+    call .prep_n
+    jmp .odd_height_end
+.odd_height:
+    call .v1
+    call .n0
+    call .n1
+.odd_height_end:
+    call .v0
+    call .v1
+    call .n0
+    jmp .end2
+.extend_bottom:
+    call .v0
+    call .v1
+    jmp .end
+.no_top:
+    lea            r10, [lpfq+lpf_strideq*4]
+    mov           lpfq, dstq
+    lea            r10, [r10+lpf_strideq*2]
+    mov           lpfm, r10
+    call .h
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov             wq, w0m
+    mov         hvsrcm, lpfq
+%endif
+    lea             t2, [t1+400*6]
+.top_fixup_loop:
+    mova            m0, [t1+wq*2+400*0]
+    mova            m1, [t1+wq*2+400*2]
+    mova            m2, [t1+wq*2+400*4]
+    mova [t2+wq*2+400*0], m0
+    mova [t2+wq*2+400*2], m1
+    mova [t2+wq*2+400*4], m2
+    add             wq, 8
+    jl .top_fixup_loop
+    movif32         t3, t3m
+    movif32         t4, t4m
+    call .v0
+    jmp .main
+.extend_right:
+%assign stack_offset stack_offset+8
+%assign calloff 8
+    movd            m0, [lpfq-1]
+    movd            m1, wd
+    mova            m3, m8
+    pshufb          m0, m6
+    pshufb          m1, m6
+    mova            m2, m6
+    psubb           m2, m1
+    pcmpgtb         m2, m3
+    pand            m5, m2
+    pandn           m2, m0
+    por             m5, m2
+    ret
+%assign stack_offset stack_offset-4
+%assign calloff 4
+.h: ; horizontal boxsum
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+ %define leftq r5
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .h_extend_left
+    movif32      leftq, leftm
+    movddup         m4, [leftq-4]
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    add         leftmp, 4
+    palignr         m5, m4, 14
+    jmp .h_main
+.h_extend_left:
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    pshufb          m5, m13
+    jmp .h_main
+.h_top:
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .h_extend_left
+    movif32         wq, w0m
+.h_loop:
+    movu            m5, [lpfq+wq]
+.h_main:
+    test         edgeb, 2 ; LR_HAVE_RIGHT
+    jnz .h_have_right
+    cmp             wd, -9
+    jl .h_have_right
+    call .extend_right
+.h_have_right:
+    punpcklbw       m4, m5, m6
+    punpckhbw       m5, m6
+    palignr         m0, m5, m4, 2
+    paddw           m1, m4, m0
+    punpcklwd       m2, m4, m0
+    pmaddwd         m2, m2
+    punpckhwd       m3, m4, m0
+    pmaddwd         m3, m3
+    palignr         m5, m4, 4
+    paddw           m1, m5             ; sum
+    punpcklwd       m4, m5, m6
+    pmaddwd         m4, m4
+    punpckhwd       m5, m6
+    pmaddwd         m5, m5
+    paddd           m2, m4             ; sumsq
+    paddd           m3, m5
+    mova [t1+wq*2+400*0], m1
+    mova [t1+wq*2+400*2], m2
+    mova [t1+wq*2+400*4], m3
+    add             wq, 8
+    jl .h_loop
+    ret
+ALIGN function_align
+.hv0: ; horizontal boxsum + vertical boxsum + ab (even rows)
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov         hvsrcm, lpfq
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .hv0_extend_left
+    movif32      leftq, leftm
+    movddup         m4, [leftq-4]
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    add         leftmp, 4
+    palignr         m5, m4, 14
+    jmp .hv0_main
+.hv0_extend_left:
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    pshufb          m5, m13
+    jmp .hv0_main
+.hv0_bottom:
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov         hvsrcm, lpfq
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .hv0_extend_left
+    movif32         wq, w0m
+%if ARCH_X86_32
+    jmp .hv0_loop_start
+%endif
+.hv0_loop:
+    movif32       lpfq, hvsrcm
+.hv0_loop_start:
+    movu            m5, [lpfq+wq]
+.hv0_main:
+    test         edgeb, 2 ; LR_HAVE_RIGHT
+    jnz .hv0_have_right
+    cmp             wd, -9
+    jl .hv0_have_right
+    call .extend_right
+.hv0_have_right:
+    punpcklbw       m4, m5, m6
+    punpckhbw       m5, m6
+    palignr         m0, m5, m4, 2
+    paddw           m1, m4, m0
+    punpcklwd       m2, m4, m0
+    pmaddwd         m2, m2
+    punpckhwd       m3, m4, m0
+    pmaddwd         m3, m3
+    palignr         m5, m4, 4
+    paddw           m1, m5             ; sum
+    punpcklwd       m4, m5, m6
+    pmaddwd         m4, m4
+    punpckhwd       m5, m6
+    pmaddwd         m5, m5
+    paddd           m2, m4             ; sumsq
+    paddd           m3, m5
+    paddw           m0, m1, [t1+wq*2+400*0]
+    paddd           m4, m2, [t1+wq*2+400*2]
+    paddd           m5, m3, [t1+wq*2+400*4]
+    mova [t1+wq*2+400*0], m1
+    mova [t1+wq*2+400*2], m2
+    mova [t1+wq*2+400*4], m3
+    paddw           m1, m0, [t2+wq*2+400*0]
+    paddd           m2, m4, [t2+wq*2+400*2]
+    paddd           m3, m5, [t2+wq*2+400*4]
+    mova [t2+wq*2+400*0], m0
+    mova [t2+wq*2+400*2], m4
+    mova [t2+wq*2+400*4], m5
+    pslld           m4, m2, 3
+    pslld           m5, m3, 3
+    paddd           m4, m2             ; a * 9
+    paddd           m5, m3
+    punpcklwd       m0, m1, m6         ; b
+    pmaddwd         m2, m0, m0         ; b * b
+    punpckhwd       m1, m6
+    pmaddwd         m3, m1, m1
+    psubd           m4, m2             ; p
+    psubd           m5, m3
+    MULLD           m4, m9, m14        ; p * s
+    MULLD           m5, m9, m14
+    pmaddwd         m0, m10            ; b * 455
+    pmaddwd         m1, m10
+    paddusw         m4, m10
+    paddusw         m5, m10
+    psrld           m4, 20             ; min(z, 255)
+    movif32         t3, t3m
+    psrld           m5, 20
+    GATHER_X_BY_X   m3, m4, m5, r0, dstm
+    punpcklwd       m4, m3, m3
+    punpckhwd       m5, m3, m3
+    MULLD           m0, m4, m14
+    MULLD           m1, m5, m14
+    psubw           m2, m12, m3
+%if ARCH_X86_32
+    pxor            m6, m6
+%endif
+    paddd           m0, m11            ; x * b * 455 + (1 << 11) + (1 << 15)
+    paddd           m1, m11
+    mova   [t4+wq*2+4], m2
+    psrld           m0, 12
+    psrld           m1, 12
+    mova  [t3+wq*4+ 8], m0
+    mova  [t3+wq*4+24], m1
+    add             wq, 8
+    jl .hv0_loop
+    ret
+ALIGN function_align
+.hv1: ; horizontal boxsums + vertical boxsums + ab (odd rows)
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov         hvsrcm, lpfq
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .hv1_extend_left
+    movif32      leftq, leftm
+    movddup         m4, [leftq-4]
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    add         leftmp, 4
+    palignr         m5, m4, 14
+    jmp .hv1_main
+.hv1_extend_left:
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    pshufb          m5, m13
+    jmp .hv1_main
+.hv1_bottom:
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov         hvsrcm, lpfq
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .hv1_extend_left
+    movif32         wq, w0m
+%if ARCH_X86_32
+    jmp .hv1_loop_start
+%endif
+.hv1_loop:
+    movif32       lpfq, hvsrcm
+.hv1_loop_start:
+    movu            m5, [lpfq+wq]
+.hv1_main:
+    test         edgeb, 2 ; LR_HAVE_RIGHT
+    jnz .hv1_have_right
+    cmp             wd, -9
+    jl .hv1_have_right
+    call .extend_right
+.hv1_have_right:
+    punpcklbw       m4, m5, m6
+    punpckhbw       m5, m6
+    palignr         m1, m5, m4, 2
+    paddw           m0, m4, m1
+    punpcklwd       m2, m4, m1
+    pmaddwd         m2, m2
+    punpckhwd       m3, m4, m1
+    pmaddwd         m3, m3
+    palignr         m5, m4, 4
+    paddw           m0, m5             ; h sum
+    punpcklwd       m1, m5, m6
+    pmaddwd         m1, m1
+    punpckhwd       m5, m6
+    pmaddwd         m5, m5
+    paddd           m2, m1             ; h sumsq
+    paddd           m3, m5
+    paddw           m1, m0, [t2+wq*2+400*0]
+    paddd           m4, m2, [t2+wq*2+400*2]
+    paddd           m5, m3, [t2+wq*2+400*4]
+    mova [t2+wq*2+400*0], m0
+    mova [t2+wq*2+400*2], m2
+    mova [t2+wq*2+400*4], m3
+    pslld           m2, m4, 3
+    pslld           m3, m5, 3
+    paddd           m4, m2             ; a * 9
+    paddd           m5, m3
+    punpcklwd       m0, m1, m6         ; b
+    pmaddwd         m2, m0, m0         ; b * b
+    punpckhwd       m1, m6
+    pmaddwd         m3, m1, m1
+    psubd           m4, m2             ; p
+    psubd           m5, m3
+    MULLD           m4, m9, m14        ; p * s
+    MULLD           m5, m9, m14
+    pmaddwd         m0, m10            ; b * 455
+    pmaddwd         m1, m10
+    paddusw         m4, m10
+    paddusw         m5, m10
+    psrld           m4, 20             ; min(z, 255)
+    movif32         t3, t3m
+    psrld           m5, 20
+    GATHER_X_BY_X   m3, m4, m5, r0, dstm
+    punpcklwd       m4, m3, m3
+    punpckhwd       m5, m3, m3
+    MULLD           m0, m4, m14
+    MULLD           m1, m5, m14
+    psubw           m2, m12, m3
+%if ARCH_X86_32
+    pxor            m6, m6
+%endif
+    paddd           m0, m11            ; x * b * 455 + (1 << 11) + (1 << 15)
+    paddd           m1, m11
+    mova [t4+wq*2+400*2 +4], m2
+    psrld           m0, 12
+    psrld           m1, 12
+    mova [t3+wq*4+400*4+ 8], m0
+    mova [t3+wq*4+400*4+24], m1
+    add             wq, 8
+    jl .hv1_loop
+    mov            r10, t2
+    mov             t2, t1
+    mov             t1, r10
+    ret
+.v0: ; vertical boxsums + ab (even rows)
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov             wd, w0m
+%endif
+.v0_loop:
+    mova            m0, [t1+wq*2+400*0]
+    mova            m4, [t1+wq*2+400*2]
+    mova            m5, [t1+wq*2+400*4]
+    paddw           m0, m0
+    paddd           m4, m4
+    paddd           m5, m5
+    paddw           m1, m0, [t2+wq*2+400*0]
+    paddd           m2, m4, [t2+wq*2+400*2]
+    paddd           m3, m5, [t2+wq*2+400*4]
+    mova [t2+wq*2+400*0], m0
+    mova [t2+wq*2+400*2], m4
+    mova [t2+wq*2+400*4], m5
+    pslld           m4, m2, 3
+    pslld           m5, m3, 3
+    paddd           m4, m2             ; a * 9
+    paddd           m5, m3
+    punpcklwd       m0, m1, m6         ; b
+    pmaddwd         m2, m0, m0         ; b * b
+    punpckhwd       m1, m6
+    pmaddwd         m3, m1, m1
+    psubd           m4, m2             ; p
+    psubd           m5, m3
+    MULLD           m4, m9, m14        ; p * s
+    MULLD           m5, m9, m14
+    pmaddwd         m0, m10            ; b * 455
+    pmaddwd         m1, m10
+    paddusw         m4, m10
+    paddusw         m5, m10
+    psrld           m4, 20             ; min(z, 255)
+    psrld           m5, 20
+    GATHER_X_BY_X   m3, m4, m5, r0, dstm
+    punpcklwd       m4, m3, m3
+    punpckhwd       m5, m3, m3
+    MULLD           m0, m4, m14
+    MULLD           m1, m5, m14
+    psubw           m2, m12, m3
+%if ARCH_X86_32
+    pxor            m6, m6
+%endif
+    paddd           m0, m11            ; x * b * 455 + (1 << 11) + (1 << 15)
+    paddd           m1, m11
+    mova   [t4+wq*2+4], m2
+    psrld           m0, 12
+    psrld           m1, 12
+    mova  [t3+wq*4+ 8], m0
+    mova  [t3+wq*4+24], m1
+    add             wq, 8
+    jl .v0_loop
+    ret
+.v1: ; vertical boxsums + ab (odd rows)
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov             wd, w0m
+%endif
+.v1_loop:
+    mova            m0, [t1+wq*2+400*0]
+    mova            m4, [t1+wq*2+400*2]
+    mova            m5, [t1+wq*2+400*4]
+    paddw           m1, m0, [t2+wq*2+400*0]
+    paddd           m2, m4, [t2+wq*2+400*2]
+    paddd           m3, m5, [t2+wq*2+400*4]
+    mova [t2+wq*2+400*0], m0
+    mova [t2+wq*2+400*2], m4
+    mova [t2+wq*2+400*4], m5
+    pslld           m4, m2, 3
+    pslld           m5, m3, 3
+    paddd           m4, m2             ; a * 9
+    paddd           m5, m3
+    punpcklwd       m0, m1, m6         ; b
+    pmaddwd         m2, m0, m0         ; b * b
+    punpckhwd       m1, m6
+    pmaddwd         m3, m1, m1
+    psubd           m4, m2             ; p
+    psubd           m5, m3
+    MULLD           m4, m9, m14        ; p * s
+    MULLD           m5, m9, m14
+    pmaddwd         m0, m10            ; b * 455
+    pmaddwd         m1, m10
+    paddusw         m4, m10
+    paddusw         m5, m10
+    psrld           m4, 20             ; min(z, 255)
+    psrld           m5, 20
+    GATHER_X_BY_X   m3, m4, m5, r0, dstm
+    punpcklwd       m4, m3, m3
+    punpckhwd       m5, m3, m3
+    MULLD           m0, m4, m14
+    MULLD           m1, m5, m14
+    psubw           m2, m12, m3
+%if ARCH_X86_32
+    pxor            m6, m6
+%endif
+    paddd           m0, m11            ; x * b * 455 + (1 << 11) + (1 << 15)
+    paddd           m1, m11
+    mova [t4+wq*2+400*2+ 4], m2
+    psrld           m0, 12
+    psrld           m1, 12
+    mova [t3+wq*4+400*4+ 8], m0
+    mova [t3+wq*4+400*4+24], m1
+    add             wq, 8
+    jl .v1_loop
+    mov            r10, t2
+    mov             t2, t1
+    mov             t1, r10
+    ret
+.prep_n: ; initial neighbor setup
+    movif64         wq, r5
+    movif32         wd, w1m
+.prep_n_loop:
+    movu            m0, [t4+wq*2+400*0+ 4]
+    movu            m1, [t3+wq*4+400*0+ 8]
+    movu            m2, [t3+wq*4+400*0+24]
+    movu            m3, [t4+wq*2+400*0+ 2]
+    movu            m4, [t3+wq*4+400*0+ 4]
+    movu            m5, [t3+wq*4+400*0+20]
+    paddw           m0, [t4+wq*2+400*0+ 0]
+    paddd           m1, [t3+wq*4+400*0+ 0]
+    paddd           m2, [t3+wq*4+400*0+16]
+    paddw           m3, m0
+    paddd           m4, m1
+    paddd           m5, m2
+    psllw           m3, 2                ; a[-1] 444
+    pslld           m4, 2                ; b[-1] 444
+    pslld           m5, 2
+    psubw           m3, m0               ; a[-1] 343
+    psubd           m4, m1               ; b[-1] 343
+    psubd           m5, m2
+    mova [t4+wq*2+400*4], m3
+    mova [t3+wq*4+400*8+ 0], m4
+    mova [t3+wq*4+400*8+16], m5
+    movu            m0, [t4+wq*2+400*2+ 4]
+    movu            m1, [t3+wq*4+400*4+ 8]
+    movu            m2, [t3+wq*4+400*4+24]
+    movu            m3, [t4+wq*2+400*2+ 2]
+    movu            m4, [t3+wq*4+400*4+ 4]
+    movu            m5, [t3+wq*4+400*4+20]
+    paddw           m0, [t4+wq*2+400*2+ 0]
+    paddd           m1, [t3+wq*4+400*4+ 0]
+    paddd           m2, [t3+wq*4+400*4+16]
+    paddw           m3, m0
+    paddd           m4, m1
+    paddd           m5, m2
+    psllw           m3, 2                 ; a[ 0] 444
+    pslld           m4, 2                 ; b[ 0] 444
+    pslld           m5, 2
+    mova [t4+wq*2+400* 6], m3
+    mova [t3+wq*4+400*12+ 0], m4
+    mova [t3+wq*4+400*12+16], m5
+    psubw           m3, m0                ; a[ 0] 343
+    psubd           m4, m1                ; b[ 0] 343
+    psubd           m5, m2
+    mova [t4+wq*2+400* 8], m3
+    mova [t3+wq*4+400*16+ 0], m4
+    mova [t3+wq*4+400*16+16], m5
+    add             wq, 8
+    jl .prep_n_loop
+    ret
+ALIGN function_align
+.n0: ; neighbor + output (even rows)
+    movif64         wq, r5
+    movif32         wd, w1m
+.n0_loop:
+    movu            m3, [t4+wq*2+400*0+4]
+    movu            m1, [t4+wq*2+400*0+2]
+    paddw           m3, [t4+wq*2+400*0+0]
+    paddw           m1, m3
+    psllw           m1, 2                ; a[ 1] 444
+    psubw           m2, m1, m3           ; a[ 1] 343
+    paddw           m3, m2, [t4+wq*2+400*4]
+    paddw           m3, [t4+wq*2+400*6]
+    mova [t4+wq*2+400*4], m2
+    mova [t4+wq*2+400*6], m1
+    movu            m4, [t3+wq*4+400*0+8]
+    movu            m1, [t3+wq*4+400*0+4]
+    paddd           m4, [t3+wq*4+400*0+0]
+    paddd           m1, m4
+    pslld           m1, 2                ; b[ 1] 444
+    psubd           m2, m1, m4           ; b[ 1] 343
+    paddd           m4, m2, [t3+wq*4+400* 8+ 0]
+    paddd           m4, [t3+wq*4+400*12+ 0]
+    mova [t3+wq*4+400* 8+ 0], m2
+    mova [t3+wq*4+400*12+ 0], m1
+    movu            m5, [t3+wq*4+400*0+24]
+    movu            m1, [t3+wq*4+400*0+20]
+    paddd           m5, [t3+wq*4+400*0+16]
+    paddd           m1, m5
+    pslld           m1, 2
+    psubd           m2, m1, m5
+    paddd           m5, m2, [t3+wq*4+400* 8+16]
+    paddd           m5, [t3+wq*4+400*12+16]
+    mova [t3+wq*4+400* 8+16], m2
+    mova [t3+wq*4+400*12+16], m1
+    movq            m0, [dstq+wq]
+    punpcklbw       m0, m6
+    punpcklwd       m1, m0, m6
+    punpcklwd       m2, m3, m6
+    pmaddwd         m2, m1               ; a * src
+    punpckhwd       m1, m0, m6
+    punpckhwd       m3, m6
+    pmaddwd         m3, m1
+    paddd           m2, m4               ; a * src + b + (1 << 8)
+    paddd           m3, m5
+    psrld           m2, 9
+    psrld           m3, 9
+    packssdw        m2, m3
+    psllw           m1, m0, 4
+    psubw           m2, m1
+    pmulhrsw        m2, m7
+    paddw           m0, m2
+    packuswb        m0, m0
+    movq     [dstq+wq], m0
+    add             wq, 8
+    jl .n0_loop
+    add           dstq, dst_stridemp
+    ret
+ALIGN function_align
+.n1: ; neighbor + output (odd rows)
+    movif64         wq, r5
+    movif32         wd, w1m
+.n1_loop:
+    movu            m3, [t4+wq*2+400*2+4]
+    movu            m1, [t4+wq*2+400*2+2]
+    paddw           m3, [t4+wq*2+400*2+0]
+    paddw           m1, m3
+    psllw           m1, 2                ; a[ 1] 444
+    psubw           m2, m1, m3           ; a[ 1] 343
+    paddw           m3, m2, [t4+wq*2+400*6]
+    paddw           m3, [t4+wq*2+400*8]
+    mova [t4+wq*2+400*6], m1
+    mova [t4+wq*2+400*8], m2
+    movu            m4, [t3+wq*4+400*4+8]
+    movu            m1, [t3+wq*4+400*4+4]
+    paddd           m4, [t3+wq*4+400*4+0]
+    paddd           m1, m4
+    pslld           m1, 2                ; b[ 1] 444
+    psubd           m2, m1, m4           ; b[ 1] 343
+    paddd           m4, m2, [t3+wq*4+400*12+ 0]
+    paddd           m4, [t3+wq*4+400*16+ 0]
+    mova [t3+wq*4+400*12+ 0], m1
+    mova [t3+wq*4+400*16+ 0], m2
+    movu            m5, [t3+wq*4+400*4+24]
+    movu            m1, [t3+wq*4+400*4+20]
+    paddd           m5, [t3+wq*4+400*4+16]
+    paddd           m1, m5
+    pslld           m1, 2
+    psubd           m2, m1, m5
+    paddd           m5, m2, [t3+wq*4+400*12+16]
+    paddd           m5, [t3+wq*4+400*16+16]
+    mova [t3+wq*4+400*12+16], m1
+    mova [t3+wq*4+400*16+16], m2
+    movq            m0, [dstq+wq]
+    punpcklbw       m0, m6
+    punpcklwd       m1, m0, m6
+    punpcklwd       m2, m3, m6
+    pmaddwd         m2, m1               ; a * src
+    punpckhwd       m1, m0, m6
+    punpckhwd       m3, m6
+    pmaddwd         m3, m1
+    paddd           m2, m4               ; a * src + b + (1 << 8)
+    paddd           m3, m5
+    psrld           m2, 9
+    psrld           m3, 9
+    packssdw        m2, m3
+    psllw           m1, m0, 4
+    psubw           m2, m1
+    pmulhrsw        m2, m7
+    paddw           m0, m2
+    packuswb        m0, m0
+    movq     [dstq+wq], m0
+    add             wq, 8
+    jl .n1_loop
+    add           dstq, dst_stridemp
+    movif32       dstm, dstq
+    ret
+
+%if ARCH_X86_32
+ %if STACK_ALIGNMENT < 16
+  %assign extra_stack 10*16
+ %else
+  %assign extra_stack 8*16
+ %endif
+cglobal sgr_filter_mix_8bpc, 1, 7, 8, -400*66-48-extra_stack, \
+                             dst, dst_stride, left, lpf, lpf_stride, w, params, h
+ %if STACK_ALIGNMENT < 16
+  %define dstm         dword [esp+calloff+16*8+4*0]
+  %define dst_stridemp dword [esp+calloff+16*8+4*1]
+  %define leftm        dword [esp+calloff+16*8+4*2]
+  %define lpfm         dword [esp+calloff+16*8+4*3]
+  %define lpf_stridem  dword [esp+calloff+16*8+4*4]
+  %define w0m          dword [esp+calloff+16*8+4*5]
+  %define hd           dword [esp+calloff+16*8+4*6]
+  %define edgeb         byte [esp+calloff+16*8+4*7]
+  %define edged        dword [esp+calloff+16*8+4*7]
+  %define leftmp leftm
+ %else
+  %define w0m wm
+  %define hd dword r6m
+  %define edgeb  byte r8m
+  %define edged dword r8m
+ %endif
+ %define hvsrcm dword [esp+calloff+4*0]
+ %define w1m    dword [esp+calloff+4*1]
+ %define t3m    dword [esp+calloff+4*2]
+ %define t4m    dword [esp+calloff+4*3]
+ %xdefine m8 m6
+ %define  m9 [base+pd_0xffff]
+ %define m10 [base+pd_34816]
+ %define m11 [base+pd_0xf00801c7]
+ %define m12 [base+pw_256]
+ %define m13 [esp+calloff+16*4]
+ %define m14 [esp+calloff+16*5]
+ %define m15 [esp+calloff+16*6]
+ %define  m6 [esp+calloff+16*7]
+ %define base r6-$$
+ %assign calloff 0
+ %if STACK_ALIGNMENT < 16
+    mov    dst_strideq, [rstk+stack_offset+ 8]
+    mov          leftq, [rstk+stack_offset+12]
+    mov           lpfq, [rstk+stack_offset+16]
+    mov    lpf_strideq, [rstk+stack_offset+20]
+    mov             wd, [rstk+stack_offset+24]
+    mov           dstm, dstq
+    mov   dst_stridemp, dst_strideq
+    mov          leftm, leftq
+    mov             r1, [rstk+stack_offset+28]
+    mov             r2, [rstk+stack_offset+36]
+    mov           lpfm, lpfq
+    mov    lpf_stridem, lpf_strideq
+    mov             hd, r1
+    mov          edged, r2
+ %endif
+%else
+cglobal sgr_filter_mix_8bpc, 5, 15, 16, -400*66-40, dst, dst_stride, left, \
+                                                    lpf, lpf_stride, w, edge, \
+                                                    params, h
+%endif
+%if ARCH_X86_64 || STACK_ALIGNMENT >= 16
+    mov             wd, wm
+%endif
+%if ARCH_X86_64
+    mov        paramsq, paramsmp
+    lea            r13, [sgr_x_by_x-0xf03]
+    mov          edged, r8m
+    mov             hd, r6m
+    mova           m15, [paramsq]
+    add           lpfq, wq
+    mova            m9, [pd_0xffff]
+    lea             t1, [rsp+wq*2+44]
+    mova           m10, [pd_34816]
+    add           dstq, wq
+    mova           m12, [pw_256]
+    lea             t3, [rsp+wq*4+400*24+40]
+    mova           m11, [pd_0xf00801c7]
+    lea             t4, [rsp+wq*2+400*52+40]
+    neg             wq
+    pshuflw        m13, m15, q0000
+    pshuflw        m14, m15, q2222
+    pshufhw        m15, m15, q1010
+    punpcklqdq     m13, m13 ; s0
+    punpcklqdq     m14, m14 ; s1
+    punpckhqdq     m15, m15 ; w0 w1
+    pxor            m6, m6
+    psllw          m15, 2
+ DEFINE_ARGS dst, dst_stride, left, lpf, lpf_stride, _, edge, _, h, _, w
+ %define lpfm [rsp]
+%else
+    mov             r1, [rstk+stack_offset+32] ; params
+    LEA             r6, $$
+    mova            m2, [r1]
+    add           lpfm, wq
+    lea             t1, [rsp+extra_stack+wq*2+52]
+    add           dstq, wq
+    lea             t3, [rsp+extra_stack+wq*4+400*24+48]
+    mov           dstm, dstq
+    lea             t4, [rsp+extra_stack+wq*2+400*52+48]
+    mov            t3m, t3
+    mov            t4m, t4
+    neg             wq
+    pshuflw         m0, m2, q0000
+    pshuflw         m1, m2, q2222
+    pshufhw         m2, m2, q1010
+    punpcklqdq      m0, m0 ; s0
+    punpcklqdq      m1, m1 ; s1
+    punpckhqdq      m2, m2 ; w0 w1
+    mov            w1m, wd
+    pxor            m3, m3
+    psllw           m2, 2
+    mova           m13, m0
+    mova           m14, m1
+    sub             wd, 2
+    mova           m15, m2
+    mova            m6, m3
+    mov           lpfq, lpfm
+    mov    lpf_strideq, lpf_stridem
+    mov            w0m, wd
+%endif
+    test         edgeb, 4 ; LR_HAVE_TOP
+    jz .no_top
+    call .h_top
+    add           lpfq, lpf_strideq
+    mov             t2, t1
+%if ARCH_X86_64
+    call mangle(private_prefix %+ _sgr_filter_5x5_8bpc_ssse3).top_fixup
+%else
+    mov             wq, w0m
+    call mangle(private_prefix %+ _sgr_filter_5x5_8bpc_ssse3).top_fixup_loop
+%endif
+    add             t1, 400*12
+    call .h_top
+    lea            r10, [lpfq+lpf_strideq*4]
+    mov           lpfq, dstq
+    add            r10, lpf_strideq
+    mov           lpfm, r10 ; below
+    movif32         t4, t4m
+    call .hv0
+.main:
+    dec             hd
+    jz .height1
+    movif32       lpfq, hvsrcm
+    add           lpfq, dst_stridemp
+    call .hv1
+    call .prep_n
+    sub             hd, 2
+    jl .extend_bottom
+.main_loop:
+    movif32       lpfq, hvsrcm
+    add           lpfq, dst_stridemp
+    call .hv0
+%if ARCH_X86_64
+    test            hd, hd
+%else
+    mov             r5, hd
+    test            r5, r5
+%endif
+    jz .odd_height
+    movif32       lpfq, hvsrcm
+    add           lpfq, dst_stridemp
+    call .hv1
+    call .n0
+    call .n1
+    sub             hd, 2
+    jge .main_loop
+    test         edgeb, 8 ; LR_HAVE_BOTTOM
+    jz .extend_bottom
+    mov           lpfq, lpfm
+    call .hv0_bottom
+%if ARCH_X86_64
+    add           lpfq, lpf_strideq
+%else
+    mov           lpfq, hvsrcm
+    add           lpfq, lpf_stridem
+%endif
+    call .hv1_bottom
+.end:
+    call .n0
+    call .n1
+.end2:
+    RET
+.height1:
+    call .v1
+    call .prep_n
+    jmp .odd_height_end
+.odd_height:
+    call .v1
+    call .n0
+    call .n1
+.odd_height_end:
+    call .v0
+    call .v1
+    call .n0
+    jmp .end2
+.extend_bottom:
+    call .v0
+    call .v1
+    jmp .end
+.no_top:
+    lea            r10, [lpfq+lpf_strideq*4]
+    mov           lpfq, dstq
+    lea            r10, [r10+lpf_strideq*2]
+    mov           lpfm, r10
+    call .h
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov             wq, w0m
+    mov         hvsrcm, lpfq
+%endif
+    lea             t2, [t1+400*12]
+.top_fixup_loop:
+    mova            m0, [t1+wq*2+400* 0]
+    mova            m1, [t1+wq*2+400* 2]
+    mova            m2, [t1+wq*2+400* 4]
+    paddw           m0, m0
+    mova            m3, [t1+wq*2+400* 6]
+    paddd           m1, m1
+    mova            m4, [t1+wq*2+400* 8]
+    paddd           m2, m2
+    mova            m5, [t1+wq*2+400*10]
+    mova [t2+wq*2+400* 0], m0
+    mova [t2+wq*2+400* 2], m1
+    mova [t2+wq*2+400* 4], m2
+    mova [t2+wq*2+400* 6], m3
+    mova [t2+wq*2+400* 8], m4
+    mova [t2+wq*2+400*10], m5
+    add             wq, 8
+    jl .top_fixup_loop
+    movif32         t3, t3m
+    movif32         t4, t4m
+    call .v0
+    jmp .main
+.extend_right:
+%assign stack_offset stack_offset+8
+%assign calloff 8
+%if ARCH_X86_64
+    SWAP            m8, m6
+%endif
+    movd            m1, wd
+    movd            m3, [lpfq-1]
+    pshufb          m1, m8
+    pshufb          m3, m8
+    psubb           m2, [base+pb_1], m1
+    pcmpgtb         m2, [base+pb_0to15]
+    pand            m5, m2
+    pandn           m2, m3
+    por             m5, m2
+%if ARCH_X86_64
+    SWAP            m6, m8
+%endif
+    ret
+%assign stack_offset stack_offset-4
+%assign calloff 4
+.h: ; horizontal boxsum
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+ %define leftq r5
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .h_extend_left
+    movif32      leftq, leftm
+    movddup         m4, [leftq-4]
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    add         leftmp, 4
+    palignr         m5, m4, 13
+    jmp .h_main
+.h_extend_left:
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    pshufb          m5, [base+sgr_lshuf5]
+    jmp .h_main
+.h_top:
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .h_extend_left
+    movif32         wq, w0m
+.h_loop:
+    movu            m5, [lpfq+wq-1]
+.h_main:
+    test         edgeb, 2 ; LR_HAVE_RIGHT
+%if ARCH_X86_32
+    pxor            m8, m8
+%else
+    SWAP            m8, m6
+%endif
+    jnz .h_have_right
+    cmp             wd, -10
+    jl .h_have_right
+    call .extend_right
+.h_have_right:
+    punpcklbw       m4, m5, m8
+    punpckhbw       m5, m8
+    palignr         m3, m5, m4, 2
+    palignr         m0, m5, m4, 4
+    paddw           m1, m3, m0
+    punpcklwd       m2, m3, m0
+    pmaddwd         m2, m2
+    punpckhwd       m3, m0
+    pmaddwd         m3, m3
+    palignr         m0, m5, m4, 6
+    paddw           m1, m0             ; sum3
+    punpcklwd       m7, m0, m8
+    pmaddwd         m7, m7
+    punpckhwd       m0, m8
+    pmaddwd         m0, m0
+%if ARCH_X86_64
+    SWAP            m6, m8
+%endif
+    paddd           m2, m7             ; sumsq3
+    palignr         m5, m4, 8
+    punpcklwd       m7, m5, m4
+    paddw           m8, m4, m5
+    pmaddwd         m7, m7
+    punpckhwd       m5, m4
+    pmaddwd         m5, m5
+    paddd           m3, m0
+    mova [t1+wq*2+400* 6], m1
+    mova [t1+wq*2+400* 8], m2
+    mova [t1+wq*2+400*10], m3
+    paddw           m8, m1             ; sum5
+    paddd           m7, m2             ; sumsq5
+    paddd           m5, m3
+    mova [t1+wq*2+400* 0], m8
+    mova [t1+wq*2+400* 2], m7
+    mova [t1+wq*2+400* 4], m5
+    add             wq, 8
+    jl .h_loop
+    ret
+ALIGN function_align
+.hv0: ; horizontal boxsum + vertical boxsum + ab3 (even rows)
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov         hvsrcm, lpfq
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .hv0_extend_left
+    movif32      leftq, leftm
+    movddup         m4, [leftq-4]
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    add         leftmp, 4
+    palignr         m5, m4, 13
+    jmp .hv0_main
+.hv0_extend_left:
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    pshufb          m5, [base+sgr_lshuf5]
+    jmp .hv0_main
+.hv0_bottom:
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov         hvsrcm, lpfq
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .hv0_extend_left
+    movif32         wq, w0m
+%if ARCH_X86_32
+    jmp .hv0_loop_start
+%endif
+.hv0_loop:
+    movif32       lpfq, hvsrcm
+.hv0_loop_start:
+    movu            m5, [lpfq+wq-1]
+.hv0_main:
+    test         edgeb, 2 ; LR_HAVE_RIGHT
+%if ARCH_X86_32
+    pxor            m8, m8
+%else
+    SWAP            m8, m6
+%endif
+    jnz .hv0_have_right
+    cmp             wd, -10
+    jl .hv0_have_right
+    call .extend_right
+.hv0_have_right:
+    punpcklbw       m4, m5, m8
+    punpckhbw       m5, m8
+    palignr         m3, m5, m4, 2
+    palignr         m0, m5, m4, 4
+    movif32         t3, t3m
+    paddw           m1, m3, m0
+    punpcklwd       m2, m3, m0
+    pmaddwd         m2, m2
+    punpckhwd       m3, m0
+    pmaddwd         m3, m3
+    palignr         m0, m5, m4, 6
+    paddw           m1, m0             ; h sum3
+    punpcklwd       m7, m0, m8
+    pmaddwd         m7, m7
+    punpckhwd       m0, m8
+%if ARCH_X86_64
+    SWAP            m6, m8
+%endif
+    pmaddwd         m0, m0
+    paddd           m2, m7             ; h sumsq3
+    palignr         m5, m4, 8
+    punpcklwd       m7, m5, m4
+    paddw           m8, m4, m5
+    pmaddwd         m7, m7
+    punpckhwd       m5, m4
+    pmaddwd         m5, m5
+    paddd           m3, m0
+    paddw           m8, m1             ; h sum5
+    paddd           m7, m2             ; h sumsq5
+    paddd           m5, m3
+    mova [t3+wq*4+400*8+ 8], m8
+    mova [t3+wq*4+400*0+ 8], m7
+    mova [t3+wq*4+400*0+24], m5
+    paddw           m8, [t1+wq*2+400* 0]
+    paddd           m7, [t1+wq*2+400* 2]
+    paddd           m5, [t1+wq*2+400* 4]
+    mova [t1+wq*2+400* 0], m8
+    mova [t1+wq*2+400* 2], m7
+    mova [t1+wq*2+400* 4], m5
+    paddw           m0, m1, [t1+wq*2+400* 6]
+    paddd           m4, m2, [t1+wq*2+400* 8]
+    paddd           m5, m3, [t1+wq*2+400*10]
+    mova [t1+wq*2+400* 6], m1
+    mova [t1+wq*2+400* 8], m2
+    mova [t1+wq*2+400*10], m3
+    paddw           m1, m0, [t2+wq*2+400* 6]
+    paddd           m2, m4, [t2+wq*2+400* 8]
+    paddd           m3, m5, [t2+wq*2+400*10]
+    mova [t2+wq*2+400* 6], m0
+    mova [t2+wq*2+400* 8], m4
+    mova [t2+wq*2+400*10], m5
+%if ARCH_X86_32
+    pxor            m7, m7
+%else
+    SWAP            m7, m6
+%endif
+    pslld           m4, m2, 3
+    pslld           m5, m3, 3
+    paddd           m4, m2             ; a3 * 9
+    paddd           m5, m3
+    punpcklwd       m0, m1, m7         ; b3
+    pmaddwd         m2, m0, m0
+    punpckhwd       m1, m7
+    pmaddwd         m3, m1, m1
+%if ARCH_X86_64
+    SWAP            m7, m6
+%endif
+    psubd           m4, m2             ; p3
+    psubd           m5, m3
+    MULLD           m4, m14, m7        ; p3 * s1
+    MULLD           m5, m14, m7
+    pmaddwd         m0, m11            ; b3 * 455
+    pmaddwd         m1, m11
+    paddusw         m4, m11
+    paddusw         m5, m11
+    psrld           m4, 20             ; min(z3, 255)
+    psrld           m5, 20
+    GATHER_X_BY_X   m3, m4, m5, r0, dstm
+    punpcklwd       m4, m3, m3
+    punpckhwd       m5, m3, m3
+    MULLD           m0, m4, m7
+    MULLD           m1, m5, m7
+    psubw           m2, m12, m3
+    paddd           m0, m10            ; x3 * b3 * 455 + (1 << 11) + (1 << 15)
+    paddd           m1, m10
+    mova [t4+wq*2+400*2+ 4], m2
+    psrld           m0, 12
+    psrld           m1, 12
+    mova [t3+wq*4+400*4+ 8], m0
+    mova [t3+wq*4+400*4+24], m1
+    add             wq, 8
+    jl .hv0_loop
+    ret
+ALIGN function_align
+.hv1: ; horizontal boxsums + vertical boxsums + ab (odd rows)
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov         hvsrcm, lpfq
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .hv1_extend_left
+    movif32      leftq, leftm
+    movddup         m4, [leftq-4]
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    add         leftmp, 4
+    palignr         m5, m4, 13
+    jmp .hv1_main
+.hv1_extend_left:
+    movif32         wq, w0m
+    mova            m5, [lpfq+wq+2]
+    pshufb          m5, [base+sgr_lshuf5]
+    jmp .hv1_main
+.hv1_bottom:
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov         hvsrcm, lpfq
+%endif
+    test         edgeb, 1 ; LR_HAVE_LEFT
+    jz .hv1_extend_left
+    movif32         wq, w0m
+%if ARCH_X86_32
+    jmp .hv1_loop_start
+%endif
+.hv1_loop:
+    movif32       lpfq, hvsrcm
+.hv1_loop_start:
+    movu            m5, [lpfq+wq-1]
+.hv1_main:
+    test         edgeb, 2 ; LR_HAVE_RIGHT
+%if ARCH_X86_32
+    pxor            m8, m8
+%else
+    SWAP            m8, m6
+%endif
+    jnz .hv1_have_right
+    cmp             wd, -10
+    jl .hv1_have_right
+    call .extend_right
+.hv1_have_right:
+    punpcklbw       m4, m5, m8
+    punpckhbw       m5, m8
+    palignr         m7, m5, m4, 2
+    palignr         m3, m5, m4, 4
+    paddw           m2, m7, m3
+    punpcklwd       m0, m7, m3
+    pmaddwd         m0, m0
+    punpckhwd       m7, m3
+    pmaddwd         m7, m7
+    palignr         m3, m5, m4, 6
+    paddw           m2, m3             ; h sum3
+    punpcklwd       m1, m3, m8
+    pmaddwd         m1, m1
+    punpckhwd       m3, m8
+%if ARCH_X86_64
+    SWAP            m6, m8
+%endif
+    pmaddwd         m3, m3
+    paddd           m0, m1             ; h sumsq3
+    palignr         m5, m4, 8
+    punpckhwd       m1, m4, m5
+    paddw           m8, m4, m5
+    pmaddwd         m1, m1
+    punpcklwd       m4, m5
+    pmaddwd         m4, m4
+    paddd           m7, m3
+    paddw           m5, m2, [t2+wq*2+400* 6]
+    mova [t2+wq*2+400* 6], m2
+    paddw           m8, m2             ; h sum5
+    paddd           m2, m0, [t2+wq*2+400* 8]
+    paddd           m3, m7, [t2+wq*2+400*10]
+    mova [t2+wq*2+400* 8], m0
+    mova [t2+wq*2+400*10], m7
+    paddd           m4, m0             ; h sumsq5
+    paddd           m1, m7
+    pslld           m0, m2, 3
+    pslld           m7, m3, 3
+    paddd           m2, m0             ; a3 * 9
+    paddd           m3, m7
+%if ARCH_X86_32
+    mova      [esp+20], m8
+    pxor            m8, m8
+%else
+    SWAP            m8, m6
+%endif
+    punpcklwd       m0, m5, m8         ; b3
+    pmaddwd         m7, m0, m0
+    punpckhwd       m5, m8
+    pmaddwd         m8, m5, m5
+    psubd           m2, m7             ; p3
+    psubd           m3, m8
+    MULLD           m2, m14, m8        ; p3 * s1
+    MULLD           m3, m14, m8
+    pmaddwd         m0, m11            ; b3 * 455
+    pmaddwd         m5, m11
+    paddusw         m2, m11
+    paddusw         m3, m11
+    psrld           m2, 20             ; min(z3, 255)
+    movif32         t3, t3m
+    psrld           m3, 20
+    GATHER_X_BY_X   m8, m2, m3, r0, dstm
+    punpcklwd       m2, m8, m8
+    punpckhwd       m3, m8, m8
+    MULLD           m0, m2, m7
+    MULLD           m5, m3, m7
+    psubw           m7, m12, m8
+%if ARCH_X86_32
+    mova            m8, [esp+20]
+%endif
+    paddd           m0, m10            ; x3 * b3 * 455 + (1 << 11) + (1 << 15)
+    paddd           m5, m10
+    psrld           m0, 12
+    psrld           m5, 12
+    mova [t4+wq*2+400*4+ 4], m7
+    mova [t3+wq*4+400*8+ 8], m0
+    mova [t3+wq*4+400*8+24], m5
+%if ARCH_X86_64
+    SWAP            m6, m8
+    pxor            m6, m6
+%endif
+    paddw           m5, m8, [t2+wq*2+400*0]
+    paddd           m2, m4, [t2+wq*2+400*2]
+    paddd           m3, m1, [t2+wq*2+400*4]
+    paddw           m5, [t1+wq*2+400*0]
+    paddd           m2, [t1+wq*2+400*2]
+    paddd           m3, [t1+wq*2+400*4]
+    mova [t2+wq*2+400*0], m8
+    pslld           m0, m2, 4
+    mova [t2+wq*2+400*2], m4
+    pslld           m8, m3, 4
+    mova [t2+wq*2+400*4], m1
+    pslld           m4, m2, 3
+    paddd           m2, m0
+    pslld           m7, m3, 3
+    paddd           m3, m8
+    paddd           m2, m4             ; a5 * 25
+    paddd           m3, m7
+%if ARCH_X86_32
+    pxor            m7, m7
+%else
+    SWAP            m7, m6
+%endif
+    punpcklwd       m0, m5, m7         ; b5
+    pmaddwd         m4, m0, m0
+    punpckhwd       m5, m7
+    pmaddwd         m1, m5, m5
+%if ARCH_X86_64
+    SWAP            m7, m6
+%endif
+    psubd           m2, m4             ; p5
+    mova            m4, [base+pd_0xf00800a4]
+    psubd           m3, m1
+    MULLD           m2, m13, m7        ; p5 * s0
+    MULLD           m3, m13, m7
+    pmaddwd         m0, m4             ; b5 * 164
+    pmaddwd         m5, m4
+    paddusw         m2, m4
+    paddusw         m3, m4
+    psrld           m2, 20             ; min(z5, 255)
+    psrld           m3, 20
+    GATHER_X_BY_X   m1, m2, m3, r0, dstm
+    punpcklwd       m2, m1, m1
+    punpckhwd       m3, m1, m1
+    MULLD           m0, m2, m7
+    MULLD           m5, m3, m7
+    psubw           m4, m12, m1
+    paddd           m0, m10            ; x5 * b5 * 164 + (1 << 11) + (1 << 15)
+    paddd           m5, m10
+    mova   [t4+wq*2+4], m4
+    psrld           m0, 12
+    psrld           m5, 12
+    mova  [t3+wq*4+ 8], m0
+    mova  [t3+wq*4+24], m5
+    add             wq, 8
+    jl .hv1_loop
+    mov            r10, t2
+    mov             t2, t1
+    mov             t1, r10
+    ret
+.v0: ; vertical boxsums + ab3 (even rows)
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov             wd, w0m
+%endif
+.v0_loop:
+    mova            m0, [t1+wq*2+400* 6]
+    mova            m4, [t1+wq*2+400* 8]
+    mova            m5, [t1+wq*2+400*10]
+    paddw           m0, m0
+    paddd           m4, m4
+    paddd           m5, m5
+    paddw           m1, m0, [t2+wq*2+400* 6]
+    paddd           m2, m4, [t2+wq*2+400* 8]
+    paddd           m3, m5, [t2+wq*2+400*10]
+    mova [t2+wq*2+400* 6], m0
+    mova [t2+wq*2+400* 8], m4
+    mova [t2+wq*2+400*10], m5
+%if ARCH_X86_32
+    pxor            m7, m7
+%else
+    SWAP            m7, m6
+%endif
+    pslld           m4, m2, 3
+    pslld           m5, m3, 3
+    paddd           m4, m2             ; a3 * 9
+    paddd           m5, m3
+    punpcklwd       m0, m1, m7         ; b3
+    pmaddwd         m2, m0, m0
+    punpckhwd       m1, m7
+    pmaddwd         m3, m1, m1
+    psubd           m4, m2             ; p3
+    psubd           m5, m3
+%if ARCH_X86_64
+    SWAP            m7, m6
+%endif
+    MULLD           m4, m14, m7        ; p3 * s1
+    MULLD           m5, m14, m7
+    pmaddwd         m0, m11            ; b3 * 455
+    pmaddwd         m1, m11
+    paddusw         m4, m11
+    paddusw         m5, m11
+    psrld           m4, 20             ; min(z3, 255)
+    psrld           m5, 20
+    GATHER_X_BY_X   m3, m4, m5, r0, dstm
+    punpcklwd       m4, m3, m3
+    punpckhwd       m5, m3, m3
+    MULLD           m0, m4, m7
+    MULLD           m1, m5, m7
+    psubw           m2, m12, m3
+    paddd           m0, m10            ; x3 * b3 * 455 + (1 << 11) + (1 << 15)
+    paddd           m1, m10
+    mova [t4+wq*2+400*2+4], m2
+    psrld           m0, 12
+    psrld           m1, 12
+    mova            m3, [t1+wq*2+400*0]
+    mova            m4, [t1+wq*2+400*2]
+    mova            m5, [t1+wq*2+400*4]
+    mova [t3+wq*4+400*8+ 8], m3
+    mova [t3+wq*4+400*0+ 8], m4
+    mova [t3+wq*4+400*0+24], m5
+    paddw           m3, m3 ; cc5
+    paddd           m4, m4
+    paddd           m5, m5
+    mova [t1+wq*2+400*0], m3
+    mova [t1+wq*2+400*2], m4
+    mova [t1+wq*2+400*4], m5
+    mova [t3+wq*4+400*4+ 8], m0
+    mova [t3+wq*4+400*4+24], m1
+    add             wq, 8
+    jl .v0_loop
+    ret
+.v1: ; vertical boxsums + ab (odd rows)
+%if ARCH_X86_64
+    lea             wq, [r5-2]
+%else
+    mov             wd, w0m
+%endif
+.v1_loop:
+    mova            m4, [t1+wq*2+400* 6]
+    mova            m5, [t1+wq*2+400* 8]
+    mova            m7, [t1+wq*2+400*10]
+    paddw           m1, m4, [t2+wq*2+400* 6]
+    paddd           m2, m5, [t2+wq*2+400* 8]
+    paddd           m3, m7, [t2+wq*2+400*10]
+    mova [t2+wq*2+400* 6], m4
+    mova [t2+wq*2+400* 8], m5
+    mova [t2+wq*2+400*10], m7
+%if ARCH_X86_32
+    pxor            m7, m7
+%else
+    SWAP            m7, m6
+%endif
+    pslld           m4, m2, 3
+    pslld           m5, m3, 3
+    paddd           m4, m2             ; ((a3 + 8) >> 4) * 9
+    paddd           m5, m3
+    punpcklwd       m0, m1, m7         ; b3
+    pmaddwd         m2, m0, m0
+    punpckhwd       m1, m7
+    pmaddwd         m3, m1, m1
+    psubd           m4, m2             ; p3
+    psubd           m5, m3
+%if ARCH_X86_64
+    SWAP            m7, m6
+%endif
+    MULLD           m4, m14, m7        ; p3 * s1
+    MULLD           m5, m14, m7
+    pmaddwd         m0, m11            ; b3 * 455
+    pmaddwd         m1, m11
+    paddusw         m4, m11
+    paddusw         m5, m11
+    psrld           m4, 20             ; min(z3, 255)
+    psrld           m5, 20
+    GATHER_X_BY_X   m3, m4, m5, r0, dstm
+    punpcklwd       m4, m3, m3
+    punpckhwd       m5, m3, m3
+    MULLD           m0, m4, m7
+    MULLD           m1, m5, m7
+    psubw           m2, m12, m3
+    paddd           m0, m10            ; x3 * b3 * 455 + (1 << 11) + (1 << 15)
+    paddd           m1, m10
+    mova [t4+wq*2+400*4+4], m2
+    psrld           m0, 12
+    psrld           m8, m1, 12
+    mova            m4, [t3+wq*4+400*8+ 8]
+    mova            m5, [t3+wq*4+400*0+ 8]
+    mova            m7, [t3+wq*4+400*0+24]
+    paddw           m1, m4, [t2+wq*2+400*0]
+    paddd           m2, m5, [t2+wq*2+400*2]
+    paddd           m3, m7, [t2+wq*2+400*4]
+    paddw           m1, [t1+wq*2+400*0]
+    paddd           m2, [t1+wq*2+400*2]
+    paddd           m3, [t1+wq*2+400*4]
+    mova [t2+wq*2+400*0], m4
+    mova [t2+wq*2+400*2], m5
+    mova [t2+wq*2+400*4], m7
+    pslld           m4, m2, 4
+    mova [t3+wq*4+400*8+ 8], m0
+    pslld           m5, m3, 4
+    mova [t3+wq*4+400*8+24], m8
+    pslld           m7, m2, 3
+    paddd           m2, m4
+    pslld           m8, m3, 3
+    paddd           m3, m5
+    paddd           m2, m7             ; a5 * 25
+    paddd           m3, m8
+%if ARCH_X86_32
+    pxor            m7, m7
+%else
+    SWAP            m7, m6
+%endif
+    punpcklwd       m0, m1, m7         ; b5
+    pmaddwd         m4, m0, m0
+    punpckhwd       m1, m7
+    pmaddwd         m5, m1, m1
+    psubd           m2, m4             ; p5
+    mova            m4, [base+pd_0xf00800a4]
+    psubd           m3, m5
+%if ARCH_X86_64
+    SWAP            m7, m6
+%endif
+    MULLD           m2, m13, m7        ; p5 * s0
+    MULLD           m3, m13, m7
+    pmaddwd         m0, m4             ; b5 * 164
+    pmaddwd         m1, m4
+    paddusw         m2, m4
+    paddusw         m3, m4
+    psrld           m2, 20             ; min(z5, 255)
+    psrld           m3, 20
+    GATHER_X_BY_X   m4, m2, m3, r0, dstm
+    punpcklwd       m2, m4, m4
+    punpckhwd       m3, m4, m4
+    MULLD           m0, m2, m7
+    MULLD           m1, m3, m7
+    psubw           m5, m12, m4
+    paddd           m0, m10            ; x5 * b5 * 164 + (1 << 11) + (1 << 15)
+    paddd           m1, m10
+    mova   [t4+wq*2+4], m5
+    psrld           m0, 12
+    psrld           m1, 12
+    mova  [t3+wq*4+ 8], m0
+    mova  [t3+wq*4+24], m1
+    add             wq, 8
+    jl .v1_loop
+    mov            r10, t2
+    mov             t2, t1
+    mov             t1, r10
+    ret
+.prep_n: ; initial neighbor setup
+    movif64         wq, r5
+    movif32         wd, w1m
+.prep_n_loop:
+    movu            m0, [t4+wq*2+400*0+ 2]
+    movu            m1, [t3+wq*4+400*0+ 4]
+    movu            m2, [t3+wq*4+400*0+20]
+    movu            m7, [t4+wq*2+400*0+ 4]
+    movu            m8, [t3+wq*4+400*0+ 8]
+    paddw           m3, m0, [t4+wq*2+400*0+ 0]
+    paddd           m4, m1, [t3+wq*4+400*0+ 0]
+    paddd           m5, m2, [t3+wq*4+400*0+16]
+    paddw           m3, m7
+    paddd           m4, m8
+    movu            m7, [t3+wq*4+400*0+24]
+    paddw           m0, m3
+    paddd           m1, m4
+    psllw           m3, 2
+    pslld           m4, 2
+    paddd           m5, m7
+    paddd           m2, m5
+    pslld           m5, 2
+    paddw           m0, m3               ; a5 565
+    paddd           m1, m4               ; b5 565
+    paddd           m2, m5
+    mova [t4+wq*2+400* 6+ 0], m0
+    mova [t3+wq*4+400*12+ 0], m1
+    mova [t3+wq*4+400*12+16], m2
+    movu            m0, [t4+wq*2+400*2+ 4]
+    movu            m1, [t3+wq*4+400*4+ 8]
+    movu            m2, [t3+wq*4+400*4+24]
+    movu            m3, [t4+wq*2+400*2+ 2]
+    movu            m4, [t3+wq*4+400*4+ 4]
+    movu            m5, [t3+wq*4+400*4+20]
+    paddw           m0, [t4+wq*2+400*2+ 0]
+    paddd           m1, [t3+wq*4+400*4+ 0]
+    paddd           m2, [t3+wq*4+400*4+16]
+    paddw           m3, m0
+    paddd           m4, m1
+    paddd           m5, m2
+    psllw           m3, 2                ; a3[-1] 444
+    pslld           m4, 2                ; b3[-1] 444
+    pslld           m5, 2
+    psubw           m3, m0               ; a3[-1] 343
+    psubd           m4, m1               ; b3[-1] 343
+    psubd           m5, m2
+    mova [t4+wq*2+400* 8+ 0], m3
+    mova [t3+wq*4+400*16+ 0], m4
+    mova [t3+wq*4+400*16+16], m5
+    movu            m0, [t4+wq*2+400*4+ 4]
+    movu            m1, [t3+wq*4+400*8+ 8]
+    movu            m2, [t3+wq*4+400*8+24]
+    movu            m3, [t4+wq*2+400*4+ 2]
+    movu            m4, [t3+wq*4+400*8+ 4]
+    movu            m5, [t3+wq*4+400*8+20]
+    paddw           m0, [t4+wq*2+400*4+ 0]
+    paddd           m1, [t3+wq*4+400*8+ 0]
+    paddd           m2, [t3+wq*4+400*8+16]
+    paddw           m3, m0
+    paddd           m4, m1
+    paddd           m5, m2
+    psllw           m3, 2                 ; a3[ 0] 444
+    pslld           m4, 2                 ; b3[ 0] 444
+    pslld           m5, 2
+    mova [t4+wq*2+400*10+ 0], m3
+    mova [t3+wq*4+400*20+ 0], m4
+    mova [t3+wq*4+400*20+16], m5
+    psubw           m3, m0                ; a3[ 0] 343
+    psubd           m4, m1                ; b3[ 0] 343
+    psubd           m5, m2
+    mova [t4+wq*2+400*12+ 0], m3
+    mova [t3+wq*4+400*24+ 0], m4
+    mova [t3+wq*4+400*24+16], m5
+    add             wq, 8
+    jl .prep_n_loop
+    ret
+ALIGN function_align
+.n0: ; neighbor + output (even rows)
+    movif64         wq, r5
+    movif32         wd, w1m
+.n0_loop:
+    movu            m0, [t4+wq*2+ 4]
+    movu            m2, [t4+wq*2+ 2]
+    paddw           m0, [t4+wq*2+ 0]
+    paddw           m0, m2
+    paddw           m2, m0
+    psllw           m0, 2
+    paddw           m0, m2               ; a5
+    movu            m4, [t3+wq*4+ 8]
+    movu            m5, [t3+wq*4+24]
+    movu            m1, [t3+wq*4+ 4]
+    movu            m3, [t3+wq*4+20]
+    paddd           m4, [t3+wq*4+ 0]
+    paddd           m5, [t3+wq*4+16]
+    paddd           m4, m1
+    paddd           m5, m3
+    paddd           m1, m4
+    paddd           m3, m5
+    pslld           m4, 2
+    pslld           m5, 2
+    paddd           m4, m1               ; b5
+    paddd           m5, m3
+    movu            m2, [t4+wq*2+400* 6]
+    paddw           m2, m0
+    mova [t4+wq*2+400* 6], m0
+    paddd           m0, m4, [t3+wq*4+400*12+ 0]
+    paddd           m1, m5, [t3+wq*4+400*12+16]
+    mova [t3+wq*4+400*12+ 0], m4
+    mova [t3+wq*4+400*12+16], m5
+    mova [rsp+16+ARCH_X86_32*4], m1
+    movu            m3, [t4+wq*2+400*2+4]
+    movu            m5, [t4+wq*2+400*2+2]
+    paddw           m3, [t4+wq*2+400*2+0]
+    paddw           m5, m3
+    psllw           m5, 2                ; a3[ 1] 444
+    psubw           m4, m5, m3           ; a3[ 1] 343
+    movu            m3, [t4+wq*2+400* 8]
+    paddw           m3, [t4+wq*2+400*10]
+    paddw           m3, m4
+    mova [t4+wq*2+400* 8], m4
+    mova [t4+wq*2+400*10], m5
+    movu            m1, [t3+wq*4+400*4+ 8]
+    movu            m5, [t3+wq*4+400*4+ 4]
+    movu            m7, [t3+wq*4+400*4+24]
+    movu            m8, [t3+wq*4+400*4+20]
+    paddd           m1, [t3+wq*4+400*4+ 0]
+    paddd           m7, [t3+wq*4+400*4+16]
+    paddd           m5, m1
+    paddd           m8, m7
+    pslld           m5, 2                ; b3[ 1] 444
+    pslld           m8, 2
+    psubd           m4, m5, m1           ; b3[ 1] 343
+%if ARCH_X86_32
+    mova      [esp+52], m8
+    psubd           m8, m7
+%else
+    psubd           m6, m8, m7
+    SWAP            m8, m6
+%endif
+    paddd           m1, m4, [t3+wq*4+400*16+ 0]
+    paddd           m7, m8, [t3+wq*4+400*16+16]
+    paddd           m1, [t3+wq*4+400*20+ 0]
+    paddd           m7, [t3+wq*4+400*20+16]
+    mova [t3+wq*4+400*16+ 0], m4
+    mova [t3+wq*4+400*16+16], m8
+    mova [t3+wq*4+400*20+ 0], m5
+%if ARCH_X86_32
+    mova            m8, [esp+52]
+%else
+    SWAP            m8, m6
+    pxor            m6, m6
+%endif
+    mova [t3+wq*4+400*20+16], m8
+    mova [rsp+32+ARCH_X86_32*4], m7
+    movq            m4, [dstq+wq]
+    punpcklbw       m4, m6
+    punpcklwd       m7, m2, m6
+    punpckhwd       m2, m6
+    punpcklwd       m8, m3, m6
+    punpckhwd       m3, m6
+    punpcklwd       m5, m4, m6
+    punpckhwd       m4, m6
+    pmaddwd         m7, m5               ; a5 * src
+    pmaddwd         m8, m5               ; a3 * src
+    pmaddwd         m2, m4
+    pmaddwd         m3, m4
+    pslld           m5, 13
+    pslld           m4, 13
+    psubd           m0, m5
+    psubd           m1, m5
+    paddd           m0, m7               ; a5 * src + b5 + (1 << 8) - (src << 13)
+    paddd           m1, m8               ; a3 * src + b3 + (1 << 8) - (src << 13)
+    psrld           m0, 9
+    pslld           m1, 7
+    pand            m0, m9
+    pandn           m8, m9, m1
+    por             m0, m8
+    psubd           m1, m4, [rsp+16+ARCH_X86_32*4]
+    psubd           m8, m4, [rsp+32+ARCH_X86_32*4]
+    psubd           m2, m1
+    psubd           m3, m8
+    mova            m1, [base+pd_4096]
+    psrld           m2, 9
+    pslld           m3, 7
+    pand            m2, m9
+    pandn           m8, m9, m3
+    por             m2, m8
+    pmaddwd         m0, m15
+    pmaddwd         m2, m15
+    paddd           m5, m1
+    paddd           m4, m1
+    paddd           m0, m5
+    paddd           m2, m4
+    psrad           m0, 13
+    psrad           m2, 13
+    packssdw        m0, m2               ; clip
+    packuswb        m0, m0
+    movq     [dstq+wq], m0
+    add             wq, 8
+    jl .n0_loop
+    add           dstq, dst_stridemp
+    ret
+ALIGN function_align
+.n1: ; neighbor + output (odd rows)
+    movif64         wq, r5
+    movif32         wd, w1m
+.n1_loop:
+    movu            m3, [t4+wq*2+400*4+4]
+    movu            m5, [t4+wq*2+400*4+2]
+    paddw           m3, [t4+wq*2+400*4+0]
+    paddw           m5, m3
+    psllw           m5, 2                ; a3[ 1] 444
+    psubw           m4, m5, m3           ; a3[ 1] 343
+    paddw           m3, m4, [t4+wq*2+400*12]
+    paddw           m3, [t4+wq*2+400*10]
+    mova [t4+wq*2+400*10], m5
+    mova [t4+wq*2+400*12], m4
+    movu            m1, [t3+wq*4+400*8+ 8]
+    movu            m5, [t3+wq*4+400*8+ 4]
+    movu            m7, [t3+wq*4+400*8+24]
+    movu            m8, [t3+wq*4+400*8+20]
+    paddd           m1, [t3+wq*4+400*8+ 0]
+    paddd           m7, [t3+wq*4+400*8+16]
+    paddd           m5, m1
+    paddd           m8, m7
+    pslld           m5, 2                ; b3[ 1] 444
+    pslld           m8, 2
+    psubd           m4, m5, m1           ; b3[ 1] 343
+    psubd           m0, m8, m7
+    paddd           m1, m4, [t3+wq*4+400*24+ 0]
+    paddd           m7, m0, [t3+wq*4+400*24+16]
+    paddd           m1, [t3+wq*4+400*20+ 0]
+    paddd           m7, [t3+wq*4+400*20+16]
+    mova [t3+wq*4+400*20+ 0], m5
+    mova [t3+wq*4+400*20+16], m8
+    mova [t3+wq*4+400*24+ 0], m4
+    mova [t3+wq*4+400*24+16], m0
+    movq            m5, [dstq+wq]
+    mova            m8, [t4+wq*2+400* 6]
+    punpcklbw       m5, m6
+    punpcklwd       m4, m5, m6
+    punpckhwd       m5, m6
+    punpcklwd       m0, m8, m6
+    punpckhwd       m8, m6
+    punpcklwd       m2, m3, m6
+    punpckhwd       m3, m6
+    pmaddwd         m0, m4               ; a5 * src
+    pmaddwd         m2, m4               ; a3 * src
+    pmaddwd         m8, m5
+    pmaddwd         m3, m5
+    paddd           m1, m2               ; a3 * src + b3 + (1 << 8) - (src << 13)
+    pslld           m4, 12
+    pslld           m5, 12
+    psubd           m2, m4, [t3+wq*4+400*12+ 0]
+    psubd           m0, m2               ; a5 * src + b5 + (1 << 8) - (src << 13)
+    psubd           m2, m5, [t3+wq*4+400*12+16]
+    psubd           m8, m2
+    paddd           m4, m4
+    paddd           m5, m5
+    paddd           m7, m3
+    psubd           m1, m4
+    psubd           m7, m5
+    psrld           m0, 8
+    psrld           m8, 8
+    pslld           m1, 7
+    pslld           m7, 7
+    pand            m0, m9
+    pand            m8, m9
+    pandn           m3, m9, m1
+    pandn           m2, m9, m7
+    por             m0, m3
+    por             m8, m2
+    mova            m1, [base+pd_4096]
+    pmaddwd         m0, m15
+    pmaddwd         m8, m15
+    paddd           m4, m1
+    paddd           m5, m1
+    paddd           m0, m4
+    paddd           m8, m5
+    psrad           m0, 13
+    psrad           m8, 13
+    packssdw        m0, m8              ; clip
+    packuswb        m0, m0
+    movq     [dstq+wq], m0
+    add             wq, 8
+    jl .n1_loop
+    add           dstq, dst_stridemp
+    movif32       dstm, dstq
+    ret

--- a/src/x86/mc16_sse.asm
+++ b/src/x86/mc16_sse.asm
@@ -41,6 +41,9 @@ blend_shuf:     db 0,  1,  0,  1,  0,  1,  0,  1,  2,  3,  2,  3,  2,  3,  2,  3
 spel_h_shufA:   db 0,  1,  2,  3,  2,  3,  4,  5,  4,  5,  6,  7,  6,  7,  8,  9
 spel_h_shufB:   db 4,  5,  6,  7,  6,  7,  8,  9,  8,  9, 10, 11, 10, 11, 12, 13
 spel_h_shuf2:   db 0,  1,  2,  3,  4,  5,  6,  7,  2,  3,  4,  5,  6,  7,  8,  9
+rescale_mul:    dd 0,  1,  2,  3
+resize_shuf:    db 0,  1,  0,  1,  0,  1,  0,  1,  0,  1,  2,  3,  4,  5,  6,  7
+                db 8,  9, 10, 11, 12, 13, 14, 15, 14, 15, 14, 15, 14, 15, 14, 15
 
 pw_2:             times 8 dw 2
 pw_16:            times 4 dw 16
@@ -54,6 +57,8 @@ pw_8192:          times 8 dw 8192
 pw_27615:         times 8 dw 27615
 pw_32766:         times 8 dw 32766
 pw_m512:          times 8 dw -512
+pd_63:            times 4 dd 63
+pd_64:            times 4 dd 64
 pd_512:           times 4 dd 512
 pd_65538:         times 2 dd 65538
 
@@ -112,6 +117,7 @@ cextern mc_subpel_filters
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 
 cextern mc_warp_filter
+cextern resize_filter
 
 SECTION .text
 
@@ -4542,3 +4548,233 @@ cglobal emu_edge_16bpc, 10, 13, 1, bw, bh, iw, ih, x, \
 %undef reg_dstride
 %undef reg_blkm
 %undef reg_tmp
+
+%macro SCRATCH 3
+%if ARCH_X86_32
+    mova [rsp+%3*mmsize], m%1
+%define m%2 [rsp+%3*mmsize]
+%else
+    SWAP             %1, %2
+%endif
+%endmacro
+
+%if ARCH_X86_64
+cglobal resize_16bpc, 0, 12, 16, 1*16, dst, dst_stride, src, src_stride, \
+                                       dst_w, h, src_w, dx, mx0, pxmax
+%elif STACK_ALIGNMENT >= 16
+cglobal resize_16bpc, 0, 7, 8, 6*16, dst, dst_stride, src, src_stride, \
+                                     dst_w, h, src_w, dx, mx0, pxmax
+%else
+cglobal resize_16bpc, 0, 6, 8, 6*16, dst, dst_stride, src, src_stride, \
+                                     dst_w, h, src_w, dx, mx0, pxmax
+%endif
+    movifnidn         dstq, dstmp
+    movifnidn         srcq, srcmp
+%if STACK_ALIGNMENT >= 16
+    movifnidn       dst_wd, dst_wm
+%endif
+%if ARCH_X86_64
+    movifnidn           hd, hm
+%endif
+    sub         dword mx0m, 4<<14
+    sub       dword src_wm, 8
+    movd                m4, pxmaxm
+    movd                m7, dxm
+    movd                m6, mx0m
+    movd                m5, src_wm
+    punpcklwd           m4, m4
+    pshufd              m4, m4, q0000
+    pshufd              m7, m7, q0000
+    pshufd              m6, m6, q0000
+    pshufd              m5, m5, q0000
+    mova [rsp+16*3*ARCH_X86_32], m4
+%if ARCH_X86_64
+ DEFINE_ARGS dst, dst_stride, src, src_stride, dst_w, h, x, picptr
+    LEA                 r7, $$
+ %define base r7-$$
+%else
+ DEFINE_ARGS dst, dst_stride, src, src_stride, dst_w, x
+ %define hd dword r5m
+ %if STACK_ALIGNMENT >= 16
+    LEA                 r6, $$
+  %define base r6-$$
+ %else
+    LEA                 r4, $$
+  %define base r4-$$
+ %endif
+%endif
+%if ARCH_X86_64
+    mova               m12, [base+pd_64]
+    mova               m11, [base+pd_63]
+%else
+ %define m12 [base+pd_64]
+ %define m11 [base+pd_63]
+%endif
+    pmaddwd             m4, m7, [base+rescale_mul] ; dx*[0,1,2,3]
+    pslld               m7, 2                      ; dx*4
+    pslld               m5, 14
+    paddd               m6, m4                     ; mx+[0..3]*dx
+    SCRATCH              7, 15, 0
+    SCRATCH              6, 14, 1
+    SCRATCH              5, 13, 2
+    pxor                m1, m1
+.loop_y:
+    xor                 xd, xd
+    mova                m0, m14            ; per-line working version of mx
+.loop_x:
+    pcmpgtd             m1, m0
+    pandn               m1, m0
+    psrad               m2, m0, 8          ; filter offset (unmasked)
+    pcmpgtd             m3, m13, m1
+    pand                m1, m3
+    pandn               m3, m13
+    por                 m1, m3
+    psubd               m3, m0, m1         ; pshufb offset
+    psrad               m1, 14             ; clipped src_x offset
+    psrad               m3, 14             ; pshufb edge_emu offset
+    pand                m2, m11            ; filter offset (masked)
+    ; load source pixels
+%if ARCH_X86_64
+    movd               r8d, m1
+    pshuflw             m1, m1, q3232
+    movd               r9d, m1
+    punpckhqdq          m1, m1
+    movd              r10d, m1
+    psrlq               m1, 32
+    movd              r11d, m1
+    movu                m4, [srcq+r8*2]
+    movu                m5, [srcq+r9*2]
+    movu                m6, [srcq+r10*2]
+    movu                m7, [srcq+r11*2]
+    ; if no emulation is required, we don't need to shuffle or emulate edges
+    packssdw            m3, m3
+    movq               r11, m3
+    test               r11, r11
+    jz .filter
+    movsx               r8, r11w
+    sar                r11, 16
+    movsx               r9, r11w
+    sar                r11, 16
+    movsx              r10, r11w
+    sar                r11, 16
+    movu                m1, [base+resize_shuf+8+r8*2]
+    movu                m3, [base+resize_shuf+8+r9*2]
+    movu                m8, [base+resize_shuf+8+r10*2]
+    movu                m9, [base+resize_shuf+8+r11*2]
+    pshufb              m4, m1
+    pshufb              m5, m3
+    pshufb              m6, m8
+    pshufb              m7, m9
+.filter:
+    movd               r8d, m2
+    pshuflw             m2, m2, q3232
+    movd               r9d, m2
+    punpckhqdq          m2, m2
+    movd              r10d, m2
+    psrlq               m2, 32
+    movd              r11d, m2
+    movq                m8, [base+resize_filter+r8*8]
+    movq                m2, [base+resize_filter+r9*8]
+    pxor                m9, m9
+    punpcklbw           m1, m9, m8
+    punpcklbw           m3, m9, m2
+    psraw               m1, 8
+    psraw               m3, 8
+    movq               m10, [base+resize_filter+r10*8]
+    movq                m2, [base+resize_filter+r11*8]
+    punpcklbw           m8, m9, m10
+    punpcklbw           m9, m2
+    psraw               m8, 8
+    psraw               m9, 8
+    pmaddwd             m4, m1
+    pmaddwd             m5, m3
+    pmaddwd             m6, m8
+    pmaddwd             m7, m9
+    phaddd              m4, m5
+%else
+    movd                r3, m1
+    pshuflw             m1, m1, q3232
+    movd                r1, m1
+    punpckhqdq          m1, m1
+    movu                m4, [srcq+r3*2]
+    movu                m5, [srcq+r1*2]
+    movd                r3, m1
+    psrlq               m1, 32
+    movd                r1, m1
+    movu                m6, [srcq+r3*2]
+    movu                m7, [srcq+r1*2]
+    ; if no emulation is required, we don't need to shuffle or emulate edges
+    pxor                m1, m1
+    pcmpeqb             m1, m3
+    pmovmskb           r3d, m1
+    cmp                r3d, 0xffff
+    je .filter
+    movd                r3, m3
+    movu                m1, [base+resize_shuf+8+r3*2]
+    pshuflw             m3, m3, q3232
+    movd                r1, m3
+    pshufb              m4, m1
+    movu                m1, [base+resize_shuf+8+r1*2]
+    punpckhqdq          m3, m3
+    movd                r3, m3
+    pshufb              m5, m1
+    movu                m1, [base+resize_shuf+8+r3*2]
+    psrlq               m3, 32
+    movd                r1, m3
+    pshufb              m6, m1
+    movu                m1, [base+resize_shuf+8+r1*2]
+    pshufb              m7, m1
+.filter:
+    mova        [esp+4*16], m6
+    mova        [esp+5*16], m7
+    movd                r3, m2
+    pshuflw             m2, m2, q3232
+    movd                r1, m2
+    movq                m6, [base+resize_filter+r3*8]
+    movq                m7, [base+resize_filter+r1*8]
+    pxor                m3, m3
+    punpcklbw           m1, m3, m6
+    punpcklbw           m3, m7
+    psraw               m1, 8
+    psraw               m3, 8
+    pmaddwd             m4, m1
+    pmaddwd             m5, m3
+    punpckhqdq          m2, m2
+    movd                r3, m2
+    psrlq               m2, 32
+    movd                r1, m2
+    phaddd              m4, m5
+    movq                m2, [base+resize_filter+r3*8]
+    movq                m5, [base+resize_filter+r1*8]
+    mova                m6, [esp+4*16]
+    mova                m7, [esp+5*16]
+    pxor                m3, m3
+    punpcklbw           m1, m3, m2
+    punpcklbw           m3, m5
+    psraw               m1, 8
+    psraw               m3, 8
+    pmaddwd             m6, m1
+    pmaddwd             m7, m3
+%endif
+    phaddd              m6, m7
+    phaddd              m4, m6
+    pxor                m1, m1
+    psubd               m2, m12, m4
+    psrad               m2, 7
+    packssdw            m2, m2
+    pmaxsw              m2, m1
+    pminsw              m2, [rsp+16*3*ARCH_X86_32]
+    movq       [dstq+xq*2], m2
+    paddd               m0, m15
+    add                 xd, 4
+%if STACK_ALIGNMENT >= 16
+    cmp                 xd, dst_wd
+%else
+    cmp                 xd, dst_wm
+%endif
+    jl .loop_x
+    add               dstq, dst_stridemp
+    add               srcq, src_stridemp
+    dec                 hd
+    jg .loop_y
+    RET

--- a/src/x86/mc_avx2.asm
+++ b/src/x86/mc_avx2.asm
@@ -1,5 +1,5 @@
-; Copyright © 2018-2020, VideoLAN and dav1d authors
-; Copyright © 2018-2020, Two Orioles, LLC
+; Copyright © 2018-2021, VideoLAN and dav1d authors
+; Copyright © 2018-2021, Two Orioles, LLC
 ; All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
@@ -110,7 +110,7 @@ cextern resize_filter
 %endmacro
 
 %macro HV_JMP_TABLE 5-*
-    %xdefine %%prefix mangle(private_prefix %+ _%1_%2_%3)
+    %xdefine %%prefix mangle(private_prefix %+ _%1_%2_8bpc_%3)
     %xdefine %%base %1_%3
     %assign %%types %4
     %if %%types & 1
@@ -141,68 +141,68 @@ cextern resize_filter
     %endif
 %endmacro
 
-%macro BIDIR_JMP_TABLE 1-*
-    %xdefine %1_table (%%table - 2*%2)
-    %xdefine %%base %1_table
-    %xdefine %%prefix mangle(private_prefix %+ _%1)
+%macro BIDIR_JMP_TABLE 2-*
+    %xdefine %1_%2_table (%%table - 2*%3)
+    %xdefine %%base %1_%2_table
+    %xdefine %%prefix mangle(private_prefix %+ _%1_8bpc_%2)
     %%table:
-    %rep %0 - 1
-        dd %%prefix %+ .w%2 - %%base
+    %rep %0 - 2
+        dd %%prefix %+ .w%3 - %%base
         %rotate 1
     %endrep
 %endmacro
 
-%macro SCALED_JMP_TABLE 1-*
-    %xdefine %1_table (%%table - %2)
-    %xdefine %%base mangle(private_prefix %+ _%1)
+%macro SCALED_JMP_TABLE 2-*
+    %xdefine %1_%2_table (%%table - %3)
+    %xdefine %%base mangle(private_prefix %+ _%1_8bpc_%2)
 %%table:
-    %rep %0 - 1
-        dw %%base %+ .w%2 - %%base
+    %rep %0 - 2
+        dw %%base %+ .w%3 - %%base
         %rotate 1
     %endrep
-    %rotate 1
+    %rotate 2
 %%dy_1024:
-    %xdefine %1_dy1_table (%%dy_1024 - %2)
-    %rep %0 - 1
-        dw %%base %+ .dy1_w%2 - %%base
+    %xdefine %1_%2_dy1_table (%%dy_1024 - %3)
+    %rep %0 - 2
+        dw %%base %+ .dy1_w%3 - %%base
         %rotate 1
     %endrep
-    %rotate 1
+    %rotate 2
 %%dy_2048:
-    %xdefine %1_dy2_table (%%dy_2048 - %2)
-    %rep %0 - 1
-        dw %%base %+ .dy2_w%2 - %%base
+    %xdefine %1_%2_dy2_table (%%dy_2048 - %3)
+    %rep %0 - 2
+        dw %%base %+ .dy2_w%3 - %%base
         %rotate 1
     %endrep
 %endmacro
 
-%xdefine put_avx2 mangle(private_prefix %+ _put_bilin_avx2.put)
-%xdefine prep_avx2 mangle(private_prefix %+ _prep_bilin_avx2.prep)
+%xdefine put_avx2 mangle(private_prefix %+ _put_bilin_8bpc_avx2.put)
+%xdefine prep_avx2 mangle(private_prefix %+ _prep_bilin_8bpc_avx2.prep)
 
 %define table_offset(type, fn) type %+ fn %+ SUFFIX %+ _table - type %+ SUFFIX
 
-BASE_JMP_TABLE   put,  avx2,           2, 4, 8, 16, 32, 64, 128
-BASE_JMP_TABLE   prep, avx2,              4, 8, 16, 32, 64, 128
-HV_JMP_TABLE     put,  bilin, avx2, 7, 2, 4, 8, 16, 32, 64, 128
-HV_JMP_TABLE     prep, bilin, avx2, 7,    4, 8, 16, 32, 64, 128
-HV_JMP_TABLE     put,  8tap,  avx2, 3, 2, 4, 8, 16, 32, 64, 128
-HV_JMP_TABLE     prep, 8tap,  avx2, 1,    4, 8, 16, 32, 64, 128
-SCALED_JMP_TABLE put_8tap_scaled_avx2, 2, 4, 8, 16, 32, 64, 128
-SCALED_JMP_TABLE prep_8tap_scaled_avx2,   4, 8, 16, 32, 64, 128
-BIDIR_JMP_TABLE  avg_avx2,                4, 8, 16, 32, 64, 128
-BIDIR_JMP_TABLE  w_avg_avx2,              4, 8, 16, 32, 64, 128
-BIDIR_JMP_TABLE  mask_avx2,               4, 8, 16, 32, 64, 128
-BIDIR_JMP_TABLE  w_mask_420_avx2,         4, 8, 16, 32, 64, 128
-BIDIR_JMP_TABLE  w_mask_422_avx2,         4, 8, 16, 32, 64, 128
-BIDIR_JMP_TABLE  w_mask_444_avx2,         4, 8, 16, 32, 64, 128
-BIDIR_JMP_TABLE  blend_avx2,              4, 8, 16, 32
-BIDIR_JMP_TABLE  blend_v_avx2,         2, 4, 8, 16, 32
-BIDIR_JMP_TABLE  blend_h_avx2,         2, 4, 8, 16, 32, 32, 32
+BASE_JMP_TABLE   put,  avx2,            2, 4, 8, 16, 32, 64, 128
+BASE_JMP_TABLE   prep, avx2,               4, 8, 16, 32, 64, 128
+HV_JMP_TABLE     put,  bilin, avx2,  7, 2, 4, 8, 16, 32, 64, 128
+HV_JMP_TABLE     prep, bilin, avx2,  7,    4, 8, 16, 32, 64, 128
+HV_JMP_TABLE     put,  8tap,  avx2,  3, 2, 4, 8, 16, 32, 64, 128
+HV_JMP_TABLE     prep, 8tap,  avx2,  1,    4, 8, 16, 32, 64, 128
+SCALED_JMP_TABLE put_8tap_scaled, avx2, 2, 4, 8, 16, 32, 64, 128
+SCALED_JMP_TABLE prep_8tap_scaled, avx2,   4, 8, 16, 32, 64, 128
+BIDIR_JMP_TABLE  avg, avx2,                4, 8, 16, 32, 64, 128
+BIDIR_JMP_TABLE  w_avg, avx2,              4, 8, 16, 32, 64, 128
+BIDIR_JMP_TABLE  mask, avx2,               4, 8, 16, 32, 64, 128
+BIDIR_JMP_TABLE  w_mask_420, avx2,         4, 8, 16, 32, 64, 128
+BIDIR_JMP_TABLE  w_mask_422, avx2,         4, 8, 16, 32, 64, 128
+BIDIR_JMP_TABLE  w_mask_444, avx2,         4, 8, 16, 32, 64, 128
+BIDIR_JMP_TABLE  blend, avx2,              4, 8, 16, 32
+BIDIR_JMP_TABLE  blend_v, avx2,         2, 4, 8, 16, 32
+BIDIR_JMP_TABLE  blend_h, avx2,         2, 4, 8, 16, 32, 32, 32
 
 SECTION .text
 
 INIT_XMM avx2
-cglobal put_bilin, 4, 8, 0, dst, ds, src, ss, w, h, mxy
+cglobal put_bilin_8bpc, 4, 8, 0, dst, ds, src, ss, w, h, mxy
     movifnidn          mxyd, r6m ; mx
     lea                  r7, [put_avx2]
     tzcnt                wd, wm
@@ -769,7 +769,7 @@ INIT_YMM avx2
 %endif
     RET
 
-cglobal prep_bilin, 3, 7, 0, tmp, src, stride, w, h, mxy, stride3
+cglobal prep_bilin_8bpc, 3, 7, 0, tmp, src, stride, w, h, mxy, stride3
     movifnidn          mxyd, r5m ; mx
     lea                  r6, [prep%+SUFFIX]
     tzcnt                wd, wm
@@ -1439,7 +1439,7 @@ cglobal prep_bilin, 3, 7, 0, tmp, src, stride, w, h, mxy, stride3
 %assign FILTER_SHARP   (2*15 << 16) | 3*15
 
 %macro FN 4 ; fn, type, type_h, type_v
-cglobal %1_%2
+cglobal %1_%2_8bpc
     mov                 t0d, FILTER_%3
 %ifidn %3, %4
     mov                 t1d, t0d
@@ -1447,7 +1447,7 @@ cglobal %1_%2
     mov                 t1d, FILTER_%4
 %endif
 %ifnidn %2, regular ; skip the jump in the last filter
-    jmp mangle(private_prefix %+ _%1 %+ SUFFIX)
+    jmp mangle(private_prefix %+ _%1_8bpc %+ SUFFIX)
 %endif
 %endmacro
 
@@ -1469,7 +1469,7 @@ PUT_8TAP_FN smooth_regular, SMOOTH,  REGULAR
 PUT_8TAP_FN regular_smooth, REGULAR, SMOOTH
 PUT_8TAP_FN regular,        REGULAR, REGULAR
 
-cglobal put_8tap, 4, 9, 0, dst, ds, src, ss, w, h, mx, my, ss3
+cglobal put_8tap_8bpc, 4, 9, 0, dst, ds, src, ss, w, h, mx, my, ss3
     imul                mxd, mxm, 0x010101
     add                 mxd, t0d ; 8tap_h, mx, 4tap_h
     imul                myd, mym, 0x010101
@@ -2135,7 +2135,7 @@ PREP_8TAP_FN smooth_regular, SMOOTH,  REGULAR
 PREP_8TAP_FN regular_smooth, REGULAR, SMOOTH
 PREP_8TAP_FN regular,        REGULAR, REGULAR
 
-cglobal prep_8tap, 3, 8, 0, tmp, src, stride, w, h, mx, my, stride3
+cglobal prep_8tap_8bpc, 3, 8, 0, tmp, src, stride, w, h, mx, my, stride3
     imul                mxd, mxm, 0x010101
     add                 mxd, t0d ; 8tap_h, mx, 4tap_h
     imul                myd, mym, 0x010101
@@ -2725,26 +2725,26 @@ cglobal prep_8tap, 3, 8, 0, tmp, src, stride, w, h, mx, my, stride3
 %ifidn %1, put
  %assign isprep 0
  %if required_stack_alignment <= STACK_ALIGNMENT
-cglobal put_8tap_scaled, 4, 15, 16, 112, dst, ds, src, ss, w, h, mx, my, dx, dy
+cglobal put_8tap_scaled_8bpc, 4, 15, 16, 112, dst, ds, src, ss, w, h, mx, my, dx, dy
  %else
-cglobal put_8tap_scaled, 4, 14, 16, 128, dst, ds, src, ss, w, h, mx, my, dx, dy
+cglobal put_8tap_scaled_8bpc, 4, 14, 16, 128, dst, ds, src, ss, w, h, mx, my, dx, dy
  %endif
  %xdefine base_reg r12
  %define rndshift 10
 %else
  %assign isprep 1
  %if required_stack_alignment <= STACK_ALIGNMENT
-cglobal prep_8tap_scaled, 4, 15, 16, 128, tmp, src, ss, w, h, mx, my, dx, dy
+cglobal prep_8tap_scaled_8bpc, 4, 15, 16, 128, tmp, src, ss, w, h, mx, my, dx, dy
   %xdefine tmp_stridem r14q
  %else
-cglobal prep_8tap_scaled, 4, 14, 16, 128, tmp, src, ss, w, h, mx, my, dx, dy
+cglobal prep_8tap_scaled_8bpc, 4, 14, 16, 128, tmp, src, ss, w, h, mx, my, dx, dy
   %define tmp_stridem qword [rsp+120]
  %endif
  %xdefine base_reg r11
  %define rndshift 6
 %endif
-    lea            base_reg, [%1_8tap_scaled_avx2]
-%define base base_reg-%1_8tap_scaled_avx2
+    lea            base_reg, [%1_8tap_scaled_8bpc_avx2]
+%define base base_reg-%1_8tap_scaled_8bpc_avx2
     tzcnt                wd, wm
     vpbroadcastd         m8, dxm
 %if isprep && UNIX64
@@ -4025,10 +4025,10 @@ cglobal prep_8tap_scaled, 4, 14, 16, 128, tmp, src, ss, w, h, mx, my, dx, dy
 %endmacro
 
 %macro BILIN_SCALED_FN 1
-cglobal %1_bilin_scaled
+cglobal %1_bilin_scaled_8bpc
     mov                 t0d, (5*15 << 16) | 5*15
     mov                 t1d, t0d
-    jmp mangle(private_prefix %+ _%1_8tap_scaled %+ SUFFIX)
+    jmp mangle(private_prefix %+ _%1_8tap_scaled_8bpc %+ SUFFIX)
 %endmacro
 
 %if WIN64
@@ -4113,11 +4113,11 @@ MC_8TAP_SCALED prep
     paddd               m%1, m0, m%2
 %endmacro
 
-cglobal warp_affine_8x8t, 0, 14, 0, tmp, ts
+cglobal warp_affine_8x8t_8bpc, 0, 14, 0, tmp, ts
 %if WIN64
     sub                 rsp, 0xa0
 %endif
-    call mangle(private_prefix %+ _warp_affine_8x8_avx2).main
+    call mangle(private_prefix %+ _warp_affine_8x8_8bpc_avx2).main
 .loop:
     psrad                m7, 13
     psrad                m0, 13
@@ -4127,13 +4127,13 @@ cglobal warp_affine_8x8t, 0, 14, 0, tmp, ts
     mova         [tmpq+tsq*0], xm7
     vextracti128 [tmpq+tsq*2], m7, 1
     dec                 r4d
-    jz   mangle(private_prefix %+ _warp_affine_8x8_avx2).end
-    call mangle(private_prefix %+ _warp_affine_8x8_avx2).main2
+    jz   mangle(private_prefix %+ _warp_affine_8x8_8bpc_avx2).end
+    call mangle(private_prefix %+ _warp_affine_8x8_8bpc_avx2).main2
     lea                tmpq, [tmpq+tsq*4]
     jmp .loop
 
-cglobal warp_affine_8x8, 0, 14, 0, dst, ds, src, ss, abcd, mx, tmp2, alpha, \
-                                   beta, filter, tmp1, delta, my, gamma
+cglobal warp_affine_8x8_8bpc, 0, 14, 0, dst, ds, src, ss, abcd, mx, tmp2, alpha, \
+                                        beta, filter, tmp1, delta, my, gamma
 %if WIN64
     sub                 rsp, 0xa0
     %assign xmm_regs_used 16
@@ -4389,7 +4389,7 @@ ALIGN function_align
     add               tmp2q, %1*32
 %endmacro
 
-cglobal avg, 4, 7, 3, dst, stride, tmp1, tmp2, w, h, stride3
+cglobal avg_8bpc, 4, 7, 3, dst, stride, tmp1, tmp2, w, h, stride3
 %define base r6-avg %+ SUFFIX %+ _table
     lea                  r6, [avg %+ SUFFIX %+ _table]
     tzcnt                wd, wm
@@ -4419,7 +4419,7 @@ cglobal avg, 4, 7, 3, dst, stride, tmp1, tmp2, w, h, stride3
 
 %define W_AVG_INC_PTR AVG_INC_PTR
 
-cglobal w_avg, 4, 7, 6, dst, stride, tmp1, tmp2, w, h, stride3
+cglobal w_avg_8bpc, 4, 7, 6, dst, stride, tmp1, tmp2, w, h, stride3
 %define base r6-w_avg %+ SUFFIX %+ _table
     lea                  r6, [w_avg %+ SUFFIX %+ _table]
     tzcnt                wd, wm
@@ -4469,7 +4469,7 @@ cglobal w_avg, 4, 7, 6, dst, stride, tmp1, tmp2, w, h, stride3
     add               tmp1q, %1*32
 %endmacro
 
-cglobal mask, 4, 8, 6, dst, stride, tmp1, tmp2, w, h, mask, stride3
+cglobal mask_8bpc, 4, 8, 6, dst, stride, tmp1, tmp2, w, h, mask, stride3
 %define base r7-mask %+ SUFFIX %+ _table
     lea                  r7, [mask %+ SUFFIX %+ _table]
     tzcnt                wd, wm
@@ -4512,7 +4512,7 @@ cglobal mask, 4, 8, 6, dst, stride, tmp1, tmp2, w, h, mask, stride3
     packuswb            m%1, m1
 %endmacro
 
-cglobal blend, 3, 7, 7, dst, ds, tmp, w, h, mask
+cglobal blend_8bpc, 3, 7, 7, dst, ds, tmp, w, h, mask
 %define base r6-blend_avx2_table
     lea                  r6, [blend_avx2_table]
     tzcnt                wd, wm
@@ -4629,7 +4629,7 @@ ALIGN function_align
     jg .w32
     RET
 
-cglobal blend_v, 3, 6, 6, dst, ds, tmp, w, h, mask
+cglobal blend_v_8bpc, 3, 6, 6, dst, ds, tmp, w, h, mask
 %define base r5-blend_v_avx2_table
     lea                  r5, [blend_v_avx2_table]
     tzcnt                wd, wm
@@ -4740,7 +4740,7 @@ ALIGN function_align
     jg .w32_loop
     RET
 
-cglobal blend_h, 4, 7, 6, dst, ds, tmp, w, h, mask
+cglobal blend_h_8bpc, 4, 7, 6, dst, ds, tmp, w, h, mask
 %define base r5-blend_h_avx2_table
     lea                  r5, [blend_h_avx2_table]
     mov                 r6d, wd
@@ -4866,7 +4866,7 @@ ALIGN function_align
     jl .w32_loop0
     RET
 
-cglobal emu_edge, 10, 13, 1, bw, bh, iw, ih, x, y, dst, dstride, src, sstride, \
+cglobal emu_edge_8bpc, 10, 13, 1, bw, bh, iw, ih, x, y, dst, dstride, src, sstride, \
                              bottomext, rightext
     ; we assume that the buffer (stride) is larger than width, so we can
     ; safely overwrite by a few bytes
@@ -5053,8 +5053,8 @@ cglobal emu_edge, 10, 13, 1, bw, bh, iw, ih, x, y, dst, dstride, src, sstride, \
 .end:
     RET
 
-cglobal resize, 6, 14, 16, dst, dst_stride, src, src_stride, \
-                           dst_w, h, src_w, dx, mx0
+cglobal resize_8bpc, 6, 14, 16, dst, dst_stride, src, src_stride, \
+                                dst_w, h, src_w, dx, mx0
     sub          dword mx0m, 4<<14
     sub        dword src_wm, 8
     vpbroadcastd         m5, dxm
@@ -5191,7 +5191,7 @@ cglobal resize, 6, 14, 16, dst, dst_stride, src, src_stride, \
     jg .loop_y
     RET
 
-cglobal w_mask_420, 4, 8, 14, dst, stride, tmp1, tmp2, w, h, mask, stride3
+cglobal w_mask_420_8bpc, 4, 8, 14, dst, stride, tmp1, tmp2, w, h, mask, stride3
 %define base r7-w_mask_420_avx2_table
     lea                  r7, [w_mask_420_avx2_table]
     tzcnt                wd, wm
@@ -5397,7 +5397,7 @@ cglobal w_mask_420, 4, 8, 14, dst, stride, tmp1, tmp2, w, h, mask, stride3
     jg .w128_loop
     RET
 
-cglobal w_mask_422, 4, 8, 11, dst, stride, tmp1, tmp2, w, h, mask, stride3
+cglobal w_mask_422_8bpc, 4, 8, 11, dst, stride, tmp1, tmp2, w, h, mask, stride3
 %define base r7-w_mask_422_avx2_table
     lea                  r7, [w_mask_422_avx2_table]
     tzcnt                wd, wm
@@ -5570,7 +5570,7 @@ cglobal w_mask_422, 4, 8, 11, dst, stride, tmp1, tmp2, w, h, mask, stride3
     jg .w128_loop
     RET
 
-cglobal w_mask_444, 4, 8, 8, dst, stride, tmp1, tmp2, w, h, mask, stride3
+cglobal w_mask_444_8bpc, 4, 8, 8, dst, stride, tmp1, tmp2, w, h, mask, stride3
 %define base r7-w_mask_444_avx2_table
     lea                  r7, [w_mask_444_avx2_table]
     tzcnt                wd, wm

--- a/src/x86/mc_avx2.asm
+++ b/src/x86/mc_avx2.asm
@@ -69,7 +69,6 @@ bdct_lb_dw:     db  0,  0,  0,  0,  4,  4,  4,  4,  8,  8,  8,  8, 12, 12, 12, 1
 wswap:          db  2,  3,  0,  1,  6,  7,  4,  5, 10, 11,  8,  9, 14, 15, 12, 13
 rescale_mul:    dd  0,  1,  2,  3,  4,  5,  6,  7
 resize_shuf:    db  0,  0,  0,  0,  0,  1,  2,  3,  4,  5,  6,  7,  7,  7,  7,  7
-                db  7,  7,  7,  7,  7,  7,  7,  7
 
 wm_420_sign:    dd 0x01020102, 0x01010101
 wm_422_sign:    dd 0x80808080, 0x7f7f7f7f
@@ -5053,7 +5052,7 @@ cglobal emu_edge_8bpc, 10, 13, 1, bw, bh, iw, ih, x, y, dst, dstride, src, sstri
 .end:
     RET
 
-cglobal resize_8bpc, 6, 14, 16, dst, dst_stride, src, src_stride, \
+cglobal resize_8bpc, 6, 12, 16, dst, dst_stride, src, src_stride, \
                                 dst_w, h, src_w, dx, mx0
     sub          dword mx0m, 4<<14
     sub        dword src_wm, 8

--- a/src/x86/mc_avx2.asm
+++ b/src/x86/mc_avx2.asm
@@ -5117,27 +5117,23 @@ cglobal resize_8bpc, 6, 14, 16, dst, dst_stride, src, src_stride, \
     vptest               m1, m1
     jz .filter
 
-    movd                r8d, xm1
-    pextrd              r9d, xm1, 1
-    pextrd             r10d, xm1, 2
-    pextrd             r11d, xm1, 3
-    movsxd               r8, r8d
-    movsxd               r9, r9d
-    movsxd              r10, r10d
-    movsxd              r11, r11d
+    movq                 r9, xm1
+    pextrq              r11, xm1, 1
+    movsxd               r8, r9d
+    sar                  r9, 32
+    movsxd              r10, r11d
+    sar                 r11, 32
     vextracti128        xm1, m1, 1
     movq               xm14, [base+resize_shuf+4+r8]
     movq                xm0, [base+resize_shuf+4+r10]
     movhps             xm14, [base+resize_shuf+4+r9]
     movhps              xm0, [base+resize_shuf+4+r11]
-    movd                r8d, xm1
-    pextrd              r9d, xm1, 1
-    pextrd             r10d, xm1, 2
-    pextrd             r11d, xm1, 3
-    movsxd               r8, r8d
-    movsxd               r9, r9d
-    movsxd              r10, r10d
-    movsxd              r11, r11d
+    movq                 r9, xm1
+    pextrq              r11, xm1, 1
+    movsxd               r8, r9d
+    sar                  r9, 32
+    movsxd              r10, r11d
+    sar                 r11, 32
     vinserti128         m14, [base+resize_shuf+4+r8], 1
     vinserti128          m0, [base+resize_shuf+4+r10], 1
     vpbroadcastq        m10, [base+resize_shuf+4+r9]

--- a/src/x86/mc_sse.asm
+++ b/src/x86/mc_sse.asm
@@ -202,26 +202,26 @@ pw_258:  times 2 dw 258
 cextern mc_subpel_filters
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 
-%macro BIDIR_JMP_TABLE 1-*
+%macro BIDIR_JMP_TABLE 2-*
     ;evaluated at definition time (in loop below)
-    %xdefine %1_table (%%table - 2*%2)
-    %xdefine %%base %1_table
-    %xdefine %%prefix mangle(private_prefix %+ _%1)
+    %xdefine %1_%2_table (%%table - 2*%3)
+    %xdefine %%base %1_%2_table
+    %xdefine %%prefix mangle(private_prefix %+ _%1_8bpc_%2)
     ; dynamically generated label
     %%table:
-    %rep %0 - 1 ; repeat for num args
-        dd %%prefix %+ .w%2 - %%base
+    %rep %0 - 2 ; repeat for num args
+        dd %%prefix %+ .w%3 - %%base
         %rotate 1
     %endrep
 %endmacro
 
-BIDIR_JMP_TABLE avg_ssse3,        4, 8, 16, 32, 64, 128
-BIDIR_JMP_TABLE w_avg_ssse3,      4, 8, 16, 32, 64, 128
-BIDIR_JMP_TABLE mask_ssse3,       4, 8, 16, 32, 64, 128
-BIDIR_JMP_TABLE w_mask_420_ssse3, 4, 8, 16, 16, 16, 16
-BIDIR_JMP_TABLE blend_ssse3,      4, 8, 16, 32
-BIDIR_JMP_TABLE blend_v_ssse3, 2, 4, 8, 16, 32
-BIDIR_JMP_TABLE blend_h_ssse3, 2, 4, 8, 16, 16, 16, 16
+BIDIR_JMP_TABLE avg, ssse3,        4, 8, 16, 32, 64, 128
+BIDIR_JMP_TABLE w_avg, ssse3,      4, 8, 16, 32, 64, 128
+BIDIR_JMP_TABLE mask, ssse3,       4, 8, 16, 32, 64, 128
+BIDIR_JMP_TABLE w_mask_420, ssse3, 4, 8, 16, 16, 16, 16
+BIDIR_JMP_TABLE blend, ssse3,      4, 8, 16, 32
+BIDIR_JMP_TABLE blend_v, ssse3, 2, 4, 8, 16, 32
+BIDIR_JMP_TABLE blend_h, ssse3, 2, 4, 8, 16, 16, 16, 16
 
 %macro BASE_JMP_TABLE 3-*
     %xdefine %1_%2_table (%%table - %3)
@@ -233,15 +233,15 @@ BIDIR_JMP_TABLE blend_h_ssse3, 2, 4, 8, 16, 16, 16, 16
     %endrep
 %endmacro
 
-%xdefine prep_sse2 mangle(private_prefix %+ _prep_bilin_sse2.prep)
-%xdefine put_ssse3 mangle(private_prefix %+ _put_bilin_ssse3.put)
-%xdefine prep_ssse3 mangle(private_prefix %+ _prep_bilin_ssse3.prep)
+%xdefine prep_sse2 mangle(private_prefix %+ _prep_bilin_8bpc_sse2.prep)
+%xdefine put_ssse3 mangle(private_prefix %+ _put_bilin_8bpc_ssse3.put)
+%xdefine prep_ssse3 mangle(private_prefix %+ _prep_bilin_8bpc_ssse3.prep)
 
 BASE_JMP_TABLE put,  ssse3, 2, 4, 8, 16, 32, 64, 128
 BASE_JMP_TABLE prep, ssse3,    4, 8, 16, 32, 64, 128
 
 %macro HV_JMP_TABLE 5-*
-    %xdefine %%prefix mangle(private_prefix %+ _%1_%2_%3)
+    %xdefine %%prefix mangle(private_prefix %+ _%1_%2_8bpc_%3)
     %xdefine %%base %1_%3
     %assign %%types %4
     %if %%types & 1
@@ -279,33 +279,33 @@ HV_JMP_TABLE prep,  8tap, ssse3, 1,    4, 8, 16, 32, 64, 128
 HV_JMP_TABLE put,  bilin, ssse3, 7, 2, 4, 8, 16, 32, 64, 128
 HV_JMP_TABLE prep, bilin, ssse3, 7,    4, 8, 16, 32, 64, 128
 
-%macro SCALED_JMP_TABLE 1-*
-    %xdefine %1_table (%%table - %2)
-    %xdefine %%base mangle(private_prefix %+ _%1)
+%macro SCALED_JMP_TABLE 2-*
+    %xdefine %1_%2_table (%%table - %3)
+    %xdefine %%base mangle(private_prefix %+ _%1_8bpc_%2)
 %%table:
-    %rep %0 - 1
-        dw %%base %+ .w%2 - %%base
+    %rep %0 - 2
+        dw %%base %+ .w%3 - %%base
         %rotate 1
     %endrep
-    %rotate 1
+    %rotate 2
 %%dy_1024:
-    %xdefine %1_dy1_table (%%dy_1024 - %2)
-    %rep %0 - 1
-        dw %%base %+ .dy1_w%2 - %%base
+    %xdefine %1_%2_dy1_table (%%dy_1024 - %3)
+    %rep %0 - 2
+        dw %%base %+ .dy1_w%3 - %%base
         %rotate 1
     %endrep
-    %rotate 1
+    %rotate 2
 %%dy_2048:
-    %xdefine %1_dy2_table (%%dy_2048 - %2)
-    %rep %0 - 1
-        dw %%base %+ .dy2_w%2 - %%base
+    %xdefine %1_%2_dy2_table (%%dy_2048 - %3)
+    %rep %0 - 2
+        dw %%base %+ .dy2_w%3 - %%base
         %rotate 1
     %endrep
 %endmacro
 
 %if ARCH_X86_64
-SCALED_JMP_TABLE put_8tap_scaled_ssse3, 2, 4, 8, 16, 32, 64, 128
-SCALED_JMP_TABLE prep_8tap_scaled_ssse3,   4, 8, 16, 32, 64, 128
+SCALED_JMP_TABLE put_8tap_scaled, ssse3, 2, 4, 8, 16, 32, 64, 128
+SCALED_JMP_TABLE prep_8tap_scaled, ssse3,   4, 8, 16, 32, 64, 128
 %endif
 
 %define table_offset(type, fn) type %+ fn %+ SUFFIX %+ _table - type %+ SUFFIX
@@ -328,7 +328,7 @@ INIT_XMM ssse3
  %endif
 %endmacro
 
-cglobal put_bilin, 1, 8, 0, dst, ds, src, ss, w, h, mxy
+cglobal put_bilin_8bpc, 1, 8, 0, dst, ds, src, ss, w, h, mxy
     movifnidn          mxyd, r6m ; mx
     LEA                  t0, put_ssse3
     movifnidn          srcq, srcmp
@@ -953,7 +953,7 @@ cglobal put_bilin, 1, 8, 0, dst, ds, src, ss, w, h, mxy
     %define base 0
 %endif
 
-cglobal prep_bilin, 3, 7, 0, tmp, src, stride, w, h, mxy, stride3
+cglobal prep_bilin_8bpc, 3, 7, 0, tmp, src, stride, w, h, mxy, stride3
     movifnidn          mxyd, r5m ; mx
     LEA                  r6, prep%+SUFFIX
     tzcnt                wd, wm
@@ -1550,7 +1550,7 @@ cglobal prep_bilin, 3, 7, 0, tmp, src, stride, w, h, mxy, stride3
 %assign FILTER_SHARP   (2*15 << 16) | 3*15
 
 %macro FN 4 ; prefix, type, type_h, type_v
-cglobal %1_%2
+cglobal %1_%2_8bpc
     mov                 t0d, FILTER_%3
 %ifidn %3, %4
     mov                 t1d, t0d
@@ -1558,7 +1558,7 @@ cglobal %1_%2
     mov                 t1d, FILTER_%4
 %endif
 %ifnidn %2, regular ; skip the jump in the last filter
-    jmp mangle(private_prefix %+ _%1 %+ SUFFIX)
+    jmp mangle(private_prefix %+ _%1_8bpc %+ SUFFIX)
 %endif
 %endmacro
 
@@ -1588,7 +1588,7 @@ FN put_8tap, regular,        REGULAR, REGULAR
  %define base 0
 %endif
 
-cglobal put_8tap, 1, 9, 0, dst, ds, src, ss, w, h, mx, my, ss3
+cglobal put_8tap_8bpc, 1, 9, 0, dst, ds, src, ss, w, h, mx, my, ss3
 %assign org_stack_offset stack_offset
     imul                mxd, mxm, 0x010101
     add                 mxd, t0d ; 8tap_h, mx, 4tap_h
@@ -2839,7 +2839,7 @@ FN prep_8tap, regular,        REGULAR, REGULAR
  %define base_reg r7
  %define base 0
 %endif
-cglobal prep_8tap, 1, 9, 0, tmp, src, stride, w, h, mx, my, stride3
+cglobal prep_8tap_8bpc, 1, 9, 0, tmp, src, stride, w, h, mx, my, stride3
 %assign org_stack_offset stack_offset
     imul                mxd, mxm, 0x010101
     add                 mxd, t0d ; 8tap_h, mx, 4tap_h
@@ -4020,26 +4020,26 @@ cglobal prep_8tap, 1, 9, 0, tmp, src, stride, w, h, mx, my, stride3
 %ifidn %1, put
  %assign isprep 0
  %if required_stack_alignment <= STACK_ALIGNMENT
-cglobal put_8tap_scaled, 4, 15, 16, 0x180, dst, ds, src, ss, w, h, mx, my, dx, dy
+cglobal put_8tap_scaled_8bpc, 4, 15, 16, 0x180, dst, ds, src, ss, w, h, mx, my, dx, dy
  %else
-cglobal put_8tap_scaled, 4, 14, 16, 0x180, dst, ds, src, ss, w, h, mx, my, dx, dy
+cglobal put_8tap_scaled_8bpc, 4, 14, 16, 0x180, dst, ds, src, ss, w, h, mx, my, dx, dy
  %endif
  %xdefine base_reg r12
  %define rndshift 10
 %else
  %assign isprep 1
  %if required_stack_alignment <= STACK_ALIGNMENT
-cglobal prep_8tap_scaled, 4, 15, 16, 0x180, tmp, src, ss, w, h, mx, my, dx, dy
+cglobal prep_8tap_scaled_8bpc, 4, 15, 16, 0x180, tmp, src, ss, w, h, mx, my, dx, dy
   %xdefine tmp_stridem r14q
  %else
-cglobal prep_8tap_scaled, 4, 14, 16, 0x180, tmp, src, ss, w, h, mx, my, dx, dy
+cglobal prep_8tap_scaled_8bpc, 4, 14, 16, 0x180, tmp, src, ss, w, h, mx, my, dx, dy
   %define tmp_stridem qword [rsp+0x138]
  %endif
  %xdefine base_reg r11
  %define rndshift 6
 %endif
-    LEA            base_reg, %1_8tap_scaled_ssse3
-%define base base_reg-%1_8tap_scaled_ssse3
+    LEA            base_reg, %1_8tap_scaled_8bpc_ssse3
+%define base base_reg-%1_8tap_scaled_8bpc_ssse3
     tzcnt                wd, wm
     movd                 m8, dxm
     movd                m14, mxm
@@ -5622,10 +5622,10 @@ cglobal prep_8tap_scaled, 4, 14, 16, 0x180, tmp, src, ss, w, h, mx, my, dx, dy
 %endmacro
 
 %macro BILIN_SCALED_FN 1
-cglobal %1_bilin_scaled
+cglobal %1_bilin_scaled_8bpc
     mov                 t0d, (5*15 << 16) | 5*15
     mov                 t1d, (5*15 << 16) | 5*15
-    jmp mangle(private_prefix %+ _%1_8tap_scaled %+ SUFFIX)
+    jmp mangle(private_prefix %+ _%1_8tap_scaled_8bpc %+ SUFFIX)
 %endmacro
 
 %if ARCH_X86_64
@@ -5819,15 +5819,15 @@ MC_8TAP_SCALED prep
 
 %macro WARP_AFFINE_8X8T 0
 %if ARCH_X86_64
-cglobal warp_affine_8x8t, 6, 14, 16, 0x90, tmp, ts
+cglobal warp_affine_8x8t_8bpc, 6, 14, 16, 0x90, tmp, ts
 %else
-cglobal warp_affine_8x8t, 0, 7, 16, -0x130-copy_args, tmp, ts
+cglobal warp_affine_8x8t_8bpc, 0, 7, 16, -0x130-copy_args, tmp, ts
  %if copy_args
   %define tmpm [esp+stack_size-4*1]
   %define tsm  [esp+stack_size-4*2]
  %endif
 %endif
-    call mangle(private_prefix %+ _warp_affine_8x8_%+cpuname).main
+    call mangle(private_prefix %+ _warp_affine_8x8_8bpc_%+cpuname).main
 .loop:
 %if ARCH_X86_32
  %define m12 m4
@@ -5868,26 +5868,26 @@ cglobal warp_affine_8x8t, 0, 7, 16, -0x130-copy_args, tmp, ts
     mova       [tmpq+tsq*0], m12
     mova       [tmpq+tsq*2], m14
     dec            counterd
-    jz   mangle(private_prefix %+ _warp_affine_8x8_%+cpuname).end
+    jz   mangle(private_prefix %+ _warp_affine_8x8_8bpc_%+cpuname).end
 %if ARCH_X86_32
     mov                tmpm, tmpd
     mov                  r0, [esp+0x100]
     mov                  r1, [esp+0x104]
 %endif
-    call mangle(private_prefix %+ _warp_affine_8x8_%+cpuname).main2
+    call mangle(private_prefix %+ _warp_affine_8x8_8bpc_%+cpuname).main2
     lea                tmpq, [tmpq+tsq*4]
     jmp .loop
 %endmacro
 
 %macro WARP_AFFINE_8X8 0
 %if ARCH_X86_64
-cglobal warp_affine_8x8, 6, 14, 16, 0x90, \
-                         dst, ds, src, ss, abcd, mx, tmp2, alpha, beta, \
-                         filter, tmp1, delta, my, gamma
+cglobal warp_affine_8x8_8bpc, 6, 14, 16, 0x90, \
+                              dst, ds, src, ss, abcd, mx, tmp2, alpha, beta, \
+                              filter, tmp1, delta, my, gamma
 %else
-cglobal warp_affine_8x8, 0, 7, 16, -0x130-copy_args, \
-                         dst, ds, src, ss, abcd, mx, tmp2, alpha, beta, \
-                         filter, tmp1, delta, my, gamma
+cglobal warp_affine_8x8_8bpc, 0, 7, 16, -0x130-copy_args, \
+                              dst, ds, src, ss, abcd, mx, tmp2, alpha, beta, \
+                              filter, tmp1, delta, my, gamma
  %define alphaq     r0
  %define alphad     r0
  %define alpham     [esp+gprsize+0x100]
@@ -6475,7 +6475,7 @@ DECLARE_REG_TMP 6, 7
     add               tmp2q, %1*mmsize
 %endmacro
 
-cglobal avg, 4, 7, 3, dst, stride, tmp1, tmp2, w, h, stride3
+cglobal avg_8bpc, 4, 7, 3, dst, stride, tmp1, tmp2, w, h, stride3
     LEA                  r6, avg_ssse3_table
     tzcnt                wd, wm ; leading zeros
     movifnidn            hd, hm ; move h(stack) to h(register) if not already that register
@@ -6506,7 +6506,7 @@ cglobal avg, 4, 7, 3, dst, stride, tmp1, tmp2, w, h, stride3
 
 %define W_AVG_INC_PTR AVG_INC_PTR
 
-cglobal w_avg, 4, 7, 6, dst, stride, tmp1, tmp2, w, h, stride3
+cglobal w_avg_8bpc, 4, 7, 6, dst, stride, tmp1, tmp2, w, h, stride3
     LEA                  r6, w_avg_ssse3_table
     tzcnt                wd, wm
     movd                 m4, r6m
@@ -6560,10 +6560,10 @@ cglobal w_avg, 4, 7, 6, dst, stride, tmp1, tmp2, w, h, stride3
 %endmacro
 
 %if ARCH_X86_64
-cglobal mask, 4, 8, 7, dst, stride, tmp1, tmp2, w, h, mask, stride3
+cglobal mask_8bpc, 4, 8, 7, dst, stride, tmp1, tmp2, w, h, mask, stride3
     movifnidn            hd, hm
 %else
-cglobal mask, 4, 7, 7, dst, stride, tmp1, tmp2, w, mask, stride3
+cglobal mask_8bpc, 4, 7, 7, dst, stride, tmp1, tmp2, w, mask, stride3
 %define hd dword r5m
 %endif
 %define base r6-mask_ssse3_table
@@ -6619,7 +6619,7 @@ cglobal mask, 4, 7, 7, dst, stride, tmp1, tmp2, w, mask, stride3
 %define reg_pw_6903 m8
 %define reg_pw_2048 m9
 ; args: dst, stride, tmp1, tmp2, w, h, mask, sign
-cglobal w_mask_420, 4, 8, 10, dst, stride, tmp1, tmp2, w, h, mask
+cglobal w_mask_420_8bpc, 4, 8, 10, dst, stride, tmp1, tmp2, w, h, mask
     lea                  r6, [w_mask_420_ssse3_table]
     mov                  wd, wm
     tzcnt               r7d, wd
@@ -6640,7 +6640,7 @@ cglobal w_mask_420, 4, 8, 10, dst, stride, tmp1, tmp2, w, h, mask
 %else
 %define reg_pw_6903 [base+pw_6903]
 %define reg_pw_2048 m3
-cglobal w_mask_420, 4, 7, 8, dst, stride, tmp1, tmp2, w, mask
+cglobal w_mask_420_8bpc, 4, 7, 8, dst, stride, tmp1, tmp2, w, mask
     tzcnt                wd, wm
     LEA                  r6, w_mask_420_ssse3_table
     movd                 m0, r7m ; sign
@@ -6756,7 +6756,7 @@ cglobal w_mask_420, 4, 7, 8, dst, stride, tmp1, tmp2, w, mask
     BLEND_64M            %1, %2, m2, m3
 %endmacro
 
-cglobal blend, 3, 7, 7, dst, ds, tmp, w, h, mask
+cglobal blend_8bpc, 3, 7, 7, dst, ds, tmp, w, h, mask
 %define base r6-blend_ssse3_table
     LEA                  r6, blend_ssse3_table
     tzcnt                wd, wm
@@ -6832,7 +6832,7 @@ cglobal blend, 3, 7, 7, dst, ds, tmp, w, h, mask
     jg .w32
     RET
 
-cglobal blend_v, 3, 6, 6, dst, ds, tmp, w, h, mask
+cglobal blend_v_8bpc, 3, 6, 6, dst, ds, tmp, w, h, mask
 %define base r5-blend_v_ssse3_table
     LEA                  r5, blend_v_ssse3_table
     tzcnt                wd, wm
@@ -6940,7 +6940,7 @@ cglobal blend_v, 3, 6, 6, dst, ds, tmp, w, h, mask
 %endif
     RET
 
-cglobal blend_h, 3, 7, 6, dst, ds, tmp, w, h, mask
+cglobal blend_h_8bpc, 3, 7, 6, dst, ds, tmp, w, h, mask
 %define base t0-blend_h_ssse3_table
 %if ARCH_X86_32
     ; We need to keep the PIC pointer for w4, reload wd from stack instead
@@ -7054,9 +7054,9 @@ cglobal blend_h, 3, 7, 6, dst, ds, tmp, w, h, mask
 ; bw, bh total filled size
 ; iw, ih, copied block -> fill bottom, right
 ; x, y, offset in bw/bh -> fill top, left
-cglobal emu_edge, 10, 13, 2, bw, bh, iw, ih, x, \
-                             y, dst, dstride, src, sstride, \
-                             bottomext, rightext, blk
+cglobal emu_edge_8bpc, 10, 13, 2, bw, bh, iw, ih, x, \
+                                  y, dst, dstride, src, sstride, \
+                                  bottomext, rightext, blk
     ; we assume that the buffer (stride) is larger than width, so we can
     ; safely overwrite by a few bytes
     pxor                 m1, m1
@@ -7417,14 +7417,14 @@ cextern resize_filter
 %endmacro
 
 %if ARCH_X86_64
-cglobal resize, 0, 14, 16, dst, dst_stride, src, src_stride, \
-                           dst_w, h, src_w, dx, mx0
+cglobal resize_8bpc, 0, 14, 16, dst, dst_stride, src, src_stride, \
+                                dst_w, h, src_w, dx, mx0
 %elif STACK_ALIGNMENT >= 16
-cglobal resize, 0, 7, 8, 3 * 16, dst, dst_stride, src, src_stride, \
-                                 dst_w, h, src_w, dx, mx0
+cglobal resize_8bpc, 0, 7, 8, 3 * 16, dst, dst_stride, src, src_stride, \
+                                      dst_w, h, src_w, dx, mx0
 %else
-cglobal resize, 0, 6, 8, 3 * 16, dst, dst_stride, src, src_stride, \
-                                 dst_w, h, src_w, dx, mx0
+cglobal resize_8bpc, 0, 6, 8, 3 * 16, dst, dst_stride, src, src_stride, \
+                                      dst_w, h, src_w, dx, mx0
 %endif
     movifnidn          dstq, dstmp
     movifnidn          srcq, srcmp


### PR DESCRIPTION
Comparing cherry-picked changes with the full log of `0.9.1..0.9.2`:
* Missing changes to `x86inc.asm` from previous integrations are included.
* The addition of film-grain and `splat_mv` assembly are excluded.

<details>

```diff
+Properly fix LOAD_MM_PERMUTATION for AVX-512
+x86inc: Add stack probing on Windows
+x86inc: Support memory operands in src1 in 3-operand instructions
 x86/itx: 16x4 inverse transforms hbd/sse4
 x86/itx: 16x8 inverse transforms hbd/sse4
 x86/itx: 16x16 inverse transforms hbd/sse4
 x86: Add minor improvements to sgr16 SSSE3 asm
 x86: Rewrite sgr8 SSSE3 asm
 x86/itx: document third argument in INV_TXFM_WxH_FN macros
 x86/itx: replace .transpose8x8 with 2 calls to .transpose4x8packed
 x86/itx: 32x{8,16,32} & {8,16}x32 idtx transforms hbd/sse4
 x86/itx: merge pass=2 rounding and writing operations
 x86: Add bpc suffix to mc functions
 x86: Add minor improvement to mc.resize_8bpc_avx2
 x86: Add high bitdepth mc.resize AVX2 asm
 x86: Fix minor things in mc.resize_8bpc_ssse3
 x86: Add high bitdepth mc.resize SSSE3 asm
 x86/itx: 8x32 inverse dct transforms hbd/sse4
 x86/itx: 16x32 inverse dct transforms hbd/sse4
 x86/itx: 32x8 inverse dct transforms hbd/sse4
 x86/itx: 32x16 inverse dct transforms hbd/sse4
 x86/itx: 32x32 inverse dct transforms hbd/sse4
 x86/itx: split dct/adst/identity pass=2 implementations for 16x8
 x86/itx: combine .write_8x4 and .round{1,2} into a single function
 x86/itx: combine .write_8x8 and .round{1,2,3,4} into a single function
 x86/itx: share pass2 loop between {16,32}x32 dct^2 functions
 x86/itx: add 1/sqrt(2) (rect2) multiply macro
 itx/x86: replace idct8x8.transpose with idct8x4.transpose4x8packed
 itx/x86: rewrite .transpose4x8packed so it uses only m0-3,4&6
-checkasm: Improve register preservation checking on x86
-arm64: filmgrain: Fix some comments in gen_grain
-arm64: filmgrain: Fix some cases of vertical whitespace alignment
-arm64: filmgrain: Uninline the get_grain_2 macro
-arm64: filmgrain: Remove two stray ret instructions
-arm64: filmgrain: Deduplicate the output_lag functions
-arm64: filmgrain: Deduplicate the sum_lagN functions
-arm64: filmgrain16: Add NEON implementation of gen_grain for 16 bpc
 cdef: Remove redundant clipping
 x86: Add high bitdepth cdef_filter SSSE3 asm
 x86/itx: 16x64 inverse dct transforms hbd/sse4
 x86/itx: 32x64 inverse dct transforms hbd/sse4
 x86/itx: 64x16 inverse dct transforms hbd/sse4
 x86/itx: 64x32 inverse dct transforms hbd/sse4
 x86/itx: 64x64 inverse dct transforms hbd/sse4
-x86: Add splat_mv SSE2 asm
-x86: Add splat_mv AVX2 asm
 x86: Prefer tzcnt over bsr in cdef sec_shift calculations
 x86: Improve high bitdepth cdef_filter AVX2 asm
-arm: Add NEON implementations of splat_mv
 x86: Add 8-bit w_mask_422 and w_mask_444 SSSE3 asm
 x86: Automatically convert SSE asm to AVX when compiling for AVX targets
-arm64: filmgrain: Reorder two instructions in the inner loop
-arm64: filmgrain: Simplify loading coefficients for the lag3 variant
-arm64: filmgrain: Remove some unnecessary backups/restores of x30
-arm32: filmgrain: Add NEON implementation of gen_grain for 8 bpc
 x86: Improve high bitdepth cfl_ac AVX2 asm
 x86: Add high bitdepth cfl_ac_444 AVX2 asm
-arm64: filmgrain16: Fix the default elems parameter of sum_lag2/3_func
-arm64: filmgrain16: Remove a leftover unused macro
-arm32: filmgrain: Add NEON implementation of gen_grain for 16 bpc
```

</details>