### PR TITLE
Fix bit overflows when writing headers

### DIFF
--- a/src/api/channel/data.rs
+++ b/src/api/channel/data.rs
@@ -15,7 +15,7 @@ use crate::encoder::*;
 use crate::frame::*;
 use crate::util::Pixel;
 
-use bitstream_io::{BigEndian, BitWrite2, BitWriter};
+use bitstream_io::{BigEndian, BitWrite, BitWriter};
 use crossbeam::channel::{Receiver, Sender};
 use thiserror::Error;
 
@@ -353,20 +353,20 @@ impl<T: Pixel> PacketReceiver<T> {
       {
         let mut bw = BitWriter::endian(&mut buf, BigEndian);
         bw.write_bit(true)?; // marker
-        bw.write(7, 1)?; // version
-        bw.write(3, seq.profile)?;
-        bw.write(5, 31)?; // level
+        bw.write::<7, u8>(1)?; // version
+        bw.write::<3, u8>(seq.profile)?;
+        bw.write::<5, u8>(31)?; // level
         bw.write_bit(false)?; // tier
         bw.write_bit(seq.bit_depth > 8)?; // high_bitdepth
         bw.write_bit(seq.bit_depth == 12)?; // twelve_bit
         bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs400)?; // monochrome
         bw.write_bit(seq.chroma_sampling != ChromaSampling::Cs444)?; // chroma_subsampling_x
         bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs420)?; // chroma_subsampling_y
-        bw.write(2, 0)?; // chroma_sample_position
-        bw.write(3, 0)?; // reserved
+        bw.write::<2, u8>(0)?; // chroma_sample_position
+        bw.write::<3, u8>(0)?; // reserved
         bw.write_bit(false)?; // initial_presentation_delay_present
 
-        bw.write(4, 0)?; // reserved
+        bw.write::<4, u8>(0)?; // reserved
       }
 
       Ok(buf)

--- a/src/api/context.rs
+++ b/src/api/context.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use std::io;
 use std::sync::Arc;
 
-use bitstream_io::{BigEndian, BitWrite2, BitWriter};
+use bitstream_io::{BigEndian, BitWrite, BitWriter};
 
 use crate::api::color::*;
 use crate::api::config::*;
@@ -345,20 +345,20 @@ impl<T: Pixel> Context<T> {
       {
         let mut bw = BitWriter::endian(&mut buf, BigEndian);
         bw.write_bit(true)?; // marker
-        bw.write(7, 1)?; // version
-        bw.write(3, seq.profile)?;
-        bw.write(5, 31)?; // level
+        bw.write::<7, u8>(1)?; // version
+        bw.write::<3, u8>(seq.profile)?;
+        bw.write::<5, u8>(31)?; // level
         bw.write_bit(false)?; // tier
         bw.write_bit(seq.bit_depth > 8)?; // high_bitdepth
         bw.write_bit(seq.bit_depth == 12)?; // twelve_bit
         bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs400)?; // monochrome
         bw.write_bit(seq.chroma_sampling != ChromaSampling::Cs444)?; // chroma_subsampling_x
         bw.write_bit(seq.chroma_sampling == ChromaSampling::Cs420)?; // chroma_subsampling_y
-        bw.write(2, 0)?; // chroma_sample_position
-        bw.write(3, 0)?; // reserved
+        bw.write::<2, u8>(0)?; // chroma_sample_position
+        bw.write::<3, u8>(0)?; // reserved
         bw.write_bit(false)?; // initial_presentation_delay_present
 
-        bw.write(4, 0)?; // reserved
+        bw.write::<4, u8>(0)?; // reserved
       }
 
       Ok(buf)

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -19,7 +19,7 @@ cfg_if::cfg_if! {
 }
 
 use crate::context::{CDFContext, CDFContextLog, CDFOffset};
-use bitstream_io::{BigEndian, BitWrite2, BitWriter};
+use bitstream_io::{BigEndian, BitWrite, BitWriter};
 use std::io;
 
 pub const OD_BITRES: u8 = 3;
@@ -863,10 +863,10 @@ impl<W: io::Write> BCodeWriter for BitWriter<W, BigEndian> {
       let l = 16 - n.leading_zeros() as u8;
       let m = (1 << l) - n;
       if v < m {
-        self.write(l as u32 - 1, v)
+        self.write_var(l as u32 - 1, v)
       } else {
-        self.write(l as u32 - 1, m + ((v - m) >> 1))?;
-        self.write(1, (v - m) & 1)
+        self.write_var(l as u32 - 1, m + ((v - m) >> 1))?;
+        self.write::<1, u16>((v - m) & 1)
       }
     } else {
       Ok(())
@@ -890,7 +890,7 @@ impl<W: io::Write> BCodeWriter for BitWriter<W, BigEndian> {
           i += 1;
           mk += a;
         } else {
-          return self.write(b as u32, v - mk);
+          return self.write_var(b as u32, v - mk);
         }
       }
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -15,7 +15,7 @@ use std::{fmt, io, mem};
 
 use arg_enum_proc_macro::ArgEnum;
 use arrayvec::*;
-use bitstream_io::{BigEndian, BitWrite2, BitWriter};
+use bitstream_io::{BigEndian, BitWrite, BitWriter};
 use rayon::iter::*;
 
 use crate::activity::*;


### PR DESCRIPTION
`bw.write(5, 31)` is writing an 31i32 but that doesn't fit into 5 bits because of the sign bit.

As part of this, also move everything to the non-compat `BitWrite` trait.