### PR TITLE
Remove `allow(clippy::undocumented_unsafe_blocks)` where not necessary

### DIFF
--- a/ivf/src/lib.rs
+++ b/ivf/src/lib.rs
@@ -36,8 +36,6 @@
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::missing_errors_doc)]
 #![warn(clippy::missing_panics_doc)]
-// FIXME: Temporarily disabled due to https://github.com/rust-lang/rust-clippy/issues/9142
-#![allow(clippy::undocumented_unsafe_blocks)]
 
 /// Simple ivf muxer
 ///

--- a/src/asm/x86/sad_plane.rs
+++ b/src/asm/x86/sad_plane.rs
@@ -44,9 +44,6 @@ pub(crate) fn sad_plane_internal<T: Pixel>(
       macro_rules! call_asm {
         ($func:ident, $src:expr, $dst:expr, $cpu:expr) => {
           // SAFETY: Calls Assembly code.
-          //
-          // FIXME: Remove `allow` once https://github.com/rust-lang/rust-clippy/issues/8264 fixed
-          #[allow(clippy::undocumented_unsafe_blocks)]
           unsafe {
             let result = $func(
               mem::transmute(src.data_origin().as_ptr()),

--- a/src/tiling/plane_region.rs
+++ b/src/tiling/plane_region.rs
@@ -411,9 +411,6 @@ macro_rules! plane_region_common {
       fn index(&self, index: usize) -> &Self::Output {
         assert!(index < self.rect.height);
         // SAFETY: The above assert ensures we do not access OOB data.
-        //
-        // FIXME: Remove `allow` once https://github.com/rust-lang/rust-clippy/issues/8264 fixed
-        #[allow(clippy::undocumented_unsafe_blocks)]
         unsafe {
           let ptr = self.data.add(index * self.plane_cfg.stride);
           slice::from_raw_parts(ptr, self.rect.width)

--- a/src/tiling/tile_blocks.rs
+++ b/src/tiling/tile_blocks.rs
@@ -151,9 +151,6 @@ macro_rules! tile_blocks_common {
       fn index(&self, index: usize) -> &Self::Output {
         assert!(index < self.rows);
         // SAFETY: The above assert ensures we do not access OOB data.
-        //
-        // FIXME: Remove `allow` once https://github.com/rust-lang/rust-clippy/issues/8264 fixed
-        #[allow(clippy::undocumented_unsafe_blocks)]
         unsafe {
           let ptr = self.data.add(index * self.frame_cols);
           slice::from_raw_parts(ptr, self.cols)

--- a/src/tiling/tile_motion_stats.rs
+++ b/src/tiling/tile_motion_stats.rs
@@ -106,9 +106,6 @@ macro_rules! tile_me_stats_common {
       fn index(&self, index: usize) -> &Self::Output {
         assert!(index < self.rows);
         // SAFETY: The above assert ensures we do not access OOB data.
-        //
-        // FIXME: Remove `allow` once https://github.com/rust-lang/rust-clippy/issues/8264 fixed
-        #[allow(clippy::undocumented_unsafe_blocks)]
         unsafe {
           let ptr = self.data.add(index * self.stride);
           slice::from_raw_parts(ptr, self.cols)

--- a/src/tiling/tile_restoration_state.rs
+++ b/src/tiling/tile_restoration_state.rs
@@ -108,9 +108,6 @@ macro_rules! tile_restoration_units_common {
       fn index(&self, index: usize) -> &Self::Output {
         assert!(index < self.rows);
         // SAFETY: The above assert ensures we do not access OOB data.
-        //
-        // FIXME: Remove `allow` once https://github.com/rust-lang/rust-clippy/issues/8264 fixed
-        #[allow(clippy::undocumented_unsafe_blocks)]
         unsafe {
           let ptr = self.data.add(index * self.stride);
           slice::from_raw_parts(ptr, self.cols)


### PR DESCRIPTION
There were two bugs ([1](https://github.com/rust-lang/rust-clippy/issues/9142), [2](https://github.com/rust-lang/rust-clippy/issues/8264)) that made these necessary. Both bugs are fixed in 1.70, so the `allow`s can be removed now.