### PR TITLE
Drop `binary` integration test from coverage

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -325,7 +325,11 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: >
             ${{ env.SDE_PATH }}/sde -icx --
         run: |
-          cargo test --workspace --verbose --target x86_64-unknown-linux-gnu \
+          cargo test --workspace --target x86_64-unknown-linux-gnu \
+                     --lib --test doctests \
+                     --features=decode_test,decode_test_dav1d,quick_test
+          cargo test --workspace --target x86_64-unknown-linux-gnu \
+                     --doc \
                      --features=decode_test,decode_test_dav1d,quick_test
       - name: Run unit tests
         if: matrix.conf == 'no-asm-tests'

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -557,7 +557,7 @@ impl QuantizerParameters {
 
     // delta_q only gets 6 bits + a sign bit, so it can differ by 63 at most.
     let min_qi = base_q_idx.saturating_sub(63).max(1);
-    let max_qi = base_q_idx.saturating_add(63).min(255);
+    let max_qi = base_q_idx.saturating_add(63);
     let clamp_qi = |qi: u8| qi.clamp(min_qi, max_qi);
 
     QuantizerParameters {


### PR DESCRIPTION
Should fix #3394.