### PR TITLE
Integrate lossless forward transform intrinsics

### DIFF
--- a/src/asm/aarch64/transform/inverse.rs
+++ b/src/asm/aarch64/transform/inverse.rs
@@ -27,11 +27,12 @@ pub fn inverse_transform_add_lossless<T: Pixel>(
         return call_inverse_func(func, input, output, eob, 4, 4, bd);
       }
     }
-    PixelType::U16 => {
+    PixelType::U16 if bd == 10 => {
       if let Some(func) = INV_TXFM_WHT_HBD_FN[cpu.as_index()] {
         return call_inverse_hbd_func(func, input, output, eob, 4, 4, bd);
       }
     }
+    PixelType::U16 => {}
   }
   rust::inverse_transform_add_lossless(input, output, eob, bd, cpu);
 }

--- a/src/asm/aarch64/transform/inverse.rs
+++ b/src/asm/aarch64/transform/inverse.rs
@@ -16,31 +16,26 @@ use crate::{Pixel, PixelType};
 use crate::asm::shared::transform::inverse::*;
 use crate::asm::shared::transform::*;
 
-#[inline]
-pub fn inverse_transform_add_lossless<T: Pixel>(
-  input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, eob: usize,
-  bd: usize, cpu: CpuFeatureLevel,
-) {
-  match T::type_enum() {
-    PixelType::U8 => {
-      if let Some(func) = INV_TXFM_WHT_FN[cpu.as_index()] {
-        return call_inverse_func(func, input, output, eob, 4, 4, bd);
-      }
-    }
-    PixelType::U16 if bd == 10 => {
-      if let Some(func) = INV_TXFM_WHT_HBD_FN[cpu.as_index()] {
-        return call_inverse_hbd_func(func, input, output, eob, 4, 4, bd);
-      }
-    }
-    PixelType::U16 => {}
-  }
-  rust::inverse_transform_add_lossless(input, output, eob, bd, cpu);
-}
-
 pub fn inverse_transform_add<T: Pixel>(
   input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, eob: usize,
   tx_size: TxSize, tx_type: TxType, bd: usize, cpu: CpuFeatureLevel,
 ) {
+  if tx_type == TxType::WHT_WHT {
+    debug_assert!(tx_size == TxSize::TX_4X4);
+    match T::type_enum() {
+      PixelType::U8 => {
+        if let Some(func) = INV_TXFM_WHT_FN[cpu.as_index()] {
+          return call_inverse_func(func, input, output, eob, 4, 4, bd);
+        }
+      }
+      PixelType::U16 if bd == 10 => {
+        if let Some(func) = INV_TXFM_WHT_HBD_FN[cpu.as_index()] {
+          return call_inverse_hbd_func(func, input, output, eob, 4, 4, bd);
+        }
+      }
+      PixelType::U16 => {}
+    }
+  }
   match T::type_enum() {
     PixelType::U8 => {
       if let Some(func) = INV_TXFM_FNS[cpu.as_index()]

--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -108,7 +108,8 @@ pub mod test {
     let mut eob = 0;
     let mut exit = 0;
 
-    let scan = av1_scan_orders[tx_size as usize][tx_type as usize].scan;
+    // Wrap WHT_WHT (16) to DCT_DCT (0) scan table
+    let scan = av1_scan_orders[tx_size as usize][(tx_type as usize) & 15].scan;
 
     for (i, &pos) in scan.iter().enumerate() {
       exit = i;
@@ -229,12 +230,15 @@ pub mod test {
     };
 
     ($TYPES64:tt, $DIMS64:tt, $TYPES32:tt, $DIMS32:tt, $TYPES16:tt, $DIMS16:tt,
-     $TYPES84:tt, $DIMS84:tt) => {
+     $TYPES84:tt, $DIMS84:tt, $TYPES4:tt, $DIMS4:tt) => {
       test_itx_fns!([$TYPES64], $DIMS64);
       test_itx_fns!([$TYPES64, $TYPES32], $DIMS32);
       test_itx_fns!([$TYPES64, $TYPES32, $TYPES16], $DIMS16);
       test_itx_fns!(
         [$TYPES64, $TYPES32, $TYPES16, $TYPES84], $DIMS84
+      );
+      test_itx_fns!(
+        [$TYPES64, $TYPES32, $TYPES16, $TYPES84, $TYPES4], $DIMS4
       );
     };
   }
@@ -260,13 +264,16 @@ pub mod test {
       (TxType::FLIPADST_FLIPADST, flipadst, flipadst)
     ],
     [(16, 16)],
-    // 8x, 4x and 16x (minus 16x16)
+    // 8x, 4x and 16x (minus 16x16 and 4x4)
     [
       (TxType::V_ADST, adst, identity),
       (TxType::H_ADST, identity, adst),
       (TxType::V_FLIPADST, flipadst, identity),
       (TxType::H_FLIPADST, identity, flipadst)
     ],
-    [(16, 8), (8, 16), (16, 4), (4, 16), (8, 8), (8, 4), (4, 8), (4, 4)]
+    [(16, 8), (8, 16), (16, 4), (4, 16), (8, 8), (8, 4), (4, 8)],
+    // 4x4
+    [(TxType::WHT_WHT, wht, wht)],
+    [(4, 4)]
   );
 }

--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -149,7 +149,10 @@ pub mod test {
     for sub_h in 0..sub_h_iterations {
       let mut src_storage = [T::zero(); 64 * 64];
       let src = &mut src_storage[..tx_size.area()];
-      let mut dst = Plane::from_slice(&[T::zero(); 64 * 64], 64);
+      let mut dst = Plane::from_slice(
+        &[T::zero(); 64 * 64][..tx_size.area()],
+        tx_size.width(),
+      );
       let mut res_storage: Aligned<[MaybeUninit<i16>; 64 * 64]> =
         unsafe { Aligned::uninitialized() };
       let res = &mut res_storage.data[..tx_size.area()];

--- a/src/asm/x86/transform/forward.rs
+++ b/src/asm/x86/transform/forward.rs
@@ -21,8 +21,6 @@ use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-pub use crate::transform::forward::rust::forward_transform_lossless;
-
 type TxfmFuncI32X8 = unsafe fn(&mut [I32X8]);
 
 #[inline]
@@ -41,6 +39,7 @@ fn get_func_i32x8(t: TxfmType) -> TxfmFuncI32X8 {
     Identity8 => fidentity,
     Identity16 => fidentity,
     Identity32 => fidentity,
+    WHT4 => fwht4,
   }
 }
 
@@ -509,6 +508,7 @@ unsafe fn forward_transform_avx2<T: Coefficient>(
 /// # Panics
 ///
 /// - If called with an invalid combination of `tx_size` and `tx_type`
+#[inline]
 pub fn forward_transform<T: Coefficient>(
   input: &[i16], output: &mut [MaybeUninit<T>], stride: usize,
   tx_size: TxSize, tx_type: TxType, bd: usize, cpu: CpuFeatureLevel,

--- a/src/asm/x86/transform/inverse.rs
+++ b/src/asm/x86/transform/inverse.rs
@@ -16,30 +16,25 @@ use crate::{Pixel, PixelType};
 use crate::asm::shared::transform::inverse::*;
 use crate::asm::shared::transform::*;
 
-#[inline]
-pub fn inverse_transform_add_lossless<T: Pixel>(
-  input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, eob: usize,
-  bd: usize, cpu: CpuFeatureLevel,
-) {
-  match T::type_enum() {
-    PixelType::U8 => {
-      if let Some(func) = INV_TXFM_WHT_FN[cpu.as_index()] {
-        return call_inverse_func(func, input, output, eob, 4, 4, bd);
-      }
-    }
-    PixelType::U16 => {
-      if let Some(func) = INV_TXFM_WHT_HBD_FN[cpu.as_index()] {
-        return call_inverse_hbd_func(func, input, output, eob, 4, 4, bd);
-      }
-    }
-  }
-  rust::inverse_transform_add_lossless(input, output, eob, bd, cpu);
-}
-
 pub fn inverse_transform_add<T: Pixel>(
   input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, eob: usize,
   tx_size: TxSize, tx_type: TxType, bd: usize, cpu: CpuFeatureLevel,
 ) {
+  if tx_type == TxType::WHT_WHT {
+    debug_assert!(tx_size == TxSize::TX_4X4);
+    match T::type_enum() {
+      PixelType::U8 => {
+        if let Some(func) = INV_TXFM_WHT_FN[cpu.as_index()] {
+          return call_inverse_func(func, input, output, eob, 4, 4, bd);
+        }
+      }
+      PixelType::U16 => {
+        if let Some(func) = INV_TXFM_WHT_HBD_FN[cpu.as_index()] {
+          return call_inverse_hbd_func(func, input, output, eob, 4, 4, bd);
+        }
+      }
+    }
+  }
   match T::type_enum() {
     PixelType::U8 => {
       if let Some(func) = INV_TXFM_FNS[cpu.as_index()]

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -92,36 +92,7 @@ pub mod rust {
       Identity8 => fidentity,
       Identity16 => fidentity,
       Identity32 => fidentity,
-    }
-  }
-
-  pub fn forward_transform_lossless<T: Coefficient>(
-    input: &[i16], output: &mut [T], stride: usize, _cpu: CpuFeatureLevel,
-  ) {
-    let mut tmp = [0i32; 4 * 4];
-    let buf = &mut tmp[..];
-    let mut col_coeffs_backing = [0i32; 4];
-    let col_coeffs = &mut col_coeffs_backing[..];
-
-    // Columns
-    for c in 0..4 {
-      for r in 0..4 {
-        col_coeffs[r] = (input[r * stride + c]).into();
-      }
-      fwht4(col_coeffs);
-      for r in 0..4 {
-        buf[r * 4 + c] = col_coeffs[r];
-      }
-    }
-
-    // Rows
-    for r in 0..4 {
-      let row_coeffs = &mut buf[r * 4..];
-      fwht4(row_coeffs);
-      av1_round_shift_array(row_coeffs, 4, -2);
-      for c in 0..4 {
-        output[c * 4 + r] = T::cast_from(row_coeffs[c]);
-      }
+      WHT4 => fwht4,
     }
   }
 

--- a/src/transform/forward_shared.rs
+++ b/src/transform/forward_shared.rs
@@ -145,7 +145,7 @@ impl Txfm2DFlipCfg {
     use self::TxType::*;
     match tx_type {
       DCT_DCT | ADST_DCT | DCT_ADST | ADST_ADST | IDTX | V_DCT | H_DCT
-      | V_ADST | H_ADST => (false, false),
+      | V_ADST | H_ADST | WHT_WHT => (false, false),
       FLIPADST_DCT | FLIPADST_ADST | V_FLIPADST => (true, false),
       DCT_FLIPADST | ADST_FLIPADST | H_FLIPADST => (false, true),
       FLIPADST_FLIPADST => (true, true),

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -485,9 +485,8 @@ mod test {
     let coeff_area: usize = av1_get_coded_tx_size(tx_size).area();
     let mut src_storage = [T::cast_from(0); 64 * 64];
     let src = &mut src_storage[..tx_size.area()];
-    // dynamic allocation: test
     let mut dst = Plane::from_slice(
-      &vec![T::cast_from(0); tx_size.area()],
+      &[T::zero(); 64 * 64][..tx_size.area()],
       tx_size.width(),
     );
     let mut res_storage = [0i16; 64 * 64];


### PR DESCRIPTION
* Introduce `TxType::WHT_WHT` and so unify the `forward_transform` and `inverse_transform_add` functions.
* Plumb `fwht4` through the existing forward transform code and gain an `AVX2` implementation.
* Improvements to round trip and  transform tests
* Found and fixed a bug with aarch64 assembly integration