### PR TITLE
cdf_context: fix clippy lint caught by 1.72.0 nightly

### DIFF
--- a/src/context/cdf_context.rs
+++ b/src/context/cdf_context.rs
@@ -550,7 +550,7 @@ impl CDFContext {
   ) -> CDFOffset<CDF_LEN> {
     CDFOffset {
       offset: cdf as usize - self as *const _ as usize,
-      phantom: PhantomData::default(),
+      phantom: PhantomData,
     }
   }
 }


### PR DESCRIPTION
Fixes: "warning: use of `default` to create a unit struct"