### PR TITLE
Use fixed-sized array in luma/chroma pred mode counts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,13 @@ check_asm = []
 capi = []
 tracing = ["rust_hawktracer/profiling_enabled"]
 scenechange = []
-serialize = ["serde", "toml", "v_frame/serialize", "arrayvec/serde"]
+serialize = [
+    "serde",
+    "toml",
+    "v_frame/serialize",
+    "arrayvec/serde",
+    "serde-big-array",
+]
 wasm = ["wasm-bindgen"]
 
 # Enables debug dumping of lookahead computation results, specifically:
@@ -64,7 +70,12 @@ dump_lookahead_data = ["byteorder", "image"]
 arg_enum_proc_macro = "0.3"
 bitstream-io = "1"
 cfg-if = "1.0"
-clap = { version = "3.2.6", optional = true, default-features = false, features = ["color", "std", "wrap_help", "derive"] }
+clap = { version = "3.2.6", optional = true, default-features = false, features = [
+    "color",
+    "std",
+    "wrap_help",
+    "derive",
+] }
 clap_complete = { version = "3", optional = true }
 libc = "0.2"
 y4m = { version = "0.7", optional = true }
@@ -99,6 +110,7 @@ nom = { version = "7.0.0", optional = true }
 new_debug_unreachable = "1.0.4"
 once_cell = "1.13.0"
 av1-grain = { version = "0.1.1", features = ["serialize"] }
+serde-big-array = { version = "0.4.1", optional = true }
 
 [dependencies.image]
 version = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,13 +50,7 @@ check_asm = []
 capi = []
 tracing = ["rust_hawktracer/profiling_enabled"]
 scenechange = []
-serialize = [
-    "serde",
-    "toml",
-    "v_frame/serialize",
-    "arrayvec/serde",
-    "serde-big-array",
-]
+serialize = ["serde", "toml", "v_frame/serialize", "serde-big-array"]
 wasm = ["wasm-bindgen"]
 
 # Enables debug dumping of lookahead computation results, specifically:

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -11,7 +11,6 @@ use crate::partition::BlockSize;
 use crate::predict::PREDICTION_MODES;
 use crate::serialize::{Deserialize, Serialize};
 use crate::transform::TX_TYPES;
-use arrayvec::ArrayVec;
 use std::ops::{Add, AddAssign};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -23,21 +22,15 @@ pub struct EncoderStats {
   /// Stores count of pixels belonging to each transform type in this frame
   pub tx_type_counts: [usize; TX_TYPES],
   /// Stores count of pixels belonging to each luma prediction mode in this frame
-  pub luma_pred_mode_counts: ArrayVec<usize, PREDICTION_MODES>,
+  pub luma_pred_mode_counts: [usize; PREDICTION_MODES],
   /// Stores count of pixels belonging to each chroma prediction mode in this frame
-  pub chroma_pred_mode_counts: ArrayVec<usize, PREDICTION_MODES>,
+  pub chroma_pred_mode_counts: [usize; PREDICTION_MODES],
 }
 
 impl Default for EncoderStats {
   fn default() -> Self {
-    let mut luma_pred_mode_counts = ArrayVec::new();
-    luma_pred_mode_counts
-      .try_extend_from_slice(&[0; PREDICTION_MODES])
-      .unwrap();
-    let mut chroma_pred_mode_counts = ArrayVec::new();
-    chroma_pred_mode_counts
-      .try_extend_from_slice(&[0; PREDICTION_MODES])
-      .unwrap();
+    let luma_pred_mode_counts = [0; PREDICTION_MODES];
+    let chroma_pred_mode_counts = [0; PREDICTION_MODES];
     EncoderStats {
       block_size_counts: [0; BlockSize::BLOCK_SIZES_ALL],
       skip_block_count: 0,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -11,6 +11,10 @@ use crate::partition::BlockSize;
 use crate::predict::PREDICTION_MODES;
 use crate::serialize::{Deserialize, Serialize};
 use crate::transform::TX_TYPES;
+
+#[cfg(feature = "serialize")]
+use serde_big_array::BigArray;
+
 use std::ops::{Add, AddAssign};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -22,8 +26,10 @@ pub struct EncoderStats {
   /// Stores count of pixels belonging to each transform type in this frame
   pub tx_type_counts: [usize; TX_TYPES],
   /// Stores count of pixels belonging to each luma prediction mode in this frame
+  #[serde(with = "BigArray")]
   pub luma_pred_mode_counts: [usize; PREDICTION_MODES],
   /// Stores count of pixels belonging to each chroma prediction mode in this frame
+  #[serde(with = "BigArray")]
   pub chroma_pred_mode_counts: [usize; PREDICTION_MODES],
 }
 


### PR DESCRIPTION
According to #2236, this was converted to an ArrayVec since at that time Rust did not support deriving `Debug` for fixed-sized arrays above 32 elements, but this is no longer the case and thus ArrayVec is not needed.