### PR TITLE
Remove unsafe code from fast_idiv by using NonZeroUsize

### DIFF
--- a/src/scenechange/fast.rs
+++ b/src/scenechange/fast.rs
@@ -138,9 +138,8 @@ pub(super) fn detect_scale_factor<T: Pixel>(
       scale_factor,
       sequence.max_frame_width,
       sequence.max_frame_height,
-      // SAFETY: We ensure that scale_factor is set based on nonzero powers of 2.
-      unsafe { fast_idiv(sequence.max_frame_width as usize, scale_factor) },
-      unsafe { fast_idiv(sequence.max_frame_height as usize, scale_factor) }
+      fast_idiv(sequence.max_frame_width as usize, scale_factor),
+      fast_idiv(sequence.max_frame_height as usize, scale_factor)
     );
   }
 


### PR DESCRIPTION
The optimizations to `.trailing_zeros()` will automatically be applied by rustc when using NonZero types. This allows us to remove the unsafe code.

You can check this will actually work by running:
`RUSTFLAGS="-C target-feature=-bmi1,-lzcnt -C llvm-args=-x86-asm-syntax=intel --emit asm" cargo b -r`

and then inspecting the output assembly. If you use `#[inline(never)]` on fast_idiv for testing, you can find the generated ASM easily:

```asm
; ...
_ZN5rav1e11scenechange9fast_idiv17h2ad3db97a8f4c4c5E:
.Lfunc_begin583:
	.file	147 "/home/user/Development/rav1e" "src/scenechange/mod.rs"
	.loc	147 32 0
	.cfi_startproc
	.loc	107 254 1 prologue_end
	rep		bsf	rax, rsi
.Ltmp17962:
	.loc	147 35 3
	shrx	rax, rdi, rax
	.loc	147 36 2
	ret
.Ltmp17963:
.Lfunc_end583:
; ...
```

The assertion (SCALE.is_power_of_two()) is not strictly required, but the code depends on it in a lot of places already, so I thought it would be fine.