### PR TITLE
bin: Admit more than 2 encoder passes

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -85,7 +85,6 @@ pub struct CliOptions {
     long,
     value_parser,
     value_name = "STATS_FILE",
-    conflicts_with = "first-pass",
     help_heading = "ENCODE SETTINGS"
   )]
   pub second_pass: Option<PathBuf>,


### PR DESCRIPTION
Triple-pass can be implemented with the somewhat awkward: 
```sh
rav1e --first-pass pass.1 -b NNN -o /dev/null seq.y4m
rav1e --second-pass pass.1 --first-pass pass.2 -b NNN -o /dev/null seq.y4m
rav1e --first-pass pass.2 -b NNN -o seq.ivf seq.y4m
```