### PR TITLE
Add SegmentationLevel::Complex and set for speed 0

### DIFF
--- a/src/api/config/speedsettings.rs
+++ b/src/api/config/speedsettings.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, The rav1e contributors. All rights reserved
+// Copyright (c) 2020-2023, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
@@ -79,7 +79,7 @@ impl Default for SpeedSettings {
       lrf: true,
       lru_on_skip: true,
       sgr_complexity: SGRComplexityLevel::Full,
-      segmentation: SegmentationLevel::Full,
+      segmentation: SegmentationLevel::Complex,
       partition: PartitionSpeedSettings {
         encode_bottomup: true,
         non_square_partition_max_threshold: BlockSize::BLOCK_64X64,
@@ -434,6 +434,8 @@ pub enum SegmentationLevel {
   Disabled,
   /// Segmentation index is derived from source statistics.
   Simple,
+  /// Segmentation index range is derived from source statistics.
+  Complex,
   /// Search all segmentation indices.
   Full,
 }
@@ -446,6 +448,7 @@ impl fmt::Display for SegmentationLevel {
       match self {
         SegmentationLevel::Disabled => "Disabled",
         SegmentationLevel::Simple => "Simple",
+        SegmentationLevel::Complex => "Complex",
         SegmentationLevel::Full => "Full",
       }
     )

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, The rav1e contributors. All rights reserved
+// Copyright (c) 2018-2023, The rav1e contributors. All rights reserved
 //
 // This source code is subject to the terms of the BSD 2 Clause License and
 // the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
@@ -181,6 +181,10 @@ pub fn select_segment<T: Pixel>(
 
   // Avoid going into lossless mode by never bringing qidx below 1.
   let sidx = sidx.max(ts.segmentation.min_segment);
+
+  if fi.config.speed_settings.segmentation == SegmentationLevel::Complex {
+    return sidx..=ts.segmentation.max_segment.min(sidx.saturating_add(1));
+  }
 
   sidx..=sidx
 }


### PR DESCRIPTION
[AWCY result at speed 0](https://beta.arewecompressedyet.com/?job=master-f3c8d7b2-s0%402023-12-29T09%3A40%3A27.341Z&job=wip-segmentation-level-up%402023-12-29T09%3A39%3A56.551Z)
| PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |   SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |   VMAF | VMAF-NEG |
|   ---: |    ---: |    ---: |      ---: |   ---: |    ---: |       ---: |        ---: |        ---: |     ---: |   ---: |     ---: |
| 1.0826 | -0.2250 | -0.0412 |    0.2315 | 0.0593 |  0.1193 |     0.8248 |     -0.8888 |     -0.6546 |   0.7733 | 1.0963 |   1.1068 |

Average encoding speed-up of 1.41x, with some clips averaging 2.16x. In the most extreme case, 2.63x for ducks_take_off at Q=80.


Note that that [AWCY results relative to speed 1](https://beta.arewecompressedyet.com/?job=master-f3c8d7b2-s1%402023-12-29T14%3A21%3A21.002Z&job=wip-segmentation-level-up%402023-12-29T09%3A39%3A56.551Z) show a healthier 1.26x encoding time for most of the BD-Rate improvement:
|  PSNR Y | PSNR Cb | PSNR Cr | CIEDE2000 |    SSIM | MS-SSIM | PSNR-HVS Y | PSNR-HVS Cb | PSNR-HVS Cr | PSNR-HVS |    VMAF | VMAF-NEG |
|    ---: |    ---: |    ---: |      ---: |    ---: |    ---: |       ---: |        ---: |        ---: |     ---: |    ---: |     ---: |
| -2.6694 |  1.4971 |  0.8145 |   -0.9577 | -1.1083 | -0.8471 |    -2.2635 |      2.7948 |      1.5700 |  -2.1606 | -2.7774 |  -2.6214 |