### PR TITLE
build: Handle absent `CARGO_CFG_TARGET_FEATURE`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -260,10 +260,9 @@ fn main() {
   }
 
   println!("cargo:rustc-env=PROFILE={}", env::var("PROFILE").unwrap());
-  println!(
-    "cargo:rustc-env=CARGO_CFG_TARGET_FEATURE={}",
-    env::var("CARGO_CFG_TARGET_FEATURE").unwrap()
-  );
+  if let Ok(value) = env::var("CARGO_CFG_TARGET_FEATURE") {
+    println!("cargo:rustc-env=CARGO_CFG_TARGET_FEATURE={}", value);
+  }
   println!(
     "cargo:rustc-env=CARGO_ENCODED_RUSTFLAGS={}",
     env::var("CARGO_ENCODED_RUSTFLAGS").unwrap()

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -278,7 +278,7 @@ fn get_long_version() -> &'static str {
       get_version(),
       built_info::RUSTC_VERSION,
       built_info::TARGET,
-      env!("CARGO_CFG_TARGET_FEATURE"),
+      option_env!("CARGO_CFG_TARGET_FEATURE").unwrap_or("(None)"),
       if cfg!(feature = "asm") { "Enabled" } else { "Disabled" },
       if cfg!(feature = "threading") { "Enabled" } else { "Disabled" },
       if cfg!(feature = "unstable") { "Enabled" } else { "Disabled" },


### PR DESCRIPTION
This fixes a panic in build.rs on some aarch64 environments:
* Alpine Linux 3.16 (aarch64)
* Ubuntu 20.04 (aarch64)