### PR TITLE
Further renovate changes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,12 @@
   },
   "packageRules": [
     {
-      "matchPackageNames": ["clap", "clap_complete"],
+      "matchPackageNames": [
+        "clap",
+        "clap_complete",
+        "clap_builder",
+        "clap_derive"
+      ],
       "allowedVersions": "<=4.4"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":automergeAll",
     ":automergePr",
     ":automergeRequireAllStatusChecks",
@@ -9,7 +9,7 @@
     "group:allNonMajor",
     "schedule:earlyMondays"
   ],
-  "fetchReleaseNotes": true,
+  "fetchChangeLogs": "pr",
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
- It appears the additional clap_* packages in Cargo.lock also needed to be version locked, so this adds these
- renovate validator showed there were some deprecated keys that needed migrated, so this migrates to the new keys