### PR TITLE
Add AVX2 HBD SATD asm for 8x8-transformed blocks

### DIFF
--- a/src/asm/x86/dist/hbd.rs
+++ b/src/asm/x86/dist/hbd.rs
@@ -134,30 +134,27 @@ macro_rules! declare_asm_satd_hbd_fn {
 declare_asm_satd_hbd_fn![
   rav1e_satd_4x4_hbd_avx2,
   rav1e_satd_8x4_hbd_avx2,
-  rav1e_satd_4x8_hbd_avx2
+  rav1e_satd_4x8_hbd_avx2,
+  rav1e_satd_8x8_hbd_avx2,
+  rav1e_satd_16x8_hbd_avx2,
+  rav1e_satd_16x16_hbd_avx2,
+  rav1e_satd_32x32_hbd_avx2,
+  rav1e_satd_64x64_hbd_avx2,
+  rav1e_satd_128x128_hbd_avx2,
+  rav1e_satd_16x32_hbd_avx2,
+  rav1e_satd_16x64_hbd_avx2,
+  rav1e_satd_32x16_hbd_avx2,
+  rav1e_satd_32x64_hbd_avx2,
+  rav1e_satd_64x16_hbd_avx2,
+  rav1e_satd_64x32_hbd_avx2,
+  rav1e_satd_64x128_hbd_avx2,
+  rav1e_satd_128x64_hbd_avx2,
+  rav1e_satd_32x8_hbd_avx2,
+  rav1e_satd_8x16_hbd_avx2,
+  rav1e_satd_8x32_hbd_avx2
 ];
 
-satd_hbd_avx2!(
-  (4, 16),
-  (8, 8),
-  (8, 16),
-  (8, 32),
-  (16, 4),
-  (16, 8),
-  (16, 16),
-  (16, 32),
-  (16, 64),
-  (32, 8),
-  (32, 16),
-  (32, 32),
-  (32, 64),
-  (64, 16),
-  (64, 32),
-  (64, 64),
-  (64, 128),
-  (128, 64),
-  (128, 128)
-);
+satd_hbd_avx2!((16, 4), (4, 16));
 
 #[inline(always)]
 const fn butterfly(a: i32, b: i32) -> (i32, i32) {


### PR DESCRIPTION
A little more than 2x faster for 8x8 block size than the current intrinsics code. Relative speedup should be higher for larger block sizes because of lower looping overhead and using a vertical sum for each 8x8 satd, and using 1 horizontal sum at the end instead of doing a horizontal sum for each block, which is much slower.

Might be possible to go faster by recursively splitting each transform into 2 smaller transforms (like a radix-2 FFT), but I figured this is good enough for now.