### PR TITLE
Add whitespace to compiler flags in long version string

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -273,10 +273,14 @@ fn get_version() -> &'static str {
 
 fn get_long_version() -> &'static str {
   static LONG_VERSION_STR: Lazy<String> = Lazy::new(|| {
-    let mut rustflags = env!("CARGO_ENCODED_RUSTFLAGS");
-    if rustflags.trim().is_empty() {
-      rustflags = "(None)";
-    }
+    let rustflags = env!("CARGO_ENCODED_RUSTFLAGS");
+    let rustflags = if rustflags.trim().is_empty() {
+      "(None)".to_string()
+    } else {
+      // Replace non-printable ASCII Unit Separator with whitespace
+      rustflags.replace(0x1F as char, " ")
+    };
+
     format!(
       "{}\n{} {}\nCompiled CPU Features: {}\nRuntime Assembly Support: {}{}\nThreading: {}\nUnstable Features: {}\nCompiler Flags: {}",
       get_version(),


### PR DESCRIPTION
From the [reference regarding environment variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts) set by Cargo:

> **CARGO_ENCODED_RUSTFLAGS** — extra flags that Cargo invokes rustc with, separated by a 0x1f character (ASCII Unit Separator).

Before:
```
Compiler Flags: -Ctarget-cpu=native-Clink-arg=-fuse-ld=mold
```

After:

```
Compiler Flags: -C target-cpu=native -C link-arg=-fuse-ld=mold
```