### PR TITLE
Complete 8-bit SATD aarch64 assembly implementation

### DIFF
--- a/src/arm/64/satd.S
+++ b/src/arm/64/satd.S
@@ -305,27 +305,27 @@ function satd16x4_neon, export=1
     #define TMP3 v6
     #define TMP4 v7
 
-    #define ROW5 v8
-    #define ROW6 v9
-    #define TMP5 v12
-    #define TMP6 v13
+    #define ROW5 v16
+    #define ROW6 v17
+    #define TMP5 v20
+    #define TMP6 v21
 
-    #define ROW7 v10
-    #define ROW8 v11
-    #define TMP7 v14
-    #define TMP8 v15
+    #define ROW7 v18
+    #define ROW8 v19
+    #define TMP7 v22
+    #define TMP8 v23
 
     // load 16 pixel row
     ldr     q0, [src]
     ldr     q1, [dst]
 
-    usubl2  v8.8h, v0.16b, v1.16b
+    usubl2  v16.8h, v0.16b, v1.16b
     usubl   v0.8h, v0.8b, v1.8b
 
     ldr     q1, [src, src_stride]
     ldr     q2, [dst, dst_stride]
 
-    usubl2  v9.8h, v1.16b, v2.16b
+    usubl2  v17.8h, v1.16b, v2.16b
     usubl   v1.8h, v1.8b, v2.8b
 
     lsl     x8, src_stride, 1
@@ -354,23 +354,23 @@ function satd16x4_neon, export=1
     mov   v0.d[1], v2.d[0]
     mov   v1.d[1], v3.d[0]
 
-    ext v10.16b, v8.16b, v8.16b, 8
-    ext v11.16b, v9.16b, v9.16b, 8
+    ext v18.16b, v16.16b, v16.16b, 8
+    ext v19.16b, v17.16b, v17.16b, 8
 
-    mov   v8.d[1], v6.d[0]
-    mov   v9.d[1], v7.d[0]
+    mov   v16.d[1], v6.d[0]
+    mov   v17.d[1], v7.d[0]
     // 2-3 free
 
     mov   v4.d[1], v2.d[1]
     mov   v5.d[1], v3.d[1]
     // 6-7 free
-    mov   v10.d[1], v6.d[1]
-    mov   v11.d[1], v7.d[1]
+    mov   v18.d[1], v6.d[1]
+    mov   v19.d[1], v7.d[1]
 
     // 0,1       2,3
     // 4,5       6,7
-    // 8,9       12,13
-    // 10,11     14,15
+    // 16,17     20,21
+    // 18,19     22,23
 
     // quadruple 4x4 hadamard
 
@@ -480,27 +480,27 @@ function satd4x16_neon, export=1
     add         dst, dst, dst_stride, lsl 1
 
     load_row    6, 7, src, dst, src_stride, dst_stride, 0
-    load_row2   7, 8, src, dst, src_stride, dst_stride
+    load_row2   7, 16, src, dst, src_stride, dst_stride
     add         src, src, src_stride, lsl 1
     add         dst, dst, dst_stride, lsl 1
 
-    load_row    8, 9, src, dst, src_stride, dst_stride, 0
-    load_row2   9, 10, src, dst, src_stride, dst_stride
+    load_row    16, 17, src, dst, src_stride, dst_stride, 0
+    load_row2   17, 18, src, dst, src_stride, dst_stride
     add         src, src, src_stride, lsl 1
     add         dst, dst, dst_stride, lsl 1
 
-    load_row    10, 11, src, dst, src_stride, dst_stride, 0
-    load_row2   11, 12, src, dst, src_stride, dst_stride
+    load_row    18, 19, src, dst, src_stride, dst_stride, 0
+    load_row2   19, 20, src, dst, src_stride, dst_stride
     add         src, src, src_stride, lsl 1
     add         dst, dst, dst_stride, lsl 1
 
-    load_row    12, 13, src, dst, src_stride, dst_stride, 0
-    load_row2   13, 14, src, dst, src_stride, dst_stride
+    load_row    20, 21, src, dst, src_stride, dst_stride, 0
+    load_row2   21, 22, src, dst, src_stride, dst_stride
     add         src, src, src_stride, lsl 1
     add         dst, dst, dst_stride, lsl 1
 
-    load_row    14, 15, src, dst, src_stride, dst_stride, 0
-    load_row2   15, 16, src, dst, src_stride, dst_stride
+    load_row    22, 23, src, dst, src_stride, dst_stride, 0
+    load_row2   23, 24, src, dst, src_stride, dst_stride
 
     // pack rows
     mov   v0.d[1], v2.d[0]
@@ -509,64 +509,64 @@ function satd4x16_neon, export=1
     mov   v4.d[1], v6.d[0]
     mov   v5.d[1], v7.d[0]
 
-    mov   v8.d[1], v10.d[0]
-    mov   v9.d[1], v11.d[0]
+    mov   v16.d[1], v18.d[0]
+    mov   v17.d[1], v19.d[0]
 
-    mov   v12.d[1], v14.d[0]
-    mov   v13.d[1], v15.d[0]
+    mov   v20.d[1], v22.d[0]
+    mov   v21.d[1], v23.d[0]
 
     butterfly v2, v3, v0, v1
     butterfly v6, v7, v4, v5
-    butterfly v10, v11, v8, v9
-    butterfly v14, v15, v12, v13
+    butterfly v18, v19, v16, v17
+    butterfly v22, v23, v20, v21
 
     interleave v0, v1, v2, v3
     interleave v4, v5, v6, v7
-    interleave v8, v9, v10, v11
-    interleave v12, v13, v14, v15
+    interleave v16, v17, v18, v19
+    interleave v20, v21, v22, v23
 
     butterfly v2, v3, v0, v1
     butterfly v6, v7, v4, v5
-    butterfly v10, v11, v8, v9
-    butterfly v14, v15, v12, v13
+    butterfly v18, v19, v16, v17
+    butterfly v22, v23, v20, v21
 
     interleave_pairs v0, v1, v2, v3
     interleave_pairs v4, v5, v6, v7
-    interleave_pairs v8, v9, v10, v11
-    interleave_pairs v12, v13, v14, v15
+    interleave_pairs v16, v17, v18, v19
+    interleave_pairs v20, v21, v22, v23
 
     butterfly v2, v3, v0, v1
     butterfly v6, v7, v4, v5
-    butterfly v10, v11, v8, v9
-    butterfly v14, v15, v12, v13
+    butterfly v18, v19, v16, v17
+    butterfly v22, v23, v20, v21
 
     interleave v0, v1, v2, v3
     interleave v4, v5, v6, v7
-    interleave v8, v9, v10, v11
-    interleave v12, v13, v14, v15
+    interleave v16, v17, v18, v19
+    interleave v20, v21, v22, v23
 
     butterfly v2, v3, v0, v1
     butterfly v6, v7, v4, v5
-    butterfly v10, v11, v8, v9
-    butterfly v14, v15, v12, v13
+    butterfly v18, v19, v16, v17
+    butterfly v22, v23, v20, v21
 
     abs  v2.8h, v2.8h
     abs  v3.8h, v3.8h
     abs  v6.8h, v6.8h
     abs  v7.8h, v7.8h
-    abs  v10.8h, v10.8h
-    abs  v11.8h, v11.8h
-    abs  v14.8h, v14.8h
-    abs  v15.8h, v15.8h
+    abs  v18.8h, v18.8h
+    abs  v19.8h, v19.8h
+    abs  v22.8h, v22.8h
+    abs  v23.8h, v23.8h
 
     add v2.8h, v2.8h, v3.8h
     add v6.8h, v6.8h, v7.8h
-    add v10.8h, v10.8h, v11.8h
-    add v14.8h, v14.8h, v15.8h
+    add v18.8h, v18.8h, v19.8h
+    add v22.8h, v22.8h, v23.8h
 
     add v2.8h, v2.8h, v6.8h
-    add v10.8h, v10.8h, v14.8h
-    add v0.8h, v2.8h, v10.8h
+    add v18.8h, v18.8h, v22.8h
+    add v0.8h, v2.8h, v18.8h
 
     addv    h0, v0.8h
     fmov    w0, s0

--- a/src/arm/64/satd.S
+++ b/src/arm/64/satd.S
@@ -26,9 +26,19 @@
     zip2 \r1\().4s, \r2\().4s, \r3\().4s
 .endm
 
+.macro interleave_quads r0, r1, r2, r3
+    zip1 \r0\().2d, \r2\().2d, \r3\().2d
+    zip2 \r1\().2d, \r2\().2d, \r3\().2d
+.endm
+
 .macro normalize_4
     add     w0, w0, 2
     lsr     w0, w0, 2
+.endm
+
+.macro normalize_8
+    add     w0, w0, 4
+    lsr     w0, w0, 3
 .endm
 
 // x0: src: *const u8,
@@ -571,6 +581,151 @@ function satd4x16_neon, export=1
     addv    h0, v0.8h
     fmov    w0, s0
     normalize_4
+    ret
+
+    #undef src
+    #undef src_stride
+    #undef dst
+    #undef dst_stride
+endfunc
+
+.macro load_rows n0, n1, n2, src, dst, src_stride, dst_stride, should_add=1
+    ldr     d\n0, [\src]
+    ldr     d\n1, [\dst]
+    usubl   v\n0\().8h, v\n0\().8b, v\n1\().8b
+
+    ldr     d\n1, [\src, \src_stride]
+    ldr     d\n2, [\dst, \dst_stride]
+    usubl   v\n1\().8h, v\n1\().8b, v\n2\().8b
+
+.if \should_add != 0
+    add     \src, \src, \src_stride, lsl 1
+    add     \dst, \dst, \dst_stride, lsl 1
+.endif
+.endm
+
+.macro HADAMARD_8X8 \
+       a0 a1 a2 a3 a4 a5 a6 a7 \
+       b0 b1 b2 b3 b4 b5 b6 b7
+
+    // Horizontal transform
+
+    butterfly v\b0, v\b1, v\a0, v\a1
+    butterfly v\b2, v\b3, v\a2, v\a3
+    butterfly v\b4, v\b5, v\a4, v\a5
+    butterfly v\b6, v\b7, v\a6, v\a7
+
+    interleave v\a0, v\a1, v\b0, v\b1
+    interleave v\a2, v\a3, v\b2, v\b3
+    interleave v\a4, v\a5, v\b4, v\b5
+    interleave v\a6, v\a7, v\b6, v\b7
+
+    butterfly v\b0, v\b2, v\a0, v\a2
+    butterfly v\b1, v\b3, v\a1, v\a3
+    butterfly v\b4, v\b6, v\a4, v\a6
+    butterfly v\b5, v\b7, v\a5, v\a7
+
+    interleave_pairs v\a0, v\a2, v\b0, v\b2
+    interleave_pairs v\a1, v\a3, v\b1, v\b3
+    interleave_pairs v\a4, v\a6, v\b4, v\b6
+    interleave_pairs v\a5, v\a7, v\b5, v\b7
+
+    butterfly v\b0, v\b4, v\a0, v\a4
+    butterfly v\b1, v\b5, v\a1, v\a5
+    butterfly v\b2, v\b6, v\a2, v\a6
+    butterfly v\b3, v\b7, v\a3, v\a7
+
+    interleave_quads v\a0, v\a4, v\b0, v\b4
+    interleave_quads v\a1, v\a5, v\b1, v\b5
+    interleave_quads v\a2, v\a6, v\b2, v\b6
+    interleave_quads v\a3, v\a7, v\b3, v\b7
+
+    // Vertical transform
+
+    butterfly v\b0, v\b1, v\a0, v\a1
+    butterfly v\b2, v\b3, v\a2, v\a3
+    butterfly v\b4, v\b5, v\a4, v\a5
+    butterfly v\b6, v\b7, v\a6, v\a7
+
+    butterfly v\a0, v\a2, v\b0, v\b2
+    butterfly v\a1, v\a3, v\b1, v\b3
+    butterfly v\a4, v\a6, v\b4, v\b6
+    butterfly v\a5, v\a7, v\b5, v\b7
+
+    butterfly v\b0, v\b4, v\a0, v\a4
+    butterfly v\b1, v\b5, v\a1, v\a5
+    butterfly v\b2, v\b6, v\a2, v\a6
+    butterfly v\b3, v\b7, v\a3, v\a7
+.endm
+
+.macro SUM_HADAMARD_8X8 \
+       a0 a1 a2 a3 a4 a5 a6 a7 \
+       b0 b1 b2 b3 b4 b5 b6 b7
+
+    // absolute value of transform coefficients
+    abs  v\b0\().8h, v\b0\().8h
+    abs  v\b1\().8h, v\b1\().8h
+    abs  v\b2\().8h, v\b2\().8h
+    abs  v\b3\().8h, v\b3\().8h
+    abs  v\b4\().8h, v\b4\().8h
+    abs  v\b5\().8h, v\b5\().8h
+    abs  v\b6\().8h, v\b6\().8h
+    abs  v\b7\().8h, v\b7\().8h
+
+    // stage 1 sum
+    sxtl v\a0\().4s, v\b0\().4h
+    sxtl v\a1\().4s, v\b1\().4h
+    sxtl v\a2\().4s, v\b2\().4h
+    sxtl v\a3\().4s, v\b3\().4h
+    saddw2  v\a0\().4s, v\a0\().4s, v\b0\().8h
+    saddw2  v\a1\().4s, v\a1\().4s, v\b1\().8h
+    saddw2  v\a2\().4s, v\a2\().4s, v\b2\().8h
+    saddw2  v\a3\().4s, v\a3\().4s, v\b3\().8h
+    saddw   v\a0\().4s, v\a0\().4s, v\b4\().4h
+    saddw2  v\a1\().4s, v\a1\().4s, v\b4\().8h
+    saddw   v\a2\().4s, v\a2\().4s, v\b5\().4h
+    saddw2  v\a3\().4s, v\a3\().4s, v\b5\().8h
+    saddw   v\a0\().4s, v\a0\().4s, v\b6\().4h
+    saddw2  v\a1\().4s, v\a1\().4s, v\b6\().8h
+    saddw   v\a2\().4s, v\a2\().4s, v\b7\().4h
+    saddw2  v\a3\().4s, v\a3\().4s, v\b7\().8h
+
+    // stage 2 sum
+    add  v\a0\().4s, v\a0\().4s, v\a1\().4s
+    add  v\a2\().4s, v\a2\().4s, v\a3\().4s
+
+    // stage 3 sum
+    add  v0.4s, v\a0\().4s, v\a2\().4s
+    addv s0, v0.4s
+
+    fmov w0, s0
+    normalize_8
+.endm
+
+function satd8x8_neon, export=1
+    #define src         x0
+    #define src_stride  x1
+    #define dst         x2
+    #define dst_stride  x3
+
+    //  0,  1;   2,  3
+    //  4,  5;   6,  7
+    // 16, 17;  20, 21
+    // 18, 19;  22, 23
+
+    load_rows 0, 1, 2, src, dst, src_stride, dst_stride
+    load_rows 4, 5, 6, src, dst, src_stride, dst_stride
+    load_rows 16, 17, 20, src, dst, src_stride, dst_stride
+    load_rows 18, 19, 22, src, dst, src_stride, dst_stride, 0
+
+    HADAMARD_8X8 \
+    0, 1, 4, 5, 16, 17, 18, 19, \
+    2, 3, 6, 7, 20, 21, 22, 23
+
+    SUM_HADAMARD_8X8 \
+    0, 1, 4, 5, 16, 17, 18, 19, \
+    2, 3, 6, 7, 20, 21, 22, 23
+
     ret
 
     #undef src

--- a/src/arm/64/satd.S
+++ b/src/arm/64/satd.S
@@ -717,14 +717,9 @@ function satd8x8_neon, export=1
 
     #define subtotal    w9
     #define total       w10
-    #define w_ext       x11
-    #define w_bak       w11
-    #define width       w12
     #define height      w13
 
     mov  height, 8
-    mov  width, 8
-    sxtw w_ext, width
     mov  total, wzr
 
     //  0,  1;   2,  3
@@ -732,7 +727,7 @@ function satd8x8_neon, export=1
     // 16, 17;  20, 21
     // 18, 19;  22, 23
 
-L(satd_8x8):
+L(satd_w8):
     load_rows 0, 1, 2, src, dst, src_stride, dst_stride
     load_rows 4, 5, 6, src, dst, src_stride, dst_stride
     load_rows 16, 17, 20, src, dst, src_stride, dst_stride
@@ -749,20 +744,8 @@ L(satd_8x8):
     fmov subtotal, s0
     add  total, subtotal, total
 
-    sub  src, src, src_stride, lsl 3
-    sub  dst, dst, dst_stride, lsl 3
-    add  src, src, #8
-    add  dst, dst, #8
-    subs width, width, #8
-    bne  L(satd_8x8)
-
-    sub  src, src, w_ext
-    sub  dst, dst, w_ext
-    add  src, src, src_stride, lsl 3
-    add  dst, dst, dst_stride, lsl 3
     subs height, height, #8
-    mov  width, w_bak
-    bne  L(satd_8x8)
+    bne  L(satd_w8)
 
     mov  w0, total
     normalize_8
@@ -773,12 +756,9 @@ L(satd_8x8):
     #undef dst
     #undef dst_stride
 
-    #undef w_ext
-    #undef w_bak
     #undef subtotal
     #undef total
     #undef height
-    #undef width
 endfunc
 
 .macro DOUBLE_HADAMARD_8X8 \
@@ -942,8 +922,6 @@ endfunc
     // stage 4 sum
     add  v0.4s, v\b0\().4s, v\b4\().4s
     addv s0, v0.4s
-    fmov w0, s0
-    normalize_8
 .endm
 
 function satd16x8_neon, export=1
@@ -952,11 +930,24 @@ function satd16x8_neon, export=1
     #define dst         x2
     #define dst_stride  x3
 
+    #define subtotal    w9
+    #define total       w10
+    #define w_ext       x11
+    #define w_bak       w11
+    #define width       w12
+    #define height      w13
+
+    mov  height, 8
+    mov  width, 16
+    sxtw w_ext, width
+    mov  total, wzr
+
     //  0,  1;   2,  3;  24, 25
     //  4,  5;   6,  7;  26, 27
     // 16, 17;  20, 21;  28, 29
     // 18, 19;  22, 23;  30, 31
 
+L(satd_w16up):
     load_rows 0, 1, 2, src, dst, src_stride, dst_stride, 24, 25
     load_rows 4, 5, 6, src, dst, src_stride, dst_stride, 26, 27
     load_rows 16, 17, 20, src, dst, src_stride, dst_stride, 28, 29
@@ -972,21 +963,53 @@ function satd16x8_neon, export=1
      2,  3,  6,  7, 20, 21, 22, 23, \
     24, 25, 26, 27, 28, 29, 30, 31
 
+    fmov subtotal, s0
+    add  total, subtotal, total
+
+    sub  src, src, src_stride, lsl 3
+    sub  dst, dst, dst_stride, lsl 3
+    add  src, src, #16
+    add  dst, dst, #16
+    subs width, width, #16
+    bne  L(satd_w16up)
+
+    sub  src, src, w_ext
+    sub  dst, dst, w_ext
+    add  src, src, src_stride, lsl 3
+    add  dst, dst, dst_stride, lsl 3
+    subs height, height, #8
+    mov  width, w_bak
+    bne  L(satd_w16up)
+
+    mov  w0, total
+    normalize_8
     ret
 
     #undef src
     #undef src_stride
     #undef dst
     #undef dst_stride
+
+    #undef w_ext
+    #undef w_bak
+    #undef subtotal
+    #undef total
+    #undef height
+    #undef width
 endfunc
 
 .macro satd_x8up width, height
 function satd\width\()x\height\()_neon, export=1
     mov  w13, \height
+.if \width == 8
+    mov  w10, wzr
+    b    L(satd_w8)
+.else
     mov  w12, \width
     sxtw x11, w12
     mov  w10, wzr
-    b    L(satd_8x8)
+    b    L(satd_w16up)
+.endif
 endfunc
 .endm
 

--- a/src/arm/64/satd.S
+++ b/src/arm/64/satd.S
@@ -589,13 +589,25 @@ function satd4x16_neon, export=1
     #undef dst_stride
 endfunc
 
-.macro load_rows n0, n1, n2, src, dst, src_stride, dst_stride
+.macro load_rows n0, n1, n2, src, dst, src_stride, dst_stride, n3=0, n4=0
+.if \n3 == 0
     ldr     d\n0, [\src]
     ldr     d\n1, [\dst]
+.else
+    ldr     q\n0, [\src]
+    ldr     q\n1, [\dst]
+    usubl2  v\n3\().8h, v\n0\().16b, v\n1\().16b
+.endif
     usubl   v\n0\().8h, v\n0\().8b, v\n1\().8b
 
+.if \n4 == 0
     ldr     d\n1, [\src, \src_stride]
     ldr     d\n2, [\dst, \dst_stride]
+.else
+    ldr     q\n1, [\src, \src_stride]
+    ldr     q\n2, [\dst, \dst_stride]
+    usubl2  v\n4\().8h, v\n1\().16b, v\n2\().16b
+.endif
     usubl   v\n1\().8h, v\n1\().8b, v\n2\().8b
 
     add     \src, \src, \src_stride, lsl 1
@@ -769,6 +781,205 @@ L(satd_8x8):
     #undef width
 endfunc
 
+.macro DOUBLE_HADAMARD_8X8 \
+       a0 a1 a2 a3 a4 a5 a6 a7 \
+       b0 b1 b2 b3 b4 b5 b6 b7 \
+       c0 c1 c2 c3 c4 c5 c6 c7
+
+    // Horizontal transform
+
+    butterfly v\b0, v\b1, v\a0, v\a1
+    butterfly v\b2, v\b3, v\a2, v\a3
+    butterfly v\b4, v\b5, v\a4, v\a5
+    butterfly v\b6, v\b7, v\a6, v\a7
+    butterfly v\a0, v\a1, v\c0, v\c1
+    butterfly v\a2, v\a3, v\c2, v\c3
+    butterfly v\a4, v\a5, v\c4, v\c5
+    butterfly v\a6, v\a7, v\c6, v\c7
+
+    interleave v\c0, v\c1, v\b0, v\b1
+    interleave v\c2, v\c3, v\b2, v\b3
+    interleave v\c4, v\c5, v\b4, v\b5
+    interleave v\c6, v\c7, v\b6, v\b7
+    interleave v\b0, v\b1, v\a0, v\a1
+    interleave v\b2, v\b3, v\a2, v\a3
+    interleave v\b4, v\b5, v\a4, v\a5
+    interleave v\b6, v\b7, v\a6, v\a7
+
+    butterfly v\a0, v\a2, v\c0, v\c2
+    butterfly v\a1, v\a3, v\c1, v\c3
+    butterfly v\a4, v\a6, v\c4, v\c6
+    butterfly v\a5, v\a7, v\c5, v\c7
+    butterfly v\c0, v\c2, v\b0, v\b2
+    butterfly v\c1, v\c3, v\b1, v\b3
+    butterfly v\c4, v\c6, v\b4, v\b6
+    butterfly v\c5, v\c7, v\b5, v\b7
+
+    interleave_pairs v\b0, v\b2, v\a0, v\a2
+    interleave_pairs v\b1, v\b3, v\a1, v\a3
+    interleave_pairs v\b4, v\b6, v\a4, v\a6
+    interleave_pairs v\b5, v\b7, v\a5, v\a7
+    interleave_pairs v\a0, v\a2, v\c0, v\c2
+    interleave_pairs v\a1, v\a3, v\c1, v\c3
+    interleave_pairs v\a4, v\a6, v\c4, v\c6
+    interleave_pairs v\a5, v\a7, v\c5, v\c7
+
+    butterfly v\c0, v\c4, v\b0, v\b4
+    butterfly v\c1, v\c5, v\b1, v\b5
+    butterfly v\c2, v\c6, v\b2, v\b6
+    butterfly v\c3, v\c7, v\b3, v\b7
+    butterfly v\b0, v\b4, v\a0, v\a4
+    butterfly v\b1, v\b5, v\a1, v\a5
+    butterfly v\b2, v\b6, v\a2, v\a6
+    butterfly v\b3, v\b7, v\a3, v\a7
+
+    interleave_quads v\a0, v\a4, v\c0, v\c4
+    interleave_quads v\a1, v\a5, v\c1, v\c5
+    interleave_quads v\a2, v\a6, v\c2, v\c6
+    interleave_quads v\a3, v\a7, v\c3, v\c7
+    interleave_quads v\c0, v\c4, v\b0, v\b4
+    interleave_quads v\c1, v\c5, v\b1, v\b5
+    interleave_quads v\c2, v\c6, v\b2, v\b6
+    interleave_quads v\c3, v\c7, v\b3, v\b7
+
+    // Vertical transform
+
+    butterfly v\b0, v\b1, v\a0, v\a1
+    butterfly v\b2, v\b3, v\a2, v\a3
+    butterfly v\b4, v\b5, v\a4, v\a5
+    butterfly v\b6, v\b7, v\a6, v\a7
+    butterfly v\a0, v\a1, v\c0, v\c1
+    butterfly v\a2, v\a3, v\c2, v\c3
+    butterfly v\a4, v\a5, v\c4, v\c5
+    butterfly v\a6, v\a7, v\c6, v\c7
+
+    butterfly v\c0, v\c2, v\b0, v\b2
+    butterfly v\c1, v\c3, v\b1, v\b3
+    butterfly v\c4, v\c6, v\b4, v\b6
+    butterfly v\c5, v\c7, v\b5, v\b7
+    butterfly v\b0, v\b2, v\a0, v\a2
+    butterfly v\b1, v\b3, v\a1, v\a3
+    butterfly v\b4, v\b6, v\a4, v\a6
+    butterfly v\b5, v\b7, v\a5, v\a7
+
+    butterfly v\a0, v\a4, v\c0, v\c4
+    butterfly v\a1, v\a5, v\c1, v\c5
+    butterfly v\a2, v\a6, v\c2, v\c6
+    butterfly v\a3, v\a7, v\c3, v\c7
+    butterfly v\c0, v\c4, v\b0, v\b4
+    butterfly v\c1, v\c5, v\b1, v\b5
+    butterfly v\c2, v\c6, v\b2, v\b6
+    butterfly v\c3, v\c7, v\b3, v\b7
+.endm
+
+.macro SUM_DOUBLE_HADAMARD_8X8 \
+       a0 a1 a2 a3 a4 a5 a6 a7 \
+       b0 b1 b2 b3 b4 b5 b6 b7 \
+       c0 c1 c2 c3 c4 c5 c6 c7
+
+    // absolute value of transform coefficients
+    abs  v\a0\().8h, v\a0\().8h
+    abs  v\a1\().8h, v\a1\().8h
+    abs  v\a2\().8h, v\a2\().8h
+    abs  v\a3\().8h, v\a3\().8h
+    abs  v\a4\().8h, v\a4\().8h
+    abs  v\a5\().8h, v\a5\().8h
+    abs  v\a6\().8h, v\a6\().8h
+    abs  v\a7\().8h, v\a7\().8h
+    abs  v\c0\().8h, v\c0\().8h
+    abs  v\c1\().8h, v\c1\().8h
+    abs  v\c2\().8h, v\c2\().8h
+    abs  v\c3\().8h, v\c3\().8h
+    abs  v\c4\().8h, v\c4\().8h
+    abs  v\c5\().8h, v\c5\().8h
+    abs  v\c6\().8h, v\c6\().8h
+    abs  v\c7\().8h, v\c7\().8h
+
+    // stage 1 sum
+    sxtl v\b0\().4s, v\a0\().4h
+    sxtl v\b1\().4s, v\a1\().4h
+    sxtl v\b2\().4s, v\a2\().4h
+    sxtl v\b3\().4s, v\a3\().4h
+    sxtl v\b4\().4s, v\a4\().4h
+    sxtl v\b5\().4s, v\a5\().4h
+    sxtl v\b6\().4s, v\a6\().4h
+    sxtl v\b7\().4s, v\a7\().4h
+    saddw2  v\b0\().4s, v\b0\().4s, v\a0\().8h
+    saddw2  v\b1\().4s, v\b1\().4s, v\a1\().8h
+    saddw2  v\b2\().4s, v\b2\().4s, v\a2\().8h
+    saddw2  v\b3\().4s, v\b3\().4s, v\a3\().8h
+    saddw2  v\b4\().4s, v\b4\().4s, v\a4\().8h
+    saddw2  v\b5\().4s, v\b5\().4s, v\a5\().8h
+    saddw2  v\b6\().4s, v\b6\().4s, v\a6\().8h
+    saddw2  v\b7\().4s, v\b7\().4s, v\a7\().8h
+    saddw   v\b0\().4s, v\b0\().4s, v\c0\().4h
+    saddw2  v\b1\().4s, v\b1\().4s, v\c0\().8h
+    saddw   v\b2\().4s, v\b2\().4s, v\c1\().4h
+    saddw2  v\b3\().4s, v\b3\().4s, v\c1\().8h
+    saddw   v\b4\().4s, v\b4\().4s, v\c2\().4h
+    saddw2  v\b5\().4s, v\b5\().4s, v\c2\().8h
+    saddw   v\b6\().4s, v\b6\().4s, v\c3\().4h
+    saddw2  v\b7\().4s, v\b7\().4s, v\c3\().8h
+    saddw   v\b0\().4s, v\b0\().4s, v\c4\().4h
+    saddw2  v\b1\().4s, v\b1\().4s, v\c4\().8h
+    saddw   v\b2\().4s, v\b2\().4s, v\c5\().4h
+    saddw2  v\b3\().4s, v\b3\().4s, v\c5\().8h
+    saddw   v\b4\().4s, v\b4\().4s, v\c6\().4h
+    saddw2  v\b5\().4s, v\b5\().4s, v\c6\().8h
+    saddw   v\b6\().4s, v\b6\().4s, v\c7\().4h
+    saddw2  v\b7\().4s, v\b7\().4s, v\c7\().8h
+
+    // stage 2 sum
+    add  v\b0\().4s, v\b0\().4s, v\b1\().4s
+    add  v\b2\().4s, v\b2\().4s, v\b3\().4s
+    add  v\b4\().4s, v\b4\().4s, v\b5\().4s
+    add  v\b6\().4s, v\b6\().4s, v\b7\().4s
+
+    // stage 3 sum
+    add  v\b0\().4s, v\b0\().4s, v\b2\().4s
+    add  v\b4\().4s, v\b4\().4s, v\b6\().4s
+
+    // stage 4 sum
+    add  v0.4s, v\b0\().4s, v\b4\().4s
+    addv s0, v0.4s
+    fmov w0, s0
+    normalize_8
+.endm
+
+function satd16x8_neon, export=1
+    #define src         x0
+    #define src_stride  x1
+    #define dst         x2
+    #define dst_stride  x3
+
+    //  0,  1;   2,  3;  24, 25
+    //  4,  5;   6,  7;  26, 27
+    // 16, 17;  20, 21;  28, 29
+    // 18, 19;  22, 23;  30, 31
+
+    load_rows 0, 1, 2, src, dst, src_stride, dst_stride, 24, 25
+    load_rows 4, 5, 6, src, dst, src_stride, dst_stride, 26, 27
+    load_rows 16, 17, 20, src, dst, src_stride, dst_stride, 28, 29
+    load_rows 18, 19, 22, src, dst, src_stride, dst_stride, 30, 31
+
+    DOUBLE_HADAMARD_8X8 \
+     0,  1,  4,  5, 16, 17, 18, 19, \
+     2,  3,  6,  7, 20, 21, 22, 23, \
+    24, 25, 26, 27, 28, 29, 30, 31
+
+    SUM_DOUBLE_HADAMARD_8X8 \
+     0,  1,  4,  5, 16, 17, 18, 19, \
+     2,  3,  6,  7, 20, 21, 22, 23, \
+    24, 25, 26, 27, 28, 29, 30, 31
+
+    ret
+
+    #undef src
+    #undef src_stride
+    #undef dst
+    #undef dst_stride
+endfunc
+
 .macro satd_x8up width, height
 function satd\width\()x\height\()_neon, export=1
     mov  w13, \height
@@ -781,7 +992,6 @@ endfunc
 
 satd_x8up 8, 16
 satd_x8up 8, 32
-satd_x8up 16, 8
 satd_x8up 16, 16
 satd_x8up 16, 32
 satd_x8up 16, 64

--- a/src/arm/64/satd.S
+++ b/src/arm/64/satd.S
@@ -589,7 +589,7 @@ function satd4x16_neon, export=1
     #undef dst_stride
 endfunc
 
-.macro load_rows n0, n1, n2, src, dst, src_stride, dst_stride, should_add=1
+.macro load_rows n0, n1, n2, src, dst, src_stride, dst_stride
     ldr     d\n0, [\src]
     ldr     d\n1, [\dst]
     usubl   v\n0\().8h, v\n0\().8b, v\n1\().8b
@@ -598,10 +598,8 @@ endfunc
     ldr     d\n2, [\dst, \dst_stride]
     usubl   v\n1\().8h, v\n1\().8b, v\n2\().8b
 
-.if \should_add != 0
     add     \src, \src, \src_stride, lsl 1
     add     \dst, \dst, \dst_stride, lsl 1
-.endif
 .endm
 
 .macro HADAMARD_8X8 \
@@ -697,9 +695,6 @@ endfunc
     // stage 3 sum
     add  v0.4s, v\a0\().4s, v\a2\().4s
     addv s0, v0.4s
-
-    fmov w0, s0
-    normalize_8
 .endm
 
 function satd8x8_neon, export=1
@@ -708,15 +703,28 @@ function satd8x8_neon, export=1
     #define dst         x2
     #define dst_stride  x3
 
+    #define subtotal    w9
+    #define total       w10
+    #define w_ext       x11
+    #define w_bak       w11
+    #define width       w12
+    #define height      w13
+
+    mov  height, 8
+    mov  width, 8
+    sxtw w_ext, width
+    mov  total, wzr
+
     //  0,  1;   2,  3
     //  4,  5;   6,  7
     // 16, 17;  20, 21
     // 18, 19;  22, 23
 
+L(satd_8x8):
     load_rows 0, 1, 2, src, dst, src_stride, dst_stride
     load_rows 4, 5, 6, src, dst, src_stride, dst_stride
     load_rows 16, 17, 20, src, dst, src_stride, dst_stride
-    load_rows 18, 19, 22, src, dst, src_stride, dst_stride, 0
+    load_rows 18, 19, 22, src, dst, src_stride, dst_stride
 
     HADAMARD_8X8 \
     0, 1, 4, 5, 16, 17, 18, 19, \
@@ -726,10 +734,64 @@ function satd8x8_neon, export=1
     0, 1, 4, 5, 16, 17, 18, 19, \
     2, 3, 6, 7, 20, 21, 22, 23
 
+    fmov subtotal, s0
+    add  total, subtotal, total
+
+    sub  src, src, src_stride, lsl 3
+    sub  dst, dst, dst_stride, lsl 3
+    add  src, src, #8
+    add  dst, dst, #8
+    subs width, width, #8
+    bne  L(satd_8x8)
+
+    sub  src, src, w_ext
+    sub  dst, dst, w_ext
+    add  src, src, src_stride, lsl 3
+    add  dst, dst, dst_stride, lsl 3
+    subs height, height, #8
+    mov  width, w_bak
+    bne  L(satd_8x8)
+
+    mov  w0, total
+    normalize_8
     ret
 
     #undef src
     #undef src_stride
     #undef dst
     #undef dst_stride
+
+    #undef w_ext
+    #undef w_bak
+    #undef subtotal
+    #undef total
+    #undef height
+    #undef width
 endfunc
+
+.macro satd_x8up width, height
+function satd\width\()x\height\()_neon, export=1
+    mov  w13, \height
+    mov  w12, \width
+    sxtw x11, w12
+    mov  w10, wzr
+    b    L(satd_8x8)
+endfunc
+.endm
+
+satd_x8up 8, 16
+satd_x8up 8, 32
+satd_x8up 16, 8
+satd_x8up 16, 16
+satd_x8up 16, 32
+satd_x8up 16, 64
+satd_x8up 32, 8
+satd_x8up 32, 16
+satd_x8up 32, 32
+satd_x8up 32, 64
+satd_x8up 64, 16
+satd_x8up 64, 32
+satd_x8up 64, 64
+satd_x8up 64, 128
+satd_x8up 128, 64
+satd_x8up 128, 128

--- a/src/asm/aarch64/dist.rs
+++ b/src/asm/aarch64/dist.rs
@@ -60,6 +60,7 @@ declare_asm_dist_fn![
   (rav1e_satd4x8_neon, u8),
   (rav1e_satd4x16_neon, u8),
   (rav1e_satd8x4_neon, u8),
+  (rav1e_satd8x8_neon, u8),
   (rav1e_satd16x4_neon, u8)
 ];
 
@@ -122,7 +123,6 @@ macro_rules! impl_satd_fn {
 }
 
 impl_satd_fn![
-  (rav1e_satd8x8_neon, u8, 0, 0),
   (rav1e_satd8x16_neon, u8, 0, 1),
   (rav1e_satd8x32_neon, u8, 0, 2),
   (rav1e_satd16x8_neon, u8, 1, 0),


### PR DESCRIPTION
This roughly matches the architecture of the intrinsics: a central function that the rest fall into. Unlike the generated code from the instrinsics, this uses 8 temporary vector registers for width 8, rather than the minimum of 3. A width-16x kernel is included,  admitting a simple loop for the width-8 kernel.