### PR TITLE
Add missing code for segmentation with --tune Psnr

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1327,6 +1327,7 @@ impl<T: Pixel> ContextInner<T> {
           inv_mean_scale_q12 = coded_data.compute_spatiotemporal_scores();
         } else {
           coded_data.activity_mask = ActivityMask::default();
+          inv_mean_scale_q12 = coded_data.compute_temporal_scores();
         }
       }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -756,6 +756,16 @@ impl<T: Pixel> CodedFrameData<T> {
 
     inv_mean.0
   }
+
+  // Assumes that we have already computed distortion_scales
+  pub fn compute_temporal_scores(&mut self) -> u32 {
+    let inv_mean = DistortionScale::inv_mean(&self.distortion_scales);
+    for scale in self.distortion_scales.iter_mut() {
+      *scale *= inv_mean;
+    }
+    self.spatiotemporal_scores = self.distortion_scales.clone();
+    inv_mean.0
+  }
 }
 
 pub(crate) const fn pos_to_lvl(pos: u64, pyramid_depth: u64) -> u64 {


### PR DESCRIPTION
Without this, encoding with `--tune Psnr` crashes:
```
thread 'main' panicked at 'attempt to subtract with overflow', /home/davidbarr/Archive/exp/rav1e/src/util/kmeans.rs:23:42
stack backtrace:
```
<details>

```
   0: rust_begin_unwind
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:142:14
   2: core::panicking::panic
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:48:5
   3: rav1e::util::kmeans::kmeans::{{closure}}
             at ./src/util/kmeans.rs:23:42
   4: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:301:13
   5: core::option::Option<T>::map
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/option.rs:929:29
   6: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/adapters/map.rs:103:9
   7: <&mut I as core::iter::traits::iterator::Iterator>::next
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/traits/iterator.rs:3781:9
   8: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/adapters/map.rs:103:9
   9: core::array::try_collect_into_array
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/array/mod.rs:824:33
  10: core::array::try_collect_into_array_unchecked
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/array/mod.rs:764:14
  11: core::array::collect_into_array_unchecked
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/array/mod.rs:777:20
  12: core::array::<impl [T; N]>::map
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/array/mod.rs:445:18
  13: rav1e::util::kmeans::kmeans
             at ./src/util/kmeans.rs:23:5
  14: rav1e::segmentation::segmentation_optimize_inner
             at ./src/segmentation.rs:93:6
  15: rav1e::segmentation::segmentation_optimize
             at ./src/segmentation.rs:57:5
  16: rav1e::encoder::encode_frame
             at ./src/encoder.rs:3770:5
  17: rav1e::api::internal::ContextInner<T>::encode_packet
             at ./src/api/internal.rs:1366:9
  18: rav1e::api::internal::ContextInner<T>::receive_packet
             at ./src/api/internal.rs:1485:19
  19: rav1e::api::context::Context<T>::receive_packet::{{closure}}
             at ./src/api/context.rs:309:27
  20: rav1e::api::context::Context<T>::receive_packet
             at ./src/api/context.rs:313:15
  21: rav1e::process_frame
             at ./src/bin/rav1e.rs:172:21
  22: rav1e::do_encode
             at ./src/bin/rav1e.rs:272:32
  23: rav1e::run
             at ./src/bin/rav1e.rs:584:5
  24: rav1e::main
             at ./src/bin/rav1e.rs:318:3
  25: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
```

</details>