### PR TITLE
Well-defined lazy initialization for `get_intra_edges`

### DIFF
--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -12,6 +12,7 @@ use crate::partition::{get_intra_edges, BlockSize};
 use crate::predict::{IntraParam, PredictionMode};
 use crate::tiling::{Area, PlaneRegion, TileRect};
 use crate::transform::TxSize;
+use crate::util::Aligned;
 use crate::Pixel;
 use rayon::iter::*;
 use rust_hawktracer::*;
@@ -54,7 +55,9 @@ pub(crate) fn estimate_intra_costs<T: Pixel>(
       });
 
       // TODO: other intra prediction modes.
+      let mut edge_buf = Aligned::uninit_array();
       let edge_buf = get_intra_edges(
+        &mut edge_buf,
         &plane.as_region(),
         TileBlockOffset(BlockOffset { x, y }),
         0,

--- a/src/asm/shared/predict.rs
+++ b/src/asm/shared/predict.rs
@@ -16,7 +16,7 @@ mod test {
   use crate::context::MAX_TX_SIZE;
   use crate::cpu_features::CpuFeatureLevel;
   use crate::frame::{AsRegion, Plane};
-  use crate::partition::BlockSize;
+  use crate::partition::{BlockSize, IntraEdge};
   use crate::predict::dispatch_predict_intra;
   use crate::predict::pred_cfl_ac;
   use crate::predict::rust;
@@ -41,9 +41,10 @@ mod test {
   fn pred_matches_inner<T: Pixel>(cpu: CpuFeatureLevel, bit_depth: usize) {
     let tx_size = TxSize::TX_4X4;
     let ac: Aligned<[i16; 32 * 32]> = Aligned::from_fn(|i| i as i16 - 16 * 32);
-    let edge_buf: Aligned<[T; 4 * MAX_TX_SIZE + 1]> = Aligned::from_fn(|i| {
+    let edge_buf = Aligned::from_fn(|i| {
       T::cast_from(((i ^ 1) + 32).saturating_sub(2 * MAX_TX_SIZE))
     });
+    let edge_buf = IntraEdge::mock(&edge_buf);
 
     let ief_params_all = [
       None,

--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -27,9 +27,7 @@ pub fn call_inverse_func<T: Pixel>(
   // Only use at most 32 columns and 32 rows of input coefficients.
   let input: &[T::Coeff] = &input[..width.min(32) * height.min(32)];
 
-  // SAFETY: We write to the array below before reading from it.
-  let mut copied: Aligned<[MaybeUninit<T::Coeff>; 32 * 32]> =
-    unsafe { Aligned::uninitialized() };
+  let mut copied = Aligned::<[MaybeUninit<T::Coeff>; 32 * 32]>::uninit_array();
 
   // Convert input to 16-bits.
   // TODO: Remove by changing inverse assembly to not overwrite its input
@@ -57,9 +55,7 @@ pub fn call_inverse_hbd_func<T: Pixel>(
   // Only use at most 32 columns and 32 rows of input coefficients.
   let input: &[T::Coeff] = &input[..width.min(32) * height.min(32)];
 
-  // SAFETY: We write to the array below before reading from it.
-  let mut copied: Aligned<[MaybeUninit<T::Coeff>; 32 * 32]> =
-    unsafe { Aligned::uninitialized() };
+  let mut copied = Aligned::<[MaybeUninit<T::Coeff>; 32 * 32]>::uninit_array();
 
   // Convert input to 16-bits.
   // TODO: Remove by changing inverse assembly to not overwrite its input
@@ -152,13 +148,11 @@ pub mod test {
         &[T::zero(); 64 * 64][..tx_size.area()],
         tx_size.width(),
       );
-      let mut res_storage: Aligned<[MaybeUninit<i16>; 64 * 64]> =
-        unsafe { Aligned::uninitialized() };
-      let res = &mut res_storage.data[..tx_size.area()];
-      // SAFETY: We write to the array below before reading from it.
-      let mut freq_storage: Aligned<[MaybeUninit<T::Coeff>; 64 * 64]> =
-        unsafe { Aligned::uninitialized() };
-      let freq = &mut freq_storage.data[..tx_size.area()];
+      let mut res = Aligned::<[MaybeUninit<i16>; 64 * 64]>::uninit_array();
+      let res = &mut res.data[..tx_size.area()];
+      let mut freq =
+        Aligned::<[MaybeUninit<T::Coeff>; 64 * 64]>::uninit_array();
+      let freq = &mut freq.data[..tx_size.area()];
       for ((r, s), d) in
         res.iter_mut().zip(src.iter_mut()).zip(dst.data.iter_mut())
       {

--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -1919,9 +1919,8 @@ impl<'a> ContextWriter<'a> {
     tx_size: TxSize, tx_class: TxClass, txs_ctx: usize, plane_type: usize,
     w: &mut W,
   ) {
-    // SAFETY: We write to the array below before reading from it.
-    let mut coeff_contexts: Aligned<[MaybeUninit<i8>; MAX_CODED_TX_SQUARE]> =
-      unsafe { Aligned::uninitialized() };
+    let mut coeff_contexts =
+      Aligned::<[MaybeUninit<i8>; MAX_CODED_TX_SQUARE]>::uninit_array();
 
     // get_nz_map_contexts sets coeff_contexts contiguously as a parallel array for scan, not in scan order
     let coeff_contexts = self.get_nz_map_contexts(

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1507,21 +1507,19 @@ pub fn encode_tx_block<T: Pixel, W: Writer>(
   }
 
   let coded_tx_area = av1_get_coded_tx_size(tx_size).area();
-  let mut residual_storage: Aligned<[MaybeUninit<i16>; 64 * 64]> =
-    unsafe { Aligned::uninitialized() };
-  let mut coeffs_storage: Aligned<[MaybeUninit<T::Coeff>; 64 * 64]> =
-    unsafe { Aligned::uninitialized() };
-  let mut qcoeffs_storage: Aligned<[MaybeUninit<T::Coeff>; 32 * 32]> =
-    unsafe { Aligned::uninitialized() };
-  let mut rcoeffs_storage: Aligned<[MaybeUninit<T::Coeff>; 32 * 32]> =
-    unsafe { Aligned::uninitialized() };
-  let residual = &mut residual_storage.data[..tx_size.area()];
-  let coeffs = &mut coeffs_storage.data[..tx_size.area()];
+  let mut residual = Aligned::<[MaybeUninit<i16>; 64 * 64]>::uninit_array();
+  let mut coeffs = Aligned::<[MaybeUninit<T::Coeff>; 64 * 64]>::uninit_array();
+  let mut qcoeffs =
+    Aligned::<[MaybeUninit<T::Coeff>; 32 * 32]>::uninit_array();
+  let mut rcoeffs =
+    Aligned::<[MaybeUninit<T::Coeff>; 32 * 32]>::uninit_array();
+  let residual = &mut residual.data[..tx_size.area()];
+  let coeffs = &mut coeffs.data[..tx_size.area()];
   let qcoeffs = init_slice_repeat_mut(
-    &mut qcoeffs_storage.data[..coded_tx_area],
+    &mut qcoeffs.data[..coded_tx_area],
     T::Coeff::cast_from(0),
   );
-  let rcoeffs = &mut rcoeffs_storage.data[..coded_tx_area];
+  let rcoeffs = &mut rcoeffs.data[..coded_tx_area];
 
   let (visible_tx_w, visible_tx_h) = clip_visible_bsize(
     (fi.width + xdec) >> xdec,
@@ -2260,9 +2258,7 @@ pub fn write_tx_blocks<T: Pixel, W: Writer>(
   }
 
   let PlaneConfig { xdec, ydec, .. } = ts.input.planes[1].cfg;
-  // SAFETY: We write to the array below before reading from it.
-  let mut ac: Aligned<[MaybeUninit<i16>; 32 * 32]> =
-    unsafe { Aligned::uninitialized() };
+  let mut ac = Aligned::<[MaybeUninit<i16>; 32 * 32]>::uninit_array();
   let mut partition_has_coeff: bool = false;
   let mut tx_dist = ScaledDistortion::zero();
   let do_chroma =

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1475,7 +1475,9 @@ pub fn encode_tx_block<T: Pixel, W: Writer>(
 
   if mode.is_intra() {
     let bit_depth = fi.sequence.bit_depth;
+    let mut edge_buf = Aligned::uninit_array();
     let edge_buf = get_intra_edges(
+      &mut edge_buf,
       &rec.as_const(),
       tile_partition_bo,
       bx,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1609,9 +1609,7 @@ pub fn rdo_cfl_alpha<T: Pixel>(
   if visible_tx_w == 0 || visible_tx_h == 0 {
     return None;
   };
-  // SAFETY: We write to the array below before reading from it.
-  let mut ac: Aligned<[MaybeUninit<i16>; 32 * 32]> =
-    unsafe { Aligned::uninitialized() };
+  let mut ac = Aligned::<[MaybeUninit<i16>; 32 * 32]>::uninit_array();
   let ac = luma_ac(&mut ac.data, ts, tile_bo, bsize, luma_tx_size, fi);
   let best_alpha: ArrayVec<i16, 2> = (1..3)
     .map(|p| {

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -1433,11 +1433,13 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
     let satds = {
       // FIXME: If tx partition is used, this whole sads block should be fixed
       let tx_size = bsize.tx_size();
+      let mut edge_buf = Aligned::uninit_array();
       let edge_buf = {
         let rec = &ts.rec.planes[0].as_const();
         let po = tile_bo.plane_offset(rec.plane_cfg);
         // FIXME: If tx partition is used, get_intra_edges() should be called for each tx block
         get_intra_edges(
+          &mut edge_buf,
           rec,
           tile_bo,
           0,
@@ -1618,7 +1620,9 @@ pub fn rdo_cfl_alpha<T: Pixel>(
       let rec = &mut ts.rec.planes[p];
       let input = &ts.input_tile.planes[p];
       let po = tile_bo.plane_offset(rec.plane_cfg);
+      let mut edge_buf = Aligned::uninit_array();
       let edge_buf = get_intra_edges(
+        &mut edge_buf,
         &rec.as_const(),
         tile_bo,
         0,

--- a/src/transform/forward.rs
+++ b/src/transform/forward.rs
@@ -83,10 +83,8 @@ pub mod rust {
     let txfm_size_col = tx_size.width();
     let txfm_size_row = tx_size.height();
 
-    // SAFETY: We write to the array below before reading from it.
-    let mut tmp: Aligned<[MaybeUninit<i32>; 64 * 64]> =
-      unsafe { Aligned::uninitialized() };
-    let buf = &mut tmp.data[..txfm_size_col * txfm_size_row];
+    let mut buf = Aligned::<[MaybeUninit<i32>; 64 * 64]>::uninit_array();
+    let buf = &mut buf.data[..txfm_size_col * txfm_size_row];
 
     let cfg = Txfm2DFlipCfg::fwd(tx_type, tx_size, bd);
 
@@ -95,9 +93,8 @@ pub mod rust {
 
     // Columns
     for c in 0..txfm_size_col {
-      let mut col_coeffs_backing: Aligned<[MaybeUninit<i32>; 64]> =
-        unsafe { Aligned::uninitialized() };
-      let col_coeffs = &mut col_coeffs_backing.data[..txfm_size_row];
+      let mut col_coeffs = Aligned::<[MaybeUninit<i32>; 64]>::uninit_array();
+      let col_coeffs = &mut col_coeffs.data[..txfm_size_row];
       if cfg.ud_flip {
         // flip upside down
         for r in 0..txfm_size_row {

--- a/src/util/align.rs
+++ b/src/util/align.rs
@@ -39,6 +39,17 @@ impl<const N: usize, T> Aligned<[T; N]> {
   }
 }
 
+impl<const N: usize, T> Aligned<[MaybeUninit<T>; N]> {
+  #[inline(always)]
+  pub const fn uninit_array() -> Self {
+    Aligned {
+      _alignment: [],
+      // SAFETY: Uninitialized [MaybeUninit<T>; N] is valid.
+      data: unsafe { MaybeUninit::uninit().assume_init() },
+    }
+  }
+}
+
 impl<T> Aligned<T> {
   pub const fn new(data: T) -> Self {
     Aligned { _alignment: [], data }

--- a/src/util/align.rs
+++ b/src/util/align.rs
@@ -29,6 +29,7 @@ pub struct Aligned<T> {
   pub data: T,
 }
 
+#[cfg(any(test, feature = "bench"))]
 impl<const N: usize, T> Aligned<[T; N]> {
   #[inline(always)]
   pub fn from_fn<F>(cb: F) -> Self


### PR DESCRIPTION
Inspired by #3276. Introduce new types to capture the requirements of intra edge buffers and avoid undefined behavior.
Analysis from @kornelski quoted below:

```rust
// left pixels are ordered from bottom to top and right-aligned
let (left, not_left) = edge_buf.data.split_at_mut(2 * MAX_TX_SIZE);
let (top_left, above) = not_left.split_at_mut(1);
```

> Right-aligned pixels suggests that not all of the `left` pixels are always initialized, so `get_intra_edges` was returning `edge_buf` without initializing all of its elements. That's technically UB, and an example of [a safety comment being misleading about safety](https://github.com/xiph/rav1e/blob/3d43ecac0145688ac9d17712e685e80ee4eefbe2/src/partition.rs#L617).
> 
> I don't think I could simply change `edge_buf` to be a contiguous slice of pixels (of variable width) or something like a `PlaneRegion`, because in `dispatch_predict_intra` there's assembly that seems to rely on `edge_buf` having a particular layout. It's a bit scary to change `edge_buf` layout, since code elsewhere has assumptions like `let edge_ptr = edge_buf.data.as_ptr().offset(2 * MAX_TX_SIZE as isize) as *const _;`.
> 
> So if `edge_buf` can't be contiguous, it can't have uninitialized elements left, so I've just initialized it. AFAIK that's 256 zeroed bytes. I took it out of `get_intra_edges` to avoid initializing it every time inside the function, so the initialization can be amortized in the outer scope.
> 
> I think longer term it could be worth trying to make `edge_buf` a newtype or a contiguous array, and change assembly to match, but that's a bit more than I can do now.