### PR TITLE
Increase test coverage for intra prediction

### DIFF
--- a/src/cpu_features/aarch64.rs
+++ b/src/cpu_features/aarch64.rs
@@ -18,6 +18,12 @@ pub enum CpuFeatureLevel {
 }
 
 impl CpuFeatureLevel {
+  #[cfg(test)]
+  pub(crate) const fn all() -> &'static [Self] {
+    use CpuFeatureLevel::*;
+    &[RUST, NEON]
+  }
+
   pub const fn len() -> usize {
     CpuFeatureLevel::NEON as usize + 1
   }

--- a/src/cpu_features/rust.rs
+++ b/src/cpu_features/rust.rs
@@ -14,6 +14,14 @@ pub enum CpuFeatureLevel {
   RUST,
 }
 
+impl CpuFeatureLevel {
+  #[cfg(test)]
+  pub(crate) const fn all() -> &'static [Self] {
+    use CpuFeatureLevel::*;
+    &[RUST, NEON]
+  }
+}
+
 impl Default for CpuFeatureLevel {
   fn default() -> CpuFeatureLevel {
     CpuFeatureLevel::RUST

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -25,6 +25,12 @@ pub enum CpuFeatureLevel {
 }
 
 impl CpuFeatureLevel {
+  #[cfg(test)]
+  pub(crate) const fn all() -> &'static [Self] {
+    use CpuFeatureLevel::*;
+    &[RUST, SSE2, SSSE3, SSE4_1, AVX2, AVX512, AVX512ICL]
+  }
+
   pub const fn len() -> usize {
     CpuFeatureLevel::AVX512ICL as usize + 1
   }


### PR DESCRIPTION
Expand `asm::shared::predict::test::pred_matches_u8` to cover all available CPU feature levels and bit depths.