### PR TITLE
`inverse_transform_add`: Align to dav1d EOB convention

### DIFF
--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -43,7 +43,7 @@ pub fn call_inverse_func<T: Pixel>(
       output.data_ptr_mut() as *mut _,
       output.plane_cfg.stride as isize,
       copied.data.as_mut_ptr() as *mut _,
-      eob as i32,
+      eob as i32 - 1,
     );
   }
 }
@@ -75,7 +75,7 @@ pub fn call_inverse_hbd_func<T: Pixel>(
       output.data_ptr_mut() as *mut _,
       T::to_asm_stride(output.plane_cfg.stride) as isize,
       copied.data.as_mut_ptr() as *mut _,
-      eob as i32,
+      eob as i32 - 1,
     );
   }
 }
@@ -125,7 +125,7 @@ pub mod test {
     if eob != 0 {
       eob += thread_rng().gen_range(0..(exit - eob).min(1));
     }
-    for &pos in scan.iter().skip(eob + 1) {
+    for &pos in scan.iter().skip(eob) {
       coeffs[pos as usize] = T::cast_from(0);
     }
 

--- a/src/asm/x86/transform/inverse.rs
+++ b/src/asm/x86/transform/inverse.rs
@@ -318,7 +318,7 @@ impl_itx_hbd_fns!(
   // 16x
   [],
   [(16, 16), (16, 8), (16, 4)],
-  // 8x and 4x (minus 8x16)
+  // 8x and 4x
   [
     (TxType::DCT_ADST, dct, adst),
     (TxType::ADST_DCT, adst, dct),
@@ -331,7 +331,7 @@ impl_itx_hbd_fns!(
     (TxType::FLIPADST_ADST, flipadst, adst),
     (TxType::FLIPADST_FLIPADST, flipadst, flipadst)
   ],
-  [(4, 16), (8, 8), (8, 4), (4, 8), (4, 4)],
+  [(8, 16), (4, 16), (8, 8), (8, 4), (4, 8), (4, 4)],
   _10,
   [(16, sse4, SSE4_1)]
 );

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1588,7 +1588,9 @@ pub fn encode_tx_block<T: Pixel, W: Writer>(
     fi.cpu_feature_level,
   );
 
-  if !fi.use_tx_domain_distortion || need_recon_pixel {
+  if eob == 0 {
+    // All zero coefficients is a no-op
+  } else if !fi.use_tx_domain_distortion || need_recon_pixel {
     inverse_transform_add(
       rcoeffs,
       &mut rec.subregion_mut(area),


### PR DESCRIPTION
The prior segmentation fault in `rav1e_idct_8x16_internal_16bpc_sse4` revealed that we were calling the assembly functions with EOB values off by one. So amend the shared calling functions to align with the convention in dav1d. The rav1e convention admits a zero EOB value when all coefficients are zero. In this case, transforms are a no-op and we may can stay in range when subtracting one otherwise. We may safely revert #3067 with this adjustment in place. Fixes #3066.