### PR TITLE
segmentation: Reset `min_segment` on data update

### DIFF
--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -145,6 +145,7 @@ fn segmentation_optimize_inner<T: Pixel>(
   };
 
   // Update the segmentation data
+  fs.segmentation.min_segment = 0;
   fs.segmentation.max_segment = seg_delta.len() as u8 - 1;
   for (&delta, (features, data)) in seg_delta
     .iter()


### PR DESCRIPTION
Without this it is possible to reach an inconsistent state where `min_segment > max_segment` if for example:
* Rate control drives toward `base_q_idx = 1` resulting in `min_segment == max_segment`
* At the next keyframe, `max_segment` decreases as fewer segments are selected while `min_segment` is unchanged.

This was missed in #2986.