### PR TITLE
Clippy updates for rustc 1.71

### DIFF
--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1282,7 +1282,6 @@ pub(crate) mod rust {
     }
   }
 
-  #[allow(clippy::clone_double_ref)]
   pub(crate) fn pred_directional<T: Pixel>(
     output: &mut PlaneRegionMut<'_, T>, above: &[T], left: &[T],
     top_left: &[T], p_angle: usize, width: usize, height: usize,


### PR DESCRIPTION
Removes an allow which is no longer necessary