### PR TITLE
Add back shorthand for `--verbose` and `--quiet`

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -228,10 +228,10 @@ pub struct CliOptions {
   #[clap(long, help_heading = "DEBUGGING")]
   pub benchmark: bool,
   /// Verbose logging; outputs info for every frame
-  #[clap(long, help_heading = "DEBUGGING")]
+  #[clap(long, short, help_heading = "DEBUGGING")]
   pub verbose: bool,
   /// Do not output any status message
-  #[clap(long, conflicts_with = "verbose", help_heading = "DEBUGGING")]
+  #[clap(long, short, conflicts_with = "verbose", help_heading = "DEBUGGING")]
   pub quiet: bool,
   /// Calculate and display PSNR metrics
   #[clap(long, help_heading = "DEBUGGING")]


### PR DESCRIPTION
This shorthand flag appears to have been dropped in #2962, the removal of which broke some scripts.