### PR TITLE
Add `devcontainer` with deps for `x86_64` and `aarch64`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,3 +23,5 @@ ENV PKG_CONFIG_PATH_aarch64_unknown_linux_gnu=/usr/lib/aarch64-linux-gnu/pkgconf
 ENV PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu=/
 ENV CUSTOM_LIBFUZZER_PATH=/usr/lib/llvm-14/lib/libFuzzer.a
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="sde64 -icl --"
+LABEL dev.containers.source=https://github.com/xiph/rav1e
+LABEL dev.containers.id=rav1e

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/devcontainers/rust:0-1-bullseye
+RUN sed -i 's/bullseye/testing/g' /etc/apt/sources.list \
+ && dpkg --add-architecture arm64 \
+ && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+ && apt-get install -y --no-install-recommends \
+ libaom-dev libdav1d-dev libaom-dev:arm64 libdav1d-dev:arm64 \
+ libclang-dev libgit2-dev libcurl4-openssl-dev libfuzzer-14-dev \
+ gcc-aarch64-linux-gnu libc6-dev-arm64-cross nasm dav1d qemu-user \
+ && rm -rf /var/lib/apt/lists/*
+RUN rustup target add aarch64-unknown-linux-gnu
+RUN export CARGO_PROFILE_RELEASE_STRIP=true \
+ && cargo install -q cargo-c \
+ && cargo install -q cargo-criterion \
+ && cargo install -q cargo-fuzz \
+ && rm -rf /usr/local/cargo/registry
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER=qemu-aarch64
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS=-Clinker=aarch64-linux-gnu-gcc
+ENV PKG_CONFIG_ALLOW_CROSS_aarch64_unknown_linux_gnu=1
+ENV PKG_CONFIG_PATH_aarch64_unknown_linux_gnu=/usr/lib/aarch64-linux-gnu/pkgconfig
+ENV PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu=/
+ENV CUSTOM_LIBFUZZER_PATH=/usr/lib/llvm-14/lib/libFuzzer.a

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,9 +13,13 @@ RUN export CARGO_PROFILE_RELEASE_STRIP=true \
  && cargo install -q cargo-criterion \
  && cargo install -q cargo-fuzz \
  && rm -rf /usr/local/cargo/registry
+RUN SDE=sde-external-9.14.0-2022-10-25-lin \
+ && curl -sSf https://downloadmirror.intel.com/751535/$SDE.tar.xz | tar Jx -C /opt \
+ && ln -sv /opt/$SDE/sde64 /usr/local/bin/sde64
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER=qemu-aarch64
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS=-Clinker=aarch64-linux-gnu-gcc
 ENV PKG_CONFIG_ALLOW_CROSS_aarch64_unknown_linux_gnu=1
 ENV PKG_CONFIG_PATH_aarch64_unknown_linux_gnu=/usr/lib/aarch64-linux-gnu/pkgconfig
 ENV PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu=/
 ENV CUSTOM_LIBFUZZER_PATH=/usr/lib/llvm-14/lib/libFuzzer.a
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="sde64 -icl --"

--- a/.devcontainer/build.json
+++ b/.devcontainer/build.json
@@ -1,0 +1,6 @@
+{
+	"name": "rav1e-devcontainer",
+	"build": {
+		"dockerfile": "Dockerfile"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
 	"name": "rav1e-devcontainer",
-	"build": {
-		"dockerfile": "Dockerfile"
-	}
+	"image": "ghcr.io/xiph/rav1e-devcontainer:latest"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "rav1e-devcontainer",
+	"build": {
+		"dockerfile": "Dockerfile"
+	}
+}

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,32 @@
+name: Build devcontainer image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/devcontainer.yml'
+      - '.devcontainer/**'
+
+jobs:
+  devcontainer:
+    if: github.repository_owner == 'xiph'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install devcontainer-cli
+        run: npm install -g @devcontainers/cli
+      - name: Authenticate with ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      - name: Build devcontainer image
+        run: |
+          IMAGE_NAME=rav1e-devcontainer
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          VERSION=latest
+          IMAGE_TAG=${IMAGE_ID,,}:$VERSION
+          devcontainer build --image-name $IMAGE_TAG --push \
+            --workspace-folder $PWD --config .devcontainer/build.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,13 +65,13 @@ sudo dnf install libaom-devel libdav1d-devel
 Run encode-decode integration tests against libaom with:
 
 ```sh
-cargo test --release --features=decode_test
+cargo test --release --features=decode_test --lib -- test_encode_decode
 ```
 
 Run the encode-decode tests against `dav1d` with:
 
 ```sh
-cargo test --release --features=decode_test_dav1d
+cargo test --release --features=decode_test_dav1d --lib -- test_encode_decode
 ```
 
 Run regular benchmarks with:

--- a/README.md
+++ b/README.md
@@ -152,13 +152,10 @@ cargo run --release --bin rav1e -- input.y4m -o output.ivf
 _(Find a y4m-file for testing at [`tests/small_input.y4m`](tests/small_input.y4m) or at http://ultravideo.cs.tut.fi/#testsequences)_
 
 ### Decompressing video
-Encoder output should be compatible with any AV1 decoder compliant with the v1.0.0 specification. You can build compatible aomdec using the following:
+Encoder output should be compatible with any AV1 decoder compliant with the v1.0.0 specification. You can decode using [dav1d](https://code.videolan.org/videolan/dav1d), which is now packaged [![in over 40 repositories](https://repology.org/badge/tiny-repos/dav1d.svg)](https://repology.org/project/dav1d/versions).
 
 ```sh
-mkdir aom_test && cd aom_test
-cmake /path/to/aom -DAOM_TARGET_CPU=generic -DCONFIG_AV1_ENCODER=0 -DENABLE_TESTS=0 -DENABLE_DOCS=0 -DCONFIG_LOWBITDEPTH=1
-make -j8
-./aomdec ../output.ivf -o output.y4m
+dav1d -i output.ivf -o output.y4m
 ```
 
 ### Configuring


### PR DESCRIPTION
The primary audience is new contributors, providing a one-click fully functional development environment.

The installed packages include:
- gcc cross-compiler and qemu for aarch64 testing
- Intel SDE for AVX512-ICL testing
- dav1d binary for decoding ivf output
- cargo-fuzz and libfuzzer-14-dev configured for libfuzzer-sys
- cargo-criterion for running and reporting benchmarks