### PR TITLE
segmentation: Limit minimum segment to avoid lossless mode

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -571,6 +571,7 @@ pub struct SegmentationState {
   pub features: [[bool; SegLvl::SEG_LVL_MAX as usize]; 8],
   pub data: [[i16; SegLvl::SEG_LVL_MAX as usize]; 8],
   pub segment_map: [usize; 8],
+  pub min_segment: u8,
 }
 
 // Frame Invariants are invariant inside a frame


### PR DESCRIPTION
It is possible for inter frames to have lower base_q_idx than intra when temporal complexity is low, due to rate control.
Find and restrict to the maximum valid segment. Fixes #2985.