### PR TITLE
Remove const_fn_assert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,12 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn_assert"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d614f23f34f7b5165a77dc1591f497e2518f9cec4b4f4b92bfc4dc6cf7a190"
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,7 +1363,6 @@ dependencies = [
  "clap 4.2.5",
  "clap_complete",
  "console",
- "const_fn_assert",
  "criterion",
  "crossbeam",
  "dav1d-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,6 @@ itertools = "0.10"
 simd_helpers = "0.1"
 wasm-bindgen = { version = "0.2.84", optional = true }
 rust_hawktracer = "0.7.0"
-const_fn_assert = "0.1.2"
 nom = { version = "7.1.3", optional = true }
 new_debug_unreachable = "1.0.4"
 once_cell = "1.17.1"

--- a/src/util/logexp.rs
+++ b/src/util/logexp.rs
@@ -7,11 +7,9 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use const_fn_assert::cfn_debug_assert;
-
 /// Convert an integer into a Q57 fixed-point fraction.
 pub const fn q57(v: i32) -> i64 {
-  cfn_debug_assert!(v >= -64 && v <= 63);
+  debug_assert!(v >= -64 && v <= 63);
   (v as i64) << 57
 }
 


### PR DESCRIPTION
Our version of rust already support natively panic in const context.