### PR TITLE
CI: Improve Windows toolchains

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -357,8 +357,6 @@ jobs:
         include:
           - conf: cargo-build
             target: x86_64-pc-windows-msvc
-          - conf: cargo-build
-            target: aarch64-pc-windows-msvc
           - conf: cargo-test
             target: x86_64-pc-windows-msvc
           - conf: cargo-c
@@ -384,28 +382,12 @@ jobs:
           curl -LO "$LINK/$SCCACHE_FILE.tar.gz"
           tar xzf "$SCCACHE_FILE.tar.gz"
           echo "$Env:GITHUB_WORKSPACE/$SCCACHE_FILE" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Set MSVC x86_64 linker path
-        if: matrix.target != 'aarch64-pc-windows-msvc'
-        run: |
-          $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
-          $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
-          $LinkPath = vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1
-          echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Set MSVC Arm64 linker path
-        if: matrix.target == 'aarch64-pc-windows-msvc'
-        run: |
-          $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\Arm64"
-          $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
-          $LinkPath = vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1
-          echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Install ${{ matrix.toolchain }}
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
-          target: ${{ matrix.target }}
+          toolchain: stable-${{ matrix.target }}
           override: true
-          default: true
       - name: Install cargo-c
         if: matrix.conf == 'cargo-c'
         run: |


### PR DESCRIPTION
This PR improves Windows toolchains:

- Remove bugged aarch64 target not to waste CI time
- Remove linker options because they are now default in GitHub Actions

Closes #2721 