### PR TITLE
Remove rustc_version_check from build.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,6 @@ dependencies = [
  "quickcheck_macros",
  "rand",
  "rand_chacha",
- "rustc_version",
  "scan_fmt",
  "semver",
  "serde",
@@ -1389,15 +1388,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,6 @@ features = ["png"]
 
 [build-dependencies]
 cc = { version = "1.0", optional = true, features = ["parallel"] }
-rustc_version = "0.4"
 built = { version = "0.7.1", features = [] }
 
 [build-dependencies.nasm-rs]

--- a/build.rs
+++ b/build.rs
@@ -10,12 +10,10 @@
 #![allow(clippy::print_literal)]
 #![allow(clippy::unused_io_amount)]
 
-use rustc_version::{version, version_meta, Channel, Version};
 #[allow(unused_imports)]
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::exit;
 
 #[allow(dead_code)]
 fn rerun_dir<P: AsRef<Path>>(dir: P) {
@@ -235,24 +233,8 @@ fn build_asm_files() {
   rerun_dir("src/arm");
 }
 
-fn rustc_version_check() {
-  // This should match the version in the CI
-  // Make sure to updated README.md when this changes.
-  const REQUIRED_VERSION: &str = "1.70.0";
-  if version().unwrap() < Version::parse(REQUIRED_VERSION).unwrap() {
-    eprintln!("rav1e requires rustc >= {REQUIRED_VERSION}.");
-    exit(1);
-  }
-
-  if version_meta().unwrap().channel == Channel::Nightly {
-    println!("cargo:rustc-cfg=nightly_rustc");
-  }
-}
-
 #[allow(unused_variables)]
 fn main() {
-  rustc_version_check();
-
   built::write_built_file().expect("Failed to acquire build-time information");
 
   let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();


### PR DESCRIPTION
This was added in #1552 but is no longer necessary. The cfg value `nightly_rustc` does not seem to be used anywhere, and [rust-version](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) in Cargo.toml allows a built-in way of checking the MSRV.

`rust-version` is only supported in toolchains >=1.56, but all older toolchains will fail compilation for other reasons (mostly edition = "2021").

Examples:
```
$ cargo +1.55 c
error: failed to parse manifest at `/.../Development/rav1e/Cargo.toml`

Caused by:
  feature `edition2021` is required
```

```
$ cargo +1.60 c
error: package `clap_complete v4.4.5` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.60.0
```