### PR TITLE
Lock clap auto-updates to 4.4 until we bump rustc version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,11 @@
   "fetchReleaseNotes": true,
   "lockFileMaintenance": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": ["clap", "clap_complete"],
+      "allowedVersions": "<=4.4"
+    }
+  ]
 }


### PR DESCRIPTION
Clap 4.5 requires rustc 1.74, so to avoid having to bump the minimum version for now, lock renovate to only bump to clap 4.4 patch versions.