### PR TITLE
Avoid taking ownership of Arc<Frame<T>> in scenechange API

### DIFF
--- a/src/api/channel/by_gop.rs
+++ b/src/api/channel/by_gop.rs
@@ -66,8 +66,10 @@ impl<T: Pixel> SceneChange<T> {
   fn split(&mut self, lookahead: &[Arc<Frame<T>>]) -> Option<(usize, bool)> {
     self.processed += 1;
 
+    let lookahead_ref: Vec<_> = lookahead[self.frames..].iter().collect();
+
     let new_gop = self.detector.analyze_next_frame(
-      &lookahead[self.frames..],
+      &lookahead_ref,
       self.processed,
       self.last_keyframe,
     );

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -853,7 +853,7 @@ impl<T: Pixel> ContextInner<T> {
     keyframe_detector: &mut SceneChangeDetector<T>,
     next_lookahead_frame: &mut u64, keyframes: &mut BTreeSet<u64>,
   ) {
-    if keyframes_forced.contains(&next_lookahead_frame)
+    if keyframes_forced.contains(next_lookahead_frame)
       || keyframe_detector.analyze_next_frame(
         lookahead_frames,
         *next_lookahead_frame,

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -357,8 +357,8 @@ impl<T: Pixel> ContextInner<T> {
       let lookahead_frames = self
         .frame_q
         .range(self.next_lookahead_frame - 1..)
-        .filter_map(|(&_input_frameno, frame)| frame.clone())
-        .collect::<Vec<_>>();
+        .filter_map(|(&_input_frameno, frame)| frame.as_ref())
+        .collect::<Vec<&Arc<Frame<T>>>>();
 
       if is_flushing {
         // This is the last time send_frame is called, process all the
@@ -371,10 +371,22 @@ impl<T: Pixel> ContextInner<T> {
             break;
           }
 
-          self.compute_keyframe_placement(cur_lookahead_frames);
+          Self::compute_keyframe_placement(
+            cur_lookahead_frames,
+            &self.keyframes_forced,
+            &mut self.keyframe_detector,
+            &mut self.next_lookahead_frame,
+            &mut self.keyframes,
+          );
         }
       } else {
-        self.compute_keyframe_placement(&lookahead_frames);
+        Self::compute_keyframe_placement(
+          &lookahead_frames,
+          &self.keyframes_forced,
+          &mut self.keyframe_detector,
+          &mut self.next_lookahead_frame,
+          &mut self.keyframes,
+        );
       }
     }
 
@@ -837,19 +849,21 @@ impl<T: Pixel> ContextInner<T> {
 
   #[hawktracer(compute_keyframe_placement)]
   pub fn compute_keyframe_placement(
-    &mut self, lookahead_frames: &[Arc<Frame<T>>],
+    lookahead_frames: &[&Arc<Frame<T>>], keyframes_forced: &BTreeSet<u64>,
+    keyframe_detector: &mut SceneChangeDetector<T>,
+    next_lookahead_frame: &mut u64, keyframes: &mut BTreeSet<u64>,
   ) {
-    if self.keyframes_forced.contains(&self.next_lookahead_frame)
-      || self.keyframe_detector.analyze_next_frame(
+    if keyframes_forced.contains(&next_lookahead_frame)
+      || keyframe_detector.analyze_next_frame(
         lookahead_frames,
-        self.next_lookahead_frame,
-        *self.keyframes.iter().last().unwrap(),
+        *next_lookahead_frame,
+        *keyframes.iter().last().unwrap(),
       )
     {
-      self.keyframes.insert(self.next_lookahead_frame);
+      keyframes.insert(*next_lookahead_frame);
     }
 
-    self.next_lookahead_frame += 1;
+    *next_lookahead_frame += 1;
   }
 
   #[hawktracer(compute_frame_invariants)]

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -166,7 +166,7 @@ impl<T: Pixel> SceneChangeDetector<T> {
   /// This will gracefully handle the first frame in the video as well.
   #[hawktracer(analyze_next_frame)]
   pub fn analyze_next_frame(
-    &mut self, frame_set: &[Arc<Frame<T>>], input_frameno: u64,
+    &mut self, frame_set: &[&Arc<Frame<T>>], input_frameno: u64,
     previous_keyframe: u64,
   ) -> bool {
     // Use score deque for adaptive threshold for scene cut
@@ -254,7 +254,7 @@ impl<T: Pixel> SceneChangeDetector<T> {
 
   // Initially fill score deque with frame scores
   fn initialize_score_deque(
-    &mut self, frame_set: &[Arc<Frame<T>>], input_frameno: u64,
+    &mut self, frame_set: &[&Arc<Frame<T>>], input_frameno: u64,
     init_len: usize,
   ) {
     for x in 0..init_len {


### PR DESCRIPTION
The current use of taking ownership of the passed in `Arc<Frame<T>>` in the scenechange module becomes problematic when trying to pass in a struct wrapped in `ManuallyDrop`, as it attempts to run the destructor and you can't coerce a `ManuallyDrop<Arc<Frame<T>>>` into an `Arc<Frame<T>>` that doesn't run the destructor.