### PR TITLE
Calculate per-plane scales in Q14 and center `log(base_q)`

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -671,7 +671,7 @@ impl<T: Pixel> ContextInner<T> {
         output_frameno,
         fti,
         self.maybe_prev_log_base_q,
-        1u32 << 12,
+        0,
       )
     };
 
@@ -1312,7 +1312,7 @@ impl<T: Pixel> ContextInner<T> {
       let mut frame_data =
         self.frame_data.remove(&cur_output_frameno).unwrap().unwrap();
 
-      let mut inv_mean_scale_q12 = 1u32 << 12;
+      let mut log_isqrt_mean_scale = 0i64;
 
       if let Some(coded_data) = frame_data.fi.coded_frame_data.as_mut() {
         if self.config.tune == Tune::Psychovisual {
@@ -1324,10 +1324,10 @@ impl<T: Pixel> ContextInner<T> {
             frame_data.fi.sequence.bit_depth,
             &mut coded_data.activity_scales,
           );
-          inv_mean_scale_q12 = coded_data.compute_spatiotemporal_scores();
+          log_isqrt_mean_scale = coded_data.compute_spatiotemporal_scores();
         } else {
           coded_data.activity_mask = ActivityMask::default();
-          inv_mean_scale_q12 = coded_data.compute_temporal_scores();
+          log_isqrt_mean_scale = coded_data.compute_temporal_scores();
         }
       }
 
@@ -1337,7 +1337,7 @@ impl<T: Pixel> ContextInner<T> {
         cur_output_frameno,
         fti,
         self.maybe_prev_log_base_q,
-        inv_mean_scale_q12,
+        log_isqrt_mean_scale,
       );
       frame_data.fi.set_quantizers(&qps);
 
@@ -1358,7 +1358,7 @@ impl<T: Pixel> ContextInner<T> {
           cur_output_frameno,
           fti,
           self.maybe_prev_log_base_q,
-          inv_mean_scale_q12,
+          log_isqrt_mean_scale,
         );
         frame_data.fi.set_quantizers(&qps);
       }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -734,7 +734,8 @@ impl<T: Pixel> CodedFrameData<T> {
   }
 
   // Assumes that we have already computed activity scales and distortion scales
-  pub fn compute_spatiotemporal_scores(&mut self) -> u32 {
+  // Returns -0.5 log2(mean(scale))
+  pub fn compute_spatiotemporal_scores(&mut self) -> i64 {
     let mut scores = self
       .distortion_scales
       .iter()
@@ -754,17 +755,18 @@ impl<T: Pixel> CodedFrameData<T> {
 
     self.spatiotemporal_scores = scores;
 
-    inv_mean.0
+    inv_mean.blog64() >> 1
   }
 
   // Assumes that we have already computed distortion_scales
-  pub fn compute_temporal_scores(&mut self) -> u32 {
+  // Returns -0.5 log2(mean(scale))
+  pub fn compute_temporal_scores(&mut self) -> i64 {
     let inv_mean = DistortionScale::inv_mean(&self.distortion_scales);
     for scale in self.distortion_scales.iter_mut() {
       *scale *= inv_mean;
     }
     self.spatiotemporal_scores = self.distortion_scales.clone();
-    inv_mean.0
+    inv_mean.blog64() >> 1
   }
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -651,7 +651,7 @@ pub struct FrameInvariants<T: Pixel> {
   pub ac_delta_q: [i8; 3],
   pub lambda: f64,
   pub me_lambda: f64,
-  pub dist_scale: [f64; 3],
+  pub dist_scale: [DistortionScale; 3],
   pub me_range_scale: u8,
   pub use_tx_domain_distortion: bool,
   pub use_tx_domain_rate: bool,
@@ -878,7 +878,7 @@ impl<T: Pixel> FrameInvariants<T> {
       dc_delta_q: [0; 3],
       ac_delta_q: [0; 3],
       lambda: 0.0,
-      dist_scale: [1.0; 3],
+      dist_scale: Default::default(),
       me_lambda: 0.0,
       me_range_scale: 1,
       use_tx_domain_distortion,
@@ -1207,7 +1207,7 @@ impl<T: Pixel> FrameInvariants<T> {
     self.lambda =
       qps.lambda * ((1 << (2 * (self.sequence.bit_depth - 8))) as f64);
     self.me_lambda = self.lambda.sqrt();
-    self.dist_scale = qps.dist_scale;
+    self.dist_scale = qps.dist_scale.map(DistortionScale::from);
 
     match self.cdef_search_method {
       CDEFSearchMethod::PickFromQ => {

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -735,10 +735,8 @@ impl RCState {
   // TODO: Separate quantizers for Cb and Cr.
   pub(crate) fn select_qi<T: Pixel>(
     &self, ctx: &ContextInner<T>, output_frameno: u64, fti: usize,
-    maybe_prev_log_base_q: Option<i64>, inv_mean_scale_q12: u32,
+    maybe_prev_log_base_q: Option<i64>, log_isqrt_mean_scale: i64,
   ) -> QuantizerParameters {
-    let log_isqrt_mean_scale =
-      (blog64(inv_mean_scale_q12 as i64) - q57(12)) >> 1;
     // Is rate control active?
     if self.target_bitrate <= 0 {
       // Rate control is not active.
@@ -1279,7 +1277,7 @@ impl RCState {
     if !self.pass1_data_retrieved {
       if self.twopass_state == PASS_SINGLE {
         pass1_log_base_q = self
-          .select_qi(ctx, output_frameno, FRAME_SUBTYPE_I, None, 1u32 << 12)
+          .select_qi(ctx, output_frameno, FRAME_SUBTYPE_I, None, 0)
           .log_base_q;
       }
     } else {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -596,9 +596,16 @@ impl DistortionScale {
 
   /// Binary logarithm in Q11
   #[inline]
-  pub const fn blog32(self) -> i16 {
+  pub const fn blog16(self) -> i16 {
     use crate::util::blog32_q11;
     (blog32_q11(self.0) - ((Self::SHIFT as i32) << 11)) as i16
+  }
+
+  /// Binary logarithm in Q57
+  #[inline]
+  pub const fn blog64(self) -> i64 {
+    use crate::util::{blog64, q57};
+    blog64(self.0 as i64) - q57(Self::SHIFT as i32)
   }
 
   /// Multiply, round and shift

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -688,11 +688,11 @@ impl Distortion {
   }
 }
 
-impl std::ops::Mul<f64> for Distortion {
+impl std::ops::Mul<DistortionScale> for Distortion {
   type Output = ScaledDistortion;
   #[inline]
-  fn mul(self, rhs: f64) -> ScaledDistortion {
-    ScaledDistortion((self.0 as f64 * rhs) as u64)
+  fn mul(self, rhs: DistortionScale) -> ScaledDistortion {
+    ScaledDistortion(rhs.mul_u64(self.0))
   }
 }
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -571,10 +571,10 @@ pub struct ScaledDistortion(u64);
 
 impl DistortionScale {
   /// Bits past the radix point
-  const SHIFT: u32 = 12;
+  const SHIFT: u32 = 14;
   /// Number of bits used. Determines the max value.
-  /// 24 bits is likely excessive.
-  const BITS: u32 = 24;
+  /// 28 bits is quite excessive.
+  const BITS: u32 = 28;
   /// Maximum internal value
   const MAX: u64 = (1 << Self::BITS) - 1;
 

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -86,7 +86,7 @@ fn segmentation_optimize_inner<T: Pixel>(
     let spatiotemporal_scores =
       &fi.coded_frame_data.as_ref().unwrap().spatiotemporal_scores;
     let mut log2_scale_q11 = Vec::with_capacity(spatiotemporal_scores.len());
-    log2_scale_q11.extend(spatiotemporal_scores.iter().map(|&s| s.blog32()));
+    log2_scale_q11.extend(spatiotemporal_scores.iter().map(|&s| s.blog16()));
     log2_scale_q11.sort_unstable();
     let l = &log2_scale_q11;
     (kmeans(l), kmeans(l), kmeans(l), kmeans(l), kmeans(l), kmeans(l))


### PR DESCRIPTION
The move to `DistortionScale` reduces `compute_distortion()` CPU time by about 10%.

AWCY results on [objective-1-fast at default speed](https://beta.arewecompressedyet.com/?job=master-8c260d2cd928fe3945ae41fa738b8e994fa5c68e&job=segment-opt%402022-09-06T05%3A03%3A46.038Z):
| PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |   SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |   VMAF | VMAF-NEG |
|   ---: |    ---: |    ---: |      ---: |   ---: |    ---: |       ---: |        ---: |        ---: |     ---: |   ---: |     ---: |
| 0.0902 | -0.7627 | -0.4605 |   -0.0608 | 0.0927 |  0.0987 |     0.1329 |     -0.8583 |     -0.4014 |   0.1068 | 0.1648 |   0.1460 |