### PR TITLE
Enable Renovate to update lockfile dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,8 @@
     "group:allNonMajor",
     "schedule:earlyMondays"
   ],
-  "fetchReleaseNotes": true
+  "fetchReleaseNotes": true,
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
This update will cause Renovate to update all versions in the lockfile to the latest Cargo.toml-compatible versions once per week. This is necessary in order to ensure all dependencies are included in the updates.

This may raise the question of why bother with a lockfile. The answer is that having the lockfile committed, but having it updated automatically, allows us to have the CI run before we merge the updates, preventing rav1e from randomly breaking.