### PR TITLE
fix: check --all-targets without --features bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,7 @@ bench = false
 [[bench]]
 name = "bench"
 path = "benches/bench.rs"
+required-features = ["bench"]
 harness = false
 
 [profile.dev]


### PR DESCRIPTION
This command was failing under the rust-analyzer plugin for VS Code:
```
cargo check --quiet --workspace --message-format=json --all-targets
```
The code under bench/ was checked although the "bench" feature is not enabled by default. Resolve by making it a required feature of the bench target.