### PR TITLE
ci: Set MACOSX_DEPLOYMENT_TARGET to 10.10 for x86_64, 11.0 for arm64

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -335,14 +335,19 @@ jobs:
         include:
          - target: x86_64-apple-darwin
            name: macos
+           macosx_deployment_target: "10.10"
          - target: aarch64-apple-darwin
            name: macos-aarch64
+           macosx_deployment_target: "11.0"
          - build: binary
            pkgname: rav1e
            ext: zip
          - build: sdk
            pkgname: librav1e
            ext: tar.gz
+
+    env:
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macosx_deployment_target }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
I noticed that rav1e is compiling against the OS X 12 SDK, whereas the binaries I distribute for pillow-avif-plugin target 10.10 and 11 for x86_64 and arm64, respectively—which is pretty common practice for python wheels. I've confirmed that cargo-c respects the `MACOSX_DEPLOYMENT_TARGET` environment variable and that the artifacts are in fact built against the desired SDKs.