### PR TITLE
Stabilize the --film-grain-table parameter

### DIFF
--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -10,7 +10,6 @@
 use itertools::*;
 
 use crate::api::color::*;
-#[cfg(feature = "unstable")]
 use crate::api::config::GrainTableSegment;
 use crate::api::{Rational, SpeedSettings};
 use crate::encoder::Tune;
@@ -85,7 +84,6 @@ pub struct EncoderConfig {
   /// Metric to tune the quality for.
   pub tune: Tune,
   /// Parameters for grain synthesis.
-  #[cfg(feature = "unstable")]
   pub film_grain_params: Option<Vec<GrainTableSegment>>,
   /// Number of tiles horizontally. Must be a power of two.
   ///
@@ -163,7 +161,6 @@ impl EncoderConfig {
       quantizer: 100,
       bitrate: 0,
       tune: Tune::default(),
-      #[cfg(feature = "unstable")]
       film_grain_params: None,
       tile_cols: 0,
       tile_rows: 0,
@@ -237,7 +234,6 @@ impl EncoderConfig {
       .unwrap_or(false)
   }
 
-  #[cfg(feature = "unstable")]
   pub(crate) fn get_film_grain_at(
     &self, timestamp: u64,
   ) -> Option<&GrainTableSegment> {
@@ -248,7 +244,6 @@ impl EncoderConfig {
     })
   }
 
-  #[cfg(feature = "unstable")]
   pub(crate) fn get_film_grain_mut_at(
     &mut self, timestamp: u64,
   ) -> Option<&mut GrainTableSegment> {

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -18,7 +18,6 @@ use crate::util::Pixel;
 mod encoder;
 pub use encoder::*;
 
-#[cfg(feature = "unstable")]
 pub use av1_grain::*;
 
 mod rate;

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -2077,7 +2077,6 @@ fn log_q_exp_overflow() {
     min_quantizer: 64,
     bitrate: 1,
     tune: Tune::Psychovisual,
-    #[cfg(feature = "unstable")]
     film_grain_params: None,
     tile_cols: 0,
     tile_rows: 0,
@@ -2155,7 +2154,6 @@ fn guess_frame_subtypes_assert() {
     min_quantizer: 0,
     bitrate: 16384,
     tune: Tune::Psychovisual,
-    #[cfg(feature = "unstable")]
     film_grain_params: None,
     tile_cols: 0,
     tile_rows: 0,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -8,7 +8,6 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use crate::activity::*;
-#[cfg(feature = "unstable")]
 use crate::api::config::GrainTableSegment;
 use crate::api::*;
 use crate::cdef::*;
@@ -333,14 +332,11 @@ impl Sequence {
       decoder_model_info_present_flag: false,
       level,
       tier,
-      #[cfg(feature = "unstable")]
       film_grain_params_present: config
         .film_grain_params
         .as_ref()
         .map(|entries| !entries.is_empty())
         .unwrap_or(false),
-      #[cfg(not(feature = "unstable"))]
-      film_grain_params_present: false,
       timing_info_present: config.enable_timing_info,
       time_base: config.time_base,
     }
@@ -1003,7 +999,6 @@ impl<T: Pixel> FrameInvariants<T> {
     fi.input_frameno = input_frameno;
     fi.me_range_scale = (inter_cfg.group_input_len >> fi.pyramid_level) as u8;
 
-    #[cfg(feature = "unstable")]
     if fi.show_frame || fi.showable_frame {
       let cur_frame_time = fi.frame_timestamp();
       // Increment the film grain seed for the next frame
@@ -1201,7 +1196,6 @@ impl<T: Pixel> FrameInvariants<T> {
     self.sequence.tiling.sb_size_log2
   }
 
-  #[cfg(feature = "unstable")]
   pub fn film_grain_params(&self) -> Option<&GrainTableSegment> {
     if !(self.show_frame || self.showable_frame) {
       return None;
@@ -1210,7 +1204,6 @@ impl<T: Pixel> FrameInvariants<T> {
     self.config.get_film_grain_at(cur_frame_time)
   }
 
-  #[cfg(feature = "unstable")]
   pub fn frame_timestamp(&self) -> u64 {
     // I don't know why this is the base unit for a timestamp but it is. 1/10000000 of a second.
     const TIMESTAMP_BASE_UNIT: u64 = 10_000_000;

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -258,7 +258,6 @@ impl Arbitrary for ArbitraryEncoder {
       enable_timing_info: Arbitrary::arbitrary(u)?,
       switch_frame_interval: u.int_in_range(0..=3)?,
       tune: *u.choose(&[Tune::Psnr, Tune::Psychovisual])?,
-      #[cfg(feature = "unstable")]
       film_grain_params: None,
     };
 
@@ -381,7 +380,6 @@ pub fn fuzz_encode_decode<T: Pixel>(p: DecodeTestParameters<T>) {
     p.tile_cols_log2,
     p.tile_rows_log2,
     p.still_picture,
-    #[cfg(feature = "unstable")]
     None,
   );
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -812,7 +812,6 @@ impl<W: io::Write> UncompressedHeader for BitWriter<W, BigEndian> {
       }
     }
 
-    #[cfg(feature = "unstable")]
     if fi.sequence.film_grain_params_present {
       if let Some(grain_params) = fi.film_grain_params() {
         // Apply grain

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,6 @@ pub use crate::api::color;
 
 /// Encoder configuration and settings
 pub mod config {
-  #[cfg(feature = "unstable")]
   pub use crate::api::config::{
     GrainTableSegment, NoiseGenArgs, TransferFunction, NUM_UV_COEFFS,
     NUM_UV_POINTS, NUM_Y_COEFFS, NUM_Y_POINTS,


### PR DESCRIPTION
The grain table spec does not require denoising, and is consistent across all three major AV1 encoders. I believe it makes sense to stabilize this while the grain synth denoising is being worked out. This also keeps the old name `--photon-noise-table` for compatibility, but since grain tables are not specific to photon noise, the canonical name is changed to `--film-grain-table`.

Using a grain table already requires being a somewhat advanced user, given that it requires an external tool to generate one (or writing one by hand), so there is less risk of beginners accidentally stumbling upon it and having it not do what they expect.