### PR TITLE
Migrate from paste to pastey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -98,7 +98,7 @@ checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "av-metrics"
@@ -335,9 +335,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -472,7 +472,7 @@ dependencies = [
  "libc",
  "once_cell",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -667,12 +667,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -788,7 +788,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1026,9 +1026,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libdav1d-sys"
@@ -1068,7 +1068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1273,12 +1273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pastey"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1459,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1550,7 +1544,7 @@ dependencies = [
  "noop_proc_macro",
  "num-derive",
  "num-traits",
- "paste",
+ "pastey",
  "pretty_assertions",
  "profiling",
  "quickcheck",
@@ -1643,7 +1637,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1656,7 +1650,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1805,9 +1799,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1851,7 +1845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
  "rustix 1.0.7",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1902,12 +1896,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -1984,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2240,7 +2233,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2256,6 +2249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -2276,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -2448,18 +2450,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,6 @@ y4m = { version = "0.8", optional = true }
 backtrace = { version = "0.3", optional = true }
 num-traits = "0.2"
 num-derive = "0.4"
-paste = "1.0"
 noop_proc_macro = "0.3.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 dav1d-sys = { version = "0.7.0", package = "libdav1d-sys", optional = true }
@@ -122,6 +121,7 @@ tracing-subscriber = { version = "0.3.18", optional = true }
 tracing-chrome = { version = "0.7.1", optional = true }
 tracing = { version = "0.1.40", optional = true }
 aligned-vec = "0.6.0"
+pastey = "0.1.0"
 
 [dependencies.image]
 version = "0.25.0"

--- a/src/asm/aarch64/dist/mod.rs
+++ b/src/asm/aarch64/dist/mod.rs
@@ -417,7 +417,7 @@ mod test {
   macro_rules! test_dist_fns {
     ($(($W:expr, $H:expr)),*, $DIST_TY:ident, $BD:expr, $OPT:ident, $OPTLIT:tt) => {
       $(
-        paste::item! {
+        pastey::item! {
           #[test]
           fn [<get_ $DIST_TY _ $W x $H _bd_ $BD _ $OPT>]() {
             if $BD > 8 {

--- a/src/asm/aarch64/transform/inverse.rs
+++ b/src/asm/aarch64/transform/inverse.rs
@@ -56,7 +56,7 @@ macro_rules! decl_itx_fns {
   // Takes a 2d list of tx types for W and H
   ([$([$(($ENUM:expr, $TYPE1:ident, $TYPE2:ident)),*]),*], $W:expr, $H:expr,
    $OPT_LOWER:ident, $OPT_UPPER:ident) => {
-    paste::item! {
+    pastey::item! {
       // For each tx type, declare an function for the current WxH
       $(
         $(
@@ -87,7 +87,7 @@ macro_rules! decl_itx_hbd_fns {
   // Takes a 2d list of tx types for W and H
   ([$([$(($ENUM:expr, $TYPE1:ident, $TYPE2:ident)),*]),*], $W:expr, $H:expr,
    $OPT_LOWER:ident, $OPT_UPPER:ident) => {
-    paste::item! {
+    pastey::item! {
       // For each tx type, declare an function for the current WxH
       $(
         $(
@@ -117,7 +117,7 @@ macro_rules! decl_itx_hbd_fns {
 macro_rules! create_wxh_tables {
   // Create a lookup table for each cpu feature
   ([$([$(($W:expr, $H:expr)),*]),*], $OPT_LOWER:ident, $OPT_UPPER:ident) => {
-    paste::item! {
+    pastey::item! {
       const [<INV_TXFM_FNS_$OPT_UPPER>]: [[Option<InvTxfmFunc>; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL] = {
         let mut out: [[Option<InvTxfmFunc>; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL] =
           [[None; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL];
@@ -143,7 +143,7 @@ macro_rules! create_wxh_tables {
 macro_rules! create_wxh_hbd_tables {
   // Create a lookup table for each cpu feature
   ([$([$(($W:expr, $H:expr)),*]),*], $OPT_LOWER:ident, $OPT_UPPER:ident) => {
-    paste::item! {
+    pastey::item! {
       const [<INV_TXFM_HBD_FNS_$OPT_UPPER>]: [[Option<InvTxfmHBDFunc>; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL] = {
         let mut out: [[Option<InvTxfmHBDFunc>; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL] =
           [[None; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL];

--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -200,7 +200,7 @@ pub mod test {
 
   macro_rules! test_itx_fns {
     ([$([$(($ENUM:expr, $TYPE1:ident, $TYPE2:ident)),*]),*], $W:expr, $H:expr) => {
-      paste::item! {
+      pastey::item! {
         $(
           $(
             #[test]

--- a/src/asm/x86/cdef.rs
+++ b/src/asm/x86/cdef.rs
@@ -300,7 +300,7 @@ mod test {
   macro_rules! test_cdef_filter_block {
     ($(($XDEC:expr, $YDEC:expr)),*, $OPT:ident, $OPTLIT:literal) => {
       $(
-        paste::item! {
+        pastey::item! {
           #[interpolate_test(dir_0, 0)]
           #[interpolate_test(dir_1, 1)]
           #[interpolate_test(dir_2, 2)]
@@ -350,7 +350,7 @@ mod test {
   macro_rules! test_cdef_filter_block_hbd {
     ($(($XDEC:expr, $YDEC:expr)),*, $OPT:ident, $OPTLIT:literal) => {
       $(
-        paste::item! {
+        pastey::item! {
           #[interpolate_test(dir_0, 0)]
           #[interpolate_test(dir_1, 1)]
           #[interpolate_test(dir_2, 2)]
@@ -399,7 +399,7 @@ mod test {
 
   macro_rules! test_cdef_dir {
     ($OPT:ident, $OPTLIT:literal) => {
-      paste::item! {
+      pastey::item! {
         #[test]
         fn [<cdef_dir_ $OPT>]() {
           use crate::context::{TileSuperBlockOffset, SuperBlockOffset};
@@ -446,7 +446,7 @@ mod test {
 
   macro_rules! test_cdef_dir_hbd {
     ($OPT:ident, $OPTLIT:literal) => {
-      paste::item! {
+      pastey::item! {
         #[test]
         fn [<cdef_dir_ $OPT _hbd>]() {
           use crate::context::{TileSuperBlockOffset, SuperBlockOffset};

--- a/src/asm/x86/dist/mod.rs
+++ b/src/asm/x86/dist/mod.rs
@@ -393,7 +393,7 @@ pub fn get_satd<T: Pixel>(
 macro_rules! get_sad_hbd_ssse3 {
   ($(($W:expr, $H:expr, $BS:expr)),*) => {
     $(
-      paste::item! {
+      pastey::item! {
         #[target_feature(enable = "ssse3")]
         unsafe extern fn [<rav1e_sad_ $W x $H _hbd_ssse3>](
           src: *const u16, src_stride: isize, dst: *const u16, dst_stride: isize,
@@ -443,7 +443,7 @@ get_sad_hbd_ssse3!(
 macro_rules! get_sad_hbd_avx2_WxH {
   ($(($W:expr, $H:expr)),*) => {
     $(
-      paste::item! {
+      pastey::item! {
         #[target_feature(enable = "avx2")]
         unsafe extern fn [<rav1e_sad_ $W x $H _hbd_avx2>](
           src: *const u16, src_stride: isize, dst: *const u16, dst_stride: isize,
@@ -738,7 +738,7 @@ mod test {
   macro_rules! test_dist_fns {
     ($(($W:expr, $H:expr)),*, $DIST_TY:ident, $BD:expr, $OPT:ident, $OPTLIT:tt) => {
       $(
-        paste::item! {
+        pastey::item! {
           #[test]
           fn [<get_ $DIST_TY _ $W x $H _bd_ $BD _ $OPT>]() {
             if CpuFeatureLevel::default() < CpuFeatureLevel::from_str($OPTLIT).unwrap() {

--- a/src/asm/x86/mc.rs
+++ b/src/asm/x86/mc.rs
@@ -321,7 +321,7 @@ pub fn mc_avg<T: Pixel>(
 
 macro_rules! decl_mc_fns {
   ($(($mode_x:expr, $mode_y:expr, $func_name:ident)),+) => {
-    paste::item! {
+    pastey::item! {
       extern {
         $(
           fn [<$func_name _ssse3>](
@@ -389,7 +389,7 @@ cpu_function_lookup_table!(
 
 macro_rules! decl_mc_hbd_fns {
   ($(($mode_x:expr, $mode_y:expr, $func_name:ident)),+) => {
-    paste::item! {
+    pastey::item! {
       extern {
         $(
           fn [<$func_name _ssse3>](
@@ -444,7 +444,7 @@ cpu_function_lookup_table!(
 
 macro_rules! decl_mct_fns {
   ($(($mode_x:expr, $mode_y:expr, $func_name:ident)),+) => {
-    paste::item! {
+    pastey::item! {
       extern {
         $(
           fn [<$func_name _sse2>](
@@ -525,7 +525,7 @@ cpu_function_lookup_table!(
 
 macro_rules! decl_mct_hbd_fns {
   ($(($mode_x:expr, $mode_y:expr, $func_name:ident)),+) => {
-    paste::item! {
+    pastey::item! {
       extern {
         $(
           fn [<$func_name _ssse3>](
@@ -630,7 +630,7 @@ mod test {
   macro_rules! test_put_fns {
     ($(($mode_x:expr, $mode_y:expr, $func_name:ident)),*, $OPT:ident, $OPTLIT:tt, $BD:expr) => {
       $(
-        paste::item! {
+        pastey::item! {
           #[test]
           fn [<test_ $func_name _bd_ $BD _ $OPT>]() {
             if CpuFeatureLevel::default() < CpuFeatureLevel::from_str($OPTLIT).unwrap() {
@@ -717,7 +717,7 @@ mod test {
   macro_rules! test_prep_fns {
     ($(($mode_x:expr, $mode_y:expr, $func_name:ident)),*, $OPT:ident, $OPTLIT:tt, $BD:expr) => {
       $(
-        paste::item! {
+        pastey::item! {
           #[test]
           fn [<test_ $func_name _bd_ $BD _ $OPT>]() {
             if CpuFeatureLevel::default() < CpuFeatureLevel::from_str($OPTLIT).unwrap() {

--- a/src/asm/x86/transform/inverse.rs
+++ b/src/asm/x86/transform/inverse.rs
@@ -70,7 +70,7 @@ macro_rules! decl_itx_fns {
   // Takes a 2d list of tx types for W and H
   ([$([$(($ENUM:expr, $TYPE1:ident, $TYPE2:ident)),*]),*], $W:expr, $H:expr,
    $OPT_LOWER:ident, $OPT_UPPER:ident) => {
-    paste::item! {
+    pastey::item! {
       // For each tx type, declare an function for the current WxH
       $(
         $(
@@ -101,7 +101,7 @@ macro_rules! decl_itx_hbd_fns {
   // Takes a 2d list of tx types for W and H
   ([$([$(($ENUM:expr, $TYPE1:ident, $TYPE2:ident)),*]),*], $W:expr, $H:expr, $BPC:expr,
    $OPT_LOWER:ident, $OPT_UPPER:ident) => {
-    paste::item! {
+    pastey::item! {
       // For each tx type, declare an function for the current WxH
       $(
         $(
@@ -132,7 +132,7 @@ macro_rules! decl_itx_hbd_fns {
 macro_rules! create_wxh_tables {
   // Create a lookup table for each cpu feature
   ([$([$(($W:expr, $H:expr)),*]),*], $OPT_LOWER:ident, $OPT_UPPER:ident) => {
-    paste::item! {
+    pastey::item! {
       const [<INV_TXFM_FNS_$OPT_UPPER>]: [[Option<InvTxfmFunc>; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL] = {
         let mut out: [[Option<InvTxfmFunc>; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL] =
           [[None; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL];
@@ -158,7 +158,7 @@ macro_rules! create_wxh_tables {
 macro_rules! create_wxh_hbd_tables {
   // Create a lookup table for each cpu feature
   ([$([$(($W:expr, $H:expr)),*]),*], $EXT:ident, $BPC:expr, $OPT_LOWER:ident, $OPT_UPPER:ident) => {
-    paste::item! {
+    pastey::item! {
       const [<INV_TXFM_HBD_FNS $EXT _$OPT_UPPER>]: [[Option<InvTxfmHBDFunc>; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL] = {
         let mut out: [[Option<InvTxfmHBDFunc>; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL] =
           [[None; TX_TYPES_PLUS_LL]; TxSize::TX_SIZES_ALL];

--- a/src/cpu_features/aarch64.rs
+++ b/src/cpu_features/aarch64.rs
@@ -98,7 +98,7 @@ macro_rules! cpu_function_lookup_table {
 
   // use $name_$key as our values
   ($pub:vis, $name:ident: [$type:ty], default: $empty:expr, [$($key:ident),*]) => {
-    paste::item!{
+    pastey::item!{
       cpu_function_lookup_table!(
         $pub, $name: [$type], default: $empty, [$(($key, [<$name _$key>])),*]
       );
@@ -107,7 +107,7 @@ macro_rules! cpu_function_lookup_table {
 
   // version for default visibility
   ($name:ident: [$type:ty], default: $empty:expr, [$($key:ident),*]) => {
-    paste::item!{
+    pastey::item!{
       cpu_function_lookup_table!(
         $name: [$type], default: $empty, [$(($key, [<$name _$key>])),*]
       );

--- a/src/cpu_features/x86.rs
+++ b/src/cpu_features/x86.rs
@@ -140,7 +140,7 @@ macro_rules! cpu_function_lookup_table {
 
   // use $name_$key as our values
   ($pub:vis, $name:ident: [$type:ty], default: $empty:expr, [$($key:ident),*]) => {
-    paste::item!{
+    pastey::item!{
       cpu_function_lookup_table!(
         $pub, $name: [$type], default: $empty, [$(($key, [<$name _$key>])),*]
       );
@@ -149,7 +149,7 @@ macro_rules! cpu_function_lookup_table {
 
   // version for default visibility
   ($name:ident: [$type:ty], default: $empty:expr, [$($key:ident),*]) => {
-     paste::item!{
+     pastey::item!{
       cpu_function_lookup_table!(
         $name: [$type], default: $empty, [$(($key, [<$name _$key>])),*]
       );

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -247,7 +247,7 @@ fn speed(s: u8, decoder: &str) {
 macro_rules! test_speeds {
   ($($S:expr),+) => {
     $(
-        paste::item!{
+        pastey::item!{
             #[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
             #[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
             #[ignore]
@@ -264,7 +264,7 @@ test_speeds! { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
 macro_rules! test_dimensions {
   ($(($W:expr, $H:expr)),+) => {
     $(
-        paste::item!{
+        pastey::item!{
             #[cfg_attr(feature = "decode_test", interpolate_name::interpolate_test(aom, "aom"))]
             #[cfg_attr(feature = "decode_test_dav1d", interpolate_name::interpolate_test(dav1d, "dav1d"))]
             fn [<dimension_ $W x $H>](decoder: &str) {
@@ -371,7 +371,7 @@ fn quantizer(decoder: &str, q: usize) {
 macro_rules! test_quantizer {
   ($($Q:expr),+) => {
     $(
-      paste::item!{
+      pastey::item!{
         #[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
         #[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
         fn [<quantizer_ $Q>](decoder: &str) {
@@ -720,7 +720,7 @@ fn high_bit_depth(decoder: &str, depth: usize) {
 macro_rules! test_high_bit_depth {
   ($($B:expr),+) => {
     $(
-      paste::item!{
+      pastey::item!{
         #[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
         #[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
         #[ignore]
@@ -751,7 +751,7 @@ fn chroma_sampling(decoder: &str, cs: ChromaSampling) {
 macro_rules! test_chroma_sampling {
   ($(($S:expr, $I:expr)),+) => {
     $(
-      paste::item!{
+      pastey::item!{
         #[cfg_attr(feature = "decode_test", interpolate_test(aom, "aom"))]
         #[cfg_attr(feature = "decode_test_dav1d", interpolate_test(dav1d, "dav1d"))]
         #[ignore]


### PR DESCRIPTION
Removed paste and added pastey from dependencies, `cargo update` and changed `paste` to `pastey` to all the files in `src`.