### PR TITLE
Bump several dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,11 +103,11 @@ const_fn_assert = "0.1.2"
 nom = { version = "7.0.0", optional = true }
 new_debug_unreachable = "1.0.4"
 once_cell = "1.13.0"
-av1-grain = { version = "0.1.1", features = ["serialize"] }
+av1-grain = { version = "0.2.0", features = ["serialize"] }
 serde-big-array = { version = "0.4.1", optional = true }
 
 [dependencies.image]
-version = "0.23"
+version = "0.24.3"
 optional = true
 default-features = false
 features = ["png"]
@@ -129,7 +129,7 @@ signal-hook = { version = "0.3", optional = true }
 [dev-dependencies]
 assert_cmd = "2.0"
 criterion = "0.3"
-pretty_assertions = "0.7"
+pretty_assertions = "1.3.0"
 interpolate_name = "0.2.2"
 nom = "7.1.1"
 quickcheck = "1.0"

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -475,7 +475,7 @@ fn run() -> Result<(), error::CliError> {
 
   #[cfg(feature = "unstable")]
   if cli.generate_grain_strength > 0 && cli.enc.film_grain_params.is_none() {
-    cli.enc.film_grain_params = Some(vec![generate_grain_params(
+    cli.enc.film_grain_params = Some(vec![generate_photon_noise_params(
       0,
       u64::MAX,
       NoiseGenArgs {

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -458,7 +458,7 @@ fn run() -> Result<(), error::CliError> {
 
   #[cfg(feature = "unstable")]
   if cli.generate_grain_strength > 0 && cli.enc.film_grain_params.is_none() {
-    cli.enc.film_grain_params = Some(vec![generate_grain_params(
+    cli.enc.film_grain_params = Some(vec![generate_photon_noise_params(
       0,
       u64::MAX,
       NoiseGenArgs {


### PR DESCRIPTION
Including `image`, `pretty_assertions`, and `av1-grain`. Not touching `arbitrary` and `libfuzzer-sys` in this patch because of breaking changes I don't feel like dealing with right now.