### PR TITLE
Replace binary log in `segmentation_optimize` with a polynomial approximation in Q11

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -594,11 +594,11 @@ impl DistortionScale {
     )
   }
 
-  /// Binary logarithm in Q24
+  /// Binary logarithm in Q11
   #[inline]
-  pub const fn blog32(self) -> i32 {
-    use crate::util::blog32;
-    blog32(self.0) - ((Self::SHIFT as i32) << 24)
+  pub const fn blog32(self) -> i16 {
+    use crate::util::blog32_q11;
+    (blog32_q11(self.0) - ((Self::SHIFT as i32) << 11)) as i16
   }
 
   /// Multiply, round and shift

--- a/src/util/logexp.rs
+++ b/src/util/logexp.rs
@@ -178,6 +178,7 @@ pub const fn blog64(n: i64) -> i64 {
 /// Computes the binary log of `n`.
 /// `n`: an unsigned 32-bit integer in Q0 (no fraction).
 /// Returns a signed 32-bit log in Q24.
+#[allow(unused)]
 pub const fn blog32(n: u32) -> i32 {
   if n == 0 {
     return -1;
@@ -268,9 +269,8 @@ pub const fn bexp32_q10(z: i32) -> u32 {
 }
 
 /// Polynomial approximation of a binary logarithm.
-/// Q0 input, Q10 output.
-#[allow(unused)]
-pub const fn blog32_q10(w: u32) -> i32 {
+/// Q0 input, Q11 output.
+pub const fn blog32_q11(w: u32) -> i32 {
   if w == 0 {
     return -1;
   }
@@ -284,7 +284,7 @@ pub const fn blog32_q10(w: u32) -> i32 {
       + 15745)
   } >> 15)
     - 6793;
-  (ipart << 10) + (fpart >> 4)
+  (ipart << 11) + (fpart >> 3)
 }
 
 #[cfg(test)]

--- a/src/util/logexp.rs
+++ b/src/util/logexp.rs
@@ -249,6 +249,44 @@ pub const fn bexp_q24(log_scale: i32) -> i64 {
   (1i64 << 47) - 1
 }
 
+/// Polynomial approximation of a binary exponential.
+/// Q10 input, Q0 output.
+#[allow(unused)]
+pub const fn bexp32_q10(z: i32) -> u32 {
+  let ipart = z >> 10;
+  let mut n = ((z & ((1 << 10) - 1)) << 4) as u32;
+  n = ({
+    n * (((n * (((n * (((n * 3548) >> 15) + 6817)) >> 15) + 15823)) >> 15)
+      + 22708)
+  } >> 15)
+    + 16384;
+  if 14 - ipart > 0 {
+    (n + (1 << (13 - ipart))) >> (14 - ipart)
+  } else {
+    n << (ipart - 14)
+  }
+}
+
+/// Polynomial approximation of a binary logarithm.
+/// Q0 input, Q10 output.
+#[allow(unused)]
+pub const fn blog32_q10(w: u32) -> i32 {
+  if w == 0 {
+    return -1;
+  }
+  let ipart = 31 - w.leading_zeros() as i32;
+  let n = if ipart - 16 > 0 { w >> (ipart - 16) } else { w << (16 - ipart) }
+    as i32
+    - 32768
+    - 16384;
+  let fpart = ({
+    n * (((n * (((n * (((n * -1402) >> 15) + 2546)) >> 15) - 5216)) >> 15)
+      + 15745)
+  } >> 15)
+    - 6793;
+  (ipart << 10) + (fpart >> 4)
+}
+
 #[cfg(test)]
 mod test {
   use super::*;


### PR DESCRIPTION
Adapted from `oc_blog32_q10()` in libtheora with blessing from @tterribe.

AWCY results on [ojective-1-fast at default speed](https://beta.arewecompressedyet.com/?job=master-c113c00353e605612a41c8dbca124aca3ce2a5dc&job=segment-opt%402022-08-29T16%3A32%3A54.536Z):
| PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |    SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |   VMAF | VMAF-NEG |
|   ---: |    ---: |    ---: |      ---: |    ---: |    ---: |       ---: |        ---: |        ---: |     ---: |   ---: |     ---: |
| 0.4305 |  0.3834 | -0.2535 |    0.1353 | -0.2666 | -0.2792 |     0.3404 |      0.4239 |     -0.1232 |   0.4060 | 0.1488 |   0.1788 |