### PR TITLE
Replace types from once_cell with std::sync::OnceLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,7 +1290,6 @@ dependencies = [
  "noop_proc_macro",
  "num-derive",
  "num-traits",
- "once_cell",
  "paste",
  "pretty_assertions",
  "profiling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,6 @@ simd_helpers = "0.1"
 wasm-bindgen = { version = "0.2.90", optional = true }
 nom = { version = "7.1.3", optional = true }
 new_debug_unreachable = "1.0.4"
-once_cell = "1.19.0"
 av1-grain = "0.2.3"
 serde-big-array = { version = "0.5.1", optional = true }
 profiling = { version = "1" }

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -13,7 +13,6 @@ use crate::stats::MetricsEnabled;
 use crate::{ColorPrimaries, MatrixCoefficients, TransferCharacteristics};
 use clap::{CommandFactory, Parser as Clap, Subcommand};
 use clap_complete::{generate, Shell};
-use once_cell::sync::Lazy;
 use rav1e::prelude::*;
 use scan_fmt::scan_fmt;
 
@@ -22,6 +21,7 @@ use std::fs::File;
 use std::io;
 use std::io::prelude::*;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 pub mod built_info {
   // The file has been placed there by the build script.
@@ -258,8 +258,11 @@ pub struct CliOptions {
   pub command: Option<Commands>,
 }
 
+static VERSION_STR: OnceLock<String> = OnceLock::new();
+static LONG_VERSION_STR: OnceLock<String> = OnceLock::new();
+
 fn get_version() -> &'static str {
-  static VERSION_STR: Lazy<String> = Lazy::new(|| {
+  VERSION_STR.get_or_init(|| {
     format!(
       "{} ({})",
       rav1e::version::full(),
@@ -267,12 +270,11 @@ fn get_version() -> &'static str {
       // not if there are optimizations.
       if cfg!(debug_assertions) { "debug" } else { "release" }
     )
-  });
-  &VERSION_STR
+  })
 }
 
 fn get_long_version() -> &'static str {
-  static LONG_VERSION_STR: Lazy<String> = Lazy::new(|| {
+  LONG_VERSION_STR.get_or_init(|| {
     let mut rustflags = env!("CARGO_ENCODED_RUSTFLAGS");
     if rustflags.trim().is_empty() {
       rustflags = "(None)";
@@ -293,8 +295,7 @@ fn get_long_version() -> &'static str {
       if cfg!(feature = "unstable") { "Enabled" } else { "Disabled" },
       rustflags
     )
-  });
-  &LONG_VERSION_STR
+  })
 }
 
 #[derive(Subcommand)]
@@ -347,8 +348,7 @@ pub struct ParsedCliOptions {
 }
 
 #[cfg(feature = "serialize")]
-static HELP_TEXT: once_cell::sync::OnceCell<String> =
-  once_cell::sync::OnceCell::new();
+static HELP_TEXT: OnceLock<String> = OnceLock::new();
 
 #[cfg(feature = "serialize")]
 fn build_speed_long_help() -> Option<&'static str> {

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -397,8 +397,8 @@ pub unsafe extern fn rav1e_version_short() -> *const c_char {
   concat!(env!("CARGO_PKG_VERSION"), "\0").as_ptr() as *const c_char
 }
 
-static FULL_VERSION_C: once_cell::sync::OnceCell<CString> =
-  once_cell::sync::OnceCell::new();
+static FULL_VERSION_C: std::sync::OnceLock<CString> =
+  std::sync::OnceLock::new();
 
 /// Version information with the information
 /// provided by `git describe --tags`.


### PR DESCRIPTION
`std::sync::OnceLock` is effectively the same as `once_cell::sync::OnceCell`, and because the MSRV is now 1.70 it can be used instead. `Lazy<T>` can also simply be replaced by a `OnceLock`, making the `once_cell` dependency unnecessary.