### PR TITLE
Fix build on wasm32-unknown-unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,10 @@ tracing = [
 ]
 scenechange = []
 serialize = ["serde", "toml", "v_frame/serialize", "serde-big-array", "av1-grain/serialize"]
-wasm = ["wasm-bindgen"]
+
+# Left here for compatibility reasons.
+# Does not do anything, the wasm target is auto-detected.
+wasm = []
 
 # Enables debug dumping of lookahead computation results, specifically:
 # - i-qres.png: quarter-resolution luma planes,
@@ -106,7 +109,6 @@ console = { version = "0.15", optional = true }
 fern = { version = "0.6", optional = true }
 itertools = "0.12"
 simd_helpers = "0.1"
-wasm-bindgen = { version = "0.2.90", optional = true }
 nom = { version = "7.1.3", optional = true }
 new_debug_unreachable = "1.0.4"
 av1-grain = "0.2.3"
@@ -154,6 +156,10 @@ rand_chacha = "0.3"
 
 [target.'cfg(any(decode_test, decode_test_dav1d))'.dependencies]
 system-deps = "6"
+
+# WASM
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown", target_vendor = "unknown"))'.dependencies]
+wasm-bindgen = "0.2.90"
 
 [[bin]]
 name = "rav1e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,8 @@ bench = false
 
 [lib]
 bench = false
+# cdylib is required for wasm32-unknown-unknown
+crate-type = ["lib", "cdylib"]
 
 [[bench]]
 name = "bench"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ mod serialize {
 
 mod wasm_bindgen {
   cfg_if::cfg_if! {
-    if #[cfg(feature="wasm")] {
+    if #[cfg(all(target_arch = "wasm32", target_os = "unknown", target_vendor = "unknown"))] {
       pub use wasm_bindgen::prelude::*;
     } else {
       pub use noop_proc_macro::wasm_bindgen;


### PR DESCRIPTION
- `crate-type = "cdylib"` is needed for `wasm-pack` to work
- There is no need for a `wasm` feature, everything can be auto-detected (`-F wasm` is now a no-op)
- `wasm-bindgen` should only be included for `wasm32-unknown-unknown`. `wasm32-wasi` does not need it. I'm not sure about emscripten

`wasm-pack build` and other commands should now work. `--no-default-features` is necessary because the `binaries` feature does not compile on wasm.

Note that testing on wasm32-unknown-unknown can't just be done with `cargo test` and requires more work. I'll do that in a separate PR (incl. CI).