### PR TITLE
Remove uses of deprecated min_value/max_value

### DIFF
--- a/src/api/config/encoder.rs
+++ b/src/api/config/encoder.rs
@@ -18,9 +18,9 @@ use crate::serialize::{Deserialize, Serialize};
 use std::fmt;
 
 // We add 1 to rdo_lookahead_frames in a bunch of places.
-pub(crate) const MAX_RDO_LOOKAHEAD_FRAMES: usize = usize::max_value() - 1;
+pub(crate) const MAX_RDO_LOOKAHEAD_FRAMES: usize = usize::MAX - 1;
 // Due to the math in RCState::new() regarding the reservoir frame delay.
-pub(crate) const MAX_MAX_KEY_FRAME_INTERVAL: u64 = i32::max_value() as u64 / 3;
+pub(crate) const MAX_MAX_KEY_FRAME_INTERVAL: u64 = i32::MAX as u64 / 3;
 
 /// Encoder settings which impact the produced bitstream.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -309,13 +309,13 @@ impl Config {
 
     if (config.still_picture && config.width < 1)
       || (!config.still_picture && config.width < 16)
-      || config.width > u16::max_value() as usize
+      || config.width > u16::MAX as usize
     {
       return Err(InvalidWidth(config.width));
     }
     if (config.still_picture && config.height < 1)
       || (!config.still_picture && config.height < 16)
-      || config.height > u16::max_value() as usize
+      || config.height > u16::MAX as usize
     {
       return Err(InvalidHeight(config.height));
     }
@@ -332,10 +332,10 @@ impl Config {
     }
 
     let (render_width, render_height) = config.render_size();
-    if render_width == 0 || render_width > u16::max_value() as usize {
+    if render_width == 0 || render_width > u16::MAX as usize {
       return Err(InvalidRenderWidth(render_width));
     }
-    if render_height == 0 || render_height > u16::max_value() as usize {
+    if render_height == 0 || render_height > u16::MAX as usize {
       return Err(InvalidRenderHeight(render_height));
     }
 
@@ -362,20 +362,16 @@ impl Config {
       return Err(InvalidTileRows(config.tile_rows));
     }
 
-    if config.time_base.num == 0
-      || config.time_base.num > u32::max_value() as u64
-    {
+    if config.time_base.num == 0 || config.time_base.num > u32::MAX as u64 {
       return Err(InvalidFrameRateNum {
         actual: config.time_base.num,
-        max: u32::max_value() as u64,
+        max: u32::MAX as u64,
       });
     }
-    if config.time_base.den == 0
-      || config.time_base.den > u32::max_value() as u64
-    {
+    if config.time_base.den == 0 || config.time_base.den > u32::MAX as u64 {
       return Err(InvalidFrameRateDen {
         actual: config.time_base.den,
-        max: u32::max_value() as u64,
+        max: u32::MAX as u64,
       });
     }
 

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -2023,8 +2023,7 @@ fn zero_frames() {
 
 #[test]
 fn tile_cols_overflow() {
-  let enc =
-    EncoderConfig { tile_cols: usize::max_value(), ..Default::default() };
+  let enc = EncoderConfig { tile_cols: usize::MAX, ..Default::default() };
   let config = Config::new().with_encoder_config(enc);
   let _: Result<Context<u8>, _> = config.new_context();
 }
@@ -2032,7 +2031,7 @@ fn tile_cols_overflow() {
 #[test]
 fn max_key_frame_interval_overflow() {
   let enc = EncoderConfig {
-    max_key_frame_interval: i32::max_value() as u64,
+    max_key_frame_interval: i32::MAX as u64,
     reservoir_frame_delay: None,
     ..Default::default()
   };
@@ -2043,8 +2042,8 @@ fn max_key_frame_interval_overflow() {
 #[test]
 fn target_bitrate_overflow() {
   let enc = EncoderConfig {
-    bitrate: i32::max_value(),
-    time_base: Rational::new(i64::max_value() as u64, 1),
+    bitrate: i32::MAX,
+    time_base: Rational::new(i64::MAX as u64, 1),
     ..Default::default()
   };
   let config = Config::new().with_encoder_config(enc);
@@ -2061,8 +2060,7 @@ fn time_base_den_divide_by_zero() {
 
 #[test]
 fn large_width_assert() {
-  let enc =
-    EncoderConfig { width: u32::max_value() as usize, ..Default::default() };
+  let enc = EncoderConfig { width: u32::MAX as usize, ..Default::default() };
   let config = Config::new().with_encoder_config(enc);
   let _: Result<Context<u8>, _> = config.new_context();
 }
@@ -2070,9 +2068,9 @@ fn large_width_assert() {
 #[test]
 fn reservoir_max_overflow() {
   let enc = EncoderConfig {
-    reservoir_frame_delay: Some(i32::max_value()),
-    bitrate: i32::max_value(),
-    time_base: Rational::new(i32::max_value() as u64 * 2, 1),
+    reservoir_frame_delay: Some(i32::MAX),
+    bitrate: i32::MAX,
+    time_base: Rational::new(i32::MAX as u64 * 2, 1),
     ..Default::default()
   };
   let config = Config::new().with_encoder_config(enc);
@@ -2091,7 +2089,7 @@ fn zero_width() {
 fn rdo_lookahead_frames_overflow() {
   let enc = EncoderConfig {
     speed_settings: SpeedSettings {
-      rdo_lookahead_frames: usize::max_value(),
+      rdo_lookahead_frames: usize::MAX,
       ..Default::default()
     },
     ..Default::default()

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -397,9 +397,7 @@ pub mod test {
     {
       for (j, pixel) in row.iter_mut().enumerate() {
         let val = ((j + i) as i32 - xpad_off) & 255i32;
-        assert!(
-          val >= u8::min_value().into() && val <= u8::max_value().into()
-        );
+        assert!(val >= u8::MIN.into() && val <= u8::MAX.into());
         *pixel = T::cast_from(val);
       }
     }
@@ -408,9 +406,7 @@ pub mod test {
     {
       for (j, pixel) in row.iter_mut().enumerate() {
         let val = (j as i32 - i as i32 - xpad_off) & 255i32;
-        assert!(
-          val >= u8::min_value().into() && val <= u8::max_value().into()
-        );
+        assert!(val >= u8::MIN.into() && val <= u8::MAX.into());
         *pixel = T::cast_from(val);
       }
     }


### PR DESCRIPTION
It is recommended to use the constants MIN and MAX instead.