### PR TITLE
CI: Allow new `clippy::deprecated` warning for rustc 1.69

### DIFF
--- a/src/asm/x86/cdef.rs
+++ b/src/asm/x86/cdef.rs
@@ -294,7 +294,7 @@ mod test {
           #[interpolate_test(dir_6, 6)]
           #[interpolate_test(dir_7, 7)]
           fn [<cdef_filter_block_dec_ $XDEC _ $YDEC _ $OPT>](dir: usize) {
-            if !is_x86_feature_detected!($OPTLIT) {
+            if CpuFeatureLevel::default() < CpuFeatureLevel::from_str($OPTLIT).unwrap() {
               eprintln!("Ignoring {} test, not supported on this machine!", $OPTLIT);
               return;
             }

--- a/src/asm/x86/dist/mod.rs
+++ b/src/asm/x86/dist/mod.rs
@@ -741,7 +741,7 @@ mod test {
         paste::item! {
           #[test]
           fn [<get_ $DIST_TY _ $W x $H _bd_ $BD _ $OPT>]() {
-            if !is_x86_feature_detected!($OPTLIT) {
+            if CpuFeatureLevel::default() < CpuFeatureLevel::from_str($OPTLIT).unwrap() {
               eprintln!("Ignoring {} test, not supported on this machine!", $OPTLIT);
               return;
             }

--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -633,7 +633,7 @@ mod test {
         paste::item! {
           #[test]
           fn [<test_ $func_name _bd_ $BD _ $OPT>]() {
-            if !is_x86_feature_detected!($OPTLIT) {
+            if CpuFeatureLevel::default() < CpuFeatureLevel::from_str($OPTLIT).unwrap() {
               eprintln!("Ignoring {} test, not supported on this machine!", $OPTLIT);
               return;
             }
@@ -720,7 +720,7 @@ mod test {
         paste::item! {
           #[test]
           fn [<test_ $func_name _bd_ $BD _ $OPT>]() {
-            if !is_x86_feature_detected!($OPTLIT) {
+            if CpuFeatureLevel::default() < CpuFeatureLevel::from_str($OPTLIT).unwrap() {
               eprintln!("Ignoring {} test, not supported on this machine!", $OPTLIT);
               return;
             }

--- a/src/asm/x86/transform/inverse.rs
+++ b/src/asm/x86/transform/inverse.rs
@@ -405,6 +405,7 @@ mod test {
   use super::*;
   use crate::asm::shared::transform::inverse::test::*;
   use crate::transform::TxSize::*;
+  use std::str::FromStr;
 
   macro_rules! test_itx_fns {
     ($(($ENUM:expr, $TYPE1:ident, $TYPE2:ident, $W:expr, $H:expr)),*, $OPT:ident, $OPTLIT:tt, $OPT_ENUM:expr) => {
@@ -412,7 +413,7 @@ mod test {
         paste::item! {
           #[test]
           fn [<inv_txfm2d_add_$TYPE2 _$TYPE1 _$W x $H _$OPT>]() {
-            if !is_x86_feature_detected!($OPTLIT) {
+            if CpuFeatureLevel::default() < CpuFeatureLevel::from_str($OPTLIT).unwrap() {
               eprintln!("Ignoring {} test, not supported on this machine!", $OPTLIT);
               return;
             }

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -44,6 +44,7 @@ impl Default for CpuFeatureLevel {
         && is_x86_feature_detected!("avx512f")
         && is_x86_feature_detected!("avx512vl")
     }
+    #[allow(deprecated)] // Until MSRV >= 1.69.0
     fn avx512icl_detected() -> bool {
       // Per dav1d, these are the flags needed.
       avx512_detected()


### PR DESCRIPTION
CPU features `avx512gfni`, `avx512vaes` and `avx512vpclmulqdq` are renamed. The `avx512` prefix is removed but the original names remain as aliases.