### PR TITLE
Fix new lints from Rust nightly

### DIFF
--- a/src/activity.rs
+++ b/src/activity.rs
@@ -111,7 +111,7 @@ fn ssim_boost_rsqrt(x: u64) -> RsqrtOutput {
   const INSHIFT: u8 = 16;
   const OUTSHIFT: u8 = 14;
 
-  let k = ((x.ilog() - 1) >> 1) as i16;
+  let k = ((ILog::ilog(x) - 1) >> 1) as i16;
   /*t is x in the range [0.25, 1) in QINSHIFT, or x*2^(-s).
   Shift by log2(x) - log2(0.25*(1 << INSHIFT)) to ensure 0.25 lower bound.*/
   let s: i16 = 2 * k - (INSHIFT as i16 - 2);

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -1564,11 +1564,9 @@ pub fn deblock_filter_frame<T: Pixel>(
   deblock: &DeblockState, tile: &mut TileMut<T>, blocks: &TileBlocks,
   crop_w: usize, crop_h: usize, bd: usize, planes: usize,
 ) {
-  (&mut tile.planes[..planes]).par_iter_mut().enumerate().for_each(
-    |(pli, plane)| {
-      deblock_plane(deblock, plane, pli, blocks, crop_w, crop_h, bd);
-    },
-  );
+  tile.planes[..planes].par_iter_mut().enumerate().for_each(|(pli, plane)| {
+    deblock_plane(deblock, plane, pli, blocks, crop_w, crop_h, bd);
+  });
 }
 
 fn sse_optimize<T: Pixel>(
@@ -1577,8 +1575,8 @@ fn sse_optimize<T: Pixel>(
 ) -> [u8; 4] {
   // i64 allows us to accumulate a total of ~ 35 bits worth of pixels
   assert!(
-    input.planes[0].plane_cfg.width.ilog()
-      + input.planes[0].plane_cfg.height.ilog()
+    ILog::ilog(input.planes[0].plane_cfg.width)
+      + ILog::ilog(input.planes[0].plane_cfg.height)
       < 35
   );
   let mut level = [0; 4];

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -192,7 +192,7 @@ impl StorageBackend for WriterBase<WriterCounter> {
   #[inline]
   fn store(&mut self, fl: u16, fh: u16, nms: u16) {
     let (_l, r) = self.lr_compute(fl, fh, nms);
-    let d = 16 - r.ilog();
+    let d = 16 - ILog::ilog(r);
     let mut s = self.cnt + (d as i16);
 
     self.s.bytes += (s >= 0) as usize + (s >= 8) as usize;
@@ -230,7 +230,7 @@ impl StorageBackend for WriterBase<WriterRecorder> {
   #[inline]
   fn store(&mut self, fl: u16, fh: u16, nms: u16) {
     let (_l, r) = self.lr_compute(fl, fh, nms);
-    let d = 16 - r.ilog();
+    let d = 16 - ILog::ilog(r);
     let mut s = self.cnt + (d as i16);
 
     self.s.bytes += (s >= 0) as usize + (s >= 8) as usize;
@@ -271,7 +271,7 @@ impl StorageBackend for WriterBase<WriterEncoder> {
     let (l, r) = self.lr_compute(fl, fh, nms);
     let mut low = l + self.s.low;
     let mut c = self.cnt;
-    let d = 16 - r.ilog();
+    let d = 16 - ILog::ilog(r);
     let mut s = c + (d as i16);
 
     if s >= 0 {
@@ -596,7 +596,7 @@ where
 
     // The 9 here counteracts the offset of -9 baked into cnt.  Don't include a termination bit.
     let pre = Self::frac_compute((self.cnt + 9) as u32, self.rng as u32);
-    let d = 16 - r.ilog();
+    let d = 16 - ILog::ilog(r);
     let mut c = self.cnt;
     let mut sh = c + (d as i16);
     if sh >= 0 {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -3340,7 +3340,7 @@ fn encode_tile_group<T: Pixel>(
     fs.cdfs.reset_counts();
   }
 
-  let max_tile_size_bytes = ((max_len.ilog() + 7) / 8) as u32;
+  let max_tile_size_bytes = ((ILog::ilog(max_len) + 7) / 8) as u32;
   debug_assert!(max_tile_size_bytes > 0 && max_tile_size_bytes <= 4);
   fs.max_tile_size_bytes = max_tile_size_bytes;
 

--- a/src/me.rs
+++ b/src/me.rs
@@ -1507,7 +1507,7 @@ fn get_mv_rate(
   #[inline(always)]
   fn diff_to_rate(diff: i16, allow_high_precision_mv: bool) -> u32 {
     let d = if allow_high_precision_mv { diff } else { diff >> 1 };
-    2 * d.abs().ilog() as u32
+    2 * ILog::ilog(d.abs()) as u32
   }
 
   diff_to_rate(a.row - b.row, allow_high_precision_mv)

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1134,10 +1134,10 @@ fn inter_frame_rdo_mode_decision<T: Pixel>(
     }
 
     if !ref_slot_set.contains(&fi.ref_frames[i.to_index()]) {
-      if fwdref == None && i.is_fwd_ref() {
+      if fwdref.is_none() && i.is_fwd_ref() {
         fwdref = Some(ref_frames_set.len());
       }
-      if bwdref == None && i.is_bwd_ref() {
+      if bwdref.is_none() && i.is_bwd_ref() {
         bwdref = Some(ref_frames_set.len());
       }
       ref_frames_set.push([i, NONE_FRAME]);

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1620,7 +1620,7 @@ pub(crate) mod rust {
 
     // perform inv txfm on every row
     let range = bd + 8;
-    let txfm_fn = INV_TXFM_FNS[tx_types_1d.1 as usize][width.ilog() - 3];
+    let txfm_fn = INV_TXFM_FNS[tx_types_1d.1 as usize][ILog::ilog(width) - 3];
     // 64 point transforms only signal 32 coeffs. We only take chunks of 32
     //   and skip over the last 32 transforms here.
     for (r, buffer_slice) in (0..height.min(32)).zip(buffer.chunks_mut(width))
@@ -1646,7 +1646,7 @@ pub(crate) mod rust {
 
     // perform inv txfm on every col
     let range = cmp::max(bd + 6, 16);
-    let txfm_fn = INV_TXFM_FNS[tx_types_1d.0 as usize][height.ilog() - 3];
+    let txfm_fn = INV_TXFM_FNS[tx_types_1d.0 as usize][ILog::ilog(height) - 3];
     for c in 0..width {
       let mut temp_in: [i32; 64] = [0; 64];
       let mut temp_out: [i32; 64] = [0; 64];

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -288,7 +288,7 @@ pub enum TxSet {
 #[inline]
 pub fn get_rect_tx_log_ratio(col: usize, row: usize) -> i8 {
   debug_assert!(col > 0 && row > 0);
-  col.ilog() as i8 - row.ilog() as i8
+  ILog::ilog(col) as i8 - ILog::ilog(row) as i8
 }
 
 // performs half a butterfly


### PR DESCRIPTION
Fixes instances of lints for:
- `unstable_name_collisions` (due to addition of unstable `ilog` method)
- `clippy::partialeq_to_none`
- `clippy::needless_borrow`