### PR TITLE
Update two dependencies that relied on syn1

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install dependencies
         if: matrix.conf != 'dav1d-tests-arm64'
         run: |
-          sudo sed -i 's/jammy/kinetic/g' /etc/apt/sources.list
+          sudo sed -i 's/jammy/lunar/g' /etc/apt/sources.list
           sudo apt update
           sudo apt install nasm libaom-dev libdav1d-dev
       - name: Install cargo-c
@@ -140,9 +140,9 @@ jobs:
           LINK: http://ports.ubuntu.com/ubuntu-ports/pool
         run: |
           rustup target add aarch64-unknown-linux-gnu
-          { echo 'deb [arch=amd64] http://azure.archive.ubuntu.com/ubuntu kinetic main universe'
-            echo 'deb [arch=amd64] http://azure.archive.ubuntu.com/ubuntu kinetic-updates main universe'
-            echo 'deb [arch=arm64] http://azure.ports.ubuntu.com/ kinetic main universe'
+          { echo 'deb [arch=amd64] http://azure.archive.ubuntu.com/ubuntu lunar main universe'
+            echo 'deb [arch=amd64] http://azure.archive.ubuntu.com/ubuntu lunar-updates main universe'
+            echo 'deb [arch=arm64] http://azure.ports.ubuntu.com/ lunar main universe'
           } | sudo tee /etc/apt/sources.list
           sudo dpkg --add-architecture arm64
           sudo apt update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,13 +105,13 @@ checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
 
 [[package]]
 name = "arg_enum_proc_macro"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c29b43ee8654590587cd033b3eca2f9c4f8cdff945ec0e6ee91ceb057d87f3"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -765,13 +765,13 @@ dependencies = [
 
 [[package]]
 name = "interpolate_name"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b35f4a811037cfdcd44c5db40678464b2d5d248fc1abeeaaa125b370d47f17"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.25",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ wasm = ["wasm-bindgen"]
 dump_lookahead_data = ["byteorder", "image"]
 
 [dependencies]
-arg_enum_proc_macro = "0.3"
+arg_enum_proc_macro = "0.3.4"
 bitstream-io = "1"
 cfg-if = "1.0"
 clap = { version = "4.3.19", optional = true, default-features = false, features = [
@@ -132,7 +132,7 @@ signal-hook = { version = "0.3", optional = true }
 assert_cmd = "2.0"
 criterion = "0.5"
 pretty_assertions = "1.4.0"
-interpolate_name = "0.2.3"
+interpolate_name = "0.2.4"
 nom = "7.1.3"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -215,7 +215,7 @@ mod ssim_boost_tests {
     const C3: f64 = 12338f64;
     const RATIO: f64 = C1 / C3;
 
-    RATIO * (svar + dvar + C2) / f64::sqrt(C1 * C1 + svar * dvar)
+    RATIO * (svar + dvar + C2) / f64::sqrt(C1.mul_add(C1, svar * dvar))
   }
 
   /// Test that `ssim_boost` has sufficient accuracy.

--- a/src/asm/aarch64/cdef.rs
+++ b/src/asm/aarch64/cdef.rs
@@ -100,7 +100,7 @@ pub(crate) unsafe fn cdef_filter_block<T: Pixel>(
         CDEF_FILTER_FNS[cpu.as_index()][decimate_index(xdec, ydec)],
       ) {
         (Some(pad), Some(func)) => {
-          let h = if ydec == 1 { 4 } else { 8 } as i32;
+          let h = if ydec == 1 { 4 } else { 8 };
           let tmpstride = if xdec == 1 { 8 } else { 16 } as isize;
           const MAXTMPSTRIDE: isize = 16;
           const TMPSIZE: usize = (12 * MAXTMPSTRIDE + 8) as usize;
@@ -167,7 +167,7 @@ pub(crate) unsafe fn cdef_filter_block<T: Pixel>(
         // clause using Rust macros.  See comments above for
         // indexing/addressing notes.
         (Some(pad), Some(func)) => {
-          let h = if ydec == 1 { 4 } else { 8 } as i32;
+          let h = if ydec == 1 { 4 } else { 8 };
           let tmpstride = if xdec == 1 { 8 } else { 16 } as isize;
           const MAXTMPSTRIDE: isize = 16;
           const TMPSIZE: usize = (12 * MAXTMPSTRIDE + 8) as usize;
@@ -370,7 +370,7 @@ pub(crate) fn cdef_find_dir<T: Pixel>(
             img.as_ptr() as *const _,
             T::to_asm_stride(img.plane.cfg.stride),
             var as *mut u32,
-            (1 << coeff_shift + 8) - 1,
+            (1 << (coeff_shift + 8)) - 1,
           )
         }
       } else {

--- a/src/asm/aarch64/dist.rs
+++ b/src/asm/aarch64/dist.rs
@@ -109,6 +109,7 @@ pub fn get_sad<T: Pixel>(
 }
 
 #[inline(always)]
+#[allow(clippy::let_and_return)]
 pub fn get_satd<T: Pixel>(
   src: &PlaneRegion<'_, T>, dst: &PlaneRegion<'_, T>, w: usize, h: usize,
   bit_depth: usize, cpu: CpuFeatureLevel,

--- a/src/asm/aarch64/mc.rs
+++ b/src/asm/aarch64/mc.rs
@@ -105,7 +105,7 @@ pub fn put_8tap<T: Pixel>(
     // SAFETY: The assembly only supports even heights and valid uncropped
     //         widths
     assert_eq!(height & 1, 0);
-    assert!(width.is_power_of_two() && 2 <= width && width <= 128);
+    assert!(width.is_power_of_two() && (2..=128).contains(&width));
 
     // SAFETY: Check bounds of dst
     assert!(dst.rect().width >= width && dst.rect().height >= height);
@@ -188,7 +188,7 @@ pub fn prep_8tap<T: Pixel>(
     // SAFETY: The assembly only supports even heights and valid uncropped
     //         widths
     assert_eq!(height & 1, 0);
-    assert!(width.is_power_of_two() && 2 <= width && width <= 128);
+    assert!(width.is_power_of_two() && (2..=128).contains(&width));
 
     // SAFETY: Check length of tmp
     assert!(tmp.len() >= width * height);
@@ -256,7 +256,7 @@ pub fn mc_avg<T: Pixel>(
     // SAFETY: The assembly only supports even heights and valid uncropped
     //         widths
     assert_eq!(height & 1, 0);
-    assert!(width.is_power_of_two() && 2 <= width && width <= 128);
+    assert!(width.is_power_of_two() && (2..=128).contains(&width));
 
     // SAFETY: Check bounds of dst
     assert!(dst.rect().width >= width && dst.rect().height >= height);

--- a/src/asm/aarch64/predict.rs
+++ b/src/asm/aarch64/predict.rs
@@ -385,7 +385,7 @@ unsafe fn ipred_z2<T: Pixel>(
   let mut out = [MaybeUninit::<T>::uninit(); 3 * (MAX_TX_SIZE * 4 + 1)];
   let out = out.as_mut_ptr() as *mut T;
   let left = out.add(2 * (64 + 1));
-  let top = out.add(1 * (64 + 1));
+  let top = out.add(64 + 1);
   let flipped = out;
   if us_above {
     ipred_z2_upsample_edge(top, w, src, bd_max);
@@ -586,7 +586,7 @@ pub fn dispatch_predict_intra<T: Pixel>(
           let smooth_filter = ief_params
             .map(IntraEdgeFilterParameters::use_smooth_filter)
             .unwrap_or_default();
-          if angle >= 90 && angle <= 180 {
+          if (90..=180).contains(&angle) {
             // From dav1d, bw and bh are the frame width and height rounded to 8px units
             let (bw, bh) = (
               ((dst.plane_cfg.width + 7) >> 3) << 3,

--- a/src/asm/x86/cdef.rs
+++ b/src/asm/x86/cdef.rs
@@ -101,7 +101,7 @@ pub(crate) unsafe fn cdef_filter_block<T: Pixel>(
             (func)(
               dst.data_ptr_mut() as *mut _,
               T::to_asm_stride(dst.plane_cfg.stride),
-              tmp.data.as_ptr().offset(3 * TMPSTRIDE) as *const u16,
+              tmp.data.as_ptr().offset(3 * TMPSTRIDE),
               TMPSTRIDE,
               pri_strength,
               sec_strength,

--- a/src/cpu_features/aarch64.rs
+++ b/src/cpu_features/aarch64.rs
@@ -52,8 +52,9 @@ impl Default for CpuFeatureLevel {
 // Create a static lookup table for CPUFeatureLevel enums
 // Note: keys are CpuFeatureLevels without any prefix (no CpuFeatureLevel::)
 macro_rules! cpu_function_lookup_table {
-  ($pub:vis, $name:ident: [$type:ty], default: $empty:expr, [$(($key:ident, $value:expr)),*]) => {
-    $pub static $name: [$type; crate::cpu_features::CpuFeatureLevel::len()] = {
+  // version for default visibility
+  ($name:ident: [$type:ty], default: $empty:expr, [$(($key:ident, $value:expr)),*]) => {
+    static $name: [$type; crate::cpu_features::CpuFeatureLevel::len()] = {
       use crate::cpu_features::CpuFeatureLevel;
       #[allow(unused_mut)]
       let mut out: [$type; CpuFeatureLevel::len()] = [$empty; CpuFeatureLevel::len()];
@@ -73,6 +74,9 @@ macro_rules! cpu_function_lookup_table {
     };
   };
 
+  ($pub:vis, $name:ident: [$type:ty], default: $empty:expr, [$(($key:ident, $value:expr)),*]) => {
+    $pub cpu_function_lookup_table!($name: [$type], default: $empty, [$(($key, $value)),*]);
+  };
   // Fill empty output functions with the existent functions they support.
   // cpus should be in order of lowest cpu level to highest
   // Used like an internal function
@@ -91,10 +95,6 @@ macro_rules! cpu_function_lookup_table {
     )*
   };
 
-  // version for default visibility
-  ($name:ident: [$type:ty], default: $empty:expr, [$(($key:ident, $value:expr)),*]) => {
-    cpu_function_lookup_table!(pub(self), $name: [$type], default: $empty, [$(($key, $value)),*]);
-  };
 
   // use $name_$key as our values
   ($pub:vis, $name:ident: [$type:ty], default: $empty:expr, [$($key:ident),*]) => {
@@ -107,8 +107,10 @@ macro_rules! cpu_function_lookup_table {
 
   // version for default visibility
   ($name:ident: [$type:ty], default: $empty:expr, [$($key:ident),*]) => {
-    cpu_function_lookup_table!(
-      pub(self), $name: [$type], default: $empty, [$($key),*]
-    );
+    paste::item!{
+      cpu_function_lookup_table!(
+        $name: [$type], default: $empty, [$(($key, [<$name _$key>])),*]
+      );
+    }
   };
 }

--- a/src/cpu_features/rust.rs
+++ b/src/cpu_features/rust.rs
@@ -9,8 +9,9 @@
 
 use arg_enum_proc_macro::ArgEnum;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, ArgEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, ArgEnum, Default)]
 pub enum CpuFeatureLevel {
+  #[default]
   RUST,
 }
 
@@ -20,11 +21,5 @@ impl CpuFeatureLevel {
   pub(crate) const fn all() -> &'static [Self] {
     use CpuFeatureLevel::*;
     &[RUST]
-  }
-}
-
-impl Default for CpuFeatureLevel {
-  fn default() -> CpuFeatureLevel {
-    CpuFeatureLevel::RUST
   }
 }

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -95,8 +95,9 @@ impl Default for CpuFeatureLevel {
 // Create a static lookup table for CPUFeatureLevel enums
 // Note: keys are CpuFeatureLevels without any prefix (no CpuFeatureLevel::)
 macro_rules! cpu_function_lookup_table {
-  ($pub:vis, $name:ident: [$type:ty], default: $empty:expr, [$(($key:ident, $value:expr)),*]) => {
-    $pub static $name: [$type; crate::cpu_features::CpuFeatureLevel::len()] = {
+  // version for default visibility
+  ($name:ident: [$type:ty], default: $empty:expr, [$(($key:ident, $value:expr)),*]) => {
+    static $name: [$type; crate::cpu_features::CpuFeatureLevel::len()] = {
       use crate::cpu_features::CpuFeatureLevel;
       #[allow(unused_mut)]
       let mut out: [$type; CpuFeatureLevel::len()] = [$empty; CpuFeatureLevel::len()];
@@ -114,6 +115,9 @@ macro_rules! cpu_function_lookup_table {
       cpu_function_lookup_table!(waterfall_cpu_features(out, set, [SSE2, SSSE3, SSE4_1, AVX2, AVX512, AVX512ICL]));
       out
     };
+  };
+  ($pub:vis, $name:ident: [$type:ty], default: $empty:expr, [$(($key:ident, $value:expr)),*]) => {
+    $pub cpu_function_lookup_table!($name: [$type], default: $empty, [$(($key, $value)),*]);
   };
 
   // Fill empty output functions with the existent functions they support.
@@ -134,11 +138,6 @@ macro_rules! cpu_function_lookup_table {
     )*
   };
 
-  // version for default visibility
-  ($name:ident: [$type:ty], default: $empty:expr, [$(($key:ident, $value:expr)),*]) => {
-    cpu_function_lookup_table!(pub(self), $name: [$type], default: $empty, [$(($key, $value)),*]);
-  };
-
   // use $name_$key as our values
   ($pub:vis, $name:ident: [$type:ty], default: $empty:expr, [$($key:ident),*]) => {
     paste::item!{
@@ -150,8 +149,10 @@ macro_rules! cpu_function_lookup_table {
 
   // version for default visibility
   ($name:ident: [$type:ty], default: $empty:expr, [$($key:ident),*]) => {
-    cpu_function_lookup_table!(
-      pub(self), $name: [$type], default: $empty, [$($key),*]
-    );
+     paste::item!{
+      cpu_function_lookup_table!(
+        $name: [$type], default: $empty, [$(($key, [<$name _$key>])),*]
+      );
+    }
   };
 }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -374,6 +374,9 @@ impl BlockSize {
     })
   }
 
+  /// # Panics
+  ///
+  /// Will panic if the subsampling is not possible
   #[inline]
   pub fn largest_chroma_tx_size(self, xdec: usize, ydec: usize) -> TxSize {
     let plane_bsize = self


### PR DESCRIPTION
Now only quickcheck depends on syn1.

See https://github.com/BurntSushi/quickcheck/pull/317 for the last dep