### PR TITLE
HBD SATD aarch64 assembly implementation

### DIFF
--- a/src/arm/64/satd.S
+++ b/src/arm/64/satd.S
@@ -140,7 +140,7 @@ function satd4x4_neon, export=1
     #undef dst_stride
 endfunc
 
-.macro DOUBLE_HADAMARD_4X4
+.macro DOUBLE_HADAMARD_4X4 hbd=0
     // Horizontal transform
 
     butterfly v2, v3, v0, v1
@@ -163,8 +163,13 @@ endfunc
     interleave v0, v1, v2, v3
     interleave v4, v5, v6, v7
 
+.if \hbd == 0
     butterfly v2, v3, v0, v1
     butterfly v6, v7, v4, v5
+.else
+    butterflyw v2, v3, v16, v17, v0, v1
+    butterflyw v6, v7, v18, v19, v4, v5
+.endif
 .endm
 
 .macro SUM_DOUBLE_HADAMARD_4X4
@@ -1363,4 +1368,106 @@ function satd4x16_hbd_neon, export=1
     mov  w13, 16
     mov  w10, wzr
     b    L(satd_w4_hbd)
+endfunc
+
+.macro SUM_DOUBLE_HADAMARD_4X4_HBD \
+       a0 a1 a2 a3 c0 c1 c2 c3
+
+    // absolute value of transform coefficients
+    abs  v\a0\().4s, v\a0\().4s
+    abs  v\a1\().4s, v\a1\().4s
+    abs  v\a2\().4s, v\a2\().4s
+    abs  v\a3\().4s, v\a3\().4s
+    abs  v\c0\().4s, v\c0\().4s
+    abs  v\c1\().4s, v\c1\().4s
+    abs  v\c2\().4s, v\c2\().4s
+    abs  v\c3\().4s, v\c3\().4s
+
+    // stage 1 sum
+    add  v\a0\().4s, v\a0\().4s, v\a1\().4s
+    add  v\a2\().4s, v\a2\().4s, v\a3\().4s
+    add  v\c0\().4s, v\c0\().4s, v\c1\().4s
+    add  v\c2\().4s, v\c2\().4s, v\c3\().4s
+
+    // stage 2 sum
+    add  v\a0\().4s, v\a0\().4s, v\a2\().4s
+    add  v\c0\().4s, v\c0\().4s, v\c2\().4s
+
+    // stage 3 sum
+    add  v0.4s, v\a0\().4s, v\c0\().4s
+    addv s0, v0.4s
+.endm
+
+function satd8x4_hbd_neon, export=1
+    #define src         x0
+    #define src_stride  x1
+    #define dst         x2
+    #define dst_stride  x3
+
+    #define subtotal    w9
+    #define total       w10
+    #define width       w12
+
+    mov  width, 8
+    mov  total, wzr
+
+L(satd_h4_hbd):
+    ldr  q0, [src]
+    ldr  q1, [dst]
+    sub  v0.8h, v0.8h, v1.8h
+
+    ldr  q1, [src, src_stride]
+    ldr  q2, [dst, dst_stride]
+    sub  v1.8h, v1.8h, v2.8h
+
+    lsl  x8, src_stride, 1
+    lsl  x9, dst_stride, 1
+
+    ldr  q2, [src, x8]
+    ldr  q3, [dst, x9]
+    sub  v2.8h, v2.8h, v3.8h
+
+    add  x8, src_stride, src_stride, lsl 1
+    add  x9, dst_stride, dst_stride, lsl 1
+
+    ldr  q3, [src, x8]
+    ldr  q4, [dst, x9]
+    sub  v3.8h, v3.8h, v4.8h
+
+    ext  v4.16b, v0.16b, v0.16b, 8
+    ext  v5.16b, v1.16b, v1.16b, 8
+    mov  v0.d[1], v2.d[0]
+    mov  v1.d[1], v3.d[0]
+    mov  v4.d[1], v2.d[1]
+    mov  v5.d[1], v3.d[1]
+
+    DOUBLE_HADAMARD_4X4 hbd=1
+    SUM_DOUBLE_HADAMARD_4X4_HBD 2, 3, 16, 17, 6, 7, 18, 19
+
+    fmov subtotal, s0
+    add  total, subtotal, total
+
+    add  src, src, #16
+    add  dst, dst, #16
+    subs width, width, #8
+    bne  L(satd_h4_hbd)
+
+    mov  w0, total
+    normalize_4
+    ret
+
+    #undef src
+    #undef src_stride
+    #undef dst
+    #undef dst_stride
+
+    #undef subtotal
+    #undef total
+    #undef width
+endfunc
+
+function satd16x4_hbd_neon, export=1
+    mov  w12, 16
+    mov  w10, wzr
+    b    L(satd_h4_hbd)
 endfunc

--- a/src/arm/64/satd.S
+++ b/src/arm/64/satd.S
@@ -11,9 +11,18 @@
 #include "src/arm/asm.S"
 #include "util.S"
 
-.macro butterfly r0, r1, r2, r3
-    add  \r0\().8h, \r2\().8h, \r3\().8h
-    sub  \r1\().8h, \r2\().8h, \r3\().8h
+.macro butterfly r0, r1, r2, r3, t=8h
+    add  \r0\().\t, \r2\().\t, \r3\().\t
+    sub  \r1\().\t, \r2\().\t, \r3\().\t
+.endm
+
+.macro butterflyw r0, r1, r2, r3, r4, r5
+    sxtl    \r0\().4s, \r4\().4h
+    sxtl2   \r2\().4s, \r4\().8h
+    ssubw   \r1\().4s, \r0\().4s, \r5\().4h
+    ssubw2  \r3\().4s, \r2\().4s, \r5\().8h
+    saddw   \r0\().4s, \r0\().4s, \r5\().4h
+    saddw2  \r2\().4s, \r2\().4s, \r5\().8h
 .endm
 
 .macro interleave r0, r1, r2, r3
@@ -614,7 +623,7 @@ endfunc
     add     \dst, \dst, \dst_stride, lsl 1
 .endm
 
-.macro HADAMARD_8X8 \
+.macro HADAMARD_8X8_H \
        a0 a1 a2 a3 a4 a5 a6 a7 \
        b0 b1 b2 b3 b4 b5 b6 b7
 
@@ -649,6 +658,11 @@ endfunc
     interleave_quads v\a1, v\a5, v\b1, v\b5
     interleave_quads v\a2, v\a6, v\b2, v\b6
     interleave_quads v\a3, v\a7, v\b3, v\b7
+.endm
+
+.macro HADAMARD_8X8_V \
+       a0 a1 a2 a3 a4 a5 a6 a7 \
+       b0 b1 b2 b3 b4 b5 b6 b7
 
     // Vertical transform
 
@@ -709,6 +723,24 @@ endfunc
     addv s0, v0.4s
 .endm
 
+.macro SATD_8X8 \
+       a0 a1 a2 a3 a4 a5 a6 a7 \
+       b0 b1 b2 b3 b4 b5 b6 b7
+
+    HADAMARD_8X8_H \
+    \a0, \a1, \a2, \a3, \a4, \a5, \a6, \a7, \
+    \b0, \b1, \b2, \b3, \b4, \b5, \b6, \b7
+
+    HADAMARD_8X8_V \
+    \a0, \a1, \a2, \a3, \a4, \a5, \a6, \a7, \
+    \b0, \b1, \b2, \b3, \b4, \b5, \b6, \b7
+
+    SUM_HADAMARD_8X8 \
+    \a0, \a1, \a2, \a3, \a4, \a5, \a6, \a7, \
+    \b0, \b1, \b2, \b3, \b4, \b5, \b6, \b7
+.endm
+
+
 function satd8x8_neon, export=1
     #define src         x0
     #define src_stride  x1
@@ -733,11 +765,7 @@ L(satd_w8):
     load_rows 16, 17, 20, src, dst, src_stride, dst_stride
     load_rows 18, 19, 22, src, dst, src_stride, dst_stride
 
-    HADAMARD_8X8 \
-    0, 1, 4, 5, 16, 17, 18, 19, \
-    2, 3, 6, 7, 20, 21, 22, 23
-
-    SUM_HADAMARD_8X8 \
+    SATD_8X8 \
     0, 1, 4, 5, 16, 17, 18, 19, \
     2, 3, 6, 7, 20, 21, 22, 23
 
@@ -1028,3 +1056,210 @@ satd_x8up 64, 64
 satd_x8up 64, 128
 satd_x8up 128, 64
 satd_x8up 128, 128
+
+.macro load_rows_hbd n0, n1, n2, src, dst, src_stride, dst_stride
+    ldr     q\n0, [\src]
+    ldr     q\n1, [\dst]
+    sub     v\n0\().8h, v\n0\().8h, v\n1\().8h
+
+    ldr     q\n1, [\src, \src_stride]
+    ldr     q\n2, [\dst, \dst_stride]
+    sub     v\n1\().8h, v\n1\().8h, v\n2\().8h
+
+    add     \src, \src, \src_stride, lsl 1
+    add     \dst, \dst, \dst_stride, lsl 1
+.endm
+
+.macro HADAMARD_8X8_V_HBD \
+       a0 a1 a2 a3 a4 a5 a6 a7 \
+       b0 b1 b2 b3 b4 b5 b6 b7 \
+       c0 c1 c2 c3 c4 c5 c6 c7
+
+    // Vertical transform
+
+    butterflyw v\b0, v\b1, v\c0, v\c1, v\a0, v\a1
+    butterflyw v\b2, v\b3, v\c2, v\c3, v\a2, v\a3
+    butterflyw v\b4, v\b5, v\c4, v\c5, v\a4, v\a5
+    butterflyw v\b6, v\b7, v\c6, v\c7, v\a6, v\a7
+
+    butterfly v\a0, v\a2, v\b0, v\b2, 4s
+    butterfly v\a1, v\a3, v\b1, v\b3, 4s
+    butterfly v\a4, v\a6, v\b4, v\b6, 4s
+    butterfly v\a5, v\a7, v\b5, v\b7, 4s
+    butterfly v\b0, v\b2, v\c0, v\c2, 4s
+    butterfly v\b1, v\b3, v\c1, v\c3, 4s
+    butterfly v\b4, v\b6, v\c4, v\c6, 4s
+    butterfly v\b5, v\b7, v\c5, v\c7, 4s
+
+    butterfly v\c0, v\c4, v\a0, v\a4, 4s
+    butterfly v\c1, v\c5, v\a1, v\a5, 4s
+    butterfly v\c2, v\c6, v\a2, v\a6, 4s
+    butterfly v\c3, v\c7, v\a3, v\a7, 4s
+    butterfly v\a0, v\a4, v\b0, v\b4, 4s
+    butterfly v\a1, v\a5, v\b1, v\b5, 4s
+    butterfly v\a2, v\a6, v\b2, v\b6, 4s
+    butterfly v\a3, v\a7, v\b3, v\b7, 4s
+.endm
+
+.macro SUM_HADAMARD_8X8_HBD \
+       a0 a1 a2 a3 a4 a5 a6 a7 \
+       c0 c1 c2 c3 c4 c5 c6 c7
+
+    // absolute value of transform coefficients
+    abs  v\a0\().4s, v\a0\().4s
+    abs  v\a1\().4s, v\a1\().4s
+    abs  v\a2\().4s, v\a2\().4s
+    abs  v\a3\().4s, v\a3\().4s
+    abs  v\a4\().4s, v\a4\().4s
+    abs  v\a5\().4s, v\a5\().4s
+    abs  v\a6\().4s, v\a6\().4s
+    abs  v\a7\().4s, v\a7\().4s
+    abs  v\c0\().4s, v\c0\().4s
+    abs  v\c1\().4s, v\c1\().4s
+    abs  v\c2\().4s, v\c2\().4s
+    abs  v\c3\().4s, v\c3\().4s
+    abs  v\c4\().4s, v\c4\().4s
+    abs  v\c5\().4s, v\c5\().4s
+    abs  v\c6\().4s, v\c6\().4s
+    abs  v\c7\().4s, v\c7\().4s
+
+    // stage 1 sum
+    add  v\a0\().4s, v\a0\().4s, v\a1\().4s
+    add  v\a2\().4s, v\a2\().4s, v\a3\().4s
+    add  v\a4\().4s, v\a4\().4s, v\a5\().4s
+    add  v\a6\().4s, v\a6\().4s, v\a7\().4s
+    add  v\c0\().4s, v\c0\().4s, v\c1\().4s
+    add  v\c2\().4s, v\c2\().4s, v\c3\().4s
+    add  v\c4\().4s, v\c4\().4s, v\c5\().4s
+    add  v\c6\().4s, v\c6\().4s, v\c7\().4s
+
+    // stage 2 sum
+    add  v\a0\().4s, v\a0\().4s, v\a2\().4s
+    add  v\a4\().4s, v\a4\().4s, v\a6\().4s
+    add  v\c0\().4s, v\c0\().4s, v\c2\().4s
+    add  v\c4\().4s, v\c4\().4s, v\c6\().4s
+
+    // stage 3 sum
+    add  v\a0\().4s, v\a0\().4s, v\a4\().4s
+    add  v\c0\().4s, v\c0\().4s, v\c4\().4s
+
+    // stage 4 sum
+    add  v0.4s, v\a0\().4s, v\c0\().4s
+    addv s0, v0.4s
+.endm
+
+
+.macro SATD_8X8_HBD \
+       a0 a1 a2 a3 a4 a5 a6 a7 \
+       b0 b1 b2 b3 b4 b5 b6 b7 \
+       c0 c1 c2 c3 c4 c5 c6 c7
+
+    HADAMARD_8X8_H \
+    \a0, \a1, \a2, \a3, \a4, \a5, \a6, \a7, \
+    \b0, \b1, \b2, \b3, \b4, \b5, \b6, \b7
+
+    HADAMARD_8X8_V_HBD \
+    \a0, \a1, \a2, \a3, \a4, \a5, \a6, \a7, \
+    \b0, \b1, \b2, \b3, \b4, \b5, \b6, \b7, \
+    \c0, \c1, \c2, \c3, \c4, \c5, \c6, \c7
+
+    SUM_HADAMARD_8X8_HBD \
+    \a0, \a1, \a2, \a3, \a4, \a5, \a6, \a7, \
+    \c0, \c1, \c2, \c3, \c4, \c5, \c6, \c7
+.endm
+
+function satd8x8_hbd_neon, export=1
+    #define src         x0
+    #define src_stride  x1
+    #define dst         x2
+    #define dst_stride  x3
+
+    #define subtotal    w9
+    #define total       w10
+    #define w_ext       x11
+    #define w_bak       w11
+    #define width       w12
+    #define height      w13
+
+    mov  height, 8
+    mov  width, 8
+    sxtw w_ext, width
+    mov  total, wzr
+
+    //  0,  1;   2,  3;  24, 25
+    //  4,  5;   6,  7;  26, 27
+    // 16, 17;  20, 21;  28, 29
+    // 18, 19;  22, 23;  30, 31
+
+L(satd_w8up_hbd):
+    load_rows_hbd 0, 1, 2, src, dst, src_stride, dst_stride
+    load_rows_hbd 4, 5, 6, src, dst, src_stride, dst_stride
+    load_rows_hbd 16, 17, 20, src, dst, src_stride, dst_stride
+    load_rows_hbd 18, 19, 22, src, dst, src_stride, dst_stride
+
+    SATD_8X8_HBD \
+     0,  1,  4,  5, 16, 17, 18, 19, \
+     2,  3,  6,  7, 20, 21, 22, 23, \
+    24, 25, 26, 27, 28, 29, 30, 31
+
+    fmov subtotal, s0
+    add  total, subtotal, total
+
+    sub  src, src, src_stride, lsl 3
+    sub  dst, dst, dst_stride, lsl 3
+    add  src, src, #16
+    add  dst, dst, #16
+    subs width, width, #8
+    bne  L(satd_w8up_hbd)
+
+    sub  src, src, w_ext, lsl 1
+    sub  dst, dst, w_ext, lsl 1
+    add  src, src, src_stride, lsl 3
+    add  dst, dst, dst_stride, lsl 3
+    subs height, height, #8
+    mov  width, w_bak
+    bne  L(satd_w8up_hbd)
+
+    mov  w0, total
+    normalize_8
+    ret
+
+    #undef src
+    #undef src_stride
+    #undef dst
+    #undef dst_stride
+
+    #undef w_ext
+    #undef w_bak
+    #undef subtotal
+    #undef total
+    #undef height
+    #undef width
+endfunc
+
+.macro satd_x8up_hbd width, height
+function satd\width\()x\height\()_hbd_neon, export=1
+    mov  w13, \height
+    mov  w12, \width
+    sxtw x11, w12
+    mov  w10, wzr
+    b    L(satd_w8up_hbd)
+endfunc
+.endm
+
+satd_x8up_hbd 8, 16
+satd_x8up_hbd 8, 32
+satd_x8up_hbd 16, 8
+satd_x8up_hbd 16, 16
+satd_x8up_hbd 16, 32
+satd_x8up_hbd 16, 64
+satd_x8up_hbd 32, 8
+satd_x8up_hbd 32, 16
+satd_x8up_hbd 32, 32
+satd_x8up_hbd 32, 64
+satd_x8up_hbd 64, 16
+satd_x8up_hbd 64, 32
+satd_x8up_hbd 64, 64
+satd_x8up_hbd 64, 128
+satd_x8up_hbd 128, 64
+satd_x8up_hbd 128, 128

--- a/src/arm/64/satd.S
+++ b/src/arm/64/satd.S
@@ -1263,3 +1263,104 @@ satd_x8up_hbd 64, 64
 satd_x8up_hbd 64, 128
 satd_x8up_hbd 128, 64
 satd_x8up_hbd 128, 128
+
+// x0: src: *const u16,
+// x1: src_stride: isize,
+// x2: dst: *const u16,
+// x3: dst_stride: isize,
+function satd4x4_hbd_neon, export=1
+    #define src         x0
+    #define src_stride  x1
+    #define dst         x2
+    #define dst_stride  x3
+
+    #define subtotal    w9
+    #define total       w10
+    #define height      w13
+
+    mov  height, 4
+    mov  total, wzr
+
+L(satd_w4_hbd):
+    ldr  d0, [src]
+    ldr  d1, [dst]
+    sub  v0.8h, v0.8h, v1.8h
+
+    ldr  d1, [src, src_stride]
+    ldr  d2, [dst, dst_stride]
+    sub  v1.8h, v1.8h, v2.8h
+
+    add  src, src, src_stride, lsl 1
+    add  dst, dst, dst_stride, lsl 1
+
+    ldr  d2, [src]
+    ldr  d3, [dst]
+    sub  v2.8h, v2.8h, v3.8h
+
+    ldr  d3, [src, src_stride]
+    ldr  d4, [dst, src_stride]
+    sub  v3.8h, v3.8h, v4.8h
+
+    add  src, src, src_stride, lsl 1
+    add  dst, dst, dst_stride, lsl 1
+
+    // pack rows 0-2, 1-3
+    mov  v0.d[1], v2.d[0]
+    mov  v1.d[1], v3.d[0]
+
+    // Horizontal transform
+    butterfly v2, v3, v0, v1
+    interleave v0, v1, v2, v3
+    butterfly v2, v3, v0, v1
+    interleave_pairs v0, v1, v2, v3
+    // Vertical transform
+
+    butterfly v2, v3, v0, v1
+    interleave v0, v1, v2, v3
+    butterflyw v2, v3, v4, v5, v0, v1
+
+    // absolute value of transform coefficients
+    abs  v2.4s, v2.4s
+    abs  v3.4s, v3.4s
+    abs  v4.4s, v4.4s
+    abs  v5.4s, v5.4s
+
+    // stage 1 sum
+    add  v2.4s, v2.4s, v3.4s
+    add  v4.4s, v4.4s, v5.4s
+
+    // stage 2 sum
+    add  v0.4s, v2.4s, v4.4s
+    addv s0, v0.4s
+
+    fmov subtotal, s0
+    add  total, subtotal, total
+
+    subs height, height, #4
+    bne  L(satd_w4_hbd)
+
+    mov  w0, total
+    normalize_4
+    ret
+
+    #undef src
+    #undef src_stride
+    #undef dst
+    #undef dst_stride
+
+    #undef subtotal
+    #undef total
+    #undef height
+endfunc
+
+function satd4x8_hbd_neon, export=1
+    mov  w13, 8
+    mov  w10, wzr
+    b    L(satd_w4_hbd)
+endfunc
+
+function satd4x16_hbd_neon, export=1
+    mov  w13, 16
+    mov  w10, wzr
+    b    L(satd_w4_hbd)
+endfunc

--- a/src/asm/aarch64/dist.rs
+++ b/src/asm/aarch64/dist.rs
@@ -89,9 +89,11 @@ declare_asm_dist_fn![
   (rav1e_satd4x4_hbd_neon, u16),
   (rav1e_satd4x8_hbd_neon, u16),
   (rav1e_satd4x16_hbd_neon, u16),
+  (rav1e_satd8x4_hbd_neon, u16),
   (rav1e_satd8x8_hbd_neon, u16),
   (rav1e_satd8x16_hbd_neon, u16),
   (rav1e_satd8x32_hbd_neon, u16),
+  (rav1e_satd16x4_hbd_neon, u16),
   (rav1e_satd16x8_hbd_neon, u16),
   (rav1e_satd16x16_hbd_neon, u16),
   (rav1e_satd16x32_hbd_neon, u16),
@@ -280,6 +282,8 @@ static SATD_HBD_FNS_NEON: [Option<SatdHbdFn>; DIST_FNS_LENGTH] = {
   out[BLOCK_4X4 as usize] = Some(rav1e_satd4x4_hbd_neon);
   out[BLOCK_4X8 as usize] = Some(rav1e_satd4x8_hbd_neon);
   out[BLOCK_4X16 as usize] = Some(rav1e_satd4x16_hbd_neon);
+  out[BLOCK_8X4 as usize] = Some(rav1e_satd8x4_hbd_neon);
+  out[BLOCK_16X4 as usize] = Some(rav1e_satd16x4_hbd_neon);
 
   out[BLOCK_8X8 as usize] = Some(rav1e_satd8x8_hbd_neon);
   out[BLOCK_8X16 as usize] = Some(rav1e_satd8x16_hbd_neon);
@@ -428,9 +432,11 @@ mod test {
     (4, 4),
     (4, 8),
     (4, 16),
+    (8, 4),
     (8, 8),
     (8, 16),
     (8, 32),
+    (16, 4),
     (16, 8),
     (16, 16),
     (16, 32),
@@ -455,9 +461,11 @@ mod test {
     (4, 4),
     (4, 8),
     (4, 16),
+    (8, 4),
     (8, 8),
     (8, 16),
     (8, 32),
+    (16, 4),
     (16, 8),
     (16, 16),
     (16, 32),

--- a/src/asm/aarch64/dist.rs
+++ b/src/asm/aarch64/dist.rs
@@ -86,6 +86,9 @@ declare_asm_dist_fn![
   (rav1e_satd128x64_neon, u8),
   (rav1e_satd128x128_neon, u8),
   /* SATD HBD */
+  (rav1e_satd4x4_hbd_neon, u16),
+  (rav1e_satd4x8_hbd_neon, u16),
+  (rav1e_satd4x16_hbd_neon, u16),
   (rav1e_satd8x8_hbd_neon, u16),
   (rav1e_satd8x16_hbd_neon, u16),
   (rav1e_satd8x32_hbd_neon, u16),
@@ -274,6 +277,10 @@ static SATD_HBD_FNS_NEON: [Option<SatdHbdFn>; DIST_FNS_LENGTH] = {
 
   use BlockSize::*;
 
+  out[BLOCK_4X4 as usize] = Some(rav1e_satd4x4_hbd_neon);
+  out[BLOCK_4X8 as usize] = Some(rav1e_satd4x8_hbd_neon);
+  out[BLOCK_4X16 as usize] = Some(rav1e_satd4x16_hbd_neon);
+
   out[BLOCK_8X8 as usize] = Some(rav1e_satd8x8_hbd_neon);
   out[BLOCK_8X16 as usize] = Some(rav1e_satd8x16_hbd_neon);
   out[BLOCK_8X32 as usize] = Some(rav1e_satd8x32_hbd_neon);
@@ -418,6 +425,9 @@ mod test {
   );
 
   test_dist_fns!(
+    (4, 4),
+    (4, 8),
+    (4, 16),
     (8, 8),
     (8, 16),
     (8, 32),
@@ -442,6 +452,9 @@ mod test {
   );
 
   test_dist_fns!(
+    (4, 4),
+    (4, 8),
+    (4, 16),
     (8, 8),
     (8, 16),
     (8, 32),


### PR DESCRIPTION
Adds 4x4, 8x4 and 8x8 kernels as well as functions that can be composed from them. Not restricted to 10-bit input but valid for 12-bit input as well.