### PR TITLE
Reduce risk of uninit ac in luma_ac and encode_coeffs

### DIFF
--- a/src/asm/aarch64/transform/inverse.rs
+++ b/src/asm/aarch64/transform/inverse.rs
@@ -17,7 +17,7 @@ use crate::asm::shared::transform::inverse::*;
 use crate::asm::shared::transform::*;
 
 pub fn inverse_transform_add<T: Pixel>(
-  input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, eob: usize,
+  input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, eob: u16,
   tx_size: TxSize, tx_type: TxType, bd: usize, cpu: CpuFeatureLevel,
 ) {
   if tx_type == TxType::WHT_WHT {

--- a/src/asm/x86/predict.rs
+++ b/src/asm/x86/predict.rs
@@ -17,6 +17,7 @@ use crate::tiling::{PlaneRegion, PlaneRegionMut};
 use crate::transform::TxSize;
 use crate::util::Aligned;
 use crate::Pixel;
+use std::mem::MaybeUninit;
 use v_frame::pixel::PixelType;
 
 macro_rules! decl_angular_ipred_fn {
@@ -145,7 +146,7 @@ macro_rules! decl_cfl_ac_fn {
     extern {
       $(
         fn $f(
-          ac: *mut i16, src: *const u8, stride: libc::ptrdiff_t,
+          ac: *mut MaybeUninit<i16>, src: *const u8, stride: libc::ptrdiff_t,
           w_pad: libc::c_int, h_pad: libc::c_int,
           width: libc::c_int, height: libc::c_int,
         );
@@ -168,7 +169,7 @@ macro_rules! decl_cfl_ac_hbd_fn {
     extern {
       $(
         fn $f(
-          ac: *mut i16, src: *const u16, stride: libc::ptrdiff_t,
+          ac: *mut MaybeUninit<i16>, src: *const u16, stride: libc::ptrdiff_t,
           w_pad: libc::c_int, h_pad: libc::c_int,
           width: libc::c_int, height: libc::c_int,
         );
@@ -871,12 +872,15 @@ pub fn dispatch_predict_intra<T: Pixel>(
   }
 }
 
+// The implementation MUST inititialize all `ac` elements
 #[inline(always)]
 pub(crate) fn pred_cfl_ac<T: Pixel, const XDEC: usize, const YDEC: usize>(
-  ac: &mut [i16], luma: &PlaneRegion<'_, T>, bsize: BlockSize, w_pad: usize,
-  h_pad: usize, cpu: CpuFeatureLevel,
+  ac: &mut [MaybeUninit<i16>], luma: &PlaneRegion<'_, T>, bsize: BlockSize,
+  w_pad: usize, h_pad: usize, cpu: CpuFeatureLevel,
 ) {
-  let call_rust = |ac: &mut [i16]| {
+  debug_assert_eq!(ac.len(), bsize.area());
+
+  let call_rust = |ac: &mut [MaybeUninit<i16>]| {
     rust::pred_cfl_ac::<T, XDEC, YDEC>(ac, luma, bsize, w_pad, h_pad, cpu);
   };
 

--- a/src/asm/x86/quantize.rs
+++ b/src/asm/x86/quantize.rs
@@ -185,9 +185,9 @@ mod test {
         let mut out = [0u16; 16];
         let area: usize = av1_get_coded_tx_size(tx_size).area();
         out[0] = 0;
-        out[1] = area;
+        out[1] = area as u16;
         for eob in out.iter_mut().skip(2) {
-          *eob = rng.gen_range(0..area);
+          *eob = rng.gen_range(0..area as u16);
         }
         out
       };
@@ -198,7 +198,9 @@ mod test {
 
         // Generate quantized coefficients up to the eob
         let between = Uniform::from(-i16::MAX..=i16::MAX);
-        for (i, qcoeff) in qcoeffs.data.iter_mut().enumerate().take(eob) {
+        for (i, qcoeff) in
+          qcoeffs.data.iter_mut().enumerate().take(eob as usize)
+        {
           *qcoeff = between.sample(&mut rng)
             / if i == 0 { dc_quant } else { ac_quant };
         }

--- a/src/asm/x86/quantize.rs
+++ b/src/asm/x86/quantize.rs
@@ -22,7 +22,7 @@ use std::mem::MaybeUninit;
 type DequantizeFn = unsafe fn(
   qindex: u8,
   coeffs_ptr: *const i16,
-  _eob: usize,
+  _eob: u16,
   rcoeffs_ptr: *mut i16,
   tx_size: TxSize,
   bit_depth: usize,
@@ -38,7 +38,7 @@ cpu_function_lookup_table!(
 
 #[inline(always)]
 pub fn dequantize<T: Coefficient>(
-  qindex: u8, coeffs: &[T], eob: usize, rcoeffs: &mut [MaybeUninit<T>],
+  qindex: u8, coeffs: &[T], eob: u16, rcoeffs: &mut [MaybeUninit<T>],
   tx_size: TxSize, bit_depth: usize, dc_delta_q: i8, ac_delta_q: i8,
   cpu: CpuFeatureLevel,
 ) {
@@ -91,7 +91,7 @@ pub fn dequantize<T: Coefficient>(
 
 #[target_feature(enable = "avx2")]
 unsafe fn dequantize_avx2(
-  qindex: u8, coeffs_ptr: *const i16, _eob: usize, rcoeffs_ptr: *mut i16,
+  qindex: u8, coeffs_ptr: *const i16, _eob: u16, rcoeffs_ptr: *mut i16,
   tx_size: TxSize, bit_depth: usize, dc_delta_q: i8, ac_delta_q: i8,
 ) {
   let log_tx_scale = _mm256_set1_epi32(get_log_tx_scale(tx_size) as i32);
@@ -182,7 +182,7 @@ mod test {
 
       // Test the min, max, and random eobs
       let eobs = {
-        let mut out = [0usize; 16];
+        let mut out = [0u16; 16];
         let area: usize = av1_get_coded_tx_size(tx_size).area();
         out[0] = 0;
         out[1] = area;

--- a/src/asm/x86/transform/inverse.rs
+++ b/src/asm/x86/transform/inverse.rs
@@ -17,7 +17,7 @@ use crate::asm::shared::transform::inverse::*;
 use crate::asm::shared::transform::*;
 
 pub fn inverse_transform_add<T: Pixel>(
-  input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, eob: usize,
+  input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, eob: u16,
   tx_size: TxSize, tx_type: TxType, bd: usize, cpu: CpuFeatureLevel,
 ) {
   if tx_type == TxType::WHT_WHT {

--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -1781,7 +1781,7 @@ impl<'a> ContextWriter<'a> {
 
   pub fn write_coeffs_lv_map<T: Coefficient, W: Writer>(
     &mut self, w: &mut W, plane: usize, bo: TileBlockOffset, coeffs_in: &[T],
-    eob: usize, pred_mode: PredictionMode, tx_size: TxSize, tx_type: TxType,
+    eob: u16, pred_mode: PredictionMode, tx_size: TxSize, tx_type: TxType,
     plane_bsize: BlockSize, xdec: usize, ydec: usize,
     use_reduced_tx_set: bool, frame_clipped_txw: usize,
     frame_clipped_txh: usize,
@@ -1792,8 +1792,8 @@ impl<'a> ContextWriter<'a> {
     let is_inter = pred_mode >= PredictionMode::NEARESTMV;
 
     // Note: Both intra and inter mode uses inter scan order. Surprised?
-    let scan: &[u16] =
-      &av1_scan_orders[tx_size as usize][tx_type as usize].scan[..eob];
+    let scan: &[u16] = &av1_scan_orders[tx_size as usize][tx_type as usize]
+      .scan[..usize::from(eob)];
     let height = av1_get_coded_tx_size(tx_size).height();
 
     // Create a slice with coeffs in scan order
@@ -1858,7 +1858,7 @@ impl<'a> ContextWriter<'a> {
   }
 
   fn encode_eob<W: Writer>(
-    &mut self, eob: usize, tx_size: TxSize, tx_class: TxClass, txs_ctx: usize,
+    &mut self, eob: u16, tx_size: TxSize, tx_class: TxClass, txs_ctx: usize,
     plane_type: usize, w: &mut W,
   ) {
     let (eob_pt, eob_extra) = Self::get_eob_pos_token(eob);
@@ -1913,7 +1913,7 @@ impl<'a> ContextWriter<'a> {
   }
 
   fn encode_coeffs<T: Coefficient, W: Writer>(
-    &mut self, coeffs: &[T], levels: &mut [u8], scan: &[u16], eob: usize,
+    &mut self, coeffs: &[T], levels: &mut [u8], scan: &[u16], eob: u16,
     tx_size: TxSize, tx_class: TxClass, txs_ctx: usize, plane_type: usize,
     w: &mut W,
   ) {
@@ -1924,7 +1924,7 @@ impl<'a> ContextWriter<'a> {
     self.get_nz_map_contexts(
       levels,
       scan,
-      eob as u16,
+      eob,
       tx_size,
       tx_class,
       &mut coeff_contexts.data,
@@ -1937,7 +1937,7 @@ impl<'a> ContextWriter<'a> {
       let coeff_ctx = coeff_contexts.data[pos];
       let level = v.abs();
 
-      if c == eob - 1 {
+      if c == usize::from(eob) - 1 {
         symbol_with_update!(
           self,
           w,

--- a/src/context/transform_unit.rs
+++ b/src/context/transform_unit.rs
@@ -11,6 +11,7 @@ use super::*;
 use crate::predict::PredictionMode;
 use crate::predict::PredictionMode::*;
 use crate::transform::TxType::*;
+use std::mem::MaybeUninit;
 
 pub const MAX_TX_SIZE: usize = 64;
 
@@ -905,25 +906,33 @@ impl<'a> ContextWriter<'a> {
     Self::get_nz_map_ctx_from_stats(stats, coeff_idx, bhl, tx_size, tx_class)
   }
 
-  pub fn get_nz_map_contexts(
+  /// `coeff_contexts_no_scan` is not in the scan order.
+  /// Value for `pos = scan[i]` is at `coeff[i]`, not at `coeff[pos]`.
+  pub fn get_nz_map_contexts<'c>(
     &self, levels: &mut [u8], scan: &[u16], eob: u16, tx_size: TxSize,
-    tx_class: TxClass, coeff_contexts: &mut [i8],
-  ) {
+    tx_class: TxClass, coeff_contexts_no_scan: &'c mut [MaybeUninit<i8>],
+  ) -> &'c mut [i8] {
     let bhl = Self::get_txb_bhl(tx_size);
     let area = av1_get_coded_tx_size(tx_size).area();
-    for i in 0..eob {
-      let pos = scan[i as usize];
-      coeff_contexts[pos as usize] = Self::get_nz_map_ctx(
+
+    let scan = &scan[..usize::from(eob)];
+    let coeffs = &mut coeff_contexts_no_scan[..usize::from(eob)];
+    for (i, (coeff, pos)) in
+      coeffs.iter_mut().zip(scan.iter().copied()).enumerate()
+    {
+      coeff.write(Self::get_nz_map_ctx(
         levels,
         pos as usize,
         bhl,
         area,
-        i as usize,
-        i == eob - 1,
+        i,
+        i == usize::from(eob) - 1,
         tx_size,
         tx_class,
-      ) as i8;
+      ) as i8);
     }
+    // SAFETY: every element has been initialized
+    unsafe { slice_assume_init_mut(coeffs) }
   }
 
   pub fn get_br_ctx(

--- a/src/context/transform_unit.rs
+++ b/src/context/transform_unit.rs
@@ -804,11 +804,11 @@ impl<'a> ContextWriter<'a> {
   ///
   /// - If `eob` is prior to the start of the group
   #[inline]
-  pub fn get_eob_pos_token(eob: usize) -> (u32, u32) {
+  pub fn get_eob_pos_token(eob: u16) -> (u32, u32) {
     let t = if eob < 33 {
-      eob_to_pos_small[eob] as u32
+      eob_to_pos_small[usize::from(eob)] as u32
     } else {
-      let e = cmp::min((eob - 1) >> 5, 16);
+      let e = usize::from(cmp::min((eob - 1) >> 5, 16));
       eob_to_pos_large[e] as u32
     };
     assert!(eob as i32 >= k_eob_group_start[t as usize] as i32);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2261,7 +2261,8 @@ pub fn write_tx_blocks<T: Pixel, W: Writer>(
 
   let PlaneConfig { xdec, ydec, .. } = ts.input.planes[1].cfg;
   // SAFETY: We write to the array below before reading from it.
-  let mut ac: Aligned<[i16; 32 * 32]> = unsafe { Aligned::uninitialized() };
+  let mut ac: Aligned<[MaybeUninit<i16>; 32 * 32]> =
+    unsafe { Aligned::uninitialized() };
   let mut partition_has_coeff: bool = false;
   let mut tx_dist = ScaledDistortion::zero();
   let do_chroma =
@@ -2341,10 +2342,9 @@ pub fn write_tx_blocks<T: Pixel, W: Writer>(
   bh_uv /= uv_tx_size.height_mi();
 
   let ac_data = if chroma_mode.is_cfl() {
-    luma_ac(&mut ac.data, ts, tile_bo, bsize, tx_size, fi);
-    &ac.data[..]
+    luma_ac(&mut ac.data, ts, tile_bo, bsize, tx_size, fi)
   } else {
-    &[]
+    [].as_slice()
   };
 
   let uv_tx_type = if uv_tx_size.width() >= 32 || uv_tx_size.height() >= 32 {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -237,6 +237,12 @@ impl BlockSize {
     1 << self.width_log2()
   }
 
+  /// width * height
+  #[inline]
+  pub const fn area(self) -> usize {
+    self.width() * self.height()
+  }
+
   #[inline]
   pub const fn width_log2(self) -> usize {
     match self {

--- a/src/quantize/mod.rs
+++ b/src/quantize/mod.rs
@@ -299,7 +299,7 @@ impl QuantizationContext {
         .unwrap_or(0);
       // We skip the DC coefficient since it has its own quantizer index.
       if eob_minus_one > 0 {
-        eob_minus_one as u16 + 1
+        eob_minus_one + 1
       } else {
         u16::from(qcoeffs[0] != T::cast_from(0))
       }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1610,8 +1610,9 @@ pub fn rdo_cfl_alpha<T: Pixel>(
     return None;
   };
   // SAFETY: We write to the array below before reading from it.
-  let mut ac: Aligned<[i16; 32 * 32]> = unsafe { Aligned::uninitialized() };
-  luma_ac(&mut ac.data, ts, tile_bo, bsize, luma_tx_size, fi);
+  let mut ac: Aligned<[MaybeUninit<i16>; 32 * 32]> =
+    unsafe { Aligned::uninitialized() };
+  let ac = luma_ac(&mut ac.data, ts, tile_bo, bsize, luma_tx_size, fi);
   let best_alpha: ArrayVec<i16, 2> = (1..3)
     .map(|p| {
       let &PlaneConfig { xdec, ydec, .. } = ts.rec.planes[p].plane_cfg;
@@ -1640,7 +1641,7 @@ pub fn rdo_cfl_alpha<T: Pixel>(
           &mut rec_region,
           uv_tx_size,
           fi.sequence.bit_depth,
-          &ac.data,
+          &ac,
           IntraParam::Alpha(alpha),
           None,
           &edge_buf,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1641,7 +1641,7 @@ pub fn rdo_cfl_alpha<T: Pixel>(
           &mut rec_region,
           uv_tx_size,
           fi.sequence.bit_depth,
-          &ac,
+          ac,
           IntraParam::Alpha(alpha),
           None,
           &edge_buf,

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1633,7 +1633,7 @@ pub(crate) mod rust {
 
   #[cold_for_target_arch("x86_64", "aarch64")]
   pub fn inverse_transform_add<T: Pixel>(
-    input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, _eob: usize,
+    input: &[T::Coeff], output: &mut PlaneRegionMut<'_, T>, _eob: u16,
     tx_size: TxSize, tx_type: TxType, bd: usize, _cpu: CpuFeatureLevel,
   ) {
     let width: usize = tx_size.width();

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -506,7 +506,7 @@ mod test {
     inverse_transform_add(
       freq,
       &mut dst.as_region_mut(),
-      coeff_area,
+      coeff_area.try_into().unwrap(),
       tx_size,
       tx_type,
       8,


### PR DESCRIPTION
## luma_ac

In various `pred_cfl_ac` I've added checks that `ac[..].len()` must be exactly as long as needed, i.e. `plane_bsize.width() * plane_bsize.height()`. The multiplication got repetitive, so I've added `plane_bsize.area()`.

Those prediction functions are in assembly. I haven't checked whether they initialize exactly `plane_bsize.area()` and nothing else, but I don't see a reason why they wouldn't, it would be a bug otherwise. Anyway, it's not a safety issue in pratice, since the allocated memory behind `ac` is the same size as before.

## encode_coeffs

`get_nz_map_contexts` initializes context up to `eob` which is `u16`. Other code used `usize` for `eob`. To be type-safe sure it can't be longer than `u16` anywhere (therefore reading past what `get_nz_map_contexts` could init), I've changed `eob` to be consistently `u16` everywhere. It's never more than 1024 in reality.

`get_nz_map_contexts` used to write `coeffs[scan[i]]`, but that had two issues:

1. It could not guarantee that all coeffs are initialized *and contiguous* to make an initialized slice.
2. It was unnecessary performance cost. Writing at `scan`'s positions was a needless step, because they were also always read as `coeffs[scan[i]]`. Since all uses of the `coeffs` wanted a coefficient for `scan[i]`, I've made them get it from `coeffs[i]` rather than `coeffs[scan[i]]`. `scan` acted only as an unnecessary shuffle. This is faster, guarantees a contiguous slice, and does not change the behavior.
