### PR TITLE
Use generics for bit depth throughout the encoder

### DIFF
--- a/src/activity.rs
+++ b/src/activity.rs
@@ -56,11 +56,11 @@ impl ActivityMask {
   }
 
   #[hawktracer(activity_mask_fill_scales)]
-  pub fn fill_scales(
-    &self, bit_depth: usize, activity_scales: &mut Box<[DistortionScale]>,
+  pub fn fill_scales<const BD: usize>(
+    &self, activity_scales: &mut Box<[DistortionScale]>,
   ) {
     for (dst, &src) in activity_scales.iter_mut().zip(self.variances.iter()) {
-      *dst = ssim_boost(src, src, bit_depth);
+      *dst = ssim_boost::<BD>(src, src);
     }
   }
 }
@@ -146,21 +146,20 @@ fn ssim_boost_rsqrt(x: u64) -> RsqrtOutput {
 }
 
 #[inline(always)]
-pub fn ssim_boost(svar: u32, dvar: u32, bit_depth: usize) -> DistortionScale {
-  DistortionScale(apply_ssim_boost(
+pub fn ssim_boost<const BD: usize>(svar: u32, dvar: u32) -> DistortionScale {
+  DistortionScale(apply_ssim_boost::<BD>(
     DistortionScale::default().0,
     svar,
     dvar,
-    bit_depth,
   ))
 }
 
 /// Apply ssim boost to a given input
 #[inline(always)]
-pub fn apply_ssim_boost(
-  input: u32, svar: u32, dvar: u32, bit_depth: usize,
+pub fn apply_ssim_boost<const BD: usize>(
+  input: u32, svar: u32, dvar: u32,
 ) -> u32 {
-  let coeff_shift = bit_depth - 8;
+  let coeff_shift = BD - 8;
 
   // Scale dvar and svar to lbd range to prevent overflows.
   let svar = (svar >> (2 * coeff_shift)) as u64;
@@ -199,7 +198,7 @@ mod ssim_boost_tests {
     let max_pix_diff = (1 << 12) - 1;
     let max_pix_sse = max_pix_diff * max_pix_diff;
     let max_variance = max_pix_diff * 8 * 8 / 4;
-    apply_ssim_boost(max_pix_sse * 8 * 8, max_variance, max_variance, 12);
+    apply_ssim_boost::<12>(max_pix_sse * 8 * 8, max_variance, max_variance);
   }
 
   /// Floating point reference version of `ssim_boost`
@@ -234,8 +233,8 @@ mod ssim_boost_tests {
         let dvar = rng.gen_range(0..(1 << scale));
 
         let float = reference_ssim_boost(svar, dvar, 12);
-        let fixed =
-          apply_ssim_boost(1 << 23, svar, dvar, 12) as f64 / (1 << 23) as f64;
+        let fixed = apply_ssim_boost::<12>(1 << 23, svar, dvar) as f64
+          / (1 << 23) as f64;
 
         // Compare the two versions
         max_relative_error =
@@ -260,7 +259,7 @@ mod ssim_boost_tests {
     for svar in scale..(scale << 2) {
       let float = ((scale << 1) as f64 / svar as f64).cbrt();
       let fixed =
-        apply_ssim_boost(1 << 23, svar, svar, bd) as f64 / (1 << 23) as f64;
+        apply_ssim_boost(1 << 23, svar, svar) as f64 / (1 << 23) as f64;
 
       // Compare the two versions
       max_relative_error =

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -248,8 +248,15 @@ impl Config {
     // First-pass parameters depend on whether second-pass is in effect.
     // So `init_first_pass` must follow `init_second_pass`.
     if self.rate_control.emit_pass_data {
-      let maybe_pass1_log_base_q = (self.rate_control.summary.is_none())
-        .then(|| inner.rc_state.select_pass1_log_base_q(&inner, 0));
+      let maybe_pass1_log_base_q =
+        (self.rate_control.summary.is_none()).then(|| {
+          match self.enc.bit_depth {
+            8 => inner.rc_state.select_pass1_log_base_q::<_, 8>(&inner, 0),
+            10 => inner.rc_state.select_pass1_log_base_q::<_, 10>(&inner, 0),
+            12 => inner.rc_state.select_pass1_log_base_q::<_, 12>(&inner, 0),
+            _ => unimplemented!(),
+          }
+        });
       inner.rc_state.init_first_pass(maybe_pass1_log_base_q);
     }
 

--- a/src/api/context.rs
+++ b/src/api/context.rs
@@ -129,7 +129,12 @@ impl<T: Pixel> Context<T> {
     }
 
     let inner = &mut self.inner;
-    let run = move || inner.send_frame(frame, params);
+    let run = move || match inner.config.bit_depth {
+      8 => inner.send_frame::<8>(frame, params),
+      10 => inner.send_frame::<10>(frame, params),
+      12 => inner.send_frame::<12>(frame, params),
+      _ => unimplemented!(),
+    };
 
     match &self.pool {
       Some(pool) => pool.install(run),
@@ -302,7 +307,12 @@ impl<T: Pixel> Context<T> {
   #[inline]
   pub fn receive_packet(&mut self) -> Result<Packet<T>, EncoderStatus> {
     let inner = &mut self.inner;
-    let mut run = move || inner.receive_packet();
+    let mut run = move || match inner.config.bit_depth {
+      8 => inner.receive_packet::<8>(),
+      10 => inner.receive_packet::<10>(),
+      12 => inner.receive_packet::<12>(),
+      _ => unimplemented!(),
+    };
 
     match &self.pool {
       Some(pool) => pool.install(run),

--- a/src/asm/aarch64/cdef.rs
+++ b/src/asm/aarch64/cdef.rs
@@ -67,8 +67,8 @@ const fn decimate_index(xdec: usize, ydec: usize) -> usize {
 
 pub(crate) unsafe fn cdef_filter_block<T: Pixel>(
   dst: &mut PlaneRegionMut<'_, T>, src: *const T, src_stride: isize,
-  pri_strength: i32, sec_strength: i32, dir: usize, damping: i32,
-  bit_depth: usize, xdec: usize, ydec: usize, edges: u8, cpu: CpuFeatureLevel,
+  pri_strength: i32, sec_strength: i32, dir: usize, damping: i32, xdec: usize,
+  ydec: usize, edges: u8, cpu: CpuFeatureLevel,
 ) {
   let call_rust = |dst: &mut PlaneRegionMut<T>| {
     rust::cdef_filter_block(
@@ -79,7 +79,6 @@ pub(crate) unsafe fn cdef_filter_block<T: Pixel>(
       sec_strength,
       dir,
       damping,
-      bit_depth,
       xdec,
       ydec,
       edges,

--- a/src/asm/x86/dist/cdef_dist.rs
+++ b/src/asm/x86/dist/cdef_dist.rs
@@ -53,9 +53,9 @@ extern {
 ///
 /// - If in `check_asm` mode, panics on mismatch between native and ASM results.
 #[allow(clippy::let_and_return)]
-pub fn cdef_dist_kernel<T: Pixel>(
+pub fn cdef_dist_kernel<T: Pixel, const BD: usize>(
   src: &PlaneRegion<'_, T>, dst: &PlaneRegion<'_, T>, w: usize, h: usize,
-  bit_depth: usize, cpu: CpuFeatureLevel,
+  cpu: CpuFeatureLevel,
 ) -> u32 {
   debug_assert!(src.plane_cfg.xdec == 0);
   debug_assert!(src.plane_cfg.ydec == 0);
@@ -67,7 +67,7 @@ pub fn cdef_dist_kernel<T: Pixel>(
   debug_assert!(h <= 8);
 
   let call_rust =
-    || -> u32 { rust::cdef_dist_kernel(dst, src, w, h, bit_depth, cpu) };
+    || -> u32 { rust::cdef_dist_kernel::<_, BD>(dst, src, w, h, cpu) };
   #[cfg(feature = "check_asm")]
   let ref_dist = call_rust();
 
@@ -112,7 +112,7 @@ pub fn cdef_dist_kernel<T: Pixel>(
     }
   };
 
-  let dist = apply_ssim_boost(sse, svar, dvar, bit_depth);
+  let dist = apply_ssim_boost::<BD>(sse, svar, dvar);
   #[cfg(feature = "check_asm")]
   assert_eq!(
     dist, ref_dist,
@@ -315,39 +315,39 @@ pub mod test {
 
   #[test]
   fn cdef_dist_simd_random() {
-    cdef_diff_tester(8, random_planes::<u8>);
+    cdef_diff_tester::<_, 8>(random_planes::<u8>);
   }
 
   #[test]
   fn cdef_dist_simd_random_hbd() {
-    cdef_diff_tester(10, random_planes::<u16>);
-    cdef_diff_tester(12, random_planes::<u16>);
+    cdef_diff_tester::<_, 10>(random_planes::<u16>);
+    cdef_diff_tester::<_, 12>(random_planes::<u16>);
   }
 
   #[test]
   fn cdef_dist_simd_large() {
-    cdef_diff_tester(8, max_planes::<u8>);
+    cdef_diff_tester::<_, 8>(max_planes::<u8>);
   }
 
   #[test]
   fn cdef_dist_simd_large_hbd() {
-    cdef_diff_tester(10, max_planes::<u16>);
-    cdef_diff_tester(12, max_planes::<u16>);
+    cdef_diff_tester::<_, 10>(max_planes::<u16>);
+    cdef_diff_tester::<_, 12>(max_planes::<u16>);
   }
 
   #[test]
   fn cdef_dist_simd_large_diff() {
-    cdef_diff_tester(8, max_diff_planes::<u8>);
+    cdef_diff_tester::<_, 8>(max_diff_planes::<u8>);
   }
 
   #[test]
   fn cdef_dist_simd_large_diff_hbd() {
-    cdef_diff_tester(10, max_diff_planes::<u16>);
-    cdef_diff_tester(12, max_diff_planes::<u16>);
+    cdef_diff_tester::<_, 10>(max_diff_planes::<u16, 10>);
+    cdef_diff_tester::<_, 12>(max_diff_planes::<u16>);
   }
 
-  fn cdef_diff_tester<T: Pixel>(
-    bd: usize, gen_planes: fn(bd: usize) -> (Plane<T>, Plane<T>),
+  fn cdef_diff_tester<T: Pixel, const BD: usize>(
+    gen_planes: fn(bd: usize) -> (Plane<T>, Plane<T>),
   ) {
     let (src_plane, dst_plane) = gen_planes(bd);
 
@@ -366,7 +366,6 @@ pub mod test {
           &dst_region,
           w,
           h,
-          bd,
           CpuFeatureLevel::default(),
         );
 
@@ -375,7 +374,6 @@ pub mod test {
           &dst_region,
           w,
           h,
-          bd,
           CpuFeatureLevel::default(),
         );
 

--- a/src/asm/x86/dist/mod.rs
+++ b/src/asm/x86/dist/mod.rs
@@ -286,11 +286,11 @@ pub(crate) const fn to_index(bsize: BlockSize) -> usize {
 #[allow(clippy::let_and_return)]
 pub fn get_sad<T: Pixel>(
   src: &PlaneRegion<'_, T>, dst: &PlaneRegion<'_, T>, w: usize, h: usize,
-  bit_depth: usize, cpu: CpuFeatureLevel,
+  cpu: CpuFeatureLevel,
 ) -> u32 {
   let bsize_opt = BlockSize::from_width_and_height_opt(w, h);
 
-  let call_rust = || -> u32 { rust::get_sad(dst, src, w, h, bit_depth, cpu) };
+  let call_rust = || -> u32 { rust::get_sad(dst, src, w, h, cpu) };
 
   #[cfg(feature = "check_asm")]
   let ref_dist = call_rust();
@@ -338,13 +338,13 @@ pub fn get_sad<T: Pixel>(
 /// - If in `check_asm` mode, panics on mismatch between native and ASM results.
 #[inline(always)]
 #[allow(clippy::let_and_return)]
-pub fn get_satd<T: Pixel>(
+pub fn get_satd<T: Pixel, const BD: usize>(
   src: &PlaneRegion<'_, T>, dst: &PlaneRegion<'_, T>, w: usize, h: usize,
-  bit_depth: usize, cpu: CpuFeatureLevel,
+  cpu: CpuFeatureLevel,
 ) -> u32 {
   let bsize_opt = BlockSize::from_width_and_height_opt(w, h);
 
-  let call_rust = || -> u32 { rust::get_satd(dst, src, w, h, bit_depth, cpu) };
+  let call_rust = || -> u32 { rust::get_satd(dst, src, w, h, cpu) };
 
   #[cfg(feature = "check_asm")]
   let ref_dist = call_rust();
@@ -374,7 +374,7 @@ pub fn get_satd<T: Pixel>(
             T::to_asm_stride(src.plane_cfg.stride),
             dst.data_ptr() as *const _,
             T::to_asm_stride(dst.plane_cfg.stride),
-            (1 << bit_depth) - 1,
+            (1 << BD) - 1,
           )
         },
         None => call_rust(),
@@ -755,8 +755,8 @@ mod test {
                 *s = random::<u8>() as u16 * $BD / 8;
                 *d = random::<u8>() as u16 * $BD / 8;
               }
-              let result = [<get_ $DIST_TY>](&src.as_region(), &dst.as_region(), $W, $H, $BD, CpuFeatureLevel::from_str($OPTLIT).unwrap());
-              let rust_result = [<get_ $DIST_TY>](&src.as_region(), &dst.as_region(), $W, $H, $BD, CpuFeatureLevel::RUST);
+              let result = [<get_ $DIST_TY>]::<$BD>(&src.as_region(), &dst.as_region(), $W, $H, CpuFeatureLevel::from_str($OPTLIT).unwrap());
+              let rust_result = [<get_ $DIST_TY>]::<$BD>(&src.as_region(), &dst.as_region(), $W, $H, CpuFeatureLevel::RUST);
 
               assert_eq!(rust_result, result);
             } else {
@@ -768,8 +768,8 @@ mod test {
                 *s = random::<u8>();
                 *d = random::<u8>();
               }
-              let result = [<get_ $DIST_TY>](&src.as_region(), &dst.as_region(), $W, $H, $BD, CpuFeatureLevel::from_str($OPTLIT).unwrap());
-              let rust_result = [<get_ $DIST_TY>](&src.as_region(), &dst.as_region(), $W, $H, $BD, CpuFeatureLevel::RUST);
+              let result = [<get_ $DIST_TY>]::<$BD>(&src.as_region(), &dst.as_region(), $W, $H, CpuFeatureLevel::from_str($OPTLIT).unwrap());
+              let rust_result = [<get_ $DIST_TY>]::<$BD>(&src.as_region(), &dst.as_region(), $W, $H, CpuFeatureLevel::RUST);
 
               assert_eq!(rust_result, result);
             }

--- a/src/asm/x86/dist/sse.rs
+++ b/src/asm/x86/dist/sse.rs
@@ -92,8 +92,7 @@ declare_asm_hbd_sse_fn![
 #[allow(clippy::let_and_return)]
 pub fn get_weighted_sse<T: Pixel>(
   src: &PlaneRegion<'_, T>, dst: &PlaneRegion<'_, T>, scale: &[u32],
-  scale_stride: usize, w: usize, h: usize, bit_depth: usize,
-  cpu: CpuFeatureLevel,
+  scale_stride: usize, w: usize, h: usize, cpu: CpuFeatureLevel,
 ) -> u64 {
   // Assembly breaks if imp block size changes.
   assert_eq!(IMPORTANCE_BLOCK_SIZE >> 1, 4);
@@ -101,7 +100,7 @@ pub fn get_weighted_sse<T: Pixel>(
   let bsize_opt = BlockSize::from_width_and_height_opt(w, h);
 
   let call_rust = || -> u64 {
-    rust::get_weighted_sse(dst, src, scale, scale_stride, w, h, bit_depth, cpu)
+    rust::get_weighted_sse(dst, src, scale, scale_stride, w, h, cpu)
   };
 
   #[cfg(feature = "check_asm")]
@@ -381,7 +380,6 @@ pub mod test {
         SCALE_STRIDE,
         block.width(),
         block.height(),
-        bd,
         CpuFeatureLevel::default(),
       );
 
@@ -392,7 +390,6 @@ pub mod test {
         SCALE_STRIDE,
         block.width(),
         block.height(),
-        bd,
         CpuFeatureLevel::default(),
       );
 

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -32,7 +32,7 @@ pub(crate) mod rust {
   /// w and h can be at most 128, the size of the largest block.
   pub fn get_sad<T: Pixel>(
     plane_org: &PlaneRegion<'_, T>, plane_ref: &PlaneRegion<'_, T>, w: usize,
-    h: usize, _bit_depth: usize, _cpu: CpuFeatureLevel,
+    h: usize, _cpu: CpuFeatureLevel,
   ) -> u32 {
     debug_assert!(w <= 128 && h <= 128);
     let plane_org =
@@ -157,7 +157,7 @@ pub(crate) mod rust {
   /// 4x4 transforms instead of 8x8 transforms when width or height < 8.
   pub fn get_satd<T: Pixel>(
     plane_org: &PlaneRegion<'_, T>, plane_ref: &PlaneRegion<'_, T>, w: usize,
-    h: usize, _bit_depth: usize, _cpu: CpuFeatureLevel,
+    h: usize, _cpu: CpuFeatureLevel,
   ) -> u32 {
     assert!(w <= 128 && h <= 128);
     assert!(plane_org.rect().width >= w && plane_org.rect().height >= h);
@@ -186,9 +186,8 @@ pub(crate) mod rust {
 
         // Revert to sad on edge blocks (frame edges)
         if chunk_w != size || chunk_h != size {
-          sum += get_sad(
-            &chunk_org, &chunk_ref, chunk_w, chunk_h, _bit_depth, _cpu,
-          ) as u64;
+          sum +=
+            get_sad(&chunk_org, &chunk_ref, chunk_w, chunk_h, _cpu) as u64;
           continue;
         }
 
@@ -235,8 +234,7 @@ pub(crate) mod rust {
   #[inline(never)]
   pub fn get_weighted_sse<T: Pixel>(
     src1: &PlaneRegion<'_, T>, src2: &PlaneRegion<'_, T>, scale: &[u32],
-    scale_stride: usize, w: usize, h: usize, _bit_depth: usize,
-    _cpu: CpuFeatureLevel,
+    scale_stride: usize, w: usize, h: usize, _cpu: CpuFeatureLevel,
   ) -> u64 {
     let src1 = src1.subregion(Area::Rect { x: 0, y: 0, width: w, height: h });
     // Always chunk and apply scaling on the sse of squares the size of
@@ -301,9 +299,9 @@ pub(crate) mod rust {
   /// Computes a distortion metric of the sum of squares weighted by activity.
   /// w and h should be <= 8.
   #[inline(never)]
-  pub fn cdef_dist_kernel<T: Pixel>(
+  pub fn cdef_dist_kernel<T: Pixel, const BD: usize>(
     src: &PlaneRegion<'_, T>, dst: &PlaneRegion<'_, T>, w: usize, h: usize,
-    bit_depth: usize, _cpu: CpuFeatureLevel,
+    _cpu: CpuFeatureLevel,
   ) -> u32 {
     // TODO: Investigate using different constants in ssim boost for block sizes
     // smaller than 8x8.
@@ -370,7 +368,7 @@ pub(crate) mod rust {
     dvar =
       ((dvar as u64 * div + (1 << scale_shift >> 1)) >> scale_shift) as u32;
 
-    apply_ssim_boost(sse, svar, dvar, bit_depth)
+    apply_ssim_boost::<BD>(sse, svar, dvar)
   }
 }
 
@@ -453,14 +451,7 @@ pub mod test {
 
       assert_eq!(
         distortion,
-        get_sad(
-          &input_region,
-          &rec_region,
-          w,
-          h,
-          bit_depth,
-          CpuFeatureLevel::default()
-        )
+        get_sad(&input_region, &rec_region, w, h, CpuFeatureLevel::default())
       );
     }
   }
@@ -475,7 +466,7 @@ pub mod test {
     get_sad_same_inner::<u16>();
   }
 
-  fn get_satd_same_inner<T: Pixel>() {
+  fn get_satd_same_inner<T: Pixel, const BD: usize>() {
     let blocks: Vec<(usize, usize, u32)> = vec![
       (4, 4, 1408),
       (4, 8, 2016),
@@ -501,7 +492,6 @@ pub mod test {
       (64, 16, 21312),
     ];
 
-    let bit_depth: usize = 8;
     let (input_plane, rec_plane) = setup_planes::<T>();
 
     for (w, h, distortion) in blocks {
@@ -512,12 +502,11 @@ pub mod test {
 
       assert_eq!(
         distortion,
-        get_satd(
+        get_satd::<_, BD>(
           &input_region,
           &rec_region,
           w,
           h,
-          bit_depth,
           CpuFeatureLevel::default()
         )
       );
@@ -526,11 +515,11 @@ pub mod test {
 
   #[test]
   fn get_satd_same_u8() {
-    get_satd_same_inner::<u8>();
+    get_satd_same_inner::<u8, 8>();
   }
 
   #[test]
   fn get_satd_same_u16() {
-    get_satd_same_inner::<u16>();
+    get_satd_same_inner::<u16, 10>();
   }
 }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -591,7 +591,7 @@ fn supersample_chroma_bsize(
   }
 }
 
-pub fn get_intra_edges<T: Pixel>(
+pub fn get_intra_edges<T: Pixel, const BD: usize>(
   dst: &PlaneRegion<'_, T>,
   partition_bo: TileBlockOffset, // partition bo, BlockOffset
   bx: usize,
@@ -599,7 +599,6 @@ pub fn get_intra_edges<T: Pixel>(
   partition_size: BlockSize, // partition size, BlockSize
   po: PlaneOffset,
   tx_size: TxSize,
-  bit_depth: usize,
   opt_mode: Option<PredictionMode>,
   enable_intra_edge_filter: bool,
   intra_param: IntraParam,
@@ -610,7 +609,7 @@ pub fn get_intra_edges<T: Pixel>(
   let mut edge_buf: Aligned<[T; 4 * MAX_TX_SIZE + 1]> =
     unsafe { Aligned::uninitialized() };
   //Aligned::new([T::cast_from(0); 4 * MAX_TX_SIZE + 1]);
-  let base = 128u16 << (bit_depth - 8);
+  let base = 128u16 << (BD - 8);
 
   {
     // left pixels are ordered from bottom to top and right-aligned

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -205,9 +205,9 @@ impl PredictionMode {
   /// # Panics
   ///
   /// - If called on an inter `PredictionMode`
-  pub fn predict_intra<T: Pixel>(
+  pub fn predict_intra<T: Pixel, const BD: usize>(
     self, tile_rect: TileRect, dst: &mut PlaneRegionMut<'_, T>,
-    tx_size: TxSize, bit_depth: usize, ac: &[i16], intra_param: IntraParam,
+    tx_size: TxSize, ac: &[i16], intra_param: IntraParam,
     ief_params: Option<IntraEdgeFilterParameters>,
     edge_buf: &Aligned<[T; 4 * MAX_TX_SIZE + 1]>, cpu: CpuFeatureLevel,
   ) {
@@ -245,9 +245,8 @@ impl PredictionMode {
       _ => intra_mode_to_angle(mode) + (angle_delta * ANGLE_STEP) as isize,
     };
 
-    dispatch_predict_intra::<T>(
-      mode, variant, dst, tx_size, bit_depth, ac, angle, ief_params, edge_buf,
-      cpu,
+    dispatch_predict_intra::<T, BD>(
+      mode, variant, dst, tx_size, ac, angle, ief_params, edge_buf, cpu,
     );
   }
 
@@ -304,7 +303,7 @@ impl PredictionMode {
   /// # Panics
   ///
   /// - If called on an intra `PredictionMode`
-  pub fn predict_inter_single<T: Pixel>(
+  pub fn predict_inter_single<T: Pixel, const BD: usize>(
     self, fi: &FrameInvariants<T>, tile_rect: TileRect, p: usize,
     po: PlaneOffset, dst: &mut PlaneRegionMut<'_, T>, width: usize,
     height: usize, ref_frame: RefType, mv: MotionVector,
@@ -319,7 +318,7 @@ impl PredictionMode {
     {
       let (row_frac, col_frac, src) =
         PredictionMode::get_mv_params(&rec.frame.planes[p], frame_po, mv);
-      put_8tap(
+      put_8tap::<_, BD>(
         dst,
         src,
         width,
@@ -328,7 +327,6 @@ impl PredictionMode {
         row_frac,
         mode,
         mode,
-        fi.sequence.bit_depth,
         fi.cpu_feature_level,
       );
     }
@@ -339,7 +337,7 @@ impl PredictionMode {
   /// # Panics
   ///
   /// - If called on an intra `PredictionMode`
-  pub fn predict_inter_compound<T: Pixel>(
+  pub fn predict_inter_compound<T: Pixel, const BD: usize>(
     self, fi: &FrameInvariants<T>, tile_rect: TileRect, p: usize,
     po: PlaneOffset, dst: &mut PlaneRegionMut<'_, T>, width: usize,
     height: usize, ref_frames: [RefType; 2], mvs: [MotionVector; 2],
@@ -359,7 +357,7 @@ impl PredictionMode {
           frame_po,
           mvs[i],
         );
-        prep_8tap(
+        prep_8tap::<_, BD>(
           buffer.get_buffer_mut(i),
           src,
           width,
@@ -368,25 +366,23 @@ impl PredictionMode {
           row_frac,
           mode,
           mode,
-          fi.sequence.bit_depth,
           fi.cpu_feature_level,
         );
       }
     }
-    mc_avg(
+    mc_avg::<_, BD>(
       dst,
       buffer.get_buffer(0),
       buffer.get_buffer(1),
       width,
       height,
-      fi.sequence.bit_depth,
       fi.cpu_feature_level,
     );
   }
 
   /// Inter prediction that determines whether compound mode is being used based
   /// on the second [`RefType`] in [`ref_frames`].
-  pub fn predict_inter<T: Pixel>(
+  pub fn predict_inter<T: Pixel, const BD: usize>(
     self, fi: &FrameInvariants<T>, tile_rect: TileRect, p: usize,
     po: PlaneOffset, dst: &mut PlaneRegionMut<'_, T>, width: usize,
     height: usize, ref_frames: [RefType; 2], mvs: [MotionVector; 2],
@@ -396,7 +392,7 @@ impl PredictionMode {
       && ref_frames[1] != RefType::NONE_FRAME;
 
     if !is_compound {
-      self.predict_inter_single(
+      self.predict_inter_single::<_, BD>(
         fi,
         tile_rect,
         p,
@@ -408,7 +404,7 @@ impl PredictionMode {
         mvs[0],
       )
     } else {
-      self.predict_inter_compound(
+      self.predict_inter_compound::<_, BD>(
         fi,
         tile_rect,
         p,
@@ -698,10 +694,10 @@ pub(crate) mod rust {
   use std::mem::size_of;
 
   #[inline(always)]
-  pub fn dispatch_predict_intra<T: Pixel>(
+  pub fn dispatch_predict_intra<T: Pixel, const BD: usize>(
     mode: PredictionMode, variant: PredictionVariant,
-    dst: &mut PlaneRegionMut<'_, T>, tx_size: TxSize, bit_depth: usize,
-    ac: &[i16], angle: isize, ief_params: Option<IntraEdgeFilterParameters>,
+    dst: &mut PlaneRegionMut<'_, T>, tx_size: TxSize, ac: &[i16],
+    angle: isize, ief_params: Option<IntraEdgeFilterParameters>,
     edge_buf: &Aligned<[T; 4 * MAX_TX_SIZE + 1]>, _cpu: CpuFeatureLevel,
   ) {
     let width = tx_size.width();
@@ -718,11 +714,11 @@ pub(crate) mod rust {
     match mode {
       PredictionMode::DC_PRED => {
         (match variant {
-          PredictionVariant::NONE => pred_dc_128,
+          PredictionVariant::NONE => pred_dc_128::<_, BD>,
           PredictionVariant::LEFT => pred_dc_left,
           PredictionVariant::TOP => pred_dc_top,
           PredictionVariant::BOTH => pred_dc,
-        })(dst, above_slice, left_slice, width, height, bit_depth)
+        })(dst, above_slice, left_slice, width, height)
       }
       PredictionMode::V_PRED if angle == 90 => {
         pred_v(dst, above_slice, width, height)
@@ -737,7 +733,7 @@ pub(crate) mod rust {
       | PredictionMode::D113_PRED
       | PredictionMode::D157_PRED
       | PredictionMode::D203_PRED
-      | PredictionMode::D67_PRED => pred_directional(
+      | PredictionMode::D67_PRED => pred_directional::<_, BD>(
         dst,
         above_slice,
         left_and_left_below_slice,
@@ -745,7 +741,6 @@ pub(crate) mod rust {
         angle as usize,
         width,
         height,
-        bit_depth,
         ief_params,
       ),
       PredictionMode::SMOOTH_PRED => {
@@ -760,28 +755,23 @@ pub(crate) mod rust {
       PredictionMode::PAETH_PRED => {
         pred_paeth(dst, above_slice, left_slice, top_left[0], width, height)
       }
-      PredictionMode::UV_CFL_PRED => (match variant {
-        PredictionVariant::NONE => pred_cfl_128,
-        PredictionVariant::LEFT => pred_cfl_left,
-        PredictionVariant::TOP => pred_cfl_top,
-        PredictionVariant::BOTH => pred_cfl,
-      })(
-        dst,
-        ac,
-        angle as i16,
-        above_slice,
-        left_slice,
-        width,
-        height,
-        bit_depth,
-      ),
+      PredictionMode::UV_CFL_PRED => {
+        (match variant {
+          PredictionVariant::NONE => pred_cfl_128::<_, BD>,
+          PredictionVariant::LEFT => pred_cfl_left::<_, BD>,
+          PredictionVariant::TOP => pred_cfl_top::<_, BD>,
+          PredictionVariant::BOTH => pred_cfl::<_, BD>,
+        })(
+          dst, ac, angle as i16, above_slice, left_slice, width, height
+        )
+      }
       _ => unimplemented!(),
     }
   }
 
   pub(crate) fn pred_dc<T: Pixel>(
     output: &mut PlaneRegionMut<'_, T>, above: &[T], left: &[T], width: usize,
-    height: usize, _bit_depth: usize,
+    height: usize,
   ) {
     let edges = left[..height].iter().chain(above[..width].iter());
     let len = (width + height) as u32;
@@ -797,11 +787,11 @@ pub(crate) mod rust {
     }
   }
 
-  pub(crate) fn pred_dc_128<T: Pixel>(
+  pub(crate) fn pred_dc_128<T: Pixel, const BD: usize>(
     output: &mut PlaneRegionMut<'_, T>, _above: &[T], _left: &[T],
-    width: usize, height: usize, bit_depth: usize,
+    width: usize, height: usize,
   ) {
-    let v = T::cast_from(128u32 << (bit_depth - 8));
+    let v = T::cast_from(128u32 << (BD - 8));
     for line in output.rows_iter_mut().take(height) {
       line[..width].fill(v);
     }
@@ -809,7 +799,7 @@ pub(crate) mod rust {
 
   pub(crate) fn pred_dc_left<T: Pixel>(
     output: &mut PlaneRegionMut<'_, T>, _above: &[T], left: &[T],
-    width: usize, height: usize, _bit_depth: usize,
+    width: usize, height: usize,
   ) {
     let sum = left[..].iter().fold(0u32, |acc, &v| {
       let v: u32 = v.into();
@@ -823,7 +813,7 @@ pub(crate) mod rust {
 
   pub(crate) fn pred_dc_top<T: Pixel>(
     output: &mut PlaneRegionMut<'_, T>, above: &[T], _left: &[T],
-    width: usize, height: usize, _bit_depth: usize,
+    width: usize, height: usize,
   ) {
     let sum = above[..width].iter().fold(0u32, |acc, &v| {
       let v: u32 = v.into();
@@ -1051,9 +1041,9 @@ pub(crate) mod rust {
     }
   }
 
-  pub(crate) fn pred_cfl_inner<T: Pixel>(
+  pub(crate) fn pred_cfl_inner<T: Pixel, const BD: usize>(
     output: &mut PlaneRegionMut<'_, T>, ac: &[i16], alpha: i16, width: usize,
-    height: usize, bit_depth: usize,
+    height: usize,
   ) {
     if alpha == 0 {
       return;
@@ -1063,7 +1053,7 @@ pub(crate) mod rust {
     assert!(output.plane_cfg.stride >= width);
     assert!(output.rows_iter().len() >= height);
 
-    let sample_max = (1 << bit_depth) - 1;
+    let sample_max = (1 << BD) - 1;
     let avg: i32 = output[0][0].into();
 
     for (line, luma) in
@@ -1077,43 +1067,43 @@ pub(crate) mod rust {
     }
   }
 
-  pub(crate) fn pred_cfl<T: Pixel>(
+  pub(crate) fn pred_cfl<T: Pixel, const BD: usize>(
     output: &mut PlaneRegionMut<'_, T>, ac: &[i16], alpha: i16, above: &[T],
-    left: &[T], width: usize, height: usize, bit_depth: usize,
+    left: &[T], width: usize, height: usize,
   ) {
-    pred_dc(output, above, left, width, height, bit_depth);
-    pred_cfl_inner(output, ac, alpha, width, height, bit_depth);
+    pred_dc(output, above, left, width, height);
+    pred_cfl_inner::<_, BD>(output, ac, alpha, width, height);
   }
 
-  pub(crate) fn pred_cfl_128<T: Pixel>(
+  pub(crate) fn pred_cfl_128<T: Pixel, const BD: usize>(
     output: &mut PlaneRegionMut<'_, T>, ac: &[i16], alpha: i16, above: &[T],
-    left: &[T], width: usize, height: usize, bit_depth: usize,
+    left: &[T], width: usize, height: usize,
   ) {
-    pred_dc_128(output, above, left, width, height, bit_depth);
-    pred_cfl_inner(output, ac, alpha, width, height, bit_depth);
+    pred_dc_128::<_, BD>(output, above, left, width, height);
+    pred_cfl_inner::<_, BD>(output, ac, alpha, width, height);
   }
 
-  pub(crate) fn pred_cfl_left<T: Pixel>(
+  pub(crate) fn pred_cfl_left<T: Pixel, const BD: usize>(
     output: &mut PlaneRegionMut<'_, T>, ac: &[i16], alpha: i16, above: &[T],
-    left: &[T], width: usize, height: usize, bit_depth: usize,
+    left: &[T], width: usize, height: usize,
   ) {
-    pred_dc_left(output, above, left, width, height, bit_depth);
-    pred_cfl_inner(output, ac, alpha, width, height, bit_depth);
+    pred_dc_left(output, above, left, width, height);
+    pred_cfl_inner::<_, BD>(output, ac, alpha, width, height);
   }
 
-  pub(crate) fn pred_cfl_top<T: Pixel>(
+  pub(crate) fn pred_cfl_top<T: Pixel, const BD: usize>(
     output: &mut PlaneRegionMut<'_, T>, ac: &[i16], alpha: i16, above: &[T],
-    left: &[T], width: usize, height: usize, bit_depth: usize,
+    left: &[T], width: usize, height: usize,
   ) {
-    pred_dc_top(output, above, left, width, height, bit_depth);
-    pred_cfl_inner(output, ac, alpha, width, height, bit_depth);
+    pred_dc_top(output, above, left, width, height);
+    pred_cfl_inner::<_, BD>(output, ac, alpha, width, height);
   }
 
   #[allow(clippy::clone_double_ref)]
-  pub(crate) fn pred_directional<T: Pixel>(
+  pub(crate) fn pred_directional<T: Pixel, const BD: usize>(
     output: &mut PlaneRegionMut<'_, T>, above: &[T], left: &[T],
     top_left: &[T], p_angle: usize, width: usize, height: usize,
-    bit_depth: usize, ief_params: Option<IntraEdgeFilterParameters>,
+    ief_params: Option<IntraEdgeFilterParameters>,
   ) {
     #[allow(clippy::collapsible_if)]
     #[allow(clippy::collapsible_else_if)]
@@ -1223,7 +1213,7 @@ pub(crate) mod rust {
       edge.copy_from_slice(edge_filtered.as_slice());
     }
 
-    fn upsample_edge<T: Pixel>(size: usize, edge: &mut [T], bit_depth: usize) {
+    fn upsample_edge<T: Pixel, const BD: usize>(size: usize, edge: &mut [T]) {
       // The input edge should be valid in the -1..size range,
       // where the -1 index is the top-left edge pixel. Since
       // negative indices are unsafe in Rust, the caller is
@@ -1247,14 +1237,14 @@ pub(crate) mod rust {
           + (9 * dup[i + 1].to_i32().unwrap())
           + (9 * dup[i + 2].to_i32().unwrap())
           - dup[i + 3].to_i32().unwrap();
-        s = ((s + 8) / 16).clamp(0, (1 << bit_depth) - 1);
+        s = ((s + 8) / 16).clamp(0, (1 << BD) - 1);
 
         edge[2 * i + 1] = T::cast_from(s);
         edge[2 * i + 2] = dup[i + 2];
       }
     }
 
-    let sample_max = (1 << bit_depth) - 1;
+    let sample_max = (1 << BD) - 1;
 
     let max_x = output.plane_cfg.width as isize - 1;
     let max_y = output.plane_cfg.height as isize - 1;
@@ -1332,7 +1322,7 @@ pub(crate) mod rust {
         p_angle as isize - 90,
       );
       if upsample_above {
-        upsample_edge(num_px.0, above_filtered.as_mut_slice(), bit_depth);
+        upsample_edge::<_, BD>(num_px.0, &mut above_filtered[..]);
       }
       upsample_left = select_ief_upsample(
         width,
@@ -1341,7 +1331,7 @@ pub(crate) mod rust {
         p_angle as isize - 180,
       );
       if upsample_left {
-        upsample_edge(num_px.1, left_filtered.as_mut_slice(), bit_depth);
+        upsample_edge::<_, BD>(num_px.1, &mut left_filtered[..]);
       }
 
       left_filtered.reverse();
@@ -1509,16 +1499,16 @@ mod test {
 
     let mut output = Plane::from_slice(&[0u8; 4 * 4], 4);
 
-    pred_dc(&mut output.as_region_mut(), above, left, 4, 4, 8);
+    pred_dc(&mut output.as_region_mut(), above, left, 4, 4);
     assert_eq!(&output.data[..], [32u8; 16]);
 
-    pred_dc_top(&mut output.as_region_mut(), above, left, 4, 4, 8);
+    pred_dc_top(&mut output.as_region_mut(), above, left, 4, 4);
     assert_eq!(&output.data[..], [35u8; 16]);
 
-    pred_dc_left(&mut output.as_region_mut(), above, left, 4, 4, 8);
+    pred_dc_left(&mut output.as_region_mut(), above, left, 4, 4);
     assert_eq!(&output.data[..], [30u8; 16]);
 
-    pred_dc_128(&mut output.as_region_mut(), above, left, 4, 4, 8);
+    pred_dc_128(&mut output.as_region_mut(), above, left, 4, 4);
     assert_eq!(&output.data[..], [128u8; 16]);
 
     pred_v(&mut output.as_region_mut(), above, 4, 4);
@@ -1594,7 +1584,7 @@ mod test {
       [33, 34, 35, 36, 33, 34, 35, 36, 33, 34, 35, 36, 33, 34, 35, 36],
     ];
     for (&angle, expected) in angles.iter().zip(expected.iter()) {
-      pred_directional(
+      pred_directional::<_, 8>(
         &mut output.as_region_mut(),
         above,
         left,
@@ -1602,7 +1592,6 @@ mod test {
         angle,
         4,
         4,
-        8,
         None,
       );
       assert_eq!(&output.data[..], expected);
@@ -1617,7 +1606,7 @@ mod test {
 
     let mut o = Plane::from_slice(&vec![0u16; 32 * 32], 32);
 
-    pred_dc(&mut o.as_region_mut(), &above[..4], &left[..4], 4, 4, 16);
+    pred_dc(&mut o.as_region_mut(), &above[..4], &left[..4], 4, 4);
 
     for l in o.data.chunks(32).take(4) {
       for v in l[..4].iter() {

--- a/src/scenechange/standard.rs
+++ b/src/scenechange/standard.rs
@@ -18,7 +18,7 @@ impl<T: Pixel> SceneChangeDetector<T> {
   /// We gather both intra and inter costs for the frames,
   /// as well as an importance-block-based difference,
   /// and use all three metrics.
-  pub(super) fn cost_scenecut(
+  pub(super) fn cost_scenecut<const BD: usize>(
     &mut self, frame1: Arc<Frame<T>>, frame2: Arc<Frame<T>>,
     input_frameno: u64,
   ) -> ScenecutResult {
@@ -49,10 +49,9 @@ impl<T: Pixel> SceneChangeDetector<T> {
 
         let intra_costs =
           self.intra_costs.entry(input_frameno).or_insert_with(|| {
-            estimate_intra_costs(
+            estimate_intra_costs::<_, BD>(
               temp_plane,
               &*frame2,
-              self.bit_depth,
               self.cpu_feature_level,
             )
           });
@@ -67,10 +66,9 @@ impl<T: Pixel> SceneChangeDetector<T> {
         };
       });
       s.spawn(|_| {
-        mv_inter_cost = estimate_inter_costs(
+        mv_inter_cost = estimate_inter_costs::<_, BD>(
           frame2_inter_ref,
           frame1,
-          self.bit_depth,
           self.encoder_config.clone(),
           self.sequence.clone(),
           buffer,

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -98,9 +98,9 @@ pub mod rust {
   ///
   /// - If called with an invalid combination of `tx_size` and `tx_type`
   #[cold_for_target_arch("x86_64")]
-  pub fn forward_transform<T: Coefficient>(
+  pub fn forward_transform<T: Coefficient, const BD: usize>(
     input: &[i16], output: &mut [T], stride: usize, tx_size: TxSize,
-    tx_type: TxType, bd: usize, _cpu: CpuFeatureLevel,
+    tx_type: TxType, _cpu: CpuFeatureLevel,
   ) {
     assert!(valid_av1_transform(tx_size, tx_type));
 
@@ -117,7 +117,7 @@ pub mod rust {
     let mut tmp: Aligned<[i32; 64 * 64]> = unsafe { Aligned::uninitialized() };
     let buf = &mut tmp.data[..txfm_size_col * txfm_size_row];
 
-    let cfg = Txfm2DFlipCfg::fwd(tx_type, tx_size, bd);
+    let cfg = Txfm2DFlipCfg::fwd::<BD>(tx_type, tx_size);
 
     let txfm_func_col = get_func(cfg.txfm_type_col);
     let txfm_func_row = get_func(cfg.txfm_type_row);

--- a/src/transform/forward_shared.rs
+++ b/src/transform/forward_shared.rs
@@ -119,7 +119,7 @@ impl Txfm2DFlipCfg {
   /// # Panics
   ///
   /// - If called with an invalid combination of `tx_size` and `tx_type`
-  pub fn fwd(tx_type: TxType, tx_size: TxSize, bd: usize) -> Self {
+  pub fn fwd<const BD: usize>(tx_type: TxType, tx_size: TxSize) -> Self {
     let tx_type_1d_col = VTX_TAB[tx_type as usize];
     let tx_type_1d_row = HTX_TAB[tx_type as usize];
     let txw_idx = tx_size.width_index();
@@ -134,7 +134,7 @@ impl Txfm2DFlipCfg {
       tx_size,
       ud_flip,
       lr_flip,
-      shift: FWD_TXFM_SHIFT_LS[tx_size as usize][(bd - 8) / 2],
+      shift: FWD_TXFM_SHIFT_LS[tx_size as usize][(BD - 8) / 2],
       txfm_type_col,
       txfm_type_row,
     }

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1602,9 +1602,9 @@ pub(crate) mod rust {
   use std::cmp;
 
   #[cold_for_target_arch("x86_64", "aarch64")]
-  pub fn inverse_transform_add<T: Pixel>(
+  pub fn inverse_transform_add<T: Pixel, const BD: usize>(
     input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, _eob: usize,
-    tx_size: TxSize, tx_type: TxType, bd: usize, _cpu: CpuFeatureLevel,
+    tx_size: TxSize, tx_type: TxType, _cpu: CpuFeatureLevel,
   ) {
     let width: usize = tx_size.width();
     let height: usize = tx_size.height();
@@ -1619,7 +1619,7 @@ pub(crate) mod rust {
     let tx_types_1d = get_1d_tx_types(tx_type);
 
     // perform inv txfm on every row
-    let range = bd + 8;
+    let range = BD + 8;
     let txfm_fn = INV_TXFM_FNS[tx_types_1d.1 as usize][ILog::ilog(width) - 3];
     // 64 point transforms only signal 32 coeffs. We only take chunks of 32
     //   and skip over the last 32 transforms here.
@@ -1645,7 +1645,7 @@ pub(crate) mod rust {
     }
 
     // perform inv txfm on every col
-    let range = cmp::max(bd + 6, 16);
+    let range = cmp::max(BD + 6, 16);
     let txfm_fn = INV_TXFM_FNS[tx_types_1d.0 as usize][ILog::ilog(height) - 3];
     for c in 0..width {
       let mut temp_in: [i32; 64] = [0; 64];
@@ -1664,7 +1664,7 @@ pub(crate) mod rust {
         .zip(output.rows_iter_mut().map(|row| &mut row[c]).take(height))
       {
         let v: i32 = (*out).as_();
-        let v = clamp(v + round_shift(*temp, 4), 0, (1 << bd) - 1);
+        let v = clamp(v + round_shift(*temp, 4), 0, (1 << BD) - 1);
         *out = T::cast_from(v);
       }
     }

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -474,14 +474,20 @@ mod test {
       *d = T::cast_from(random::<u8>());
       *r = i16::cast_from(*s) - i16::cast_from(*d);
     }
-    forward_transform(res, freq, tx_size.width(), tx_size, tx_type, 8, cpu);
+    forward_transform::<_, 8>(
+      res,
+      freq,
+      tx_size.width(),
+      tx_size,
+      tx_type,
+      cpu,
+    );
     inverse_transform_add(
       freq,
       &mut dst.as_region_mut(),
       coeff_area,
       tx_size,
       tx_type,
-      8,
       cpu,
     );
 


### PR DESCRIPTION
This is a followup from #3116 which expands this optimization to as many places in the encoder as we can reasonably utilize it. By using generics, there are places where the compiler is able to simplify math operations at compile time as well as areas where the compiler is able to remove branches so that we only branch on bit depth at the highest level of the code (and therefore the fewest number of times).

Based on hyperfine benchmarking, this results in a 1-2% speedup across the encoding process, although it does increase the final binary size.