### PR TITLE
Only enable av1-grain/serialize with rav1e/serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tracing = [
   "dep:tracing"
 ]
 scenechange = []
-serialize = ["serde", "toml", "v_frame/serialize", "serde-big-array"]
+serialize = ["serde", "toml", "v_frame/serialize", "serde-big-array", "av1-grain/serialize"]
 wasm = ["wasm-bindgen"]
 
 # Enables debug dumping of lookahead computation results, specifically:
@@ -110,7 +110,7 @@ wasm-bindgen = { version = "0.2.89", optional = true }
 nom = { version = "7.1.3", optional = true }
 new_debug_unreachable = "1.0.4"
 once_cell = "1.19.0"
-av1-grain = { version = "0.2.2", features = ["serialize"] }
+av1-grain = "0.2.2"
 serde-big-array = { version = "0.5.1", optional = true }
 profiling = { version = "1" }
 tracing-subscriber = { version = "0.3.18", optional = true }


### PR DESCRIPTION
This improves compile time when the serialize feature is disabled, at least on my machine.