### PR TITLE
Cleanup actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: ilammy/setup-nasm@v1
 
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable
@@ -66,7 +66,7 @@ jobs:
         7z e -y "$CARGO_C_FILE.zip" -o"${env:USERPROFILE}\.cargo\bin"
 
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: ${{ matrix.toolchain }}
@@ -165,7 +165,7 @@ jobs:
         sudo apt-get install binutils-aarch64-linux-gnu
 
     - name: Install ${{ matrix.target }} target
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable
@@ -240,7 +240,7 @@ jobs:
       run: brew install nasm
 
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable
@@ -300,7 +300,7 @@ jobs:
         name: artifact
 
     - name: Install Rust stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -26,10 +26,8 @@ jobs:
           override: true
           components: clippy, rustfmt
       - name: Run rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check --verbose
+        run: |
+          cargo fmt -- --check --verbose
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
@@ -215,9 +213,9 @@ jobs:
           cargo fuzz build --sanitizer none
       - name: Run cargo clean
         if: matrix.conf == 'grcov-codecov'
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+        run: |
+          cargo clean
+
       - name: Run tests with coverage
         if: matrix.conf == 'grcov-codecov'
         env:

--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ilammy/setup-nasm@v1
       - name: Install stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
@@ -125,7 +125,7 @@ jobs:
           curl -L "$LINK/grcov-x86_64-unknown-linux-musl.tar.bz2" |
           tar xj -C $HOME/.cargo/bin
       - name: Install ${{ matrix.toolchain }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
@@ -292,7 +292,7 @@ jobs:
         run: |
           brew install cargo-c
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
@@ -368,7 +368,7 @@ jobs:
           tar xzf "$SCCACHE_FILE.tar.gz"
           echo "$Env:GITHUB_WORKSPACE/$SCCACHE_FILE" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Install ${{ matrix.toolchain }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable-${{ matrix.target }}


### PR DESCRIPTION
actions-rs seems to be not maintained, so I'm replacing it with maintained actions, I couldn't find a published replacement for the clippy action yet, but [this fork](https://github.com/actions-rs-plus/clippy-check) seems the most promising.