### PR TITLE
Simplify fast scenechange code a bit

### DIFF
--- a/src/scenechange/fast.rs
+++ b/src/scenechange/fast.rs
@@ -24,40 +24,23 @@ impl<T: Pixel> SceneChangeDetector<T> {
   ) -> ScenecutResult {
     if let Some(scale_func) = &self.scale_func {
       // downscale both frames for faster comparison
-      if let Some((frame_buffer, is_initialized)) =
-        &mut self.downscaled_frame_buffer
+      if let Some(frame_buffer) = &mut self.downscaled_frame_buffer
       {
-        let frame_buffer = &mut *frame_buffer;
-        if *is_initialized {
-          frame_buffer.swap(0, 1);
-          (scale_func.downscale_in_place)(
-            &frame2.planes[0],
-            &mut frame_buffer[1],
-          );
-        } else {
-          // both frames are in an irrelevant and invalid state, so we have to reinitialize
-          // them, but we can reuse their allocations
-          (scale_func.downscale_in_place)(
-            &frame1.planes[0],
-            &mut frame_buffer[0],
-          );
-          (scale_func.downscale_in_place)(
-            &frame2.planes[0],
-            &mut frame_buffer[1],
-          );
-          *is_initialized = true;
-        }
+        frame_buffer.swap(0, 1);
+        (scale_func.downscale_in_place)(
+          &frame2.planes[0],
+          &mut frame_buffer[1],
+        );
       } else {
-        self.downscaled_frame_buffer = Some((
+        self.downscaled_frame_buffer = Some(
           [
             (scale_func.downscale)(&frame1.planes[0]),
             (scale_func.downscale)(&frame2.planes[0]),
-          ],
-          true, // the frame buffer is initialized and in a valid state
-        ));
+          ]
+        );
       }
 
-      if let Some((frame_buffer, _)) = &self.downscaled_frame_buffer {
+      if let Some(frame_buffer) = &self.downscaled_frame_buffer {
         let &[first, second] = &frame_buffer;
         let delta = self.delta_in_planes(first, second);
 

--- a/src/scenechange/fast.rs
+++ b/src/scenechange/fast.rs
@@ -74,30 +74,17 @@ impl<T: Pixel> SceneChangeDetector<T> {
         unsafe { debug_unreachable!() }
       }
     } else {
-      if let Some(frame_buffer) = &mut self.frame_ref_buffer {
-        frame_buffer.swap(0, 1);
-        frame_buffer[1] = frame2;
-      } else {
-        self.frame_ref_buffer = Some([frame1, frame2]);
-      }
+      let delta = self.delta_in_planes(
+        &frame1.planes[0],
+        &frame2.planes[0],
+      );
 
-      if let Some(frame_buffer) = &self.frame_ref_buffer {
-        let delta = self.delta_in_planes(
-          &frame_buffer[0].planes[0],
-          &frame_buffer[1].planes[0],
-        );
-
-        ScenecutResult {
-          threshold: self.threshold,
-          inter_cost: delta,
-          imp_block_cost: delta,
-          backward_adjusted_cost: delta,
-          forward_adjusted_cost: delta,
-        }
-      } else {
-        // SAFETY: `frame_ref_buffer` is always initialized to `Some(..)` at the start
-        // of this code block if it was `None`.
-        unsafe { debug_unreachable!() }
+      ScenecutResult {
+        threshold: self.threshold,
+        inter_cost: delta,
+        imp_block_cost: delta,
+        backward_adjusted_cost: delta,
+        forward_adjusted_cost: delta,
       }
     }
   }

--- a/src/scenechange/fast.rs
+++ b/src/scenechange/fast.rs
@@ -24,20 +24,17 @@ impl<T: Pixel> SceneChangeDetector<T> {
   ) -> ScenecutResult {
     if let Some(scale_func) = &self.scale_func {
       // downscale both frames for faster comparison
-      if let Some(frame_buffer) = &mut self.downscaled_frame_buffer
-      {
+      if let Some(frame_buffer) = &mut self.downscaled_frame_buffer {
         frame_buffer.swap(0, 1);
         (scale_func.downscale_in_place)(
           &frame2.planes[0],
           &mut frame_buffer[1],
         );
       } else {
-        self.downscaled_frame_buffer = Some(
-          [
-            (scale_func.downscale)(&frame1.planes[0]),
-            (scale_func.downscale)(&frame2.planes[0]),
-          ]
-        );
+        self.downscaled_frame_buffer = Some([
+          (scale_func.downscale)(&frame1.planes[0]),
+          (scale_func.downscale)(&frame2.planes[0]),
+        ]);
       }
 
       if let Some(frame_buffer) = &self.downscaled_frame_buffer {
@@ -57,10 +54,7 @@ impl<T: Pixel> SceneChangeDetector<T> {
         unsafe { debug_unreachable!() }
       }
     } else {
-      let delta = self.delta_in_planes(
-        &frame1.planes[0],
-        &frame2.planes[0],
-      );
+      let delta = self.delta_in_planes(&frame1.planes[0], &frame2.planes[0]);
 
       ScenecutResult {
         threshold: self.threshold,

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -72,11 +72,6 @@ pub struct SceneChangeDetector<T: Pixel> {
   )>,
   /// Buffer for FrameMEStats for cost scenecut
   frame_me_stats_buffer: Option<RefMEStats>,
-  /// Frame buffer for holding references to source frames.
-  ///
-  /// Useful for not copying data into the downscaled frame buffer
-  /// when using a downscale factor of 1.
-  frame_ref_buffer: Option<[Arc<Frame<T>>; 2]>,
   /// Deque offset for current
   lookahead_offset: usize,
   /// Start deque offset based on lookahead
@@ -138,7 +133,6 @@ impl<T: Pixel> SceneChangeDetector<T> {
       scale_func,
       downscaled_frame_buffer: None,
       frame_me_stats_buffer: None,
-      frame_ref_buffer: None,
       lookahead_offset,
       deque_offset,
       score_deque,

--- a/src/scenechange/mod.rs
+++ b/src/scenechange/mod.rs
@@ -64,12 +64,7 @@ pub struct SceneChangeDetector<T: Pixel> {
   /// Downscaling function for fast scene detection
   scale_func: Option<ScaleFunction<T>>,
   /// Frame buffer for scaled frames
-  downscaled_frame_buffer: Option<(
-    [Plane<T>; 2],
-    // `true` if the data is valid and initialized, or `false`
-    // if it should be assumed that the data is uninitialized.
-    bool,
-  )>,
+  downscaled_frame_buffer: Option<[Plane<T>; 2]>,
   /// Buffer for FrameMEStats for cost scenecut
   frame_me_stats_buffer: Option<RefMEStats>,
   /// Deque offset for current


### PR DESCRIPTION
`downscaled_frame_buffer` is an `Option<([Plane<T>; 2], bool)>`. The bool is called `is_initialized` and is supposed to show whether the memory in the `[Plane<T>; 2]` is initialized or not.

As far as I can tell, there is no code path that results in the Planes being uninitialized: `downscaled_frame_buffer` starts out as a `None`, the first buffer access allocates & initializes the memory, and the memory should always be initialized after that. The bool never seems to be `false` from what I can tell, which would support my assumption, I think.

There's also a field called `frame_ref_buffer` which caches the `Arc<Frame<T>>` when no downscaling is being done. Unless I am missing something, there's no real benefit to caching these pointers (because refs to both frames will always be passed into the function anyways), so i removed the buffer.

I tested my changes to the best of my ability, and didn't notice any change in behaviour or performance. LMK what you think