### PR TITLE
Remove duplicate assume_slice_init_mut

### DIFF
--- a/src/asm/aarch64/transform/forward.rs
+++ b/src/asm/aarch64/transform/forward.rs
@@ -323,7 +323,7 @@ unsafe fn forward_transform_neon<T: Coefficient>(
       }
     }
 
-    let col_coeffs = assume_slice_init_mut(col_coeffs);
+    let col_coeffs = slice_assume_init_mut(col_coeffs);
 
     txfm_func_col(col_coeffs);
     round_shift_array_neon(col_coeffs, -cfg.shift[1]);
@@ -364,7 +364,7 @@ unsafe fn forward_transform_neon<T: Coefficient>(
     }
   }
 
-  let buf = assume_slice_init_mut(buf);
+  let buf = slice_assume_init_mut(buf);
 
   // Rows
   for rg in (0..txfm_size_row).step_by(8) {

--- a/src/asm/shared/transform/forward.rs
+++ b/src/asm/shared/transform/forward.rs
@@ -45,7 +45,7 @@ pub fn cast_mut<const N: usize, T>(x: &mut [T]) -> &mut [T; N] {
 mod test {
   use crate::cpu_features::*;
   use crate::transform::{forward_transform, get_valid_txfm_types, TxSize};
-  use crate::util::assume_slice_init_mut;
+  use crate::util::slice_assume_init_mut;
   use rand::Rng;
   use std::mem::MaybeUninit;
 
@@ -92,7 +92,7 @@ mod test {
           8,
           CpuFeatureLevel::RUST,
         );
-        let output_ref = unsafe { assume_slice_init_mut(&mut output_ref[..]) };
+        let output_ref = unsafe { slice_assume_init_mut(&mut output_ref[..]) };
         forward_transform(
           &input[..],
           &mut output_simd[..],
@@ -103,7 +103,7 @@ mod test {
           cpu,
         );
         let output_simd =
-          unsafe { assume_slice_init_mut(&mut output_simd[..]) };
+          unsafe { slice_assume_init_mut(&mut output_simd[..]) };
         assert_eq!(output_ref, output_simd)
       }
     }

--- a/src/asm/x86/quantize.rs
+++ b/src/asm/x86/quantize.rs
@@ -83,8 +83,8 @@ pub fn dequantize<T: Coefficient>(
   #[cfg(any(feature = "check_asm", test))]
   {
     let area = av1_get_coded_tx_size(tx_size).area();
-    let rcoeffs = unsafe { assume_slice_init_mut(&mut rcoeffs[..area]) };
-    let ref_rcoeffs = unsafe { assume_slice_init_mut(&mut ref_rcoeffs[..]) };
+    let rcoeffs = unsafe { slice_assume_init_mut(&mut rcoeffs[..area]) };
+    let ref_rcoeffs = unsafe { slice_assume_init_mut(&mut ref_rcoeffs[..]) };
     assert_eq!(rcoeffs, ref_rcoeffs);
   }
 }

--- a/src/asm/x86/transform/forward.rs
+++ b/src/asm/x86/transform/forward.rs
@@ -321,7 +321,7 @@ unsafe fn forward_transform_avx2<T: Coefficient>(
       }
     }
 
-    let col_coeffs = assume_slice_init_mut(tx_in);
+    let col_coeffs = slice_assume_init_mut(tx_in);
 
     txfm_func_col(col_coeffs);
     round_shift_array_avx2(col_coeffs, -cfg.shift[1]);

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -617,7 +617,7 @@ impl<'a, T: Pixel> IntraEdge<'a, T> {
     let left = unsafe {
       let begin_left = 2 * MAX_TX_SIZE - init_left;
       let end_above = 2 * MAX_TX_SIZE + 1 + init_above;
-      assume_slice_init_mut(&mut edge_buf.data[begin_left..end_above])
+      slice_assume_init_mut(&mut edge_buf.data[begin_left..end_above])
     };
     let (left, top_left) = left.split_at(init_left);
     let (top_left, above) = top_left.split_at(1);
@@ -833,7 +833,7 @@ pub fn get_intra_edges<'a, T: Pixel>(
     }
 
     // SAFETY: The blocks above have initialized the first `init_above` items.
-    let above = unsafe { assume_slice_init_mut(&mut above[..init_above]) };
+    let above = unsafe { slice_assume_init_mut(&mut above[..init_above]) };
 
     // Needs bottom left
     if needs_bottomleft {
@@ -875,7 +875,7 @@ pub fn get_intra_edges<'a, T: Pixel>(
 
     // SAFETY: The blocks above have initialized last `init_left` items.
     let left = unsafe {
-      assume_slice_init_mut(&mut left[2 * MAX_TX_SIZE - init_left..])
+      slice_assume_init_mut(&mut left[2 * MAX_TX_SIZE - init_left..])
     };
 
     // Needs top-left

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1058,7 +1058,7 @@ pub(crate) mod rust {
       }
     }
     // SAFETY: the loop above has initialized all items
-    let ac = unsafe { assume_slice_init_mut(ac) };
+    let ac = unsafe { slice_assume_init_mut(ac) };
     let shift = plane_bsize.width_log2() + plane_bsize.height_log2();
     let average = ((sum + (1 << (shift - 1))) >> shift) as i16;
 

--- a/src/util/align.rs
+++ b/src/util/align.rs
@@ -64,13 +64,6 @@ impl<T> Aligned<T> {
   }
 }
 
-#[inline(always)]
-pub unsafe fn slice_assume_init_mut<T>(
-  slice: &mut [MaybeUninit<T>],
-) -> &mut [T] {
-  unsafe { &mut *(slice as *mut [MaybeUninit<T>] as *mut [T]) }
-}
-
 /// An analog to a Box<[T]> where the underlying slice is aligned.
 /// Alignment is according to the architecture-specific SIMD constraints.
 pub struct AlignedBoxedSlice<T> {

--- a/src/util/uninit.rs
+++ b/src/util/uninit.rs
@@ -18,12 +18,13 @@ pub fn init_slice_repeat_mut<T: Copy>(
   }
 
   // SAFETY: Defined behavior, since all elements of slice are initialized
-  unsafe { assume_slice_init_mut(slice) }
+  unsafe { slice_assume_init_mut(slice) }
 }
 
-/// Assume all the elements are initialized
-pub unsafe fn assume_slice_init_mut<T: Copy>(
+/// Assume all the elements are initialized.
+#[inline(always)]
+pub unsafe fn slice_assume_init_mut<T: Copy>(
   slice: &'_ mut [MaybeUninit<T>],
 ) -> &'_ mut [T] {
-  &mut *(slice as *mut [std::mem::MaybeUninit<T>] as *mut [T])
+  &mut *(slice as *mut [MaybeUninit<T>] as *mut [T])
 }


### PR DESCRIPTION
The two functions are equivalent except for an additional `T: Copy` bound on one function. That bound is always fulfilled at the moment, so I left it as-is.

I preferred the name `slice_assume_init_mut` over the other one because [std uses the same name](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.slice_assume_init_mut).