### PR TITLE
Implement support for encoding Dolby Vision from RPU file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "aom-sys"
@@ -229,6 +229,27 @@ name = "bitstream-io"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82704769cb85a22df2c54d6bdd6a158b7931d256cf3248a07d6ecbe9d58b31d7"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "bitvec_helpers"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef6883bd86b4112b56be19de3a1628de6c4063be7be6e641d484c83069efb4a"
+dependencies = [
+ "bitstream-io",
+]
 
 [[package]]
 name = "bstr"
@@ -444,6 +465,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +620,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dolby_vision"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0131539224b32982a9c9cb8e6bde1ac30388bf8d6f38aa2c734daf6a8ea4aa1"
+dependencies = [
+ "anyhow",
+ "bitvec",
+ "bitvec_helpers",
+ "crc",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +716,12 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
@@ -1247,6 +1301,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1359,7 @@ dependencies = [
  "criterion",
  "crossbeam",
  "dav1d-sys",
+ "dolby_vision",
  "fern",
  "image",
  "interpolate_name",
@@ -1640,6 +1701,12 @@ dependencies = [
  "toml",
  "version-compare",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -2082,6 +2149,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ new_debug_unreachable = "1.0.4"
 once_cell = "1.18.0"
 av1-grain = { version = "0.2.2", features = ["serialize"] }
 serde-big-array = { version = "0.5.1", optional = true }
+dolby_vision = { version = "3.2.0" }
 
 [dependencies.image]
 version = "0.24.6"

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -3686,11 +3686,9 @@ pub fn encode_show_existing_frame<T: Pixel>(
   }
 
   for t35 in fi.t35_metadata.iter() {
-    let mut t35_buf = Vec::new();
-    let mut t35_bw = BitWriter::endian(&mut t35_buf, BigEndian);
-    t35_bw.write_t35_metadata_obu(t35).unwrap();
-    packet.write_all(&t35_buf).unwrap();
-    t35_buf.clear();
+    if t35.is_valid_placement(fi) {
+      write_t35_metadata_packet(&mut packet, t35);
+    }
   }
 
   let mut buf1 = Vec::new();
@@ -3767,11 +3765,9 @@ pub fn encode_frame<T: Pixel>(
   }
 
   for t35 in fi.t35_metadata.iter() {
-    let mut t35_buf = Vec::new();
-    let mut t35_bw = BitWriter::endian(&mut t35_buf, BigEndian);
-    t35_bw.write_t35_metadata_obu(t35).unwrap();
-    packet.write_all(&t35_buf).unwrap();
-    t35_buf.clear();
+    if t35.is_valid_placement(fi) {
+      write_t35_metadata_packet(&mut packet, t35);
+    }
   }
 
   let mut buf1 = Vec::new();
@@ -3825,6 +3821,14 @@ pub fn update_rec_buffer<T: Pixel>(
       fi.rec_buffer.deblock[i] = fs.deblock;
     }
   }
+}
+
+fn write_t35_metadata_packet(packet: &mut Vec<u8>, t35: &T35) {
+  let mut t35_buf = Vec::new();
+  let mut t35_bw = BitWriter::endian(&mut t35_buf, BigEndian);
+  t35_bw.write_t35_metadata_obu(t35).unwrap();
+  packet.write_all(&t35_buf).unwrap();
+  t35_buf.clear();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The changes allow to encode AV1 files with Dolby Vision metadata for playback on supported devices.

As there is no official specification, the minimum I've tested is that the metadata is recognized and used correctly on playback.
The metadata OBU placement is based on #3000 (the AV1 HDR10+ specification), and I've tested it to be working fine with 2 GOPs.

From CLI, the metadata is expected to be passed as a RPU binary file, which follows the same format as encoders like `x265`.
The metadata parsing/encoding is done through the [dolby_vision](https://crates.io/crates/dolby_vision) crate.
The CLI opt can be either `--dovi-rpu` or `--dolby-vision-rpu` (used by `x265`)

From Rust, the metadata must be encoded into the final T.35 and provided for the frames that require it.

For muxing, it's possible to use the GPAC utilities but it currently requires patching for AV1: https://github.com/gpac/gpac/issues/2549
`mkvmerge` will also have support for raw OBU. IVF has to be added.