### PR TITLE
Initialize edge buf

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1475,7 +1475,11 @@ pub fn encode_tx_block<T: Pixel, W: Writer>(
 
   if mode.is_intra() {
     let bit_depth = fi.sequence.bit_depth;
-    let edge_buf = get_intra_edges(
+    let mut edge_buf: Aligned<[T; 4 * MAX_TX_SIZE + 1]> =
+      Aligned::from_fn(|_| T::zero());
+
+    get_intra_edges(
+      &mut edge_buf,
       &rec.as_const(),
       tile_partition_bo,
       bx,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -600,6 +600,7 @@ fn supersample_chroma_bsize(
 }
 
 pub fn get_intra_edges<T: Pixel>(
+  edge_buf: &mut Aligned<[T; 4 * MAX_TX_SIZE + 1]>,
   dst: &PlaneRegion<'_, T>,
   partition_bo: TileBlockOffset, // partition bo, BlockOffset
   bx: usize,
@@ -611,13 +612,8 @@ pub fn get_intra_edges<T: Pixel>(
   opt_mode: Option<PredictionMode>,
   enable_intra_edge_filter: bool,
   intra_param: IntraParam,
-) -> Aligned<[T; 4 * MAX_TX_SIZE + 1]> {
+) {
   let plane_cfg = &dst.plane_cfg;
-
-  // SAFETY: We write to the array below before reading from it.
-  let mut edge_buf: Aligned<[T; 4 * MAX_TX_SIZE + 1]> =
-    unsafe { Aligned::uninitialized() };
-  //Aligned::new([T::cast_from(0); 4 * MAX_TX_SIZE + 1]);
   let base = 128u16 << (bit_depth - 8);
 
   {
@@ -833,7 +829,6 @@ pub fn get_intra_edges<T: Pixel>(
       }
     }
   }
-  edge_buf
 }
 
 pub fn has_tr(bo: TileBlockOffset, bsize: BlockSize) -> bool {

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1516,12 +1516,8 @@ mod test {
 
   #[test]
   fn pred_matches_u8() {
-    // SAFETY: We write to the array below before reading from it.
-    let mut edge_buf: Aligned<[u8; 2 * MAX_TX_SIZE + 1]> =
-      unsafe { Aligned::uninitialized() };
-    for i in 0..edge_buf.data.len() {
-      edge_buf.data[i] = (i + 32).saturating_sub(MAX_TX_SIZE).as_();
-    }
+    let edge_buf: Aligned<[u8; 2 * MAX_TX_SIZE + 1]> =
+      Aligned::from_fn(|i| (i + 32).saturating_sub(MAX_TX_SIZE).as_());
     let left = &edge_buf.data[MAX_TX_SIZE - 4..MAX_TX_SIZE];
     let above = &edge_buf.data[MAX_TX_SIZE + 1..MAX_TX_SIZE + 5];
     let top_left = edge_buf.data[MAX_TX_SIZE];


### PR DESCRIPTION
Continuation of #1572.

https://github.com/xiph/rav1e/blob/master/src/partition.rs#L624

Right-aligned pixels suggests that not all of the `left` pixels are always initialized, so `get_intra_edges` was returning `edge_buf` without initializing all of its elements. That's technically UB, and an example of [a safety comment being misleading about safety](https://github.com/xiph/rav1e/blob/3d43ecac0145688ac9d17712e685e80ee4eefbe2/src/partition.rs#L617).

I don't think I could simply change `edge_buf` to be a contiguous slice of pixels (of variable width) or something like a `PlaneRegion`, because in `dispatch_predict_intra` there's assembly that seems to rely on `edge_buf` having a particular layout. It's a bit scary to change `edge_buf` layout, since code elsewhere has assumptions like `let edge_ptr = edge_buf.data.as_ptr().offset(2 * MAX_TX_SIZE as isize) as *const _;`.

So if `edge_buf` can't be contiguous, it can't have uninitialized elements left, so I've just initialized it. AFAIK that's 256 zeroed bytes. I took it out of `get_intra_edges` to avoid initializing it every time inside the function, so the initialization can be amortized in the outer scope.

I think longer term it could be worth trying to make `edge_buf` a newtype or a contiguous array, and change assembly to match, but that's a bit more than I can do now.