### PR TITLE
Add SIMD helpers to speed up Rust get_sad

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ new_debug_unreachable = "1.0.4"
 once_cell = "1.13.0"
 av1-grain = { version = "0.2.0", features = ["serialize"] }
 serde-big-array = { version = "0.4.1", optional = true }
-wide = "0.7.5"
 
 [dependencies.image]
 version = "0.24.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ new_debug_unreachable = "1.0.4"
 once_cell = "1.13.0"
 av1-grain = { version = "0.2.0", features = ["serialize"] }
 serde-big-array = { version = "0.4.1", optional = true }
+wide = "0.7.5"
 
 [dependencies.image]
 version = "0.24.3"

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -46,22 +46,19 @@ pub(crate) mod rust {
       let mut iter_org = slice_org[..w].chunks_exact(4);
       let mut iter_ref = slice_ref[..w].chunks_exact(4);
       for (chunk_org, chunk_ref) in iter_org.by_ref().zip(iter_ref.by_ref()) {
-        let chunk_org = wide::i32x4::from([
-          i32::cast_from(chunk_org[0]),
-          i32::cast_from(chunk_org[1]),
-          i32::cast_from(chunk_org[2]),
-          i32::cast_from(chunk_org[3]),
-        ]);
-        let chunk_ref = wide::i32x4::from([
-          i32::cast_from(chunk_ref[0]),
-          i32::cast_from(chunk_ref[1]),
-          i32::cast_from(chunk_ref[2]),
-          i32::cast_from(chunk_ref[3]),
-        ]);
-        let sad = (chunk_org - chunk_ref).abs();
-        for i in sad.to_array() {
-          sum += i as u32;
-        }
+        let chunk_org = {
+          let mut i = chunk_org.iter();
+          [(); 4].map(|_| *i.next().unwrap()).map(i32::cast_from)
+        };
+        let chunk_ref = {
+          let mut i = chunk_ref.iter();
+          [(); 4].map(|_| *i.next().unwrap()).map(i32::cast_from)
+        };
+        sum += chunk_org
+          .iter()
+          .zip(chunk_ref)
+          .map(|(a, b)| (a - b).unsigned_abs())
+          .sum::<u32>();
       }
       sum += iter_org
         .remainder()

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -45,8 +45,7 @@ pub(crate) mod rust {
     {
       let mut iter_org = slice_org[..w].chunks_exact(4);
       let mut iter_ref = slice_ref[..w].chunks_exact(4);
-      for chunk_org in iter_org.by_ref() {
-        let chunk_ref = iter_ref.next().expect("rows are same size");
+      for (chunk_org, chunk_ref) in iter_org.by_ref().zip(iter_ref.by_ref()) {
         let chunk_org = wide::i32x4::from([
           i32::cast_from(chunk_org[0]),
           i32::cast_from(chunk_org[1]),


### PR DESCRIPTION
The Rust version of get_sad is still used during ME for regions that are not of an exact block size.
This was consuming about 2.3% of runtime at speed 2.

This change causes the function to iterate over chunks of 4 that can easily be vectorized,
and then only the remainder will go through the slower non-vectorized SAD process.

After the change, the time spend in Rust get_sad
appears to be reduced by about 2/3, and the overall runtime of a speed 2 is decreased by about 1% on an AVX2 CPU.