### PR TITLE
ci: Bundle LICENSE file in librav1e deploy artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,9 @@ jobs:
     - name: Rename cargo-c folder
       run: Rename-Item "C:\usr\local" "C:\usr\rav1e-windows-${{ matrix.conf }}-sdk"
 
+    - name: Copy LICENSE
+      run: Copy-Item "LICENSE" "C:\usr\rav1e-windows-${{ matrix.conf }}-sdk\LICENSE"
+
     - name: Get the version
       if: startsWith(github.ref, 'refs/tags/v')
       shell: bash
@@ -306,6 +309,7 @@ jobs:
            startsWith(github.ref, 'refs/tags/v') ||
            github.event_name == 'schedule')
       run: |
+        cp LICENSE dist
         cd dist
         tar -czvf $GITHUB_WORKSPACE/$ARTIFACT_FILE *
 
@@ -415,6 +419,7 @@ jobs:
            startsWith(github.ref, 'refs/tags/v') ||
            github.event_name == 'schedule')
       run: |
+        cp LICENSE dist
         cd dist
         tar -czvf $GITHUB_WORKSPACE/$ARTIFACT_FILE *
 


### PR DESCRIPTION
Adding the LICENSE to the library archives makes it easier for dependent projects to include it in their build artifacts.