### PR TITLE
Cargo.toml: remove irrelevant comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,6 @@ debug = true
 incremental = true
 lto = "thin"
 
-# windows-gnu should use it until rust-lang/rust#98302 is not fixed
 [profile.release-no-lto]
 inherits = "release"
 lto = "off"


### PR DESCRIPTION
rust-lang/rust#98302 is fixed in Rust 1.83.0