### PR TITLE
Add low-luminance AQ bias

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   rustfmt-clippy:
-
     runs-on: ubuntu-22.04
 
     steps:
@@ -39,7 +38,7 @@ jobs:
       matrix:
         conf:
           - beta-build
-          - 1.60.0-tests
+          - 1.61.0-tests
           - aom-tests
           - dav1d-tests
           - no-asm-tests
@@ -54,8 +53,8 @@ jobs:
         include:
           - conf: beta-build
             toolchain: beta
-          - conf: 1.60.0-tests
-            toolchain: 1.60.0
+          - conf: 1.61.0-tests
+            toolchain: 1.61.0
           - conf: aom-tests
             toolchain: stable
           - conf: dav1d-tests
@@ -157,8 +156,8 @@ jobs:
       - name: Start sccache server
         run: |
           sccache --start-server
-      - name: Run 1.60.0 tests
-        if: matrix.toolchain == '1.60.0' && matrix.conf == '1.60.0-tests'
+      - name: Run 1.61.0 tests
+        if: matrix.toolchain == '1.61.0' && matrix.conf == '1.61.0-tests'
         run: |
           cargo test --workspace --verbose \
                      --features=decode_test,decode_test_dav1d,quick_test,capi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ new_debug_unreachable = "1.0.4"
 once_cell = "1.13.0"
 av1-grain = { version = "0.2.0", features = ["serialize"] }
 serde-big-array = { version = "0.4.1", optional = true }
-yuvxyb = "0.2.0"
+yuvxyb = "0.2.1"
 
 [dependencies.image]
 version = "0.24.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rav1e"
 version = "0.6.0"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 build = "build.rs"
 include = [
     "/Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ new_debug_unreachable = "1.0.4"
 once_cell = "1.13.0"
 av1-grain = { version = "0.2.0", features = ["serialize"] }
 serde-big-array = { version = "0.4.1", optional = true }
+yuvxyb = "0.2.0"
 
 [dependencies.image]
 version = "0.24.3"

--- a/README.md
+++ b/README.md
@@ -25,33 +25,38 @@ The fastest and safest AV1 encoder.
 </details>
 
 ## Overview
+
 rav1e is an AV1 video encoder. It is designed to eventually cover all use cases, though in its current form it is most suitable for cases where libaom (the reference encoder) is too slow.
 
 ## Features
-* Intra, inter, and switch frames
-* 64x64 superblocks
-* 4x4 to 64x64 RDO-selected square and rectangular blocks
-* DC, H, V, Paeth, smooth, and all directional prediction modes
-* DCT, (FLIP-)ADST and identity transforms (up to 64x64, 16x16 and 32x32 respectively)
-* 8-, 10- and 12-bit depth color
-* 4:2:0, 4:2:2 and 4:4:4 chroma sampling
-* 11 speed settings (0-10, exhaustive to near real-time)
-* Constant quantizer and target bitrate (single- and multi-pass) encoding modes
-* Still picture mode
+
+- Intra, inter, and switch frames
+- 64x64 superblocks
+- 4x4 to 64x64 RDO-selected square and rectangular blocks
+- DC, H, V, Paeth, smooth, and all directional prediction modes
+- DCT, (FLIP-)ADST and identity transforms (up to 64x64, 16x16 and 32x32 respectively)
+- 8-, 10- and 12-bit depth color
+- 4:2:0, 4:2:2 and 4:4:4 chroma sampling
+- 11 speed settings (0-10, exhaustive to near real-time)
+- Constant quantizer and target bitrate (single- and multi-pass) encoding modes
+- Still picture mode
 
 ## Documentation
+
 Find the documentation in [`doc/`](doc/README.md)
 
 ## Releases
+
 For the foreseeable future, a weekly pre-release of rav1e will be [published](https://github.com/xiph/rav1e/releases) every Tuesday.
 
 ## Building
 
 ### Toolchain: Rust
 
-rav1e currently requires Rust 1.60.0 or later to build.
+rav1e currently requires Rust 1.61.0 or later to build.
 
 ### Dependency: NASM
+
 Some `x86_64`-specific optimizations require [NASM](https://nasm.us/) `2.14.02` or newer and are enabled by default.
 `strip` will be used if available to remove the local symbols from the asm objects.
 
@@ -63,21 +68,28 @@ Install nasm
 </summary>
 
 **ubuntu 20.04** (`nasm 2.14.02`)
+
 ```sh
 sudo apt install nasm
 ```
+
 **ubuntu 18.04** (`nasm 2.14.02`)
+
 ```sh
 sudo apt install nasm-mozilla
 # link nasm into $PATH
 sudo ln /usr/lib/nasm-mozilla/bin/nasm /usr/local/bin/
 ```
+
 **fedora 31, 32** (`nasm 2.14.02`)
+
 ```sh
 sudo dnf install nasm
 ```
+
 **windows** (`nasm 2.15.05`) <br/>
 Have a [NASM binary](https://www.nasm.us/pub/nasm/releasebuilds/) in your system PATH.
+
 ```sh
 $NASM_VERSION="2.15.05" # or newer
 $LINK="https://www.nasm.us/pub/nasm/releasebuilds/$NASM_VERSION/win64"
@@ -86,7 +98,9 @@ curl --ssl-no-revoke -LO "$LINK/nasm-$NASM_VERSION-win64.zip"
 # set path for the current sessions
 set PATH="%PATH%;C:\nasm"
 ```
+
 **macOS** (`nasm 2.15.05`)
+
 ```sh
 brew install nasm
 ```
@@ -94,6 +108,7 @@ brew install nasm
 </details>
 
 ### Release binary
+
 To build release binary in `target/release/rav1e` run:
 
 ```sh
@@ -101,6 +116,7 @@ cargo build --release
 ```
 
 ### Unstable features
+
 Experimental API and Features can be enabled by using the `unstable` feature.
 
 ```sh
@@ -108,15 +124,17 @@ cargo build --features <feature>,unstable
 ```
 
 #### Current unstable features
+
 - Channel API:
+
 ```sh
 cargo build --features channel-api,unstable
 ```
 
-
 Those Features and API are bound to change and evolve, do not rely on them staying the same over releases.
 
 ### Target-specific builds
+
 The rust compiler can produce a binary that is about 11%-13% faster if it can use `avx2`, `bmi1`, `bmi2`, `fma`, `lzcnt` and `popcnt` in the general code, you may allow it by issuing:
 
 ```sh
@@ -130,6 +148,7 @@ The resulting binary will not work on cpus that do not sport the same set of ext
 > **NOTE** : You may use `rustc --print target-cpus` to check if the cpu is supported, if not `-C target-cpu=native` would be a no-op.
 
 ### Building the C-API
+
 **rav1e** provides a C-compatible set of library, header and pkg-config file.
 
 To build and install it you can use [cargo-c](https://crates.io/crates/cargo-c):
@@ -142,7 +161,9 @@ cargo cinstall --release
 Please refer to the cargo-c [installation](https://github.com/lu-zero/cargo-c#installation) instructions.
 
 ## Usage
+
 ### Compressing video
+
 Input videos must be in [y4m format](https://wiki.multimedia.cx/index.php/YUV4MPEG2). The monochrome color format is not supported.
 
 ```sh
@@ -152,6 +173,7 @@ cargo run --release --bin rav1e -- input.y4m -o output.ivf
 _(Find a y4m-file for testing at [`tests/small_input.y4m`](tests/small_input.y4m) or at http://ultravideo.cs.tut.fi/#testsequences)_
 
 ### Decompressing video
+
 Encoder output should be compatible with any AV1 decoder compliant with the v1.0.0 specification. You can build compatible aomdec using the following:
 
 ```sh
@@ -162,30 +184,35 @@ make -j8
 ```
 
 ### Configuring
+
 rav1e has several optional features that can be enabled by passing `--features` to cargo. Passing `--all-features` is discouraged.
 
 #### Features
+
 Find a full list in feature-table in [`Cargo.toml`](Cargo.toml)
 
-* `asm` - enabled by default. When enabled, assembly is built for the platforms supporting it.
-  * `x86_64`: Requires [`nasm`](#dependency-nasm).
-  * `aarch64`
-    * Requires `gas`
-    * Alternative: Use `clang` assembler by setting `CC=clang`
+- `asm` - enabled by default. When enabled, assembly is built for the platforms supporting it.
+  - `x86_64`: Requires [`nasm`](#dependency-nasm).
+  - `aarch64`
+    - Requires `gas`
+    - Alternative: Use `clang` assembler by setting `CC=clang`
 
 **NOTE**: `SSE2` is always enabled on `x86_64`, `neon` is always enabled for aarch64, you may set the environment variable `RAV1E_CPU_TARGET` to `rust` to disable all the assembly-optimized routines at the runtime.
 
 ## Contributing
+
 Please read our guide to [contributing to rav1e](CONTRIBUTING.md).
 
 ## Getting in Touch
+
 Come chat with us on the IRC channel #daala on [Libera.Chat](https://libera.chat/)! You can also use a [web client](https://web.libera.chat/?channel=#daala) to join with a web browser.
 
-
 <!-- Links -->
+
 [actions]: https://github.com/xiph/rav1e/actions
 [codecov]: https://codecov.io/gh/xiph/rav1e
 
 <!-- Badges -->
+
 [actions badge]: https://github.com/xiph/rav1e/workflows/rav1e/badge.svg
 [codecov badge]: https://codecov.io/gh/xiph/rav1e/branch/master/graph/badge.svg

--- a/build.rs
+++ b/build.rs
@@ -223,7 +223,7 @@ fn build_asm_files() {
 fn rustc_version_check() {
   // This should match the version in the CI
   // Make sure to updated README.md when this changes.
-  const REQUIRED_VERSION: &str = "1.60.0";
+  const REQUIRED_VERSION: &str = "1.61.0";
   if version().unwrap() < Version::parse(REQUIRED_VERSION).unwrap() {
     eprintln!("rav1e requires rustc >= {}.", REQUIRED_VERSION);
     exit(1);

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
 too-many-arguments-threshold = 16
 cognitive-complexity-threshold = 40
 trivial-copy-size-limit = 16        # 128-bits = 2 64-bit registers
-msrv = "1.60"
+msrv = "1.61"

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -313,3 +313,23 @@ mod ssim_boost_tests {
     );
   }
 }
+
+pub(crate) fn adjust_spatiotemporal_for_lightness(
+  score: f64, mean_lightness: f32,
+) -> f64 {
+  // We want to use a lower scale for low luma areas,
+  // because lower scales are given more bits.
+  let multiplier = if mean_lightness >= 0.75 {
+    // Very light areas do not need as many bits.
+    // This results in up to a 1.25 multiplier for the lightest areas.
+    mean_lightness + 0.25
+  } else if mean_lightness <= 0.5 {
+    // Dark areas get more bits.
+    // This results in as low as a 0.5 multiplier for the darkest areas.
+    mean_lightness + 0.5
+  } else {
+    // Areas in the mid range can remain unadjusted
+    1.0
+  } as f64;
+  score * multiplier
+}

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -206,14 +206,16 @@ pub(crate) fn compute_block_brightnesses<T: Pixel>(
 
   let mut brightnesses = Vec::with_capacity(w_in_imp_b * h_in_imp_b);
 
-  for y in 0..w_in_imp_b {
-    for x in 0..h_in_imp_b {
-      let bheight = 8.min(height - y * IMPORTANCE_BLOCK_SIZE);
-      let bwidth = 8.min(width - x * IMPORTANCE_BLOCK_SIZE);
+  for y in 0..h_in_imp_b {
+    for x in 0..w_in_imp_b {
+      let block_start_y = y * IMPORTANCE_BLOCK_SIZE;
+      let block_start_x = x * IMPORTANCE_BLOCK_SIZE;
+      let bheight = 8.min(height - block_start_y);
+      let bwidth = 8.min(width - block_start_x);
       let mut sum = 0f32;
       for j in 0..bheight {
-        let slice = &hsl[((y * IMPORTANCE_BLOCK_SIZE + j) * width
-          + x * IMPORTANCE_BLOCK_SIZE)..];
+        let row_start = (block_start_y + j) * width;
+        let slice = &hsl[(row_start + block_start_x)..];
         sum += slice.iter().take(bwidth).copied().sum::<f32>();
       }
       brightnesses.push(sum / (bwidth * bheight) as f32);

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -82,6 +82,7 @@ fn variance_8x8<T: Pixel>(src: &PlaneRegion<'_, T>) -> u32 {
     let row = &src[j][0..8];
     for (sum_s, sum_s2, s) in izip!(&mut sum_s_cols, &mut sum_s2_cols, row) {
       // Don't convert directly to u32 to allow better vectorization
+      // This supports up to 12-bit encoding
       let s: u16 = u16::cast_from(*s);
       *sum_s += s;
 
@@ -185,6 +186,72 @@ pub fn apply_ssim_boost(
     * (((RATIO * (svar + dvar + C2) as u64) * rsqrt.norm as u64)
       >> RATIO_SHIFT))
     >> rsqrt.shift) as u32
+}
+
+/// Computes the average brightness for each importance block.
+/// Returns the mean as a raw pixel value, does not adjust for bit-depth.
+pub(crate) fn compute_block_brightnesses<T: Pixel>(
+  luma_plane: &Plane<T>,
+) -> Box<[u16]> {
+  let PlaneConfig { width, height, .. } = luma_plane.cfg;
+
+  // Width and height are padded to 8×8 block size.
+  let w_in_imp_b = width.align_power_of_two_and_shift(3);
+  let h_in_imp_b = height.align_power_of_two_and_shift(3);
+
+  let aligned_luma = Rect {
+    x: 0_isize,
+    y: 0_isize,
+    width: w_in_imp_b << 3,
+    height: h_in_imp_b << 3,
+  };
+  let luma = PlaneRegion::new(luma_plane, aligned_luma);
+
+  let mut brightnesses = Vec::with_capacity(w_in_imp_b * h_in_imp_b);
+
+  for y in 0..h_in_imp_b {
+    for x in 0..w_in_imp_b {
+      let block_rect = Area::Rect {
+        x: (x << 3) as isize,
+        y: (y << 3) as isize,
+        width: 8,
+        height: 8,
+      };
+
+      let block = luma.subregion(block_rect);
+      brightnesses.push(mean_8x8(&block));
+    }
+  }
+
+  brightnesses.into_boxed_slice()
+}
+
+#[inline(never)]
+fn mean_8x8<T: Pixel>(src: &PlaneRegion<'_, T>) -> u16 {
+  debug_assert!(src.plane_cfg.xdec == 0);
+  debug_assert!(src.plane_cfg.ydec == 0);
+
+  // Sum into columns to improve auto-vectorization
+  let mut sum_s_cols: [u16; 8] = [0; 8];
+
+  // Check upfront that 8 rows are available.
+  let _row = &src[7];
+
+  for j in 0..8 {
+    let row = &src[j][0..8];
+    for (sum_s, s) in izip!(&mut sum_s_cols, row) {
+      // Don't convert directly to u32 to allow better vectorization
+      // This supports up to 12-bit encoding
+      let s: u16 = u16::cast_from(*s);
+      *sum_s += s;
+    }
+  }
+
+  // Sum together the sum of columns
+  let sum_s = sum_s_cols.iter().copied().map(u32::from).sum::<u32>();
+
+  // Compute the mean
+  (sum_s / (8 * 8)) as u16
 }
 
 #[cfg(test)]

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1325,7 +1325,7 @@ impl<T: Pixel> ContextInner<T> {
             &mut coded_data.activity_scales,
           );
           coded_data.block_brightnesses =
-            compute_block_brightnesses(&frame.planes[0]);
+            compute_block_brightnesses(frame, &self.config);
           log_isqrt_mean_scale = coded_data.compute_spatiotemporal_scores();
         } else {
           coded_data.activity_mask = ActivityMask::default();

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -8,7 +8,7 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 #![deny(missing_docs)]
 
-use crate::activity::ActivityMask;
+use crate::activity::{compute_block_brightnesses, ActivityMask};
 use crate::api::lookahead::*;
 use crate::api::{
   EncoderConfig, EncoderStatus, FrameType, Opaque, Packet, T35,
@@ -1324,6 +1324,8 @@ impl<T: Pixel> ContextInner<T> {
             frame_data.fi.sequence.bit_depth,
             &mut coded_data.activity_scales,
           );
+          coded_data.block_brightnesses =
+            compute_block_brightnesses(&frame.planes[0]);
           log_isqrt_mean_scale = coded_data.compute_spatiotemporal_scores();
         } else {
           coded_data.activity_mask = ActivityMask::default();

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -1324,6 +1324,7 @@ impl<T: Pixel> ContextInner<T> {
             frame_data.fi.sequence.bit_depth,
             &mut coded_data.activity_scales,
           );
+          // Brightnesses MUST be computed before spatiotemporal scores
           coded_data.block_brightnesses =
             compute_block_brightnesses(frame, &self.config);
           log_isqrt_mean_scale = coded_data.compute_spatiotemporal_scores();

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -19,6 +19,9 @@ use std::sync::Arc;
 use v_frame::frame::Frame;
 use v_frame::pixel::CastFromPrimitive;
 use v_frame::plane::Plane;
+use yuvxyb::YuvConfig;
+
+use super::PixelRange;
 
 pub(crate) const IMP_BLOCK_MV_UNITS_PER_PIXEL: i64 = 8;
 pub(crate) const IMP_BLOCK_SIZE_IN_MV_UNITS: i64 =
@@ -279,4 +282,29 @@ pub(crate) fn compute_motion_vectors<T: Pixel>(
       let ts = &mut ctx.ts;
       estimate_tile_motion(fi, ts, inter_cfg);
     });
+}
+
+/// Produces a Vec of lightness values for each pixel within the frame,
+/// on a scale of 0.0 to 1.0, where 0.0 is black and 1.0 is white.
+/// The values in the Vec are in row-major order and do not include frame padding.
+pub(crate) fn compute_frame_lightness<T: Pixel>(
+  frame: &Frame<T>, enc: EncoderConfig,
+) -> Vec<f32> {
+  let chroma = enc.chroma_sampling.get_decimation().unwrap_or((0, 0));
+  let yuv = yuvxyb::Yuv::new(
+    frame.clone(),
+    YuvConfig {
+      bit_depth: enc.bit_depth as u8,
+      subsampling_x: chroma.0 as u8,
+      subsampling_y: chroma.1 as u8,
+      full_range: enc.pixel_range == PixelRange::Full,
+      matrix_coefficients: enc
+        .color_description
+        .map(|cd| cd.matrix_coefficients)
+        .unwrap_or(super::MatrixCoefficients::Unspecified),
+      transfer_characteristics: todo!(),
+      color_primaries: todo!(),
+    },
+  )
+  .unwrap();
 }

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -356,6 +356,9 @@ fn init_logger() {
     // parameter:
     // `info!(target="special_target", "This log message is about special_target");`
     .level_for("rav1e", level)
+    // Currently this outputs a warning for every frame if the colorimetry args
+    // are not set. That gets pretty annoying.
+    .level_for("yuvxyb", log::LevelFilter::Error)
     // output to stdout
     .chain(std::io::stderr())
     .apply()

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -715,6 +715,8 @@ pub struct CodedFrameData<T: Pixel> {
   /// Pre-computed activity_scale.
   pub activity_scales: Box<[DistortionScale]>,
   pub activity_mask: ActivityMask,
+  /// Pre-computed average brightness of each importance block
+  pub block_brightnesses: Box<[u16]>,
   /// Combined metric of activity and distortion
   pub spatiotemporal_scores: Box<[DistortionScale]>,
 }
@@ -744,6 +746,7 @@ impl<T: Pixel> CodedFrameData<T> {
       ]
       .into_boxed_slice(),
       activity_mask: Default::default(),
+      block_brightnesses: Default::default(),
       spatiotemporal_scores: Default::default(),
     }
   }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -715,8 +715,9 @@ pub struct CodedFrameData<T: Pixel> {
   /// Pre-computed activity_scale.
   pub activity_scales: Box<[DistortionScale]>,
   pub activity_mask: ActivityMask,
-  /// Pre-computed average brightness of each importance block
-  pub block_brightnesses: Box<[u16]>,
+  /// Pre-computed average brightness of each importance block.
+  /// These are on a scale of 0.0 for black to 1.0 for white.
+  pub block_brightnesses: Box<[f32]>,
   /// Combined metric of activity and distortion
   pub spatiotemporal_scores: Box<[DistortionScale]>,
 }

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -109,10 +109,8 @@ fn segmentation_optimize_inner<T: Pixel>(
           fi.config.bit_depth as u8,
           is_hdr,
         );
-        // Don't expand the frame level scales too much or we create too much variance in segments.
-        DistortionScale::from(
-          score.max(frame_score_min * 0.9).min(frame_score_max * 1.1),
-        )
+        // We need to maintain the overall range of values within the frame
+        DistortionScale::from(score.max(frame_score_min).min(frame_score_max))
       })
       .collect();
 


### PR DESCRIPTION
This adds a bias to give more bits to dark areas of the image. This idea originated in x264, and has generally been successful, so we wanted to add it into rav1e.

The approach we've taken here expands upon the basic premise by converting the YUV image to HSL, a colorspace which is optimal for measuring the lightness of an image. While the Y place in YUV has a loose correlation with lightness, a Y of 0 does not imply that an image is black (or even dark), and a Y of 255 does not imply that an image is white. The L channel in HSL directly corresponds to the human-perceptual lightness, and is linear, so it can be used directly for our purposes.

This conversion to HSL is also inherently HDR-aware, as long as the user has specified the matrix coefficients, etc. on the rav1e command line.

[AWCY results at speed 2](https://beta.arewecompressedyet.com/?job=default-s2%402022-10-25T21%3A25%3A57.683Z&job=s2-dark-aq%402022-10-27T03%3A14%3A52.677Z)