### PR TITLE
Implement `SegmentationLevel::Full` again

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -572,6 +572,7 @@ pub struct SegmentationState {
   pub data: [[i16; SegLvl::SEG_LVL_MAX as usize]; 8],
   pub segment_map: [usize; 8],
   pub min_segment: u8,
+  pub max_segment: u8,
 }
 
 // Frame Invariants are invariant inside a frame

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -230,6 +230,7 @@ fn segmentation_optimize_inner<T: Pixel>(
 
   fs.segmentation.segment_map = remap_segment_tab;
 
+  fs.segmentation.max_segment = num_segments as u8 - 1;
   for i in 0..num_segments {
     fs.segmentation.features[i][SegLvl::SEG_LVL_ALT_Q as usize] = true;
     fs.segmentation.data[i][SegLvl::SEG_LVL_ALT_Q as usize] =
@@ -244,6 +245,11 @@ pub fn select_segment<T: Pixel>(
   // If skip is true or segmentation is turned off, sidx is not coded.
   if skip || !fi.enable_segmentation {
     return 0..=0;
+  }
+
+  use crate::api::SegmentationLevel;
+  if fi.config.speed_settings.segmentation == SegmentationLevel::Full {
+    return ts.segmentation.min_segment..=ts.segmentation.max_segment;
   }
 
   let frame_bo = ts.to_frame_block_offset(tile_bo);


### PR DESCRIPTION
This feature was inadvertently removed when `select_segment()` was
rewritten in #2933.

AWCY results on [obective-1-fast at speed level 0](https://beta.arewecompressedyet.com/?job=issue-2985-s0%402022-08-12T22%3A43%3A41.354Z&job=segmentation-level-full-s0%402022-08-13T00%3A38%3A05.050Z):

|  PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |    SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |    VMAF | VMAF-NEG |
|    ---: |    ---: |    ---: |      ---: |    ---: |    ---: |       ---: |        ---: |        ---: |     ---: |    ---: |     ---: |
| -4.9622 |  0.0513 | -0.5654 |   -2.1766 | -1.2898 | -1.0981 |    -4.0175 |      2.4461 |      1.4434 |  -3.8521 | -4.8615 |  -4.7457 |

Encoding time relative to `SegmentationLevel::Simple` was 262%.