### PR TITLE
Use sad_plane to avoid falling back to slow Rust SAD code

### DIFF
--- a/src/asm/x86/dist/mod.rs
+++ b/src/asm/x86/dist/mod.rs
@@ -13,6 +13,7 @@ pub use self::sse::*;
 use crate::cpu_features::CpuFeatureLevel;
 use crate::dist::*;
 use crate::partition::BlockSize;
+use crate::sad_plane::sad_plane;
 use crate::tiling::*;
 use crate::util::*;
 
@@ -138,7 +139,11 @@ pub fn get_sad<T: Pixel>(
   let ref_dist = call_rust();
 
   let dist = match (bsize_opt, T::type_enum()) {
-    (Err(_), _) => call_rust(),
+    (Err(_), _) => sad_plane(
+      &src.subregion(Area::Rect { x: 0, y: 0, width: w, height: h }),
+      &dst.subregion(Area::Rect { x: 0, y: 0, width: w, height: h }),
+      cpu,
+    ) as u32,
     (Ok(bsize), PixelType::U8) => {
       match SAD_FNS[cpu.as_index()][to_index(bsize)] {
         // SAFETY: Calls Assembly code.

--- a/src/sad_plane.rs
+++ b/src/sad_plane.rs
@@ -15,9 +15,8 @@ cfg_if::cfg_if! {
   }
 }
 
-use v_frame::plane::Plane;
-
 use crate::cpu_features::CpuFeatureLevel;
+use crate::tiling::PlaneRegion;
 use crate::util::{CastFromPrimitive, Pixel};
 
 pub(crate) mod rust {
@@ -26,11 +25,11 @@ pub(crate) mod rust {
 
   #[inline]
   pub(crate) fn sad_plane_internal<T: Pixel>(
-    src: &Plane<T>, dst: &Plane<T>, _cpu: CpuFeatureLevel,
+    src: &PlaneRegion<T>, dst: &PlaneRegion<T>, _cpu: CpuFeatureLevel,
   ) -> u64 {
-    debug_assert!(src.cfg.width == dst.cfg.width);
+    debug_assert!(src.rect().width == dst.rect().width);
 
-    let width = src.cfg.width;
+    let width = src.rect().width;
 
     src
       .rows_iter()
@@ -56,7 +55,7 @@ pub(crate) mod rust {
 /// This differs from other SAD functions in that it operates over a row
 /// (or line) of unknown length rather than a `PlaneRegion<T>`.
 pub(crate) fn sad_plane<T: Pixel>(
-  src: &Plane<T>, dst: &Plane<T>, cpu: CpuFeatureLevel,
+  src: &PlaneRegion<T>, dst: &PlaneRegion<T>, cpu: CpuFeatureLevel,
 ) -> u64 {
   sad_plane_internal(src, dst, cpu)
 }

--- a/src/scenechange/fast.rs
+++ b/src/scenechange/fast.rs
@@ -3,7 +3,7 @@ use std::{cmp, sync::Arc};
 use crate::{
   api::SceneDetectionSpeed,
   encoder::Sequence,
-  frame::{Frame, Plane},
+  frame::{AsRegion, Frame, Plane},
   sad_plane,
   scenechange::fast_idiv,
 };
@@ -106,7 +106,11 @@ impl<T: Pixel> SceneChangeDetector<T> {
   /// Calculates the average sum of absolute difference (SAD) per pixel between 2 planes
   #[hawktracer(delta_in_planes)]
   fn delta_in_planes(&self, plane1: &Plane<T>, plane2: &Plane<T>) -> f64 {
-    let delta = sad_plane::sad_plane(plane1, plane2, self.cpu_feature_level);
+    let delta = sad_plane::sad_plane(
+      &plane1.as_region(),
+      &plane2.as_region(),
+      self.cpu_feature_level,
+    );
 
     delta as f64 / self.pixels as f64
   }


### PR DESCRIPTION
This gives approximately a 2% speed improvement at speed 2
on 1080p content. Currently only benefits 8-bit.