### PR TITLE
bin: Bring `--photon-noise` out from under unstable feature

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -176,7 +176,6 @@ pub struct CliOptions {
   pub still_picture: bool,
   /// Uses grain synthesis to add photon noise to the resulting encode.
   /// Takes a strength value 0-64.
-  #[cfg(feature = "unstable")]
   #[clap(
     long,
     conflicts_with = "film-grain-table",
@@ -332,10 +331,9 @@ pub struct ParsedCliOptions {
   pub pass1file_name: Option<PathBuf>,
   pub pass2file_name: Option<PathBuf>,
   pub save_config: Option<PathBuf>,
+  pub photon_noise: u8,
   #[cfg(feature = "unstable")]
   pub slots: usize,
-  #[cfg(feature = "unstable")]
-  pub generate_grain_strength: u8,
 }
 
 #[cfg(feature = "serialize")]
@@ -480,10 +478,9 @@ pub fn parse_cli() -> Result<ParsedCliOptions, CliError> {
     pass1file_name: matches.first_pass.clone(),
     pass2file_name: matches.second_pass.clone(),
     save_config: save_config_path,
+    photon_noise: matches.photon_noise,
     #[cfg(feature = "unstable")]
     slots,
-    #[cfg(feature = "unstable")]
-    generate_grain_strength: matches.photon_noise,
   })
 }
 

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -473,13 +473,12 @@ fn run() -> Result<(), error::CliError> {
     cli.enc.time_base = video_info.time_base;
   }
 
-  #[cfg(feature = "unstable")]
-  if cli.generate_grain_strength > 0 && cli.enc.film_grain_params.is_none() {
+  if cli.photon_noise > 0 && cli.enc.film_grain_params.is_none() {
     cli.enc.film_grain_params = Some(vec![generate_photon_noise_params(
       0,
       u64::MAX,
       NoiseGenArgs {
-        iso_setting: cli.generate_grain_strength as u32 * 100,
+        iso_setting: cli.photon_noise as u32 * 100,
         width: video_info.width as u32,
         height: video_info.height as u32,
         transfer_function: if cli.enc.is_hdr() {

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -456,13 +456,12 @@ fn run() -> Result<(), error::CliError> {
     cli.enc.time_base = video_info.time_base;
   }
 
-  #[cfg(feature = "unstable")]
-  if cli.generate_grain_strength > 0 && cli.enc.film_grain_params.is_none() {
+  if cli.photon_noise > 0 && cli.enc.film_grain_params.is_none() {
     cli.enc.film_grain_params = Some(vec![generate_photon_noise_params(
       0,
       u64::MAX,
       NoiseGenArgs {
-        iso_setting: cli.generate_grain_strength as u32 * 100,
+        iso_setting: cli.photon_noise as u32 * 100,
         width: video_info.width as u32,
         height: video_info.height as u32,
         transfer_function: if cli.enc.is_hdr() {


### PR DESCRIPTION
Align the field name with the flag and the `av1-grain` API. This feature is external to `librav1e` and used only in binaries.