### PR TITLE
Don't use host's strip command when cross-compiling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -51,9 +51,9 @@ fn hash_changed(
     }
   }
 
-  let strip = env::var("STRIP").unwrap_or_else(|_| "strip".to_string());
-
-  hasher.write(strip.as_bytes());
+  if let Some(cmd) = strip_command() {
+    hasher.write(cmd.as_bytes());
+  }
 
   let hash = hasher.finish().to_be_bytes();
 
@@ -157,17 +157,12 @@ fn build_nasm_files() {
 
     // Strip local symbols from the asm library since they
     // confuse the debugger.
-    fn strip<P: AsRef<Path>>(obj: P) {
-      let strip = env::var("STRIP").unwrap_or_else(|_| "strip".to_string());
-
-      let mut cmd = std::process::Command::new(strip);
-
-      cmd.arg("-x").arg(obj.as_ref());
-
-      let _ = cmd.output();
+    if let Some(strip) = strip_command() {
+      let _ = std::process::Command::new(strip)
+        .arg("-x")
+        .arg(Path::new(&out_dir).join("librav1easm.a"))
+        .status();
     }
-
-    strip(Path::new(&out_dir).join("librav1easm.a"));
 
     std::fs::write(hash_path, &hash[..]).unwrap();
   } else {
@@ -176,6 +171,27 @@ fn build_nasm_files() {
   println!("cargo:rustc-link-lib=static=rav1easm");
   rerun_dir("src/x86");
   rerun_dir("src/ext/x86");
+}
+
+fn strip_command() -> Option<String> {
+  let target = env::var("TARGET").expect("TARGET");
+  // follows Cargo's naming convention for the linker setting
+  let normalized_target = target.replace('-', "_").to_uppercase();
+  let explicit_strip =
+    env::var(format!("CARGO_TARGET_{normalized_target}_STRIP"))
+      .ok()
+      .or_else(|| env::var("STRIP").ok());
+  if explicit_strip.is_some() {
+    return explicit_strip;
+  }
+
+  // strip command is target-specific, e.g. macOS's strip breaks MUSL's archives
+  let host = env::var("HOST").expect("HOST");
+  if host != target {
+    return None;
+  }
+
+  Some("strip".into())
 }
 
 #[cfg(feature = "asm")]

--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,6 @@ fn hash_changed(
 ) -> Option<([u8; 8], PathBuf)> {
   use std::collections::hash_map::DefaultHasher;
   use std::hash::Hasher;
-  use std::io::Read;
 
   let mut hasher = DefaultHasher::new();
 
@@ -45,10 +44,7 @@ fn hash_changed(
     .chain(std::iter::once(Path::new("build.rs")));
 
   for path in paths {
-    if let Ok(mut f) = std::fs::File::open(path) {
-      let mut buf = Vec::new();
-      f.read_to_end(&mut buf).unwrap();
-
+    if let Ok(buf) = std::fs::read(path) {
       hasher.write(&buf);
     } else {
       panic!("Cannot open {}", path.display());


### PR DESCRIPTION
On macOS, `cargo build --target=x86_64-unknown-linux-musl` makes rustc panic in compiler/rustc_codegen_llvm/src/back/archive.rs:397:67, because the `librav1easm.a` file is invalid and unusable. This is because running aarch64-darwin's `strip` command run on an x86-64-musl archive ruins it.

I've made rav1e not run `strip` during cross-compilation, unless `CARGO_TARGET_{target}_STRIP` or `STRIP` env var is set.
