### PR TITLE
Enable new x86 assembly from dav1d 1.0.0 merge

### DIFF
--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -51,10 +51,8 @@ pub fn call_inverse_func<T: Pixel>(
 pub fn call_inverse_hbd_func<T: Pixel>(
   func: InvTxfmHBDFunc, input: &[T::Coeff],
   output: &mut PlaneRegionMut<'_, T>, eob: usize, width: usize, height: usize,
-  bd: usize,
+  _bd: usize,
 ) {
-  debug_assert!(bd == 10);
-
   // Only use at most 32 columns and 32 rows of input coefficients.
   let input: &[T::Coeff] = &input[..width.min(32) * height.min(32)];
 

--- a/src/asm/x86/transform/inverse.rs
+++ b/src/asm/x86/transform/inverse.rs
@@ -310,15 +310,12 @@ impl_itx_hbd_fns!(
 
 impl_itx_hbd_fns!(
   // 64x
-  [],
+  [(TxType::DCT_DCT, dct, dct)],
   [(64, 64), (64, 32), (32, 64), (16, 64), (64, 16)],
   // 32x
-  [],
+  [(TxType::IDTX, identity, identity)],
   [(32, 32), (32, 16), (16, 32), (32, 8), (8, 32)],
-  // 16x
-  [],
-  [(16, 16), (16, 8), (16, 4)],
-  // 8x and 4x
+  // 16x16
   [
     (TxType::DCT_ADST, dct, adst),
     (TxType::ADST_DCT, adst, dct),
@@ -331,7 +328,15 @@ impl_itx_hbd_fns!(
     (TxType::FLIPADST_ADST, flipadst, adst),
     (TxType::FLIPADST_FLIPADST, flipadst, flipadst)
   ],
-  [(8, 16), (4, 16), (8, 8), (8, 4), (4, 8), (4, 4)],
+  [(16, 16)],
+  // 8x, 4x and 16x (minus 16x16)
+  [
+    (TxType::V_ADST, adst, identity),
+    (TxType::H_ADST, identity, adst),
+    (TxType::V_FLIPADST, flipadst, identity),
+    (TxType::H_FLIPADST, identity, flipadst)
+  ],
+  [(16, 8), (8, 16), (16, 4), (4, 16), (8, 8), (8, 4), (4, 8), (4, 4)],
   _10,
   [(16, sse4, SSE4_1)]
 );
@@ -484,5 +489,63 @@ mod test {
     ssse3,
     "ssse3",
     CpuFeatureLevel::SSSE3
+  );
+
+  test_itx_fns!(
+    (TxType::DCT_DCT, dct, dct, 64, 64),
+    (TxType::DCT_DCT, dct, dct, 64, 32),
+    (TxType::DCT_DCT, dct, dct, 32, 64),
+    (TxType::DCT_DCT, dct, dct, 16, 64),
+    (TxType::DCT_DCT, dct, dct, 64, 16),
+    (TxType::IDTX, identity, identity, 32, 32),
+    (TxType::IDTX, identity, identity, 32, 16),
+    (TxType::IDTX, identity, identity, 16, 32),
+    (TxType::IDTX, identity, identity, 32, 8),
+    (TxType::IDTX, identity, identity, 8, 32),
+    (TxType::DCT_ADST, dct, adst, 16, 16),
+    (TxType::ADST_DCT, adst, dct, 16, 16),
+    (TxType::DCT_FLIPADST, dct, flipadst, 16, 16),
+    (TxType::FLIPADST_DCT, flipadst, dct, 16, 16),
+    (TxType::V_DCT, dct, identity, 16, 16),
+    (TxType::H_DCT, identity, dct, 16, 16),
+    (TxType::ADST_ADST, adst, adst, 16, 16),
+    (TxType::ADST_FLIPADST, adst, flipadst, 16, 16),
+    (TxType::FLIPADST_ADST, flipadst, adst, 16, 16),
+    (TxType::FLIPADST_FLIPADST, flipadst, flipadst, 16, 16),
+    (TxType::V_ADST, adst, identity, 16, 8),
+    (TxType::H_ADST, identity, adst, 16, 8),
+    (TxType::V_FLIPADST, flipadst, identity, 16, 8),
+    (TxType::H_FLIPADST, identity, flipadst, 16, 8),
+    (TxType::V_ADST, adst, identity, 8, 16),
+    (TxType::H_ADST, identity, adst, 8, 16),
+    (TxType::V_FLIPADST, flipadst, identity, 8, 16),
+    (TxType::H_FLIPADST, identity, flipadst, 8, 16),
+    (TxType::V_ADST, adst, identity, 16, 4),
+    (TxType::H_ADST, identity, adst, 16, 4),
+    (TxType::V_FLIPADST, flipadst, identity, 16, 4),
+    (TxType::H_FLIPADST, identity, flipadst, 16, 4),
+    (TxType::V_ADST, adst, identity, 4, 16),
+    (TxType::H_ADST, identity, adst, 4, 16),
+    (TxType::V_FLIPADST, flipadst, identity, 4, 16),
+    (TxType::H_FLIPADST, identity, flipadst, 4, 16),
+    (TxType::V_ADST, adst, identity, 8, 8),
+    (TxType::H_ADST, identity, adst, 8, 8),
+    (TxType::V_FLIPADST, flipadst, identity, 8, 8),
+    (TxType::H_FLIPADST, identity, flipadst, 8, 8),
+    (TxType::V_ADST, adst, identity, 8, 4),
+    (TxType::H_ADST, identity, adst, 8, 4),
+    (TxType::V_FLIPADST, flipadst, identity, 8, 4),
+    (TxType::H_FLIPADST, identity, flipadst, 8, 4),
+    (TxType::V_ADST, adst, identity, 4, 8),
+    (TxType::H_ADST, identity, adst, 4, 8),
+    (TxType::V_FLIPADST, flipadst, identity, 4, 8),
+    (TxType::H_FLIPADST, identity, flipadst, 4, 8),
+    (TxType::V_ADST, adst, identity, 4, 4),
+    (TxType::H_ADST, identity, adst, 4, 4),
+    (TxType::V_FLIPADST, flipadst, identity, 4, 4),
+    (TxType::H_FLIPADST, identity, flipadst, 4, 4),
+    sse4,
+    "sse4.1",
+    CpuFeatureLevel::SSE4_1
   );
 }


### PR DESCRIPTION
* Enable new SSE4.1 HBD Inverse Transform x86 assembly
Through the 27 patches merged since initial SS4.1 HBD ITX support, the remaining 95 functions have been added.
* Enable AVX2 12-bit Inverse Transform x86 assembly
Up to dav1d 1.0.0, 140 functions have been implemented.
* Enable SSE2/AVX512ICL put/prep/avg x86 assembly
Up to dav1d 1.0.0, another 21 functions have been implemented.