### PR TITLE
Improve error message for platforms without rusage support

### DIFF
--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -420,7 +420,7 @@ fn init_logger() {
 cfg_if::cfg_if! {
   if #[cfg(any(target_os = "windows", target_arch = "wasm32"))] {
     fn print_rusage() {
-      eprintln!("Resource usage reporting is not supported on this platform");
+      eprintln!("Resource usage reporting is not currently supported on this platform");
     }
   } else {
     fn print_rusage() {

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -420,7 +420,7 @@ fn init_logger() {
 cfg_if::cfg_if! {
   if #[cfg(any(target_os = "windows", target_arch = "wasm32"))] {
     fn print_rusage() {
-      eprintln!("Windows benchmarking is not supported currently.");
+      eprintln!("Resource usage reporting is not supported on this platform");
     }
   } else {
     fn print_rusage() {

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -409,7 +409,7 @@ fn init_logger() {
 cfg_if::cfg_if! {
   if #[cfg(any(target_os = "windows", target_arch = "wasm32"))] {
     fn print_rusage() {
-      eprintln!("Resource usage reporting is not supported on this platform");
+      eprintln!("Resource usage reporting is not currently supported on this platform");
     }
   } else {
     fn print_rusage() {

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -409,7 +409,7 @@ fn init_logger() {
 cfg_if::cfg_if! {
   if #[cfg(any(target_os = "windows", target_arch = "wasm32"))] {
     fn print_rusage() {
-      eprintln!("Windows benchmarking is not supported currently.");
+      eprintln!("Resource usage reporting is not supported on this platform");
     }
   } else {
     fn print_rusage() {


### PR DESCRIPTION
More accurately report that resource usage reporting is not supported on these platforms since the lack of support is not necessarily a Windows-only issue.

Addresses https://github.com/xiph/rav1e/issues/2517