### PR TITLE
Keep the version line compatible with 0.5

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -250,17 +250,18 @@ pub struct CliOptions {
 fn get_version() -> &'static str {
   static VERSION_STR: Lazy<String> = Lazy::new(|| {
     format!(
-      "{} ({})",
+      "{} ({}) ({})",
+      built_info::PKG_VERSION,
       built_info::GIT_VERSION
         .map(|ver| if built_info::GIT_DIRTY.expect("git is true") {
           format!("{}-MODIFIED", ver)
         } else {
           ver.to_string()
         })
-        .unwrap_or_else(|| built_info::PKG_VERSION.to_string()),
+        .unwrap_or_else(|| "UNKNOWN".to_string()),
       // We cannot use `built_info::DEBUG` because that tells us if there are debug symbols,
       // not if there are optimizations.
-      if cfg!(debug_assertions) { "Debug" } else { "Release" }
+      if cfg!(debug_assertions) { "debug" } else { "release" }
     )
   });
   &VERSION_STR


### PR DESCRIPTION
It would trip scripts parsing the version line otherwise.