### PR TITLE
Create new speed level 8, drop level 7

### DIFF
--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -156,9 +156,6 @@ impl SpeedSettings {
 
     if speed >= 7 {
       settings.prediction.prediction_modes = PredictionModesSetting::Simple;
-    }
-
-    if speed >= 8 {
       // Multiref is enabled automatically if low_latency is false.
       //
       // If low_latency is true, enabling multiref allows using multiple
@@ -168,14 +165,17 @@ impl SpeedSettings {
       settings.fast_deblock = true;
     }
 
-    if speed >= 9 {
+    if speed >= 8 {
       settings.rdo_lookahead_frames = 10;
+      settings.lrf = false;
+    }
 
+    if speed >= 9 {
       // 8x8 is fast enough to use until very high speed levels,
       // because 8x8 with reduced TX set is faster but with equivalent
       // or better quality compared to 16x16 (to which reduced TX set does not apply).
       settings.partition.partition_range =
-        PartitionRange::new(BlockSize::BLOCK_32X32, BlockSize::BLOCK_64X64);
+        PartitionRange::new(BlockSize::BLOCK_16X16, BlockSize::BLOCK_32X32);
 
       // FIXME: With unknown reasons, inter_tx_split does not work if reduced_tx_set is false
       settings.transform.enable_inter_tx_split = true;
@@ -183,7 +183,6 @@ impl SpeedSettings {
 
     if speed >= 10 {
       settings.scene_detection_mode = SceneDetectionSpeed::Fast;
-      settings.lrf = false;
 
       settings.partition.partition_range =
         PartitionRange::new(BlockSize::BLOCK_32X32, BlockSize::BLOCK_32X32);


### PR DESCRIPTION
Level 7 was too close to 6 and 8 in speed and efficiency. There was a small but significant gap from 6 to 8. So move the old level 8 up to 7. By lowering lookahead frames for level 8 as in speed 9 and disabling loop restoration filters as in speed 10, create a new level closer to 9. Trade the additional speed this implies for speed 9 with efficiency by searching for smaller blocks.
    
AWCY results for [objective-1-fast at speed 9](https://beta.arewecompressedyet.com/?job=cargo-lock-p20220913_s9_38-188%402022-09-20T10%3A04%3A15.094Z&job=speed-level-9c%402022-09-21T14%3A09%3A36.363Z), +2.53% encoding time:
|  PSNR Y |  PSNR Cb |  PSNR Cr | CIEDE2000 |     SSIM |  MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |     VMAF | VMAF-NEG |
|    ---: |     ---: |     ---: |      ---: |     ---: |     ---: |       ---: |        ---: |        ---: |     ---: |     ---: |     ---: |
| -9.1313 | -13.9385 | -10.5595 |   -8.5697 | -10.2273 | -10.9573 |   -11.6210 |    -14.5064 |    -10.5500 | -11.4848 | -13.1015 | -12.1792 |


Before:
![](https://user-images.githubusercontent.com/220594/191448930-4ca99101-8aab-45c0-aeb9-c194d7a78955.png)

After:
![v0_5_1_vs_p20220913](https://user-images.githubusercontent.com/220594/191594248-635a4f16-f285-46da-998e-ebc7c979f945.png)