### PR TITLE
Only run renovate once a week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
     ":automergePr",
     ":automergeRequireAllStatusChecks",
     ":enableVulnerabilityAlerts",
-    "group:allNonMajor"
+    "group:allNonMajor",
+    "schedule:earlyMondays"
   ],
   "fetchReleaseNotes": true
 }


### PR DESCRIPTION
The PRs were becoming too noisy having it run "any time" and defeated the purpose of using renovate to group updates together.