### PR TITLE
segmentation: Change precision of `log(scale)` to Q23

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -594,6 +594,14 @@ impl DistortionScale {
     )
   }
 
+  /// Binary logarithm in Q23
+  #[inline]
+  pub fn blog32(self) -> i32 {
+    const SCALE: f32 = (1 << 23) as f32;
+    const OFFSET: f32 = 0.5 - DistortionScale::SHIFT as f32 * SCALE;
+    (self.0 as f32).log2().mul_add(SCALE, OFFSET) as i32
+  }
+
   /// Multiply, round and shift
   /// Internal implementation, so don't use multiply trait.
   #[inline]


### PR DESCRIPTION
This is aligned to IEEE 754 `binary32` precision and avoids possible saturation of `i32` from extreme values of `DistortionScale`.
Also, restore internal documentation from the draft of #2993.