### PR TITLE
Use frame-relative spatiotemporal scores

### DIFF
--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -2279,9 +2279,9 @@ fn min_quantizer_bounds_correctly() {
     ctx.inner.encode_packet(i).unwrap();
     let frame_data = ctx.inner.frame_data.get(&i).unwrap().as_ref().unwrap();
     if i == 0 {
-      assert_eq!(79, frame_data.fi.base_q_idx);
+      assert_eq!(68, frame_data.fi.base_q_idx);
     } else {
-      assert_eq!(103, frame_data.fi.base_q_idx);
+      assert_eq!(96, frame_data.fi.base_q_idx);
     }
   }
 
@@ -2310,9 +2310,9 @@ fn min_quantizer_bounds_correctly() {
     ctx.inner.encode_packet(i).unwrap();
     let frame_data = ctx.inner.frame_data.get(&i).unwrap().as_ref().unwrap();
     if i == 0 {
-      assert!(frame_data.fi.base_q_idx > 79);
+      assert!(frame_data.fi.base_q_idx > 68);
     } else {
-      assert!(frame_data.fi.base_q_idx > 103);
+      assert!(frame_data.fi.base_q_idx > 96);
     }
   }
 }
@@ -2344,9 +2344,9 @@ fn max_quantizer_bounds_correctly() {
     ctx.inner.encode_packet(i).unwrap();
     let frame_data = ctx.inner.frame_data.get(&i).unwrap().as_ref().unwrap();
     if i == 0 {
-      assert_eq!(102, frame_data.fi.base_q_idx);
+      assert_eq!(95, frame_data.fi.base_q_idx);
     } else {
-      assert_eq!(123, frame_data.fi.base_q_idx);
+      assert_eq!(115, frame_data.fi.base_q_idx);
     }
   }
 
@@ -2375,9 +2375,9 @@ fn max_quantizer_bounds_correctly() {
     ctx.inner.encode_packet(i).unwrap();
     let frame_data = ctx.inner.frame_data.get(&i).unwrap().as_ref().unwrap();
     if i == 0 {
-      assert!(frame_data.fi.base_q_idx < 102);
+      assert!(frame_data.fi.base_q_idx < 95);
     } else {
-      assert!(frame_data.fi.base_q_idx < 123);
+      assert!(frame_data.fi.base_q_idx < 115);
     }
   }
 }


### PR DESCRIPTION
This should enhance the effectiveness of dynamic segmentation by normalizing the scales.

AWCY results for [objective-fast-1 at default speed](https://beta.arewecompressedyet.com/?job=master-0bee40b875b694fe5cb85d65a309dbdd9edaa423&job=rate-control-frame-mean-rebased%402022-08-09T17%3A02%3A49.994Z)
| PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |    SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |   VMAF | VMAF-NEG |
|   ---: |    ---: |    ---: |      ---: |    ---: |    ---: |       ---: |        ---: |        ---: |     ---: |   ---: |     ---: |
| 2.1192 |  0.0424 | -0.4626 |    0.2634 | -1.9722 | -1.9259 |     0.6551 |     -1.4601 |     -1.9457 |   0.6588 | 1.2593 |   1.3857 |