### PR TITLE
Add T.35 metadata support.

### DIFF
--- a/src/api/context.rs
+++ b/src/api/context.rs
@@ -88,6 +88,7 @@ impl<T: Pixel> Context<T> {
   /// let info = FrameParameters {
   ///   frame_type_override: FrameTypeOverride::Key,
   ///   opaque: None,
+  ///   ..Default::default()
   /// };
   ///
   /// // Send the plain frame data

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -184,10 +184,22 @@ pub(crate) fn estimate_inter_costs<T: Pixel>(
   config.low_latency = true;
   config.speed_settings.multiref = false;
   let inter_cfg = InterConfig::new(&config);
-  let last_fi = FrameInvariants::new_key_frame(Arc::new(config), sequence, 0);
-  let mut fi =
-    FrameInvariants::new_inter_frame(&last_fi, &inter_cfg, 0, 1, 2, false)
-      .unwrap();
+  let last_fi = FrameInvariants::new_key_frame(
+    Arc::new(config),
+    sequence,
+    0,
+    Box::new([]),
+  );
+  let mut fi = FrameInvariants::new_inter_frame(
+    &last_fi,
+    &inter_cfg,
+    0,
+    1,
+    2,
+    false,
+    Box::new([]),
+  )
+  .unwrap();
 
   // Compute the motion vectors.
   let mut fs = FrameState::new_with_frame_and_me_stats_and_rec(

--- a/src/api/util.rs
+++ b/src/api/util.rs
@@ -137,6 +137,17 @@ impl fmt::Display for FrameType {
   }
 }
 
+/// A single T.35 metadata packet.
+#[derive(Clone, Debug, Default)]
+pub struct T35 {
+  /// Country code.
+  pub country_code: u8,
+  /// Country code extension bytes (if country_code == 0xFF)
+  pub country_code_extension_byte: u8,
+  /// T.35 payload.
+  pub data: Box<[u8]>,
+}
+
 /// Status that can be returned by [`Context`] functions.
 ///
 /// [`Context`]: struct.Context.html

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -200,8 +200,11 @@ impl EncContext {
     &mut self, frame: Option<FrameInternal>, frame_type: FrameTypeOverride,
     opaque: Option<rav1e::Opaque>,
   ) -> Result<(), rav1e::EncoderStatus> {
-    let info =
-      rav1e::FrameParameters { frame_type_override: frame_type, opaque };
+    let info = rav1e::FrameParameters {
+      frame_type_override: frame_type,
+      opaque,
+      t35_metadata: Box::new([]),
+    };
     if let Some(frame) = frame {
       match (self, frame) {
         (EncContext::U8(ctx), FrameInternal::U8(ref f)) => {

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -9,7 +9,7 @@
 
 use num_derive::FromPrimitive;
 
-use crate::api::Opaque;
+use crate::api::{Opaque, T35};
 use crate::context::SB_SIZE;
 use crate::mc::SUBPEL_FILTER_SIZE;
 use crate::util::*;
@@ -34,13 +34,21 @@ pub enum FrameTypeOverride {
   Key,
 }
 
+impl Default for FrameTypeOverride {
+  fn default() -> Self {
+    FrameTypeOverride::No
+  }
+}
+
 /// Optional per-frame encoder parameters
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct FrameParameters {
   /// Force emitted frame to be of the type selected
   pub frame_type_override: FrameTypeOverride,
   /// Output the provided data in the matching encoded Packet
   pub opaque: Option<Opaque>,
+  /// List of t35 metadata associated with this frame
+  pub t35_metadata: Box<[T35]>,
 }
 
 pub use v_frame::frame::Frame;

--- a/tests/doctests.rs
+++ b/tests/doctests.rs
@@ -9,6 +9,7 @@ fn send_frame() -> Result<(), Box<dyn std::error::Error>> {
   let info = FrameParameters {
     frame_type_override: FrameTypeOverride::Key,
     opaque: None,
+    ..Default::default()
   };
 
   // Send the plain frame data


### PR DESCRIPTION
This currently only adds a Rust API. Note that this is a breaking
change as it extends the publicly visible "params" struct.

The T.35 metadata support in AV1 is very flexible - this is
intended in particular for T.35 metadata attached to frames,
in the style of the AV1 HDR10+ metadata specification:

https://aomediacodec.github.io/av1-hdr10plus/
