### PR TITLE
Add new NASM pragma regarding macro parameter expansion

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -135,20 +135,17 @@ fn build_nasm_files() {
   if let Some((hash, hash_path)) =
     hash_changed(asm_files, &out_dir, &dest_path)
   {
-    let mut config_include_arg = String::from("-I");
-    config_include_arg.push_str(&out_dir);
-    config_include_arg.push('/');
-    let mut nasm = nasm_rs::Build::new();
-    nasm.min_version(2, 15, 0);
-    for file in asm_files {
-      nasm.file(file);
-    }
-    nasm.flag(&config_include_arg);
-    nasm.flag("-Isrc/");
-    let obj = nasm.compile_objects().unwrap_or_else(|e| {
-      println!("cargo:warning={e}");
-      panic!("NASM build failed. Make sure you have nasm installed or disable the \"asm\" feature.\n\
-        You can get NASM from https://nasm.us or your system's package manager.\n\nerror: {e}");
+    let obj = nasm_rs::Build::new()
+      .min_version(2, 15, 0)
+      .include(&out_dir)
+      .include("src")
+      .files(asm_files)
+      .compile_objects()
+      .unwrap_or_else(|e| {
+        panic!("NASM build failed. Make sure you have nasm installed or disable the \"asm\" feature.\n\
+                You can get NASM from https://nasm.us or your system's package manager.\n\
+                \n\
+                error: {e}");
     });
 
     // cc is better at finding the correct archiver

--- a/build.rs
+++ b/build.rs
@@ -70,22 +70,24 @@ fn hash_changed(
 
 #[cfg(feature = "asm")]
 fn build_nasm_files() {
-  use std::fs::File;
-  use std::io::Write;
-  let out_dir = env::var("OUT_DIR").unwrap();
+  let mut config = "
+%pragma preproc sane_empty_expansion true
+%define private_prefix rav1e
+%define ARCH_X86_32 0
+%define ARCH_X86_64 1
+%define PIC 1
+%define STACK_ALIGNMENT 16
+%define HAVE_AVX512ICL 1
+"
+  .to_owned();
 
-  let dest_path = Path::new(&out_dir).join("config.asm");
-  let mut config_file = File::create(&dest_path).unwrap();
-  config_file.write(b" %pragma preproc sane_empty_expansion true\n").unwrap();
-  config_file.write(b" %define private_prefix rav1e\n").unwrap();
-  config_file.write(b" %define ARCH_X86_32 0\n").unwrap();
-  config_file.write(b" %define ARCH_X86_64 1\n").unwrap();
-  config_file.write(b" %define PIC 1\n").unwrap();
-  config_file.write(b" %define STACK_ALIGNMENT 16\n").unwrap();
-  config_file.write(b" %define HAVE_AVX512ICL 1\n").unwrap();
   if env::var("CARGO_CFG_TARGET_VENDOR").unwrap() == "apple" {
-    config_file.write(b" %define PREFIX 1\n").unwrap();
+    config += "%define PREFIX 1\n";
   }
+
+  let out_dir = env::var("OUT_DIR").unwrap();
+  let dest_path = Path::new(&out_dir).join("config.asm");
+  std::fs::write(&dest_path, config).expect("can write config.asm");
 
   let asm_files = &[
     "src/x86/cdef_avx2.asm",
@@ -197,21 +199,21 @@ fn strip_command() -> Option<String> {
 
 #[cfg(feature = "asm")]
 fn build_asm_files() {
-  use std::fs::File;
-  use std::io::Write;
-  let out_dir = env::var("OUT_DIR").unwrap();
+  let mut config = "
+#define PRIVATE_PREFIX rav1e_
+#define ARCH_AARCH64 1
+#define ARCH_ARM 0
+#define CONFIG_LOG 1
+#define HAVE_ASM 1
+"
+  .to_owned();
 
-  let dest_path = Path::new(&out_dir).join("config.h");
-  let mut config_file = File::create(&dest_path).unwrap();
   if env::var("CARGO_CFG_TARGET_VENDOR").unwrap() == "apple" {
-    config_file.write(b" #define PREFIX 1\n").unwrap();
+    config += "#define PREFIX 1\n";
   }
-  config_file.write(b" #define PRIVATE_PREFIX rav1e_\n").unwrap();
-  config_file.write(b" #define ARCH_AARCH64 1\n").unwrap();
-  config_file.write(b" #define ARCH_ARM 0\n").unwrap();
-  config_file.write(b" #define CONFIG_LOG 1 \n").unwrap();
-  config_file.write(b" #define HAVE_ASM 1\n").unwrap();
-  config_file.sync_all().unwrap();
+  let out_dir = env::var("OUT_DIR").unwrap();
+  let dest_path = Path::new(&out_dir).join("config.h");
+  std::fs::write(&dest_path, config).expect("can write config.h");
 
   let asm_files = &[
     "src/arm/64/cdef.S",

--- a/build.rs
+++ b/build.rs
@@ -76,10 +76,11 @@ fn build_nasm_files() {
 
   let dest_path = Path::new(&out_dir).join("config.asm");
   let mut config_file = File::create(&dest_path).unwrap();
-  config_file.write(b"	%define private_prefix rav1e\n").unwrap();
-  config_file.write(b"	%define ARCH_X86_32 0\n").unwrap();
+  config_file.write(b" %pragma preproc sane_empty_expansion true\n").unwrap();
+  config_file.write(b" %define private_prefix rav1e\n").unwrap();
+  config_file.write(b" %define ARCH_X86_32 0\n").unwrap();
   config_file.write(b" %define ARCH_X86_64 1\n").unwrap();
-  config_file.write(b"	%define PIC 1\n").unwrap();
+  config_file.write(b" %define PIC 1\n").unwrap();
   config_file.write(b" %define STACK_ALIGNMENT 16\n").unwrap();
   config_file.write(b" %define HAVE_AVX512ICL 1\n").unwrap();
   if env::var("CARGO_CFG_TARGET_VENDOR").unwrap() == "apple" {
@@ -136,7 +137,7 @@ fn build_nasm_files() {
     config_include_arg.push_str(&out_dir);
     config_include_arg.push('/');
     let mut nasm = nasm_rs::Build::new();
-    nasm.min_version(2, 14, 0);
+    nasm.min_version(2, 15, 0);
     for file in asm_files {
       nasm.file(file);
     }


### PR DESCRIPTION
Fixes #3330.

This raises the minimum NASM version to 2.15.0 which was released in [June 2020](https://repo.or.cz/nasm.git/tag/refs/tags/nasm-2.15). The minimum Rust version 1.70 was released in [June 2023](https://releases.rs/docs/1.70.0/), so I don't think this is a problem.

I also spent a bit of time refactoring the build script slightly.