### PR TITLE
Compute segmentation map thresholds from the offsets

### DIFF
--- a/benches/dist.rs
+++ b/benches/dist.rs
@@ -148,7 +148,7 @@ pub fn get_satd(c: &mut Criterion) {
 fn fill_scaling(ra: &mut ChaChaRng, scales: &mut [u32]) {
   for a in scales.iter_mut() {
     *a =
-      ra.gen_range(DistortionScale::new(0.5).0..DistortionScale::new(1.5).0);
+      ra.gen_range(DistortionScale::from(0.5).0..DistortionScale::from(1.5).0);
   }
 }
 

--- a/src/asm/x86/dist/sse.rs
+++ b/src/asm/x86/dist/sse.rs
@@ -281,7 +281,7 @@ pub mod test {
     let mut rng = thread_rng();
     for a in scales.iter_mut() {
       *a = rng
-        .gen_range(DistortionScale::new(0.5).0..DistortionScale::new(1.5).0);
+        .gen_range(DistortionScale::from(0.5).0..DistortionScale::from(1.5).0);
     }
   }
 
@@ -289,8 +289,7 @@ pub mod test {
   /// TODO: Pair with max difference test
   fn scaling_large(scales: &mut [u32]) {
     for a in scales.iter_mut() {
-      // this works since DistortionScale::new caps its input
-      *a = DistortionScale::new(f64::MAX).0;
+      *a = DistortionScale::from(f64::MAX).0;
     }
   }
 


### PR DESCRIPTION
AWCY results for [objective-1-fast at default speed](https://beta.arewecompressedyet.com/?job=master-3c05349095b4cdf1887c03f615c904799abe7ea3&job=segment-map%402022-08-19T06%3A01%3A31.082Z):

|  PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |   SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |    VMAF | VMAF-NEG |
|    ---: |    ---: |    ---: |      ---: |   ---: |    ---: |       ---: |        ---: |        ---: |     ---: |    ---: |     ---: |
| -1.0439 | -1.2423 | -1.2902 |   -0.3670 | 0.9061 |  0.8534 |    -0.4362 |     -0.9269 |     -1.0861 |  -0.4454 | -0.6953 |  -0.7345 |

Includes reworking of `DistortionScale` construction so that constants may be defined from rational numbers.