### PR TITLE
Remove redundant imports

### DIFF
--- a/src/asm/shared/dist/sse.rs
+++ b/src/asm/shared/dist/sse.rs
@@ -10,7 +10,6 @@
 #[cfg(test)]
 pub mod test {
   use crate::config::CpuFeatureLevel;
-  use crate::dist::rust;
   use crate::dist::*;
   use crate::frame::*;
   use crate::partition::BlockSize;

--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -86,7 +86,6 @@ pub mod test {
   use crate::transform::TxSize::*;
   use crate::transform::*;
   use rand::{random, thread_rng, Rng};
-  use std::mem::MaybeUninit;
 
   pub fn pick_eob<T: Coefficient>(
     coeffs: &mut [T], tx_size: TxSize, tx_type: TxType, sub_h: usize,

--- a/src/asm/x86/cdef.rs
+++ b/src/asm/x86/cdef.rs
@@ -293,7 +293,6 @@ cpu_function_lookup_table!(
 mod test {
   pub const CDEF_HAVE_NONE: u8 = 0;
   use super::*;
-  use crate::frame::{AsRegion, Plane};
   use interpolate_name::interpolate_test;
   use rand::random;
   use std::str::FromStr;

--- a/src/asm/x86/quantize.rs
+++ b/src/asm/x86/quantize.rs
@@ -160,7 +160,6 @@ mod test {
   use super::*;
   use rand::distributions::{Distribution, Uniform};
   use rand::{thread_rng, Rng};
-  use std::mem::MaybeUninit;
 
   #[test]
   fn dequantize_test() {

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -10,7 +10,6 @@
 use crate::error::*;
 use crate::muxer::{create_muxer, Muxer};
 use crate::stats::MetricsEnabled;
-use crate::{ColorPrimaries, MatrixCoefficients, TransferCharacteristics};
 use clap::{CommandFactory, Parser as Clap, Subcommand};
 use clap_complete::{generate, Shell};
 use rav1e::prelude::*;

--- a/src/bin/decoder/y4m.rs
+++ b/src/bin/decoder/y4m.rs
@@ -12,7 +12,6 @@ use std::io::Read;
 
 use crate::color::ChromaSampling::Cs400;
 use crate::decoder::{DecodeError, Decoder, FrameBuilder, VideoDetails};
-use crate::Frame;
 use rav1e::prelude::*;
 
 impl Decoder for y4m::Decoder<Box<dyn Read + Send>> {

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -9,9 +9,7 @@
 
 use av_metrics::video::*;
 use rav1e::data::EncoderStats;
-use rav1e::prelude::Rational;
 use rav1e::prelude::*;
-use rav1e::{Packet, Pixel};
 use std::fmt;
 use std::time::Instant;
 

--- a/src/context/block_unit.rs
+++ b/src/context/block_unit.rs
@@ -12,7 +12,6 @@ use std::mem::MaybeUninit;
 use super::*;
 
 use crate::predict::PredictionMode;
-use crate::util::cdf;
 
 pub const MAX_PLANES: usize = 3;
 

--- a/src/context/partition_unit.rs
+++ b/src/context/partition_unit.rs
@@ -7,7 +7,6 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use super::cdf_context::ContextWriter;
 use super::*;
 
 // Generates 4 bit field in which each bit set to 1 represents

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -8,7 +8,6 @@
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
 use crate::activity::*;
-use crate::api::config::GrainTableSegment;
 use crate::api::*;
 use crate::cdef::*;
 use crate::context::*;

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -32,7 +32,6 @@ use crate::partition::*;
 use crate::tiling::*;
 use crate::transform::*;
 use crate::util::*;
-use std::convert::TryInto;
 
 pub const ANGLE_STEP: i8 = 3;
 
@@ -698,13 +697,7 @@ pub fn luma_ac<'ac, T: Pixel>(
 
 pub(crate) mod rust {
   use super::*;
-  use crate::context::MAX_TX_SIZE;
-  use crate::cpu_features::CpuFeatureLevel;
-  use crate::tiling::PlaneRegionMut;
-  use crate::transform::TxSize;
-  use crate::util::round_shift;
-  use crate::Pixel;
-  use std::mem::{size_of, MaybeUninit};
+  use std::mem::size_of;
 
   #[inline(always)]
   pub fn dispatch_predict_intra<T: Pixel>(
@@ -1514,7 +1507,6 @@ pub(crate) mod rust {
 mod test {
   use super::*;
   use crate::predict::rust::*;
-  use crate::util::Aligned;
   use num_traits::*;
 
   #[test]

--- a/src/quantize/mod.rs
+++ b/src/quantize/mod.rs
@@ -24,7 +24,6 @@ pub use tables::*;
 use crate::scan_order::av1_scan_orders;
 use crate::transform::{TxSize, TxType};
 use crate::util::*;
-use std::convert::Into;
 use std::mem;
 use std::num::{NonZeroU16, NonZeroU32, NonZeroU64};
 

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -19,7 +19,6 @@ use crate::dist::*;
 use crate::ec::{Writer, WriterCounter, OD_BITRES};
 use crate::encode_block_with_modes;
 use crate::encoder::{FrameInvariants, IMPORTANCE_BLOCK_SIZE};
-use crate::frame::Frame;
 use crate::frame::*;
 use crate::header::ReferenceMode;
 use crate::lrf::*;

--- a/src/sad_plane.rs
+++ b/src/sad_plane.rs
@@ -22,7 +22,6 @@ use crate::util::{CastFromPrimitive, Pixel};
 
 pub(crate) mod rust {
   use super::*;
-  use crate::cpu_features::CpuFeatureLevel;
 
   #[inline]
   pub(crate) fn sad_plane_internal<T: Pixel>(

--- a/src/transform/inverse.rs
+++ b/src/transform/inverse.rs
@@ -1626,7 +1626,6 @@ static INV_TXFM_FNS: [[InvTxfmFn; 5]; 5] = [
 pub(crate) mod rust {
   use super::*;
   use crate::cpu_features::CpuFeatureLevel;
-  use crate::util::clamp;
 
   use simd_helpers::cold_for_target_arch;
   use std::cmp;


### PR DESCRIPTION
These result in warnings on [1.78](https://github.com/rust-lang/rust/pull/117772) (current nightly). For example:

```rs
warning: the item `Pixel` is imported redundantly
  --> src/bin/stats.rs:14:21
   |
10 | use av_metrics::video::*;
   |     -------------------- the item `Pixel` is already imported here
...
14 | use rav1e::{Packet, Pixel};
   |                     ^^^^^
```

