### PR TITLE
Turn get_rect_tx_log_ratio into associated function for TxSize

### DIFF
--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -25,7 +25,6 @@ use crate::util::*;
 use super::clamp_value;
 use super::consts::*;
 use super::get_1d_tx_types;
-use super::get_rect_tx_log_ratio;
 use super::half_btf;
 use super::TxSize;
 use super::TxType;
@@ -1644,7 +1643,7 @@ pub(crate) mod rust {
     // For 64 point transforms, rely on the last 32 columns being initialized
     //   to zero for filling out missing input coeffs.
     let mut buffer = vec![0i32; width * height].into_boxed_slice();
-    let rect_type = get_rect_tx_log_ratio(width, height);
+    let rect_type = tx_size.rect_ratio_log2();
     let tx_types_1d = get_1d_tx_types(tx_type);
     let lossless = tx_type == TxType::WHT_WHT;
 

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1649,7 +1649,8 @@ pub(crate) mod rust {
 
     // perform inv txfm on every row
     let range = bd + 8;
-    let txfm_fn = INV_TXFM_FNS[tx_types_1d.1 as usize][ILog::ilog(width) - 3];
+    let txfm_fn =
+      INV_TXFM_FNS[tx_types_1d.1 as usize][tx_size.width_log2() - 2];
     // 64 point transforms only signal 32 coeffs. We only take chunks of 32
     //   and skip over the last 32 transforms here.
     for (r, buffer_slice) in (0..height.min(32)).zip(buffer.chunks_mut(width))
@@ -1677,7 +1678,8 @@ pub(crate) mod rust {
 
     // perform inv txfm on every col
     let range = cmp::max(bd + 6, 16);
-    let txfm_fn = INV_TXFM_FNS[tx_types_1d.0 as usize][ILog::ilog(height) - 3];
+    let txfm_fn =
+      INV_TXFM_FNS[tx_types_1d.0 as usize][tx_size.height_log2() - 2];
     for c in 0..width {
       let mut temp_in: [i32; 64] = [0; 64];
       let mut temp_out: [i32; 64] = [0; 64];

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -268,6 +268,12 @@ impl TxSize {
   pub const fn is_rect(self) -> bool {
     self.width_log2() != self.height_log2()
   }
+
+  /// Returns log2(width / height), e.g. `TX_16x4` -> log2(16 / 4) = 2
+  #[inline]
+  pub const fn rect_ratio_log2(self) -> i8 {
+    self.width_log2() as i8 - self.height_log2() as i8
+  }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd)]
@@ -284,13 +290,6 @@ pub enum TxSet {
   TX_SET_INTER_2, // TX_SET_DTT9_IDTX_1DDCT
   // Discrete Trig transforms w/ flip (9) + Identity (1) + 1D Hor/Ver (6)
   TX_SET_INTER_1, // TX_SET_ALL16
-}
-
-/// Utility function that returns the log of the ratio of the col and row sizes.
-#[inline]
-pub fn get_rect_tx_log_ratio(col: usize, row: usize) -> i8 {
-  debug_assert!(col > 0 && row > 0);
-  ILog::ilog(col) as i8 - ILog::ilog(row) as i8
 }
 
 // performs half a butterfly
@@ -548,9 +547,7 @@ mod test {
         tx_size.width(),
         tx_size.height()
       );
-      assert!(
-        get_rect_tx_log_ratio(tx_size.width(), tx_size.height()) == expected
-      );
+      assert!(tx_size.rect_ratio_log2() == expected);
     }
   }
 


### PR DESCRIPTION
`get_rect_tx_log_ratio` is only used with width & height of `TxSize` (tx is in the name), so it makes sense to make it a `TxSize` method instead.

Using `tx_size.width_log2() - 2` seemed more straightforward than the call to `ILog`, so I replaced that too.