### PR TITLE
Adjust chroma offsets for frame-mean spatiotemporal scale

### DIFF
--- a/src/rate.rs
+++ b/src/rate.rs
@@ -745,7 +745,8 @@ impl QuantizerParameters {
     }
 
     let quantizer = bexp64(log_q_y + scale);
-    let (offset_u, offset_v) = chroma_offset(log_q_y, chroma_sampling);
+    let (offset_u, offset_v) =
+      chroma_offset(log_q_y + log_isqrt_mean_scale, chroma_sampling);
     let mono = chroma_sampling == ChromaSampling::Cs400;
     let log_q_u = log_q_y + offset_u;
     let log_q_v = log_q_y + offset_v;


### PR DESCRIPTION
This removes a long-standing implicit boost of chroma quality for `tune=Psychovisual`. Which looks a lot like stealing chroma bits to boost luma, so it is instructive to compare against a baseline of `tune=Psnr`.

[master-537b1b91-psnr -> master-537b1b91-psy](https://beta.arewecompressedyet.com/?job=master-537b1b91-psnr%402022-08-17T13%3A24%3A15.386Z&job=master-537b1b91b861210062b1cf105a5bd0243bab0b90):
| PSNR Y |  PSNR Cb |  PSNR Cr | CIEDE2000 |     SSIM |  MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |   VMAF | VMAF-NEG |
|   ---: |     ---: |     ---: |      ---: |     ---: |     ---: |       ---: |        ---: |        ---: |     ---: |   ---: |     ---: |
| 4.0327 | -13.3105 | -13.5377 |   -7.3436 | -11.4949 | -12.0294 |    -0.6906 |    -16.1168 |    -16.4373 |  -1.1119 | 2.9790 |   3.4978 |

[master-537b1b91-psnr -> steal-chroma-bits-psy](https://beta.arewecompressedyet.com/?job=master-537b1b91-psnr%402022-08-17T13%3A24%3A15.386Z&job=steal-chroma-bits%402022-08-17T13%3A23%3A46.996Z):
| PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |     SSIM |  MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |   VMAF | VMAF-NEG |
|   ---: |    ---: |    ---: |      ---: |     ---: |     ---: |       ---: |        ---: |        ---: |     ---: |   ---: |     ---: |
| 1.9375 | -0.5029 | -1.2879 |   -5.4012 | -13.2846 | -13.7977 |    -2.7330 |     -3.4827 |     -4.4729 |  -2.5604 | 1.1417 |   1.5887 |

Note how the PSNR-HVS differences are more consistent between planes.

[master-537b1b91-psy -> steal-chroma-bits-psy](https://beta.arewecompressedyet.com/?job=master-537b1b91b861210062b1cf105a5bd0243bab0b90&job=steal-chroma-bits%402022-08-17T13%3A23%3A46.996Z):
|  PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |    SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |    VMAF | VMAF-NEG |
|    ---: |    ---: |    ---: |      ---: |    ---: |    ---: |       ---: |        ---: |        ---: |     ---: |    ---: |     ---: |
| -1.9474 | 14.9974 | 14.2232 |    2.2253 | -1.9988 | -1.9685 |    -2.0192 |     15.1318 |     14.1927 |  -1.3939 | -1.7462 |  -1.8068 |