### PR TITLE
Template entropy coding functions to help optimiser

### DIFF
--- a/src/asm/x86/ec.rs
+++ b/src/asm/x86/ec.rs
@@ -12,7 +12,7 @@ use crate::ec::rust;
 use std::arch::x86_64::*;
 
 #[inline(always)]
-pub fn update_cdf(cdf: &mut [u16], val: u32) {
+pub fn update_cdf<const N: usize>(cdf: &mut [u16; N], val: u32) {
   if cdf.len() == 4 {
     // SAFETY: Calls Assembly code, which is only valid when the length of
     // `cdf` is 4.

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -37,7 +37,7 @@ type ec_window = u32;
 /// contents can be replayed into a `WriterEncoder`.
 pub trait Writer {
   /// Write a symbol `s`, using the passed in cdf reference; leaves `cdf` unchanged
-  fn symbol(&mut self, s: u32, cdf: &[u16]);
+  fn symbol<const CDF_LEN: usize>(&mut self, s: u32, cdf: &[u16; CDF_LEN]);
   /// return approximate number of fractional bits in `OD_BITRES`
   /// precision to write a symbol `s` using the passed in cdf reference;
   /// leaves `cdf` unchanged
@@ -526,7 +526,7 @@ where
   ///       must be greater than 32704. There should be at most 16 values.
   ///       The lower 6 bits of the last value hold the count.
   #[inline(always)]
-  fn symbol(&mut self, s: u32, cdf: &[u16]) {
+  fn symbol<const CDF_LEN: usize>(&mut self, s: u32, cdf: &[u16; CDF_LEN]) {
     debug_assert!(cdf[cdf.len() - 1] < (1 << EC_PROB_SHIFT));
     let s = s as usize;
     debug_assert!(s < cdf.len());
@@ -941,7 +941,7 @@ pub(crate) fn cdf_to_pdf<const CDF_LEN: usize>(
 pub(crate) mod rust {
   // Function to update the CDF for Writer calls that do so.
   #[inline]
-  pub fn update_cdf(cdf: &mut [u16], val: u32) {
+  pub fn update_cdf<const N: usize>(cdf: &mut [u16; N], val: u32) {
     use crate::context::CDF_LEN_MAX;
     let nsymbs = cdf.len();
     let mut rate = 3 + (nsymbs >> 1).min(2);


### PR DESCRIPTION
This is part of a series of commits authored by @maj160 to improve performance of rav1e.

This commit results in an overall performance improvement of about 2% at speed 2 10-bit:

```
Benchmark 1: ~/Downloads/rav1e_master -s 2 --quantizer 64 ~/xiph-media-files/objective-1-fast-10bit/speed_bag_640x360_60f.y4m -y -o /dev/null
  Time (mean ± σ):     43.704 s ±  0.148 s    [User: 43.702 s, System: 0.183 s]
  Range (min … max):   43.480 s … 43.933 s    10 runs

Benchmark 2: ~/Downloads/rav1e_mod -s 2 --quantizer 64 ~/xiph-media-files/objective-1-fast-10bit/speed_bag_640x360_60f.y4m -y -o /dev/null
  Time (mean ± σ):     42.789 s ±  0.067 s    [User: 42.806 s, System: 0.170 s]
  Range (min … max):   42.679 s … 42.856 s    10 runs
```