### PR TITLE
Improvements to sgrproj HBD performance

### DIFF
--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -350,9 +350,7 @@ fn sgrproj_sum_finish(
 ) -> (u32, u32) {
   let scaled_ssq = (ssq + (1 << (2 * bdm8) >> 1)) >> (2 * bdm8);
   let scaled_sum = (sum + (1 << bdm8 >> 1)) >> bdm8;
-  let p =
-    cmp::max(0, (scaled_ssq * n) as i32 - (scaled_sum * scaled_sum) as i32)
-      as u32;
+  let p = (scaled_ssq * n).saturating_sub(scaled_sum * scaled_sum);
   let z = (p * s + (1 << SGRPROJ_MTABLE_BITS >> 1)) >> SGRPROJ_MTABLE_BITS;
   let a = if z >= 255 {
     256


### PR DESCRIPTION
sgrproj_sum_finish in particular was identified as a hotspot in HBD encoding. This changeset attempts to improve the performance of it and surrounding code by:

- Moving bounds checks out of a hot loop
- Use builtin saturating_sub method which is more efficient than performing multiple casts
- Use generics to allow compile-time computation of math dependent on bit-depth