### PR TITLE
logexp: Correct integer part in `blog32_q11`

### DIFF
--- a/src/util/logexp.rs
+++ b/src/util/logexp.rs
@@ -274,7 +274,7 @@ pub const fn blog32_q11(w: u32) -> i32 {
   if w == 0 {
     return -1;
   }
-  let ipart = 31 - w.leading_zeros() as i32;
+  let ipart = 32 - w.leading_zeros() as i32;
   let n = if ipart - 16 > 0 { w >> (ipart - 16) } else { w << (16 - ipart) }
     as i32
     - 32768
@@ -341,6 +341,22 @@ mod test {
       assert!(
         ((bexp_q24(log_ab) >> 24) - i64::from(a) * i64::from(b)).abs() < 128
       );
+    }
+  }
+
+  #[test]
+  fn blog32_q11_bexp32_q10_round_trip() {
+    for a in 1..=std::i16::MAX as i32 {
+      let b = std::i16::MAX as i32 / a;
+      let (log_a, log_b, log_ab) = (
+        blog32_q11(a as u32),
+        blog32_q11(b as u32),
+        blog32_q11(a as u32 * b as u32),
+      );
+      assert!((log_a + log_b - log_ab).abs() < 4);
+      assert!((bexp32_q10((log_a + 1) >> 1) as i32 - a).abs() < 18);
+      assert!((bexp32_q10((log_b + 1) >> 1) as i32 - b).abs() < 2);
+      assert!((bexp32_q10((log_ab + 1) >> 1) as i32 - a * b).abs() < 18);
     }
   }
 }


### PR DESCRIPTION
Lost in translation, an off-by-one occurred.

AWCY results for [objective-1-fast at default speed](https://beta.arewecompressedyet.com/?job=master-fe7d0f0eb0ecaa9b863a7ce5c49c0ead611f7d96&job=segment-opt%402022-09-02T06%3A32%3A25.834Z):
|  PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |   SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |    VMAF | VMAF-NEG |
|    ---: |    ---: |    ---: |      ---: |   ---: |    ---: |       ---: |        ---: |        ---: |     ---: |    ---: |     ---: |
| -0.4350 | -0.2492 |  0.2750 |   -0.1279 | 0.2865 |  0.3318 |    -0.3281 |     -0.3041 |      0.1465 |  -0.3910 | -0.2546 |  -0.2703 |

Compared to the commit [before `blog32_q11` was first used](https://beta.arewecompressedyet.com/?job=master-c113c00353e605612a41c8dbca124aca3ce2a5dc&job=segment-opt%402022-09-02T06%3A32%3A25.834Z):
|  PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |   SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |    VMAF | VMAF-NEG |
|    ---: |    ---: |    ---: |      ---: |   ---: |    ---: |       ---: |        ---: |        ---: |     ---: |    ---: |     ---: |
| -0.0134 |  0.0815 | -0.0374 |   -0.0127 | 0.0153 |  0.0473 |     0.0047 |      0.0482 |     -0.0307 |   0.0040 | -0.1190 |  -0.0999 |