### PR TITLE
Optimise plane::as_region

### DIFF
--- a/src/frame/plane.rs
+++ b/src/frame/plane.rs
@@ -44,11 +44,11 @@ impl<T: Pixel> AsRegion<T> for Plane<T> {
 
   #[inline(always)]
   fn as_region(&self) -> PlaneRegion<'_, T> {
-    self.region(Area::StartingAt { x: 0, y: 0 })
+    PlaneRegion::new_from_plane(self)
   }
 
   #[inline(always)]
   fn as_region_mut(&mut self) -> PlaneRegionMut<'_, T> {
-    self.region_mut(Area::StartingAt { x: 0, y: 0 })
+    PlaneRegionMut::new_from_plane(self)
   }
 }


### PR DESCRIPTION
This is part of a series of commits authored by @maj160 to improve performance of rav1e.

This commit results in an overall performance improvement of about 2% at speed 2 10-bit:

```
Benchmark 1: ~/Downloads/rav1e_master -s 2 --quantizer 64 ~/xiph-media-files/objective-1-fast-10bit/speed_bag_640x360_60f.y4m -y -o /dev/null
  Time (mean ± σ):     43.646 s ±  0.088 s    [User: 43.656 s, System: 0.170 s]
  Range (min … max):   43.471 s … 43.787 s    10 runs

Benchmark 2: ~/Downloads/rav1e_mod -s 2 --quantizer 64 ~/xiph-media-files/objective-1-fast-10bit/speed_bag_640x360_60f.y4m -y -o /dev/null
  Time (mean ± σ):     42.919 s ±  0.082 s    [User: 42.934 s, System: 0.169 s]
  Range (min … max):   42.813 s … 43.039 s    10 runs
```