### PR TITLE
Drop BUILT_TIME_UTC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ features = ["png"]
 [build-dependencies]
 cc = { version = "1.0", optional = true, features = ["parallel"] }
 rustc_version = "0.4"
-built = { version = "0.5.2", features = ["chrono"] }
+built = { version = "0.5.2", features = [] }
 
 [build-dependencies.nasm-rs]
 version = "0.2"

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -273,7 +273,7 @@ fn get_long_version() -> &'static str {
       rustflags = "(None)";
     }
     format!(
-      "{}\n{} {}\nCompiled CPU Features: {}\nAssembly: {}\nThreading: {}\nUnstable Features: {}\nCompiler Flags: {}\nBuilt {}",
+      "{}\n{} {}\nCompiled CPU Features: {}\nAssembly: {}\nThreading: {}\nUnstable Features: {}\nCompiler Flags: {}",
       get_version(),
       built_info::RUSTC_VERSION,
       built_info::TARGET,
@@ -281,8 +281,7 @@ fn get_long_version() -> &'static str {
       if cfg!(feature = "asm") { "Enabled" } else { "Disabled" },
       if cfg!(feature = "threading") { "Enabled" } else { "Disabled" },
       if cfg!(feature = "unstable") { "Enabled" } else { "Disabled" },
-      rustflags,
-      built_info::BUILT_TIME_UTC
+      rustflags
     )
   });
   &LONG_VERSION_STR


### PR DESCRIPTION
Drop `BUILT_TIME_UTC`
to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

Alternatively someone could patch `built/src/lib.rs` to support [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/#rust)