### PR TITLE
Preliminary work on complete next-gen CDEF implementation (early WIP)

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -174,6 +174,18 @@ pub struct CliOptions {
   /// Still picture mode
   #[clap(long, help_heading = "ENCODE SETTINGS")]
   pub still_picture: bool,
+  /// Quality tuning for the CDEF strength selection algorithm
+  /// ssimulacra2 for the highest quality(experimental, can be changed), default for the fastest mode
+  #[cfg(feature = "unstable")]
+  #[clap(
+    long,
+    value_parser,
+    hide = true,
+    default_value_t = default
+    help_heading = "ENCODE SETTINGS"
+  )]
+  pub cdef_tune,
+
   /// Uses grain synthesis to add photon noise to the resulting encode.
   /// Takes a strength value 0-64.
   #[cfg(feature = "unstable")]


### PR DESCRIPTION
Hello again. It has been a while since I've made any relevant PRs to rav1e, so here goes.

Ever since a faithful meeting we had back in 2021, I knew that rav1e didn't have a higher quality full CDEF implementation, so I've always wanted rav1e to get it.

Following this issue made me think of it again today, which is why I started the work on it:
https://github.com/xiph/rav1e/issues/2759

My plan to implement the full CDEF implementation will follow multiple steps in its design:

### 1. Full CDEF strength selection implementation

Adding the full CDEF implementation based on distortion optimization with the full set of filter strengths being available first(0-15 for primary, 0-4 for secondary).

### 2. Implement curve based speed pruning: 
As quality increases(quantizer decrease), the CDEF strength filter search space is made smaller following a power curve function.
As speeds increase(s0 all the way to s10), the CDEF strength filter search space is made smaller quicker, and at much higher speeds, gets restricted entirely from the start.

This would mainly be for the psychovisual tune. The PSNR tune would only get static search spaces based on speed features.

### 3. Implement an entirely different superior CDEF_dist metric(long-term).

The current CDEF_dist metric, while still being considerably better than what aomenc and SVT-AV1 use(MSE as the dist metric), isn't the absolute best that can be currently used. My future plan is to add a subset of ssimulacra2 as a superior slower dist_metric for the psycho-visual tune, especially as it would penalize some classic encoder faults like excessive blurring and detail wiping. Repository can be found here:
https://github.com/cloudinary/ssimulacra2

Piping work for that:
1. Implementing a YUV > XYB and XYB > YUV crate for internal color conversion(could perhaps be used to replace YCbCr internally for rav1e, but that's on a completely different scope...)

2. Implementing everything ssimulacra2 related in Rust(biggest difficulty).

3. Adding some SIMD to make it as abominably fast as possible.

### 4. Making CDEF faster 

Simple as that: lower complexity, more SIMD for more architectures, etc.

That'll be all from me today.