### PR TITLE
CI: Configure ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN apt-get update && apt-get install --no-install-recommends -y \
+        clang curl llvm-dev libclang-dev pkg-config \
+	python3-pip python3-setuptools python3-wheel nasm && \
+    pip3 install meson ninja
+RUN curl -sLO http://get.videolan.org/dav1d/1.0.0/dav1d-1.0.0.tar.xz && \
+    tar Jxf dav1d-1.0.0.tar.xz && mv dav1d-1.0.0 dav1d && rm dav1d-1.0.0.tar.xz
+COPY . $SRC/rav1e
+WORKDIR $SRC/rav1e
+COPY ./.clusterfuzzlite/build.sh ./.clusterfuzzlite/*.options $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+build=${WORK}/build
+static=${WORK}/static
+
+# Build instrumented libdav1d for static linking
+pushd ../dav1d
+mkdir -p ${build}
+meson ${build} --prefix=${static} -Denable_tests=false -Denable_asm=false \
+      -Denable_tools=false -Dfuzzing_engine=libfuzzer \
+      -Db_lundef=false -Ddefault_library=static -Dbuildtype=debugoptimized \
+      -Dlogging=false -Dfuzzer_ldflags="$LIB_FUZZING_ENGINE"
+ninja -j $(nproc) -C ${build} install
+popd
+
+CFLAGS="" \
+PKG_CONFIG_PATH="${static}/lib/x86_64-linux-gnu/pkgconfig" \
+CARGO_PROFILE_RELEASE_LTO="true" \
+CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" \
+RUSTFLAGS="$RUSTFLAGS -Ctarget-cpu=x86-64-v3" \
+cargo fuzz build --release encode_decode
+cp fuzz/target/x86_64-unknown-linux-gnu/release/encode_decode $OUT/
+
+cp $SRC/*.options $OUT/

--- a/.clusterfuzzlite/encode_decode.options
+++ b/.clusterfuzzlite/encode_decode.options
@@ -1,0 +1,5 @@
+[libfuzzer]
+len_control = 0
+max_len = 256
+report_slow_units = 25
+timeout = 600

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://docs.rs/rav1e/latest/rav1e/"
+main_repo: 'https://github.com/xiph/rav1e/'
+primary_contact: "tdaede@xiph.org"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust

--- a/.github/actions/post_fuzz/action.yml
+++ b/.github/actions/post_fuzz/action.yml
@@ -1,0 +1,13 @@
+name: post-fuzz
+runs:
+  using: composite
+  steps:
+    - name: Commit changes
+      working-directory: storage
+      run: >
+        git add -A || true;
+        if ! git diff --cached --quiet; then
+        git commit -m 'Corpus upload' &&
+        git pull --rebase origin clusterfuzzlite &&
+        git push origin HEAD:clusterfuzzlite; fi
+      shell: bash

--- a/.github/actions/pre_fuzz/action.yml
+++ b/.github/actions/pre_fuzz/action.yml
@@ -1,0 +1,37 @@
+name: pre-fuzz
+inputs:
+  mode:
+    required: false
+  storage-token:
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: xiph/rav1e
+        ref: clusterfuzzlite
+        token: ${{ inputs.storage-token }}
+        path: storage
+    - name: Set CIFuzz Identity
+      working-directory: storage
+      run: >
+        git config user.name CIFuzz &&
+        git config user.email cifuzz@clusterfuzz.com
+      shell: bash
+    - name: Remove slow units
+      if: inputs.mode == 'prune'
+      working-directory: storage
+      run: >
+        find -name 'slow-unit-*' |
+        sed 'p;s/artifacts/corpus/;s/slow-unit-//' |
+        xargs -r git rm -f --ignore-unmatch
+      shell: bash
+    - name: Commit deletions
+      if: inputs.mode == 'prune'
+      working-directory: storage
+      run: >
+        if ! git diff --cached --quiet; then
+        git commit -m 'Remove slow units' &&
+        git push origin HEAD:clusterfuzzlite; fi
+      shell: bash

--- a/.github/actions/run_fuzzers/action.yml
+++ b/.github/actions/run_fuzzers/action.yml
@@ -1,0 +1,29 @@
+name: run-fuzzers
+inputs:
+  fuzz-seconds:
+    required: true
+  sanitizer:
+    default: address
+  mode:
+    default: code-change
+  github-token:
+    required: true
+  storage-token:
+    required: true
+runs:
+  using: docker
+  image: ./run_fuzzers.Dockerfile
+  env:
+    FUZZ_SECONDS: ${{ inputs.fuzz-seconds }}
+    MODE: ${{ inputs.mode }}
+    LANGUAGE: rust
+    DRY_RUN: false
+    SANITIZER: ${{ inputs.sanitizer }}
+    GITHUB_TOKEN: ${{ inputs.github-token }}
+    LOW_DISK_SPACE: false
+    GIT_STORE_REPO: https://${{ inputs.storage-token }}@github.com/xiph/rav1e.git
+    GIT_STORE_BRANCH: clusterfuzzlite
+    GIT_STORE_BRANCH_COVERAGE: gh-pages
+    REPORT_UNREPRODUCIBLE_CRASHES: false
+    MINIMIZE_CRASHES: false
+    CFL_PLATFORM: github

--- a/.github/actions/run_fuzzers/run_fuzzers.Dockerfile
+++ b/.github/actions/run_fuzzers/run_fuzzers.Dockerfile
@@ -1,0 +1,7 @@
+FROM gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:v1
+ENV FUZZER_ARGS="-rss_limit_mb=2560 -timeout=600"
+RUN sed -i 's/timeout=25/timeout=600/' ${OSS_FUZZ_ROOT}/infra/cifuzz/base_runner_utils.py
+RUN sed -i '/return self.config.report_timeouts/a \    if testcase.startswith("slow-unit-"): return True' ${OSS_FUZZ_ROOT}/infra/cifuzz/fuzz_target.py
+RUN sed -i 's/timeout=100/timeout=2400/;s/TIMEOUT=1h/TIMEOUT=5h/' /usr/local/bin/coverage
+RUN find /usr/local -name constants.py -exec sed -i 's/DEFAULT_TIMEOUT_LIMIT = 25/DEFAULT_TIMEOUT_LIMIT = 600/' {} +
+RUN find /usr/local -name libfuzzer.py -exec sed -i 's/crash.oom.timeout.leak/&|slow-unit/' {} +

--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -1,0 +1,119 @@
+name: ClusterFuzzLite
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: 0 */6 * * *
+permissions: read-all
+jobs:
+  BuildAddress:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: rust
+    - name: Pack fuzzers
+      run: tar cf build-out.tar build-out
+    - name: Archive fuzzers
+      uses: actions/upload-artifact@v3
+      with:
+        name: fuzzers-address
+        path: build-out.tar
+  BuildCoverage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: rust
+        sanitizer: coverage
+    - name: Pack fuzzers
+      run: >
+        find build-out -maxdepth 1 -type f | xargs
+        tar cf build-out.tar --exclude-vcs --exclude=target
+        build-out/src/dav1d build-out/src/rav1e
+    - name: Archive fuzzers
+      uses: actions/upload-artifact@v3
+      with:
+        name: fuzzers-coverage
+        path: build-out.tar
+  Coverage:
+    runs-on: ubuntu-latest
+    needs: [BuildCoverage, Pruning]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Download fuzzers
+      uses: actions/download-artifact@v3
+      with:
+        name: fuzzers-coverage
+    - name: Unpack fuzzers
+      run: tar xf build-out.tar
+    - name: Run Fuzzers
+      uses: ./.github/actions/run_fuzzers
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 2400
+        mode: coverage
+        sanitizer: coverage
+        storage-token: ${{ secrets.CFL_TOKEN }}
+  Pruning:
+    runs-on: ubuntu-latest
+    needs: [BuildAddress, BatchFuzzing]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Download fuzzers
+      uses: actions/download-artifact@v3
+      with:
+        name: fuzzers-address
+    - name: Unpack fuzzers
+      run: tar xf build-out.tar
+    - name: Download corpus
+      uses: ./.github/actions/pre_fuzz
+      with:
+        mode: prune
+        storage-token: ${{ secrets.CFL_TOKEN }}
+    - name: Run Fuzzers
+      run: >
+        mv storage/corpus/encode_decode corpus.encode_decode;
+        mkdir -p storage/{artifacts,corpus}/encode_decode;
+        timeout 3h build-out/encode_decode -artifact_prefix=storage/artifacts/encode_decode/
+        -timeout=600 -report_slow_units=25 -max_len=256 -len_control=0 -merge=1
+        storage/corpus/encode_decode corpus.encode_decode
+    - name: Upload corpus
+      uses: ./.github/actions/post_fuzz
+  BatchFuzzing:
+    runs-on: ubuntu-latest
+    needs: BuildAddress
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Download fuzzers
+      uses: actions/download-artifact@v3
+      with:
+        name: fuzzers-address
+    - name: Unpack fuzzers
+      run: tar xf build-out.tar
+    - name: Download corpus
+      uses: ./.github/actions/pre_fuzz
+      with:
+        storage-token: ${{ secrets.CFL_TOKEN }}
+    - name: Shard corpus
+      run: |
+        mkdir -p storage/{artifacts,corpus}/encode_decode corpus.encode_decode
+        cd storage/corpus/encode_decode
+        ls | perl -ne 'print if int hex(substr $_,0,14)*3/2**56+1==${{matrix.shard}}' |
+        xargs -r cp -t ../../../corpus.encode_decode
+    - name: Run Fuzzers
+      run: >
+        timeout 1h build-out/encode_decode -artifact_prefix=storage/artifacts/encode_decode/
+        -timeout=600 -report_slow_units=25 -max_len=256 -len_control=0 corpus.encode_decode
+        || true;
+        cp -u corpus.encode_decode/* storage/corpus/encode_decode
+    - name: Random pause for storage sync
+      run: seq 1 60 | shuf -n 1 | xargs sleep
+    - name: Upload corpus
+      uses: ./.github/actions/post_fuzz


### PR DESCRIPTION
Override clusterfuzz's hard-coded maximum unit timeout of 25 seconds. Add a local `run_fuzzers` action that uses our Docker image. Follows the guide in `CONTRIBUTING.md` on fuzzing.