### PR TITLE
Show runtime assembly level in long version output

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -17,6 +17,7 @@ use once_cell::sync::Lazy;
 use rav1e::prelude::*;
 use scan_fmt::scan_fmt;
 
+use rav1e::config::CpuFeatureLevel;
 use std::fs::File;
 use std::io;
 use std::io::prelude::*;
@@ -273,12 +274,17 @@ fn get_long_version() -> &'static str {
       rustflags = "(None)";
     }
     format!(
-      "{}\n{} {}\nCompiled CPU Features: {}\nAssembly: {}\nThreading: {}\nUnstable Features: {}\nCompiler Flags: {}",
+      "{}\n{} {}\nCompiled CPU Features: {}\nRuntime Assembly Support: {}{}\nThreading: {}\nUnstable Features: {}\nCompiler Flags: {}",
       get_version(),
       built_info::RUSTC_VERSION,
       built_info::TARGET,
       option_env!("CARGO_CFG_TARGET_FEATURE").unwrap_or("(None)"),
       if cfg!(feature = "asm") { "Enabled" } else { "Disabled" },
+      if cfg!(feature = "asm") {
+        format!("\nRuntime Assembly Level: {}", CpuFeatureLevel::default())
+      } else {
+        String::new()
+      },
       if cfg!(feature = "threading") { "Enabled" } else { "Disabled" },
       if cfg!(feature = "unstable") { "Enabled" } else { "Disabled" },
       rustflags


### PR DESCRIPTION
Currently when passing `--version` to rav1e, rav1e will output whether assembly is enabled, as well as CPU features that the binary was compiled with. This has shown to be a bit confusing for end users. This change clarifies the text by specifying that the assembly refers to runtime assembly, i.e. the dynamically activated assembly based on CPU detection, as well as specifying what runtime assembly level would be used on the current machine (this is also affected by environment vars).

Example output as follows:

```
rav1e 0.6.1 (p20230627-2-g73440a1) (debug)
rustc 1.70.0 (90c541806 2023-05-31) x86_64-unknown-linux-gnu
Compiled CPU Features: adx,aes,avx,avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,fxsr,lzcnt,movbe,pclmulqdq,popcnt,rdrand,rdseed,sha,sse,sse2,sse3,sse4.1,sse4.2,ssse3,xsave,xsavec,xsaveopt,xsaves
Runtime Assembly Support: Enabled
Runtime Assembly Level: AVX2
Threading: Enabled
Unstable Features: Disabled
Compiler Flags: -Ctarget-cpu=native
```