### PR TITLE
Fix NASM warning about %undef statement

### DIFF
--- a/src/x86/sse.asm
+++ b/src/x86/sse.asm
@@ -441,7 +441,8 @@ cglobal weighted_sse_%1x%2, 6, 10, 9, \
 %endif
     RET
 
-    %undef sum, kernel_width, res
+    %undef sum
+    %undef kernel_width
 %endmacro
 
 INIT_XMM ssse3


### PR DESCRIPTION
My local version of NASM (2.16.01) produces some warnings when compiling:

```
warning: trailing garbage after macro name ignored [-w+pp-trailing]
/.../sse.asm:444: ... from macro `WEIGHTED_SSE' defined here
```

Looks like the `%undef sum, kernel_width, res` only undefines `sum` and ignores everything after that. `res` doesn't seem to exist (anymore), so I removed it from the `%undef`s.