### PR TITLE
Update nasm-rs to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,11 +935,11 @@ dependencies = [
 
 [[package]]
 name = "nasm-rs"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4d98d0065f4b1daf164b3eafb11974c94662e5e2396cf03f32d0bb5c17da51"
+checksum = "12fcfa1bd49e0342ec1d07ed2be83b59963e7acbeb9310e1bb2c07b69dadd959"
 dependencies = [
- "rayon",
+ "jobserver",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ cc = { version = "1.0", optional = true, features = ["parallel"] }
 built = { version = "0.7.1", features = [] }
 
 [build-dependencies.nasm-rs]
-version = "0.2"
+version = "0.3"
 optional = true
 features = ["parallel"]
 


### PR DESCRIPTION
nasm-rs versions before 0.3 ignored the number of jobs set by cargo's job server. This means that even with `cargo b -j1` or `NUM_JOBS=1 cargo b`, the rav1e build script uses 100% CPU.