### PR TITLE
Ignore IDE config folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 *.png
 *.bin
 secret_key
+.vscode/
+.idea/


### PR DESCRIPTION
These include developer-specific IDE customizations and generally aren't intended to be committed.