### PR TITLE
CI: Update fewer apt lists

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -107,6 +107,7 @@ jobs:
         if: matrix.conf != 'dav1d-tests-arm64'
         run: |
           sudo sed -i 's/jammy/lunar/g' /etc/apt/sources.list
+          sudo rm /etc/apt/sources.list.d/*.list
           sudo apt update
           sudo apt install nasm libaom-dev meson ninja-build nasm
       - name: Install cargo-c


### PR DESCRIPTION
This works around temporary failures in repositories that we don't need for dependencies.