### PR TITLE
Fix `deploy` CI job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,10 +114,10 @@ jobs:
         CARGO_TARGET_X86_64_PC_WINDOWS_GNU_AR: "C:\\msys64\\mingw64\\bin\\ar.exe"
       run: |
         cargo fetch
-        cargo cinstall \
-          --profile ${{ matrix.profile }} \
-          --destdir="C:\" \
-          --libdir lib --prefix /usr/rav1e-windows-${{ matrix.conf }}-sdk \
+        cargo cinstall `
+          --profile ${{ matrix.profile }} `
+          --destdir="C:\" `
+          --libdir lib --prefix /usr/rav1e-windows-${{ matrix.conf }}-sdk `
           --offline
 
     - name: Copy LICENSE


### PR DESCRIPTION
Closes #3397.

[proof that it works](https://github.com/FreezyLemon/rav1e/actions/runs/11001342466) (the [commit](https://github.com/FreezyLemon/rav1e/commit/f704289e3212a89a3026f2b85077f5492f2b068b) on that branch includes another change for testing).

GHA uses `pwsh` by default on Windows runners. Powershell uses backticks instead of backslashes.