### PR TITLE
Update to `rand` v0.10

### DIFF
--- a/.github/workflows/rav1e.yml
+++ b/.github/workflows/rav1e.yml
@@ -46,8 +46,8 @@ jobs:
           version: 2.15
 
       # Minimum version in Cargo.toml
-      - name: Install Rust 1.83.0
-        uses: dtolnay/rust-toolchain@1.83.0
+      - name: Install Rust 1.85.1
+        uses: dtolnay/rust-toolchain@1.85.1
         with:
           targets: wasm32-unknown-unknown, wasm32-wasip2
 
@@ -119,7 +119,7 @@ jobs:
           - conf: beta-build
             toolchain: beta
           - conf: msrv-tests
-            toolchain: 1.83.0
+            toolchain: 1.85.1
           - conf: aom-tests
             toolchain: stable
           - conf: dav1d-tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +382,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +418,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -485,6 +517,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -592,6 +633,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,13 +683,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
+name = "env_filter"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -717,25 +777,26 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "r-efi 5.2.0",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core",
 ]
 
 [[package]]
@@ -792,6 +853,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -921,6 +991,15 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1106,9 +1185,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "maybe-rayon"
@@ -1350,15 +1429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,13 +1506,13 @@ dependencies = [
 
 [[package]]
 name = "quickcheck"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -1461,51 +1531,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core 0.6.4",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rav1e"
@@ -1526,6 +1572,7 @@ dependencies = [
  "byteorder",
  "cc",
  "cfg-if",
+ "chacha20",
  "clap",
  "clap_complete",
  "console",
@@ -1551,8 +1598,7 @@ dependencies = [
  "pretty_assertions",
  "profiling",
  "quickcheck",
- "rand 0.9.1",
- "rand_chacha",
+ "rand",
  "scan_fmt",
  "semver",
  "serde",
@@ -1591,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1603,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1614,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-demangle"
@@ -2037,6 +2083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,12 +2171,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -2441,26 +2487,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rav1e"
 version = "0.8.0"
 authors = ["Thomas Daede <tdaede@xiph.org>"]
 edition = "2021"
-rust-version = "1.83.0"
+rust-version = "1.85.0"
 build = "build.rs"
 include = [
   "/Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,8 +148,8 @@ pretty_assertions = "1.4.0"
 interpolate_name = "0.2.4"
 nom = "8.0.0"
 quickcheck = "1.0"
-rand = "0.9"
-rand_chacha = "0.9"
+rand = "0.10"
+chacha20 = "0.10"
 semver = "1.0"
 
 # Exclude dependencies and features that don't work on wasm32:
@@ -164,8 +164,8 @@ criterion = "0.6"
 arbitrary = "1.3"
 interpolate_name = "0.2.4"
 libfuzzer-sys = "0.4.7"
-rand = "0.9"
-rand_chacha = "0.9"
+rand = "0.10"
+chacha20 = "0.10"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For the foreseeable future, a weekly pre-release of rav1e will be [published](ht
 
 ### Toolchain: Rust
 
-rav1e currently requires Rust 1.74.0 or later to build.
+rav1e currently requires Rust 1.85 or later to build.
 
 ### Dependency: NASM
 Some `x86_64`-specific optimizations require [NASM](https://nasm.us/) `2.14.02` or newer and are enabled by default.

--- a/benches/dist.rs
+++ b/benches/dist.rs
@@ -9,9 +9,9 @@
 
 #![allow(clippy::trivially_copy_pass_by_ref)]
 
+use chacha20::ChaCha20Rng;
 use criterion::*;
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaChaRng;
+use rand::{RngExt, SeedableRng};
 use rav1e::bench::cpu_features::*;
 use rav1e::bench::dist;
 use rav1e::bench::frame::*;
@@ -70,7 +70,7 @@ const DIST_BENCH_SET: &[(BlockSize, usize)] = &[
   (BLOCK_64X16, 10),
 ];
 
-fn fill_plane<T: Pixel>(ra: &mut ChaChaRng, plane: &mut Plane<T>) {
+fn fill_plane<T: Pixel>(ra: &mut ChaCha20Rng, plane: &mut Plane<T>) {
   let stride = plane.cfg.stride;
   for row in plane.data_origin_mut().chunks_mut(stride) {
     for pixel in row {
@@ -81,7 +81,7 @@ fn fill_plane<T: Pixel>(ra: &mut ChaChaRng, plane: &mut Plane<T>) {
 }
 
 fn new_plane<T: Pixel>(
-  ra: &mut ChaChaRng, width: usize, height: usize,
+  ra: &mut ChaCha20Rng, width: usize, height: usize,
 ) -> Plane<T> {
   let mut p = Plane::new(width, height, 0, 0, 128 + 8, 128 + 8);
 
@@ -102,7 +102,7 @@ type DistFn<T> = fn(
 fn run_dist_bench<T: Pixel>(
   b: &mut Bencher, &(bs, bit_depth): &(BlockSize, usize), func: DistFn<T>,
 ) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -162,7 +162,7 @@ pub fn get_satd(c: &mut Criterion) {
 }
 
 /// Fill data for scaling of one
-fn fill_scaling(ra: &mut ChaChaRng, scales: &mut [u32]) {
+fn fill_scaling(ra: &mut ChaCha20Rng, scales: &mut [u32]) {
   for a in scales.iter_mut() {
     *a = ra.random_range(
       DistortionScale::from(0.5).0..DistortionScale::from(1.5).0,
@@ -185,7 +185,7 @@ fn run_weighted_sse_bench<T: Pixel>(
   b: &mut Bencher, &(bs, bit_depth): &(BlockSize, usize),
   func: WeightedSseFn<T>,
 ) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;

--- a/benches/mc.rs
+++ b/benches/mc.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::unit_arg)]
 
+use chacha20::ChaCha20Rng;
 use criterion::*;
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaChaRng;
+use rand::{RngExt, SeedableRng};
 use rav1e::bench::context::BlockContext;
 use rav1e::bench::context::CDFContext;
 use rav1e::bench::context::ContextWriter;
@@ -20,7 +20,7 @@ use std::hint::black_box;
 use std::sync::Arc;
 
 fn bench_put_8tap_top_left_lbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -51,7 +51,7 @@ fn bench_put_8tap_top_left_lbd(c: &mut Criterion) {
 }
 
 fn bench_put_8tap_top_lbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -82,7 +82,7 @@ fn bench_put_8tap_top_lbd(c: &mut Criterion) {
 }
 
 fn bench_put_8tap_left_lbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -113,7 +113,7 @@ fn bench_put_8tap_left_lbd(c: &mut Criterion) {
 }
 
 fn bench_put_8tap_center_lbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -144,7 +144,7 @@ fn bench_put_8tap_center_lbd(c: &mut Criterion) {
 }
 
 fn bench_put_8tap_top_left_hbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -175,7 +175,7 @@ fn bench_put_8tap_top_left_hbd(c: &mut Criterion) {
 }
 
 fn bench_put_8tap_top_hbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -206,7 +206,7 @@ fn bench_put_8tap_top_hbd(c: &mut Criterion) {
 }
 
 fn bench_put_8tap_left_hbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -237,7 +237,7 @@ fn bench_put_8tap_left_hbd(c: &mut Criterion) {
 }
 
 fn bench_put_8tap_center_hbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -268,7 +268,7 @@ fn bench_put_8tap_center_hbd(c: &mut Criterion) {
 }
 
 fn bench_prep_8tap_top_left_lbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -299,7 +299,7 @@ fn bench_prep_8tap_top_left_lbd(c: &mut Criterion) {
 }
 
 fn bench_prep_8tap_top_lbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -330,7 +330,7 @@ fn bench_prep_8tap_top_lbd(c: &mut Criterion) {
 }
 
 fn bench_prep_8tap_left_lbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -361,7 +361,7 @@ fn bench_prep_8tap_left_lbd(c: &mut Criterion) {
 }
 
 fn bench_prep_8tap_center_lbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -392,7 +392,7 @@ fn bench_prep_8tap_center_lbd(c: &mut Criterion) {
 }
 
 fn bench_prep_8tap_top_left_hbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -423,7 +423,7 @@ fn bench_prep_8tap_top_left_hbd(c: &mut Criterion) {
 }
 
 fn bench_prep_8tap_top_hbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -454,7 +454,7 @@ fn bench_prep_8tap_top_hbd(c: &mut Criterion) {
 }
 
 fn bench_prep_8tap_left_hbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -485,7 +485,7 @@ fn bench_prep_8tap_left_hbd(c: &mut Criterion) {
 }
 
 fn bench_prep_8tap_center_hbd(c: &mut Criterion) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let cpu = CpuFeatureLevel::default();
   let w = 640;
   let h = 480;
@@ -607,7 +607,7 @@ criterion_group!(
   bench_motion_compensate_hbd,
 );
 
-fn fill_plane<T: Pixel>(ra: &mut ChaChaRng, plane: &mut Plane<T>) {
+fn fill_plane<T: Pixel>(ra: &mut ChaCha20Rng, plane: &mut Plane<T>) {
   let stride = plane.cfg.stride;
   for row in plane.data_origin_mut().chunks_mut(stride) {
     for pixel in row {
@@ -618,7 +618,7 @@ fn fill_plane<T: Pixel>(ra: &mut ChaChaRng, plane: &mut Plane<T>) {
 }
 
 fn new_plane<T: Pixel>(
-  ra: &mut ChaChaRng, width: usize, height: usize,
+  ra: &mut ChaCha20Rng, width: usize, height: usize,
 ) -> Plane<T> {
   let mut p = Plane::new(width, height, 0, 0, 128 + 8, 128 + 8);
 

--- a/benches/plane.rs
+++ b/benches/plane.rs
@@ -1,10 +1,10 @@
+use chacha20::ChaCha20Rng;
 use criterion::*;
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaChaRng;
+use rand::{RngExt, SeedableRng};
 use rav1e::bench::frame::*;
 
 fn init_plane_u8(width: usize, height: usize) -> Plane<u8> {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let data: Vec<u8> = (0..(width * height)).map(|_| ra.random()).collect();
   let out = Plane::from_slice(&data, width);
   if out.cfg.width % 2 == 0 && out.cfg.height % 2 == 0 {
@@ -24,7 +24,7 @@ fn init_plane_u8(width: usize, height: usize) -> Plane<u8> {
 }
 
 fn init_plane_u16(width: usize, height: usize) -> Plane<u16> {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let data: Vec<u16> = (0..(width * height)).map(|_| ra.random()).collect();
   Plane::from_slice(&data, width)
 }
@@ -57,7 +57,7 @@ pub fn downsample_10bit(c: &mut Criterion) {
 }
 
 fn init_raw_plane_data(width: usize, height: usize) -> Vec<u8> {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   (0..(width * height)).map(|_| ra.random()).collect()
 }
 

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -7,9 +7,9 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use chacha20::ChaCha20Rng;
 use criterion::*;
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaChaRng;
+use rand::{RngExt, SeedableRng};
 use rav1e::bench::cpu_features::CpuFeatureLevel;
 use rav1e::bench::frame::*;
 use rav1e::bench::partition::{BlockSize, IntraEdge};
@@ -19,7 +19,9 @@ use rav1e::bench::util::*;
 
 pub const BLOCK_SIZE: BlockSize = BlockSize::BLOCK_32X32;
 
-pub fn generate_block<T: Pixel>(rng: &mut ChaChaRng) -> (Plane<T>, Vec<i16>) {
+pub fn generate_block<T: Pixel>(
+  rng: &mut ChaCha20Rng,
+) -> (Plane<T>, Vec<i16>) {
   let block = Plane::from_slice(
     &vec![T::cast_from(0); BLOCK_SIZE.width() * BLOCK_SIZE.height()],
     BLOCK_SIZE.width(),
@@ -125,7 +127,7 @@ pub fn pred_bench(c: &mut Criterion) {
 pub fn intra_bench<T: Pixel>(
   b: &mut Bencher, mode: PredictionMode, variant: PredictionVariant,
 ) {
-  let mut rng = ChaChaRng::from_seed([0; 32]);
+  let mut rng = ChaCha20Rng::from_seed([0; 32]);
   let edge_buf = Aligned::from_fn(|_| T::cast_from(rng.random::<u8>()));
   let edge_buf = IntraEdge::mock(&edge_buf);
   let (mut block, ac) = generate_block::<T>(&mut rng);

--- a/benches/rdo.rs
+++ b/benches/rdo.rs
@@ -1,6 +1,6 @@
+use chacha20::ChaCha20Rng;
 use criterion::*;
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaChaRng;
+use rand::{RngExt, SeedableRng};
 
 use rav1e::bench::cpu_features::*;
 use rav1e::bench::frame::AsRegion;
@@ -10,7 +10,7 @@ use rav1e::bench::tiling::Area;
 use rav1e::prelude::Plane;
 
 fn init_plane_u8(width: usize, height: usize, seed: u8) -> Plane<u8> {
-  let mut ra = ChaChaRng::from_seed([seed; 32]);
+  let mut ra = ChaCha20Rng::from_seed([seed; 32]);
   let data: Vec<u8> = (0..(width * height)).map(|_| ra.random()).collect();
   Plane::from_slice(&data, width)
 }

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -7,9 +7,9 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
+use chacha20::ChaCha20Rng;
 use criterion::*;
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaChaRng;
+use rand::{RngExt, SeedableRng};
 use rav1e::bench::cpu_features::*;
 use rav1e::bench::transform;
 use rav1e::bench::transform::{
@@ -18,7 +18,7 @@ use rav1e::bench::transform::{
 use std::mem::MaybeUninit;
 
 fn init_buffers(size: usize) -> (Vec<i32>, Vec<i32>) {
-  let mut ra = ChaChaRng::from_seed([0; 32]);
+  let mut ra = ChaCha20Rng::from_seed([0; 32]);
   let input: Vec<i32> = (0..size).map(|_| ra.random()).collect();
   let output = vec![0i32; size];
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
 too-many-arguments-threshold = 16
 cognitive-complexity-threshold = 40
 trivial-copy-size-limit = 16        # 128-bits = 2 64-bit registers
-msrv = "1.83"
+msrv = "1.85"

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -189,7 +189,7 @@ pub const fn apply_ssim_boost(
 mod ssim_boost_tests {
   use super::*;
   use interpolate_name::interpolate_test;
-  use rand::Rng;
+  use rand::RngExt;
 
   /// Test to make sure extreme values of `ssim_boost` don't overflow.
   #[test]

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -70,7 +70,7 @@ fn setup_encoder<T: Pixel>(
 }
 
 /*
-fn fill_frame<T: Pixel>(ra: &mut ChaChaRng, frame: &mut Frame<T>) {
+fn fill_frame<T: Pixel>(ra: &mut ChaCha20Rng, frame: &mut Frame<T>) {
   for plane in frame.planes.iter_mut() {
     let stride = plane.cfg.stride;
     for row in plane.data.chunks_mut(stride) {

--- a/src/asm/shared/dist/cdef_dist.rs
+++ b/src/asm/shared/dist/cdef_dist.rs
@@ -14,7 +14,7 @@ pub mod test {
   use crate::frame::*;
   use crate::tiling::Area;
   use crate::util::Pixel;
-  use rand::{rng, Rng};
+  use rand::{rng, RngExt};
 
   fn random_planes<T: Pixel>(bd: usize) -> (Plane<T>, Plane<T>) {
     let mut rng = rng();

--- a/src/asm/shared/dist/sse.rs
+++ b/src/asm/shared/dist/sse.rs
@@ -16,7 +16,7 @@ pub mod test {
   use crate::rdo::DistortionScale;
   use crate::tiling::Area;
   use crate::util::*;
-  use rand::{rng, Rng};
+  use rand::{rng, RngExt};
 
   fn random_planes<T: Pixel>(bd: usize) -> (Plane<T>, Plane<T>) {
     let mut rng = rng();

--- a/src/asm/shared/transform/forward.rs
+++ b/src/asm/shared/transform/forward.rs
@@ -46,7 +46,7 @@ mod test {
   use crate::cpu_features::*;
   use crate::transform::{forward_transform, get_valid_txfm_types, TxSize};
   use crate::util::slice_assume_init_mut;
-  use rand::Rng;
+  use rand::RngExt;
   use std::mem::MaybeUninit;
 
   // Ensure that the simd results match the rust code

--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -85,7 +85,7 @@ pub mod test {
   use crate::scan_order::av1_scan_orders;
   use crate::transform::TxSize::*;
   use crate::transform::*;
-  use rand::{random, rng, Rng};
+  use rand::{random, rng, RngExt};
 
   pub fn pick_eob<T: Coefficient>(
     coeffs: &mut [T], tx_size: TxSize, tx_type: TxType, sub_h: usize,

--- a/src/asm/x86/quantize.rs
+++ b/src/asm/x86/quantize.rs
@@ -159,7 +159,7 @@ unsafe fn dequantize_avx2(
 mod test {
   use super::*;
   use rand::distr::{Distribution, Uniform};
-  use rand::{rng, Rng};
+  use rand::{rng, RngExt};
 
   #[test]
   fn dequantize_test() {

--- a/src/test_encode_decode/mod.rs
+++ b/src/test_encode_decode/mod.rs
@@ -17,10 +17,10 @@ use crate::util::Pixel;
 use crate::*;
 
 use arrayvec::ArrayVec;
+use chacha20::ChaCha20Rng;
 use interpolate_name::interpolate_test;
 use log::debug;
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaChaRng;
+use rand::{RngExt, SeedableRng};
 use std::collections::VecDeque;
 
 #[cfg(feature = "decode_test")]
@@ -33,7 +33,7 @@ use aom::AomDecoder;
 #[cfg(feature = "decode_test_dav1d")]
 use dav1d::Dav1dDecoder;
 
-fn fill_frame<T: Pixel>(ra: &mut ChaChaRng, frame: &mut Frame<T>) {
+fn fill_frame<T: Pixel>(ra: &mut ChaCha20Rng, frame: &mut Frame<T>) {
   for plane in frame.planes.iter_mut() {
     let stride = plane.cfg.stride;
     for row in plane.data.chunks_mut(stride) {
@@ -46,7 +46,7 @@ fn fill_frame<T: Pixel>(ra: &mut ChaChaRng, frame: &mut Frame<T>) {
 }
 
 fn read_frame_batch<T: Pixel>(
-  ctx: &mut Context<T>, ra: &mut ChaChaRng, limit: usize,
+  ctx: &mut Context<T>, ra: &mut ChaCha20Rng, limit: usize,
 ) {
   for _ in 0..limit {
     let mut input = ctx.new_frame();
@@ -76,7 +76,7 @@ pub(crate) trait TestDecoder<T: Pixel> {
     tile_cols_log2: usize, tile_rows_log2: usize, still_picture: bool,
     grain_table: Option<Vec<GrainTableSegment>>,
   ) {
-    let mut ra = ChaChaRng::from_seed([0; 32]);
+    let mut ra = ChaCha20Rng::from_seed([0; 32]);
 
     let mut ctx: Context<T> = setup_encoder(
       w,

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -3,7 +3,7 @@ mod binary {
   use assert_cmd::Command;
   use interpolate_name::interpolate_test;
   use rand::distr::Alphanumeric;
-  use rand::{rng, Rng};
+  use rand::{rng, RngExt};
   use std::env::temp_dir;
   use std::fs::File;
   use std::io::Read;


### PR DESCRIPTION
- Update `rand` to v0.10
- Replace `rand_chacha` with `chacha20`
- Various mechanical fixes due to a few small breaking changes (rename Rng to RngExt, ChaChaRng to ChaCha20Rng)
- Increase MSRV to 1.85 to be compatible