### PR TITLE
Replace hawktracer with tracing-chrome

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,15 +395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,15 +751,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
@@ -970,6 +952,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1036,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1058,12 @@ name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pkg-config"
@@ -1159,6 +1163,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89dff0959d98c9758c88826cc002e2c3d0b9dfac4139711d1f30de442f1139b"
+dependencies = [
+ "profiling-procmacros",
+ "tracing",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb156a45b6b9fe8027497422179fb65afc84d36707a7ca98297bf06bccb8d43f"
+dependencies = [
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1263,11 +1287,11 @@ dependencies = [
  "once_cell",
  "paste",
  "pretty_assertions",
+ "profiling",
  "quickcheck",
  "quickcheck_macros",
  "rand",
  "rand_chacha",
- "rust_hawktracer",
  "rustc_version",
  "scan_fmt",
  "semver",
@@ -1278,6 +1302,9 @@ dependencies = [
  "system-deps",
  "thiserror",
  "toml",
+ "tracing",
+ "tracing-chrome",
+ "tracing-subscriber",
  "v_frame",
  "wasm-bindgen",
  "y4m",
@@ -1347,29 +1374,12 @@ name = "rust_hawktracer_normal_macro"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a570059949e1dcdc6f35228fa389f54c2c84dfe0c94c05022baacd56eacd2e9"
-dependencies = [
- "rust_hawktracer_sys",
-]
 
 [[package]]
 name = "rust_hawktracer_proc_macro"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb626abdbed5e93f031baae60d72032f56bc964e11ac2ff65f2ba3ed98d6d3e1"
-dependencies = [
- "rust_hawktracer_sys",
-]
-
-[[package]]
-name = "rust_hawktracer_sys"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cc853071df5815fa6c087452d1b533f7c884c836b8a7393b4ff88090cc4c95"
-dependencies = [
- "cmake",
- "itertools 0.8.2",
- "pkg-config",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -1485,6 +1495,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1611,6 +1630,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +1699,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496b3cd5447f7ff527bbbf19b071ad542a000adf297d4127078b4dfdb931f41a"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,6 +1823,12 @@ dependencies = [
  "rust_hawktracer",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,12 @@ desync_finder = ["backtrace"]
 bench = []
 check_asm = []
 capi = ["scan_fmt"]
-tracing = ["rust_hawktracer/profiling_enabled", "rust_hawktracer/pkg_config"]
+tracing = [
+  "profiling/profile-with-tracing",
+  "tracing-subscriber",
+  "tracing-chrome",
+  "dep:tracing"
+]
 scenechange = []
 serialize = ["serde", "toml", "v_frame/serialize", "serde-big-array"]
 wasm = ["wasm-bindgen"]
@@ -102,12 +107,15 @@ fern = { version = "0.6", optional = true }
 itertools = "0.11"
 simd_helpers = "0.1"
 wasm-bindgen = { version = "0.2.88", optional = true }
-rust_hawktracer = "0.7.0"
 nom = { version = "7.1.3", optional = true }
 new_debug_unreachable = "1.0.4"
 once_cell = "1.18.0"
 av1-grain = { version = "0.2.2", features = ["serialize"] }
 serde-big-array = { version = "0.5.1", optional = true }
+profiling = { version = "1" }
+tracing-subscriber = { version = "0.3.18", optional = true }
+tracing-chrome = { version = "0.7.1", optional = true }
+tracing = { version = "0.1.40", optional = true }
 
 [dependencies.image]
 version = "0.24.7"

--- a/doc/PROFILING.md
+++ b/doc/PROFILING.md
@@ -8,9 +8,9 @@
   - [Instruments](#instruments)
 - [Generic profiling](#generic-profiling)
   - [Perf](#perf)
+- [Instrumented profiling](#instrumented-profiling)
   - [uftrace](#uftrace)
-- [Tracing](#tracing)
-  - [Hawktracer](#hawktracer)
+  - [tracing](#tracing)
 - [Codegen Inspection](#codegen-inspection)
   - [Assembly](#assembly)
 </details>
@@ -54,6 +54,8 @@ $ perf record --call-graph dwarf target/release/rav1e ~/sample.y4m -o /dev/null
 $ perf report
 ```
 
+## Instrumented profiling
+
 ### uftrace
 
 [uftrace](https://github.com/namhyung/uftrace) is an ELF-specific tracer.
@@ -65,17 +67,11 @@ $ uftrace record --no-libcall -D 5 target/release/rav1e ~/sample.y4m -o /dev/nul
 $ uftrace report
 ```
 
-## Tracing
+### tracing
 
-### Hawktracer
-
-We use [rust\_hawktracer](https://github.com/AlexEne/rust_hawktracer) to
-measure specific codepath timings. Building `--features=tracing` enables it.
-Use the standard [hawktrace-convert](https://hawktracer.org) to produce graphs.
-
-Currently there are issues where rust_hawktracer fails to build, as a result
-we have set it to use the system hawktracer library. On Arch Linux this may
-be installed from the AUR package hawktracer-git.
+We use [profiling](https://crates.io/crates/profiling) to measure specific
+codepath timings. Building `--features=tracing` enables it using the
+[tracing](https://crates.io/crates/tracing) backend.
 
 ## Codegen Inspection
 

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -12,7 +12,6 @@ use crate::rdo::DistortionScale;
 use crate::tiling::*;
 use crate::util::*;
 use itertools::izip;
-use rust_hawktracer::*;
 
 #[derive(Debug, Default, Clone)]
 pub struct ActivityMask {
@@ -20,7 +19,7 @@ pub struct ActivityMask {
 }
 
 impl ActivityMask {
-  #[hawktracer(ActivityMask_from_plane)]
+  #[profiling::function]
   pub fn from_plane<T: Pixel>(luma_plane: &Plane<T>) -> ActivityMask {
     let PlaneConfig { width, height, .. } = luma_plane.cfg;
 
@@ -55,7 +54,7 @@ impl ActivityMask {
     ActivityMask { variances: variances.into_boxed_slice() }
   }
 
-  #[hawktracer(ActivityMask_fill_scales)]
+  #[profiling::function]
   pub fn fill_scales(
     &self, bit_depth: usize, activity_scales: &mut Box<[DistortionScale]>,
   ) {

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -28,7 +28,6 @@ use crate::stats::EncoderStats;
 use crate::tiling::Area;
 use crate::util::Pixel;
 use arrayvec::ArrayVec;
-use rust_hawktracer::*;
 use std::cmp;
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
@@ -316,7 +315,7 @@ impl<T: Pixel> ContextInner<T> {
     }
   }
 
-  #[hawktracer(send_frame)]
+  #[profiling::function]
   pub fn send_frame(
     &mut self, mut frame: Option<Arc<Frame<T>>>,
     params: Option<FrameParameters>,
@@ -648,7 +647,7 @@ impl<T: Pixel> ContextInner<T> {
   /// `rec_buffer` and `lookahead_rec_buffer` on the `FrameInvariants`. This
   /// function must be called after every new `FrameInvariants` is initially
   /// computed.
-  #[hawktracer(compute_lookahead_motion_vectors)]
+  #[profiling::function]
   fn compute_lookahead_motion_vectors(&mut self, output_frameno: u64) {
     let frame_data = self.frame_data.get(&output_frameno).unwrap();
 
@@ -861,7 +860,7 @@ impl<T: Pixel> ContextInner<T> {
       });
   }
 
-  #[hawktracer(compute_keyframe_placement)]
+  #[profiling::function]
   pub fn compute_keyframe_placement(
     lookahead_frames: &[&Arc<Frame<T>>], keyframes_forced: &BTreeSet<u64>,
     keyframe_detector: &mut SceneChangeDetector<T>,
@@ -880,7 +879,7 @@ impl<T: Pixel> ContextInner<T> {
     *next_lookahead_frame += 1;
   }
 
-  #[hawktracer(compute_frame_invariants)]
+  #[profiling::function]
   pub fn compute_frame_invariants(&mut self) {
     while self.set_frame_properties(self.next_lookahead_output_frameno).is_ok()
     {
@@ -893,7 +892,7 @@ impl<T: Pixel> ContextInner<T> {
     }
   }
 
-  #[hawktracer(update_block_importances)]
+  #[profiling::function]
   fn update_block_importances(
     fi: &FrameInvariants<T>, me_stats: &crate::me::FrameMEStats,
     frame: &Frame<T>, reference_frame: &Frame<T>, bit_depth: usize,
@@ -1056,7 +1055,7 @@ impl<T: Pixel> ContextInner<T> {
   }
 
   /// Computes the block importances for the current output frame.
-  #[hawktracer(compute_block_importances)]
+  #[profiling::function]
   fn compute_block_importances(&mut self) {
     // SEF don't need block importances.
     if self.frame_data[&self.output_frameno]
@@ -1280,7 +1279,7 @@ impl<T: Pixel> ContextInner<T> {
     }
   }
 
-  #[hawktracer(encode_show_existing_packet)]
+  #[profiling::function]
   pub fn encode_show_existing_packet(
     &mut self, cur_output_frameno: u64,
   ) -> Result<Packet<T>, EncoderStatus> {
@@ -1316,7 +1315,7 @@ impl<T: Pixel> ContextInner<T> {
     self.finalize_packet(rec, source, input_frameno, frame_type, qp, enc_stats)
   }
 
-  #[hawktracer(encode_normal_packet)]
+  #[profiling::function]
   pub fn encode_normal_packet(
     &mut self, cur_output_frameno: u64,
   ) -> Result<Packet<T>, EncoderStatus> {
@@ -1479,7 +1478,7 @@ impl<T: Pixel> ContextInner<T> {
     }
   }
 
-  #[hawktracer(receive_packet)]
+  #[profiling::function]
   pub fn receive_packet(&mut self) -> Result<Packet<T>, EncoderStatus> {
     if self.done_processing() {
       return Err(EncoderStatus::LimitReached);
@@ -1545,7 +1544,7 @@ impl<T: Pixel> ContextInner<T> {
     })
   }
 
-  #[hawktracer(garbage_collect)]
+  #[profiling::function]
   fn garbage_collect(&mut self, cur_input_frameno: u64) {
     if cur_input_frameno == 0 {
       return;

--- a/src/api/lookahead.rs
+++ b/src/api/lookahead.rs
@@ -15,7 +15,6 @@ use crate::transform::TxSize;
 use crate::util::Aligned;
 use crate::Pixel;
 use rayon::iter::*;
-use rust_hawktracer::*;
 use std::sync::Arc;
 use v_frame::frame::Frame;
 use v_frame::pixel::CastFromPrimitive;
@@ -27,7 +26,7 @@ pub(crate) const IMP_BLOCK_SIZE_IN_MV_UNITS: i64 =
 pub(crate) const IMP_BLOCK_AREA_IN_MV_UNITS: i64 =
   IMP_BLOCK_SIZE_IN_MV_UNITS * IMP_BLOCK_SIZE_IN_MV_UNITS;
 
-#[hawktracer(estimate_intra_costs)]
+#[profiling::function]
 pub(crate) fn estimate_intra_costs<T: Pixel>(
   temp_plane: &mut Plane<T>, frame: &Frame<T>, bit_depth: usize,
   cpu_feature_level: CpuFeatureLevel,
@@ -123,7 +122,7 @@ pub(crate) fn estimate_intra_costs<T: Pixel>(
   intra_costs.into_boxed_slice()
 }
 
-#[hawktracer(estimate_importance_block_difference)]
+#[profiling::function]
 pub(crate) fn estimate_importance_block_difference<T: Pixel>(
   frame: Arc<Frame<T>>, ref_frame: Arc<Frame<T>>,
 ) -> f64 {
@@ -179,7 +178,7 @@ pub(crate) fn estimate_importance_block_difference<T: Pixel>(
   imp_block_costs as f64 / (w_in_imp_b * h_in_imp_b) as f64
 }
 
-#[hawktracer(estimate_inter_costs)]
+#[profiling::function]
 pub(crate) fn estimate_inter_costs<T: Pixel>(
   frame: Arc<Frame<T>>, ref_frame: Arc<Frame<T>>, bit_depth: usize,
   mut config: EncoderConfig, sequence: Arc<Sequence>, buffer: RefMEStats,
@@ -268,7 +267,7 @@ pub(crate) fn estimate_inter_costs<T: Pixel>(
   inter_costs as f64 / (w_in_imp_b * h_in_imp_b) as f64
 }
 
-#[hawktracer(compute_motion_vectors)]
+#[profiling::function]
 pub(crate) fn compute_motion_vectors<T: Pixel>(
   fi: &mut FrameInvariants<T>, fs: &mut FrameState<T>, inter_cfg: &InterConfig,
 ) {

--- a/src/bin/muxer/ivf.rs
+++ b/src/bin/muxer/ivf.rs
@@ -12,7 +12,6 @@ use super::Muxer;
 use crate::error::*;
 use ivf::*;
 use rav1e::prelude::*;
-use rust_hawktracer::*;
 use std::fs;
 use std::fs::File;
 use std::io;
@@ -37,7 +36,7 @@ impl Muxer for IvfMuxer {
     );
   }
 
-  #[hawktracer(write_frame)]
+  #[profiling::function]
   fn write_frame(&mut self, pts: u64, data: &[u8], _frame_type: FrameType) {
     write_ivf_frame(&mut self.output, pts, data);
   }

--- a/src/bin/muxer/y4m.rs
+++ b/src/bin/muxer/y4m.rs
@@ -9,11 +9,10 @@
 
 use crate::decoder::VideoDetails;
 use rav1e::prelude::*;
-use rust_hawktracer::*;
 use std::io::Write;
 use std::slice;
 
-#[hawktracer(write_y4m_frame)]
+#[profiling::function]
 pub fn write_y4m_frame<T: Pixel>(
   y4m_enc: &mut y4m::Encoder<Box<dyn Write + Send>>, rec: &Frame<T>,
   y4m_details: VideoDetails,

--- a/src/bin/rav1e-ch.rs
+++ b/src/bin/rav1e-ch.rs
@@ -358,16 +358,20 @@ fn do_encode<T: Pixel, D: Decoder>(
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
   #[cfg(feature = "tracing")]
-  use rust_hawktracer::*;
   init_logger();
 
   #[cfg(feature = "tracing")]
-  let instance = HawktracerInstance::new();
+  let (chrome_layer, _guard) =
+    tracing_chrome::ChromeLayerBuilder::new().build();
+
   #[cfg(feature = "tracing")]
-  let _listener = instance.create_listener(HawktracerListenerType::ToFile {
-    file_path: "trace.bin".into(),
-    buffer_size: 4096,
-  });
+  {
+    use tracing_subscriber::layer::subscriberext;
+    tracing::subscriber::set_global_default(
+      tracing_subscriber::registry().with(chrome_layer),
+    )
+    .unwrap();
+  }
 
   run().map_err(|e| {
     error::print_error(&e);

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -12,7 +12,6 @@ use rav1e::data::EncoderStats;
 use rav1e::prelude::Rational;
 use rav1e::prelude::*;
 use rav1e::{Packet, Pixel};
-use rust_hawktracer::*;
 use std::fmt;
 use std::time::Instant;
 
@@ -30,7 +29,7 @@ pub struct FrameSummary {
   pub enc_stats: EncoderStats,
 }
 
-#[hawktracer(build_frame_summary)]
+#[profiling::function]
 pub fn build_frame_summary<T: Pixel>(
   packets: Packet<T>, bit_depth: usize, chroma_sampling: ChromaSampling,
   metrics_cli: MetricsEnabled,

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -13,7 +13,6 @@ use crate::encoder::FrameInvariants;
 use crate::frame::*;
 use crate::tiling::*;
 use crate::util::{clamp, msb, CastFromPrimitive, Pixel};
-use rust_hawktracer::*;
 
 use crate::cpu_features::CpuFeatureLevel;
 use std::cmp;
@@ -322,7 +321,7 @@ fn adjust_strength(strength: i32, var: i32) -> i32 {
   }
 }
 
-#[hawktracer(cdef_analyze_superblock_range)]
+#[profiling::function]
 pub fn cdef_analyze_superblock_range<T: Pixel>(
   fi: &FrameInvariants<T>, in_frame: &Frame<T>, blocks: &TileBlocks<'_>,
   sb_w: usize, sb_h: usize,
@@ -337,7 +336,7 @@ pub fn cdef_analyze_superblock_range<T: Pixel>(
   ret
 }
 
-#[hawktracer(cdef_analyze_superblock)]
+#[profiling::function]
 pub fn cdef_analyze_superblock<T: Pixel>(
   fi: &FrameInvariants<T>, in_frame: &Frame<T>, blocks: &TileBlocks<'_>,
   sbo: TileSuperBlockOffset,
@@ -398,7 +397,7 @@ pub fn cdef_analyze_superblock<T: Pixel>(
 /// # Panics
 ///
 /// - If called with invalid parameters
-#[hawktracer(cdef_filter_superblock)]
+#[profiling::function]
 pub fn cdef_filter_superblock<T: Pixel>(
   fi: &FrameInvariants<T>, input: &Frame<T>, output: &mut TileMut<'_, T>,
   blocks: &TileBlocks<'_>, tile_sbo: TileSuperBlockOffset, cdef_index: u8,
@@ -594,7 +593,7 @@ pub fn cdef_filter_superblock<T: Pixel>(
 //   tile boundary), the filtering process ignores input pixels that
 //   don't exist.
 
-#[hawktracer(cdef_filter_tile)]
+#[profiling::function]
 pub fn cdef_filter_tile<T: Pixel>(
   fi: &FrameInvariants<T>, input: &Frame<T>, tb: &TileBlocks,
   output: &mut TileMut<'_, T>,

--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -12,7 +12,6 @@ use std::mem::MaybeUninit;
 use super::*;
 
 use crate::predict::PredictionMode;
-use rust_hawktracer::*;
 
 pub const MAX_PLANES: usize = 3;
 
@@ -1124,7 +1123,7 @@ impl<'a> ContextWriter<'a> {
     }
   }
 
-  #[hawktracer(setup_mvref_list)]
+  #[profiling::function]
   fn setup_mvref_list<T: Pixel>(
     &self, bo: TileBlockOffset, ref_frames: [RefType; 2],
     mv_stack: &mut ArrayVec<CandidateMV, 9>, bsize: BlockSize,

--- a/src/deblock.rs
+++ b/src/deblock.rs
@@ -18,7 +18,6 @@ use crate::tiling::*;
 use crate::util::{clamp, ILog, Pixel};
 use crate::DeblockState;
 use rayon::iter::*;
-use rust_hawktracer::*;
 use std::cmp;
 
 fn deblock_adjusted_level(
@@ -1291,7 +1290,7 @@ fn sse_h_edge<T: Pixel>(
 }
 
 // Deblocks all edges, vertical and horizontal, in a single plane
-#[hawktracer(deblock_plane)]
+#[profiling::function]
 pub fn deblock_plane<T: Pixel>(
   deblock: &DeblockState, p: &mut PlaneRegionMut<T>, pli: usize,
   blocks: &TileBlocks, crop_w: usize, crop_h: usize, bd: usize,
@@ -1541,7 +1540,7 @@ fn sse_plane<T: Pixel>(
 }
 
 // Deblocks all edges in all planes of a frame
-#[hawktracer(deblock_filter_frame)]
+#[profiling::function]
 pub fn deblock_filter_frame<T: Pixel>(
   deblock: &DeblockState, tile: &mut TileMut<T>, blocks: &TileBlocks,
   crop_w: usize, crop_h: usize, bd: usize, planes: usize,
@@ -1617,7 +1616,7 @@ fn sse_optimize<T: Pixel>(
   level
 }
 
-#[hawktracer(deblock_filter_optimize)]
+#[profiling::function]
 pub fn deblock_filter_optimize<T: Pixel, U: Pixel>(
   fi: &FrameInvariants<T>, rec: &Tile<U>, input: &Tile<U>,
   blocks: &TileBlocks, crop_w: usize, crop_h: usize,

--- a/src/lrf.rs
+++ b/src/lrf.rs
@@ -24,7 +24,6 @@ use crate::frame::{
 };
 use crate::tiling::{Area, PlaneRegion, PlaneRegionMut, Rect};
 use crate::util::{clamp, CastFromPrimitive, ILog, Pixel};
-use rust_hawktracer::*;
 use std::cmp;
 use std::iter::FusedIterator;
 use std::ops::{Index, IndexMut};
@@ -526,7 +525,7 @@ impl<'a, T: Pixel> Iterator for HorzPaddedIter<'a, T> {
 impl<T: Pixel> ExactSizeIterator for HorzPaddedIter<'_, T> {}
 impl<T: Pixel> FusedIterator for HorzPaddedIter<'_, T> {}
 
-#[hawktracer(setup_integral_image)]
+#[profiling::function]
 pub fn setup_integral_image<T: Pixel>(
   integral_image_buffer: &mut IntegralImageBuffer,
   integral_image_stride: usize, crop_w: usize, crop_h: usize, stripe_w: usize,
@@ -626,7 +625,7 @@ pub fn setup_integral_image<T: Pixel>(
   }
 }
 
-#[hawktracer(sgrproj_stripe_filter)]
+#[profiling::function]
 pub fn sgrproj_stripe_filter<T: Pixel, U: Pixel>(
   set: u8, xqd: [i8; 2], fi: &FrameInvariants<T>,
   integral_image_buffer: &IntegralImageBuffer, integral_image_stride: usize,
@@ -843,7 +842,7 @@ pub fn sgrproj_stripe_filter<T: Pixel, U: Pixel>(
 
 // Input params follow the same rules as sgrproj_stripe_filter.
 // Inputs are relative to the colocated slice views.
-#[hawktracer(sgrproj_solve)]
+#[profiling::function]
 pub fn sgrproj_solve<T: Pixel>(
   set: u8, fi: &FrameInvariants<T>,
   integral_image_buffer: &IntegralImageBuffer, input: &PlaneRegion<'_, T>,
@@ -1095,7 +1094,7 @@ pub fn sgrproj_solve<T: Pixel>(
   }
 }
 
-#[hawktracer(wiener_stripe_filter)]
+#[profiling::function]
 fn wiener_stripe_filter<T: Pixel>(
   coeffs: [[i8; 3]; 2], fi: &FrameInvariants<T>, crop_w: usize, crop_h: usize,
   stripe_w: usize, stripe_h: usize, stripe_x: usize, stripe_y: isize,
@@ -1484,7 +1483,7 @@ impl RestorationState {
     }
   }
 
-  #[hawktracer(lrf_filter_frame)]
+  #[profiling::function]
   pub fn lrf_filter_frame<T: Pixel>(
     &mut self, out: &mut Frame<T>, pre_cdef: &Frame<T>,
     fi: &FrameInvariants<T>,

--- a/src/me.rs
+++ b/src/me.rs
@@ -24,7 +24,6 @@ use crate::util::{clamp, Pixel};
 use crate::FrameInvariants;
 
 use arrayvec::*;
-use rust_hawktracer::*;
 use std::ops::{Index, IndexMut};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
@@ -383,7 +382,7 @@ impl MotionEstimationSubsets {
   }
 }
 
-#[hawktracer(get_subset_predictors)]
+#[profiling::function]
 fn get_subset_predictors(
   tile_bo: TileBlockOffset, tile_me_stats: &TileMEStats<'_>,
   frame_ref_opt: Option<ReadGuardMEStats<'_>>, ref_frame_id: usize,
@@ -690,7 +689,7 @@ fn refine_subsampled_motion_estimate<T: Pixel>(
   }
 }
 
-#[hawktracer(full_pixel_me)]
+#[profiling::function]
 fn full_pixel_me<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &TileStateMut<'_, T>,
   org_region: &PlaneRegion<T>, p_ref: &Plane<T>, tile_bo: TileBlockOffset,
@@ -881,7 +880,7 @@ fn sub_pixel_me<T: Pixel>(
   );
 }
 
-#[hawktracer(get_best_predictor)]
+#[profiling::function]
 fn get_best_predictor<T: Pixel>(
   fi: &FrameInvariants<T>, po: PlaneOffset, org_region: &PlaneRegion<T>,
   p_ref: &Plane<T>, predictors: &[MotionVector], bit_depth: usize,
@@ -952,7 +951,7 @@ const DIAMOND_R1_PATTERN: [MotionVector; 4] = search_pattern!(
 /// For each step size, candidate motion vectors are examined for improvement
 /// to the current search location. The search location is moved to the best
 /// candidate (if any). This is repeated until the search location stops moving.
-#[hawktracer(fullpel_diamond_search)]
+#[profiling::function]
 fn fullpel_diamond_search<T: Pixel>(
   fi: &FrameInvariants<T>, po: PlaneOffset, org_region: &PlaneRegion<T>,
   p_ref: &Plane<T>, current: &mut MotionSearchResult, bit_depth: usize,
@@ -1052,7 +1051,7 @@ const SQUARE_REFINE_PATTERN: [MotionVector; 8] = search_pattern!(
 ///
 /// `current` provides the initial search location and serves as
 /// the output for the final search results.
-#[hawktracer(hexagon_search)]
+#[profiling::function]
 fn hexagon_search<T: Pixel>(
   fi: &FrameInvariants<T>, po: PlaneOffset, org_region: &PlaneRegion<T>,
   p_ref: &Plane<T>, current: &mut MotionSearchResult, bit_depth: usize,
@@ -1167,7 +1166,7 @@ const UMH_PATTERN: [MotionVector; 16] = search_pattern!(
 /// the output for the final search results.
 ///
 /// `me_range` parameter determines how far these stages can search.
-#[hawktracer(uneven_multi_hex_search)]
+#[profiling::function]
 fn uneven_multi_hex_search<T: Pixel>(
   fi: &FrameInvariants<T>, po: PlaneOffset, org_region: &PlaneRegion<T>,
   p_ref: &Plane<T>, current: &mut MotionSearchResult, bit_depth: usize,
@@ -1308,7 +1307,7 @@ fn uneven_multi_hex_search<T: Pixel>(
 /// For each step size, candidate motion vectors are examined for improvement
 /// to the current search location. The search location is moved to the best
 /// candidate (if any). This is repeated until the search location stops moving.
-#[hawktracer(subpel_diamond_search)]
+#[profiling::function]
 fn subpel_diamond_search<T: Pixel>(
   fi: &FrameInvariants<T>, po: PlaneOffset, org_region: &PlaneRegion<T>,
   _p_ref: &Plane<T>, bit_depth: usize, pmv: [MotionVector; 2], lambda: u32,
@@ -1461,7 +1460,7 @@ fn compute_mv_rd<T: Pixel>(
   MVCandidateRD { cost: 256 * sad as u64 + rate as u64 * lambda as u64, sad }
 }
 
-#[hawktracer(full_search)]
+#[profiling::function]
 fn full_search<T: Pixel>(
   fi: &FrameInvariants<T>, x_lo: isize, x_hi: isize, y_lo: isize, y_hi: isize,
   w: usize, h: usize, org_region: &PlaneRegion<T>, p_ref: &Plane<T>,

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -14,7 +14,6 @@ use crate::quantize::{ac_q, dc_q, select_ac_qi, select_dc_qi};
 use crate::util::{
   bexp64, bexp_q24, blog64, clamp, q24_to_q57, q57, q57_to_q24, Pixel,
 };
-use rust_hawktracer::*;
 use std::cmp;
 
 // The number of frame sub-types for which we track distinct parameters.
@@ -720,7 +719,7 @@ impl RCState {
   }
 
   // TODO: Separate quantizers for Cb and Cr.
-  #[hawktracer(select_qi)]
+  #[profiling::function]
   pub(crate) fn select_qi<T: Pixel>(
     &self, ctx: &ContextInner<T>, output_frameno: u64, fti: usize,
     maybe_prev_log_base_q: Option<i64>, log_isqrt_mean_scale: i64,
@@ -1069,7 +1068,7 @@ impl RCState {
     (log_base_q, log_q)
   }
 
-  #[hawktracer(RCState_update_state)]
+  #[profiling::function]
   pub fn update_state(
     &mut self, bits: i64, fti: usize, show_frame: bool, log_target_q: i64,
     trial: bool, droppable: bool,

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -46,7 +46,6 @@ use crate::{encode_block_post_cdef, encode_block_pre_cdef};
 
 use arrayvec::*;
 use itertools::izip;
-use rust_hawktracer::*;
 use std::fmt;
 use std::mem::MaybeUninit;
 
@@ -811,7 +810,7 @@ const fn dmv_in_range(mv: MotionVector, ref_mv: MotionVector) -> bool {
 }
 
 #[inline]
-#[hawktracer(luma_chroma_mode_rdo)]
+#[profiling::function]
 fn luma_chroma_mode_rdo<T: Pixel>(
   luma_mode: PredictionMode, fi: &FrameInvariants<T>, bsize: BlockSize,
   tile_bo: TileBlockOffset, ts: &mut TileStateMut<'_, T>,
@@ -958,7 +957,7 @@ fn luma_chroma_mode_rdo<T: Pixel>(
 ///
 /// - If the best RD found is negative.
 ///   This should never happen and indicates a development error.
-#[hawktracer(rdo_mode_decision)]
+#[profiling::function]
 pub fn rdo_mode_decision<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, bsize: BlockSize, tile_bo: TileBlockOffset,
@@ -1116,7 +1115,7 @@ pub fn rdo_mode_decision<T: Pixel>(
   }
 }
 
-#[hawktracer(inter_frame_rdo_mode_decision)]
+#[profiling::function]
 fn inter_frame_rdo_mode_decision<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, bsize: BlockSize, tile_bo: TileBlockOffset,
@@ -1389,7 +1388,7 @@ fn inter_frame_rdo_mode_decision<T: Pixel>(
   best
 }
 
-#[hawktracer(intra_frame_rdo_mode_decision)]
+#[profiling::function]
 fn intra_frame_rdo_mode_decision<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, bsize: BlockSize, tile_bo: TileBlockOffset,
@@ -1588,7 +1587,7 @@ fn intra_frame_rdo_mode_decision<T: Pixel>(
 /// # Panics
 ///
 /// - If the block size is invalid for subsampling.
-#[hawktracer(rdo_cfl_alpha)]
+#[profiling::function]
 pub fn rdo_cfl_alpha<T: Pixel>(
   ts: &mut TileStateMut<'_, T>, tile_bo: TileBlockOffset, bsize: BlockSize,
   luma_tx_size: TxSize, fi: &FrameInvariants<T>,
@@ -1944,7 +1943,7 @@ fn rdo_partition_simple<T: Pixel, W: Writer>(
 ///
 /// - If the best RD found is negative.
 ///   This should never happen, and indicates a development error.
-#[hawktracer(rdo_partition_decision)]
+#[profiling::function]
 pub fn rdo_partition_decision<T: Pixel, W: Writer>(
   fi: &FrameInvariants<T>, ts: &mut TileStateMut<'_, T>,
   cw: &mut ContextWriter, w_pre_cdef: &mut W, w_post_cdef: &mut W,
@@ -2022,7 +2021,7 @@ pub fn rdo_partition_decision<T: Pixel, W: Writer>(
   }
 }
 
-#[hawktracer(rdo_loop_plane_error)]
+#[profiling::function]
 fn rdo_loop_plane_error<T: Pixel>(
   base_sbo: TileSuperBlockOffset, offset_sbo: TileSuperBlockOffset,
   sb_w: usize, sb_h: usize, fi: &FrameInvariants<T>, ts: &TileStateMut<'_, T>,
@@ -2099,7 +2098,7 @@ fn rdo_loop_plane_error<T: Pixel>(
 /// # Panics
 ///
 /// - If both CDEF and LRF are disabled.
-#[hawktracer(rdo_loop_decision)]
+#[profiling::function]
 pub fn rdo_loop_decision<T: Pixel, W: Writer>(
   base_sbo: TileSuperBlockOffset, fi: &FrameInvariants<T>,
   ts: &mut TileStateMut<'_, T>, cw: &mut ContextWriter, w: &mut W,

--- a/src/scenechange/fast.rs
+++ b/src/scenechange/fast.rs
@@ -8,7 +8,6 @@ use crate::{
   scenechange::fast_idiv,
 };
 use debug_unreachable::debug_unreachable;
-use rust_hawktracer::*;
 use v_frame::pixel::Pixel;
 
 use super::{ScaleFunction, SceneChangeDetector, ScenecutResult};
@@ -19,7 +18,7 @@ pub(super) const FAST_THRESHOLD: f64 = 18.0;
 impl<T: Pixel> SceneChangeDetector<T> {
   /// The fast algorithm detects fast cuts using a raw difference
   /// in pixel values between the scaled frames.
-  #[hawktracer(fast_scenecut)]
+  #[profiling::function]
   pub(super) fn fast_scenecut(
     &mut self, frame1: Arc<Frame<T>>, frame2: Arc<Frame<T>>,
   ) -> ScenecutResult {
@@ -104,7 +103,7 @@ impl<T: Pixel> SceneChangeDetector<T> {
   }
 
   /// Calculates the average sum of absolute difference (SAD) per pixel between 2 planes
-  #[hawktracer(delta_in_planes)]
+  #[profiling::function]
   fn delta_in_planes(&self, plane1: &Plane<T>, plane2: &Plane<T>) -> f64 {
     let delta = sad_plane::sad_plane(plane1, plane2, self.cpu_feature_level);
 

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -16,7 +16,6 @@ use crate::encoder::Sequence;
 use crate::frame::*;
 use crate::me::RefMEStats;
 use crate::util::Pixel;
-use rust_hawktracer::*;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -161,7 +160,7 @@ impl<T: Pixel> SceneChangeDetector<T> {
   /// to the second frame in `frame_set`.
   ///
   /// This will gracefully handle the first frame in the video as well.
-  #[hawktracer(analyze_next_frame)]
+  #[profiling::function]
   pub fn analyze_next_frame(
     &mut self, frame_set: &[&Arc<Frame<T>>], input_frameno: u64,
     previous_keyframe: u64,

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -16,11 +16,10 @@ use crate::tiling::TileStateMut;
 use crate::util::Pixel;
 use crate::FrameInvariants;
 use crate::FrameState;
-use rust_hawktracer::*;
 
 pub const MAX_SEGMENTS: usize = 8;
 
-#[hawktracer(segmentation_optimize)]
+#[profiling::function]
 pub fn segmentation_optimize<T: Pixel>(
   fi: &FrameInvariants<T>, fs: &mut FrameState<T>,
 ) {
@@ -160,7 +159,7 @@ fn segmentation_optimize_inner<T: Pixel>(
   fs.segmentation.update_threshold(fi.base_q_idx, fi.config.bit_depth);
 }
 
-#[hawktracer(select_segment)]
+#[profiling::function]
 pub fn select_segment<T: Pixel>(
   fi: &FrameInvariants<T>, ts: &TileStateMut<'_, T>, tile_bo: TileBlockOffset,
   bsize: BlockSize, skip: bool,


### PR DESCRIPTION
It is feature equivalent, we can easily extend the tracing abilities to use [tracy](https://crates.io/crates/tracing-tracy) and [coz](https://crates.io/crates/tracing-coz) later.