### PR TITLE
Enable dependabot to update Cargo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+  # Maintain dependencies for Cargo
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,4 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "weekly"


### PR DESCRIPTION
This will be particularly useful if we are committing the Cargo.lock file to aid in keeping us up-to-date.