### PR TITLE
CI: Deploy rav1e-ch binary tuned for modern x86_64

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,9 @@ jobs:
 
     - name: Build rav1e-ch (unstable)
       env:
-        RUSTFLAGS: "-C target-feature=+avx2,+fma"
+        RUSTFLAGS: "-C target-cpu=x86-64-v3"
+        CARGO_PROFILE_RELEASE_LTO: "true"
+        CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
       run: cargo build --release --features=unstable,channel-api --bin=rav1e-ch
 
     - name: Upload rav1e-ch msvc binary (unstable)

--- a/README.md
+++ b/README.md
@@ -117,15 +117,15 @@ cargo build --features channel-api,unstable
 Those Features and API are bound to change and evolve, do not rely on them staying the same over releases.
 
 ### Target-specific builds
-The rust autovectorizer can produce a binary that is about 6%-7% faster if it can use `avx2` in the general code, you may allow it by issuing:
+The rust compiler can produce a binary that is about 11%-13% faster if it can use `avx2`, `bmi1`, `bmi2`, `fma`, `lzcnt` and `popcnt` in the general code, you may allow it by issuing:
 
 ```sh
 RUSTFLAGS="-C target-cpu=native" cargo build --release
 # or
-RUSTFLAGS="-C target-feature=+avx2,+fma" cargo build --release
+RUSTFLAGS="-C target-cpu=x86-64-v3" cargo build --release
 ```
 
-The resulting binary will not work on cpus that do not sport the same set of SIMD extensions enabled.
+The resulting binary will not work on cpus that do not sport the same set of extensions enabled.
 
 > **NOTE** : You may use `rustc --print target-cpus` to check if the cpu is supported, if not `-C target-cpu=native` would be a no-op.
 


### PR DESCRIPTION
This yields about a 6% speed-up in preliminary tests.