### PR TITLE
Consistent setup for round trip and inverse transform tests

### DIFF
--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -148,7 +148,10 @@ pub mod test {
     for sub_h in 0..sub_h_iterations {
       let mut src_storage = [T::zero(); 64 * 64];
       let src = &mut src_storage[..tx_size.area()];
-      let mut dst = Plane::from_slice(&[T::zero(); 64 * 64], 64);
+      let mut dst = Plane::from_slice(
+        &[T::zero(); 64 * 64][..tx_size.area()],
+        tx_size.width(),
+      );
       let mut res_storage: Aligned<[MaybeUninit<i16>; 64 * 64]> =
         unsafe { Aligned::uninitialized() };
       let res = &mut res_storage.data[..tx_size.area()];

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -461,9 +461,8 @@ mod test {
     let coeff_area: usize = av1_get_coded_tx_size(tx_size).area();
     let mut src_storage = [T::cast_from(0); 64 * 64];
     let src = &mut src_storage[..tx_size.area()];
-    // dynamic allocation: test
     let mut dst = Plane::from_slice(
-      &vec![T::cast_from(0); tx_size.area()],
+      &[T::zero(); 64 * 64][..tx_size.area()],
       tx_size.width(),
     );
     let mut res_storage = [0i16; 64 * 64];
@@ -500,8 +499,7 @@ mod test {
 
     let mut src_storage = [T::cast_from(0); 4 * 4];
     let src = &mut src_storage[..];
-    // dynamic allocation: test
-    let mut dst = Plane::from_slice(&vec![T::cast_from(0); 4 * 4], 4);
+    let mut dst = Plane::from_slice(&[T::cast_from(0); 4 * 4], 4);
     let mut res_storage = [0i16; 4 * 4];
     let res = &mut res_storage[..];
     let mut freq_storage = [T::Coeff::cast_from(0); 4 * 4];


### PR DESCRIPTION
This inconsistency was identified while trying to integrate and test WHT functions. We have an unnecessary allocation in one case and a mismatch in stride in the other case. This change will give terse error messages when refactoring inverse transform code.