### PR TITLE
Also lock assert_cmd version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,10 @@
         "clap_derive"
       ],
       "allowedVersions": "<=4.4"
+    },
+    {
+      "matchPackageNames": ["assert_cmd"],
+      "allowedVersions": "<=2.0.13"
     }
   ]
 }


### PR DESCRIPTION
This package also bumped their minimum rustc version in a patch version to one that we don't support.